### PR TITLE
Removing Matt from the required reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-*       @matthewphsmith @wild-endeavor @kumare3
+*       @wild-endeavor @kumare3 @katrogan

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-*       @wild-endeavor @kumare3 @katrogan
+*       @wild-endeavor @kumare3 @katrogan @honnix


### PR DESCRIPTION
# TL;DR
The new-codebase has new contributors and currently Matt is not an active collaborator on the codebase. This change makes it faster to get PR's and directs it to more relevant users
