### PR TITLE
[BUG] Unset Outputs in Unit Tests Can Lead to Null Dereferences

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 import flytekit.plugins
 
-__version__ = '0.1.6'
+__version__ = '0.1.7'

--- a/flytekit/engines/unit/engine.py
+++ b/flytekit/engines/unit/engine.py
@@ -134,10 +134,9 @@ class ReturnOutputsTask(UnitTestEngineTask):
         """
         literal_map = outputs[_sdk_constants.OUTPUT_FILE_NAME]
         return {
-            name: _type_helpers.get_sdk_type_from_literal_type(
-                variable.type
-            ).promote_from_model(
-                literal_map.literals[name]
+            name: _type_helpers.get_sdk_value_from_literal(
+                literal_map.literals[name],
+                sdk_type=_type_helpers.get_sdk_type_from_literal_type(variable.type)
             ).to_python_std()
             for name, variable in _six.iteritems(self.sdk_task.interface.outputs)
         }

--- a/tests/flytekit/unit/use_scenarios/unit_testing/test_schemas.py
+++ b/tests/flytekit/unit/use_scenarios/unit_testing/test_schemas.py
@@ -191,3 +191,13 @@ def test_subset_of_columns():
 
     o = source.unit_test()
     sink.unit_test(**o)
+
+
+@flyte_test
+def test_no_output_set():
+    @outputs(a=Types.Schema())
+    @python_task()
+    def null_set(wf_params, a):
+        pass
+
+    assert null_set.unit_test()['a'] is None


### PR DESCRIPTION
In the case an output is unset, the expected behavior is that the output is None for all types.  This behavior is embedded in the type engine layer which is accessed via a helper interface.  The engine incorrectly bypassed this interface thus breaking that specification. This change uses appropriate helper methods to ensure unpacking of null outputs doesn't result in a null dereference.