### PR TITLE
List lps without erroring when they have no schedule data

### DIFF
--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -268,9 +268,9 @@ def _update_one_launch_plan(urn, host, insecure, state):
 
 def _render_schedule_expr(lp):
     sched_expr = "NONE"
-    if lp.spec.entity_metadata.schedule.cron_expression:
+    if lp.spec.entity_metadata.schedule and lp.spec.entity_metadata.schedule.cron_expression:
         sched_expr = "cron({cron_expr})".format(cron_expr=_tt(lp.spec.entity_metadata.schedule.cron_expression))
-    elif lp.spec.entity_metadata.schedule.rate:
+    elif lp.spec.entity_metadata.schedule and lp.spec.entity_metadata.schedule.rate:
         sched_expr = "rate({unit}={value})".format(
             unit=_tt(_Schedule.FixedRateUnit.enum_to_string(lp.spec.entity_metadata.schedule.rate.unit)),
             value=_tt(lp.spec.entity_metadata.schedule.rate.value),

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -927,7 +927,8 @@ def list_launch_plan_versions(
                     "{:50} {:80} ".format(_tt(l.id.version), _tt(_identifier.Identifier.promote_from_model(l.id)),),
                     nl=False,
                 )
-                if l.spec.entity_metadata.schedule.cron_expression or l.spec.entity_metadata.schedule.rate:
+                if l.spec.entity_metadata.schedule is not None and (
+                        l.spec.entity_metadata.schedule.cron_expression or l.spec.entity_metadata.schedule.rate):
                     _click.echo("{:30} ".format(_render_schedule_expr(l)), nl=False)
                     _click.secho(
                         _launch_plan.LaunchPlanState.enum_to_string(l.closure.state),

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -928,7 +928,8 @@ def list_launch_plan_versions(
                     nl=False,
                 )
                 if l.spec.entity_metadata.schedule is not None and (
-                        l.spec.entity_metadata.schedule.cron_expression or l.spec.entity_metadata.schedule.rate):
+                    l.spec.entity_metadata.schedule.cron_expression or l.spec.entity_metadata.schedule.rate
+                ):
                     _click.echo("{:30} ".format(_render_schedule_expr(l)), nl=False)
                     _click.secho(
                         _launch_plan.LaunchPlanState.enum_to_string(l.closure.state),


### PR DESCRIPTION
# TL;DR
List active lps without erroring when they have no schedule data

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
