### PR TITLE
One last change to make --config an optional arg to pyflyte

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -19,7 +19,7 @@ from flytekit.annotated.type_engine import TypeEngine, TypeTransformer
 from flytekit.annotated.workflow import WorkflowFailurePolicy, reference_workflow, workflow
 from flytekit.loggers import logger
 
-__version__ = "0.16.0b5"
+__version__ = "0.16.0b6"
 
 
 def current_context() -> ExecutionParameters:

--- a/flytekit/configuration/images.py
+++ b/flytekit/configuration/images.py
@@ -15,12 +15,14 @@ def get_specified_images() -> typing.Dict[str, str]:
 
     :returns a dictionary of name: image<fqn+version> Version is optional
     """
+    images: typing.Dict[str, str] = {}
+    if _config_common.CONFIGURATION_SINGLETON.config is None:
+        return images
     try:
         image_names = _config_common.CONFIGURATION_SINGLETON.config.options("images")
     except configparser.NoSectionError:
         print("No images specified, will use the default image")
         image_names = None
-    images: typing.Dict[str, str] = {}
     if image_names:
         for i in image_names:
             images[str(i)] = _config_common.FlyteStringConfigurationEntry("images", i).get()

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras_require = {
 
 setup(
     name="flytekit",
-    version="0.16.0b5",
+    version="0.16.0b6",
     maintainer="Flyte Org",
     maintainer_email="admin@flyte.org",
     packages=find_packages(exclude=["tests*"]),


### PR DESCRIPTION
# TL;DR
One last change to make --config an optional arg to pyflyte for out of container serialize. Tested locally

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_