### PR TITLE
Add call _handle_rpc_error() for missed create task & create execution

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -19,7 +19,7 @@ from flytekit.annotated.type_engine import TypeEngine, TypeTransformer
 from flytekit.annotated.workflow import WorkflowFailurePolicy, reference_workflow, workflow
 from flytekit.loggers import logger
 
-__version__ = "0.16.0b3"
+__version__ = "0.16.0b4"
 
 
 def current_context() -> ExecutionParameters:

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -457,7 +457,7 @@ class RawSynchronousFlyteClient(object):
     #
     ####################################################################################################################
 
-    @_handle_rpc_error
+    @_handle_rpc_error()
     def create_execution(self, create_execution_request):
         """
         This will create an execution for the given execution spec.

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -177,7 +177,7 @@ class RawSynchronousFlyteClient(object):
     #
     ####################################################################################################################
 
-    @_handle_rpc_error
+    @_handle_rpc_error()
     @_handle_invalid_create_request
     def create_task(self, task_create_request):
         """

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras_require = {
 
 setup(
     name="flytekit",
-    version="0.16.0b3",
+    version="0.16.0b4",
     maintainer="Lyft",
     maintainer_email="flyte-eng@lyft.com",
     packages=find_packages(exclude=["tests*"]),


### PR DESCRIPTION
# TL;DR
Add call _handle_rpc_error() for missed create task & create execution in raw client otherwise creating tasks or executions fails.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
User-reported bug

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
