### PR TITLE
Remove required string configuration options

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -19,7 +19,7 @@ from flytekit.annotated.type_engine import TypeEngine, TypeTransformer
 from flytekit.annotated.workflow import WorkflowFailurePolicy, reference_workflow, workflow
 from flytekit.loggers import logger
 
-__version__ = "0.16.0b4"
+__version__ = "0.16.0b5"
 
 
 def current_context() -> ExecutionParameters:

--- a/flytekit/configuration/platform.py
+++ b/flytekit/configuration/platform.py
@@ -1,7 +1,7 @@
 from flytekit.common import constants as _constants
 from flytekit.configuration import common as _config_common
 
-URL = _config_common.FlyteRequiredStringConfigurationEntry("platform", "url")
+URL = _config_common.FlyteStringConfigurationEntry("platform", "url")
 
 HTTP_URL = _config_common.FlyteStringConfigurationEntry("platform", "http_url", default=None)
 """

--- a/flytekit/configuration/sdk.py
+++ b/flytekit/configuration/sdk.py
@@ -31,7 +31,7 @@ SDK_PYTHON_VENV = _config_common.FlyteStringListConfigurationEntry("sdk", "pytho
 This is a list of commands/args which will be prefixed to the entrypoint command by SDK.
 """
 
-ROLE = _config_common.FlyteRequiredStringConfigurationEntry("sdk", "role")
+ROLE = _config_common.FlyteStringConfigurationEntry("sdk", "role")
 """
 This is the role the SDK will use by default to execute workflows.  For example, in AWS this should be an IAM role
 string.

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras_require = {
 
 setup(
     name="flytekit",
-    version="0.16.0b4",
+    version="0.16.0b5",
     maintainer="Lyft",
     maintainer_email="flyte-eng@lyft.com",
     packages=find_packages(exclude=["tests*"]),

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ extras_require = {
 setup(
     name="flytekit",
     version="0.16.0b5",
-    maintainer="Lyft",
-    maintainer_email="flyte-eng@lyft.com",
+    maintainer="Flyte Org",
+    maintainer_email="admin@flyte.org",
     packages=find_packages(exclude=["tests*"]),
     url="https://github.com/lyft/flytekit",
     description="Flyte SDK for Python",


### PR DESCRIPTION
# TL;DR
Remove flyte platform url and flyte sdk role as required config options

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
It's no longer necessary to specify the platform url in the config because `pyflyte serialize` should not make any network calls.

The flyte sdk role has been deprecated in favor of kubernetes-service-account or assumable-iam-role

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_