### PR TITLE
Set in container serialize spark path to sys.executable

### DIFF
--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -1,6 +1,7 @@
 import logging as _logging
 import math as _math
 import os as _os
+import sys
 import tarfile as _tarfile
 from enum import Enum as _Enum
 from typing import List
@@ -263,11 +264,7 @@ def serialize(ctx, image, local_source_root, in_container_config_path, in_contai
     else:
         # For in container serialize we make sure to never accept an override the entrypoint path and determine it here
         # instead.
-        entrypoint_path = _os.path.abspath(_flytekit.__file__)
-        if entrypoint_path.endswith(".pyc"):
-            entrypoint_path = entrypoint_path[:-1]
-
-        ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] = entrypoint_path
+        ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] = sys.executable
 
 
 @click.command("tasks")

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -8,7 +8,6 @@ from typing import List
 
 import click
 
-import flytekit as _flytekit
 from flytekit.clis.sdk_in_container.constants import CTX_PACKAGES
 from flytekit.common import utils as _utils
 from flytekit.common.core import identifier as _identifier


### PR DESCRIPTION
# TL;DR
Set in container serialize spark path to sys.executable. Reverts https://github.com/flyteorg/flytekit/pull/344/files#diff-632d372ce8489b928502cba2517307448a28d0a46dd3c06017c6b90c7c765be3L89

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
User-reported bug

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
