### PR TITLE
A few small fixes for serialize & register

### DIFF
--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1830,13 +1830,15 @@ def fast_register_files(
             _click.echo(f"  {f}")
             pb_files.append(f)
 
-    if not compressed_source:
-        _click.UsageError("Could not discover compressed source, did you remember to run `pyflyte serialize fast ...`?")
+    if compressed_source is None:
+        raise _click.UsageError(
+            "Could not discover compressed source, did you remember to run `pyflyte serialize fast ...`?"
+        )
 
     version = version if version else digest
     full_remote_path = _get_additional_distribution_loc(additional_distribution_dir, version)
     Data.put_data(compressed_source, full_remote_path)
-    _click.echo(f"Uploaded compressed code archive {compressed_source} to {full_remote_path}")
+    _click.secho(f"Uploaded compressed code archive {compressed_source} to {full_remote_path}", fg="green")
 
     def fast_register_task(entity: _GeneratedProtocolMessageType) -> _GeneratedProtocolMessageType:
         """


### PR DESCRIPTION
# TL;DR

- Make it more clear that serialize terminated successfully
- Default to user's currently working dir when local source root is omitted in out of container serialize
- Raise an error when the expected tar file is missing during fast register

Tested locally.

**Note** I still can't recreate the

```
flytekit.common.exceptions.user.FlyteAssertion: No configuration set for [internal] image.  This is a required configuration.
```
issue or the case where a custom version is specified during fast register and tar file is not uploaded with the specified version as the filename.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Discovered while onboarding a new user.

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_