### PR TITLE
Bump all (new) plugins to 0.1.1s

### DIFF
--- a/plugins/awssagemaker/setup.py
+++ b/plugins/awssagemaker/setup.py
@@ -9,7 +9,7 @@ plugin_requires = ["flytekit>=0.16.0b0,<1.0.0", "sagemaker-training>=3.6.2,<4.0.
 # TODO: move sagemaker install script here.
 setup(
     name=microlib_name,
-    version="0.1.0",
+    version="0.1.1",
     author="flyteorg",
     author_email="admin@flyte.org",
     description="AWS Plugins for flytekit",

--- a/plugins/hive/setup.py
+++ b/plugins/hive/setup.py
@@ -8,7 +8,7 @@ plugin_requires = ["flytekit>=0.16.0b0,<1.0.0"]
 
 setup(
     name=microlib_name,
-    version="0.1.0",
+    version="0.1.1",
     author="flyteorg",
     author_email="admin@flyte.org",
     description="This package holds Hive plugins for flytekit",

--- a/plugins/kfpytorch/setup.py
+++ b/plugins/kfpytorch/setup.py
@@ -8,7 +8,7 @@ plugin_requires = ["flytekit>=0.16.0b0,<1.0.0"]
 
 setup(
     name=microlib_name,
-    version="0.1.0",
+    version="0.1.1",
     author="flyteorg",
     author_email="admin@flyte.org",
     description="K8s based Pytorch plugin for Flytekit",

--- a/plugins/kftensorflow/setup.py
+++ b/plugins/kftensorflow/setup.py
@@ -9,7 +9,7 @@ plugin_requires = ["flytekit>=0.16.0b0,<1.0.0"]
 
 setup(
     name=microlib_name,
-    version="0.1.0",
+    version="0.1.1",
     author="flyteorg",
     author_email="admin@flyte.org",
     description="K8s based Tensorflow plugin for flytekit",

--- a/plugins/papermill/setup.py
+++ b/plugins/papermill/setup.py
@@ -8,7 +8,7 @@ plugin_requires = ["flytekit>=0.16.0b0,<1.0.0", "papermill>=1.2.0", "nbconvert>=
 
 setup(
     name=microlib_name,
-    version="0.1.0",
+    version="0.1.1",
     author="flyteorg",
     author_email="admin@flyte.org",
     description="This is the flytekit papermill plugin",

--- a/plugins/pod/setup.py
+++ b/plugins/pod/setup.py
@@ -8,7 +8,7 @@ plugin_requires = ["flytekit>=0.16.0b0,<1.0.0", "k8s-proto>=0.0.3,<1.0.0"]
 
 setup(
     name=microlib_name,
-    version="0.1.0",
+    version="0.1.1",
     author="flyteorg",
     author_email="admin@flyte.org",
     description="Flytekit plugin to support K8s Pod tasks",

--- a/plugins/spark/setup.py
+++ b/plugins/spark/setup.py
@@ -8,7 +8,7 @@ plugin_requires = ["flytekit>=0.16.0b0,<1.0.0", "pyspark>=3.0.0"]
 
 setup(
     name=microlib_name,
-    version="0.1.0",
+    version="0.1.1",
     author="flyteorg",
     author_email="admin@flyte.org",
     description="Spark 3 plugin for flytekit",


### PR DESCRIPTION
# TL;DR
This should've been part of https://github.com/flyteorg/flytekit/pull/356

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Without this, users won't have a new version of plugins to bump to, and without that, the plugins will continue to look for things in the `annotated` folder, which as of the new release, no longer exists.
