### PR TITLE
Fix executor path and application file parameters for Spark Tasks

### DIFF
--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -260,6 +260,7 @@ def serialize(ctx, image, local_source_root, in_container_config_path, in_contai
             if in_container_virtualenv_root is not None
             else _DEFAULT_FLYTEKIT_VIRTUALENV_ROOT
         )
+        ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] = ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] + "/bin/python3"
     else:
         # For in container serialize we make sure to never accept an override the entrypoint path and determine it here
         # instead.

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -100,23 +100,24 @@ def serialize_all(
     python_interpreter: str = None,
 ):
     """
-    In order to register, we have to comply with Admin's endpoints. Those endpoints take the following objects. These
-    flyteidl.admin.launch_plan_pb2.LaunchPlanSpec
-    flyteidl.admin.workflow_pb2.WorkflowSpec
-    flyteidl.admin.task_pb2.TaskSpec
+      This function will write to the folder specified the following protobuf types ::
+          flyteidl.admin.launch_plan_pb2.LaunchPlan
+          flyteidl.admin.workflow_pb2.WorkflowSpec
+          flyteidl.admin.task_pb2.TaskSpec
 
-    However, if we were to merely call .to_flyte_idl() on all the discovered entities, what we would get are:
-    flyteidl.admin.launch_plan_pb2.LaunchPlanSpec
-    flyteidl.core.workflow_pb2.WorkflowTemplate
-    flyteidl.core.tasks_pb2.TaskTemplate
+      These can be inspected by calling (in the launch plan case) ::
+          flyte-cli parse-proto -f filename.pb -p flyteidl.admin.launch_plan_pb2.LaunchPlan
 
-    For Workflows and Tasks therefore, there is special logic in the serialize function that translates these objects.
-
-    :param list[Text] pkgs:
-    :param Text folder:
-
-    :return:
-    """
+      See :py:class:`flytekit.models.core.identifier.ResourceType` to match the trailing index in the file name with the
+      entity type.
+      :param pkgs: Dot-delimited Python packages/subpackages to look into for serialization.
+      :param local_source_root: Where to start looking for the code.
+      :param folder: Where to write the output protobuf files
+      :param mode: Regular vs fast
+      :param image: The fully qualified and versioned default image to use
+      :param config_path: Path to the config file, if any, to be used during serialization
+      :param flytekit_virtualenv_root: The full path of the virtual env in the container.
+      """
 
     # m = module (i.e. python file)
     # k = value of dir(m), type str

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -270,15 +270,11 @@ def serialize(ctx, image, local_source_root, in_container_config_path, in_contai
     else:
         # For in container serialize we make sure to never accept an override the entrypoint path and determine it here
         # instead.
-
-        # is this needed now? Or should we revert to how it was prior to change https://github.com/flyteorg/flytekit/pull/379
-        # ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] = sys.executable
         entrypoint_path = _os.path.abspath(_flytekit.__file__)
         if entrypoint_path.endswith(".pyc"):
             entrypoint_path = entrypoint_path[:-1]
 
         ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] = _os.path.dirname(entrypoint_path)
-
         ctx.obj[CTX_PYTHON_INTERPRETER] = sys.executable
 
 

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -8,6 +8,7 @@ from typing import List
 
 import click
 
+import flytekit as _flytekit
 from flytekit.clis.sdk_in_container.constants import CTX_PACKAGES
 from flytekit.common import utils as _utils
 from flytekit.common.core import identifier as _identifier
@@ -271,7 +272,12 @@ def serialize(ctx, image, local_source_root, in_container_config_path, in_contai
         # instead.
 
         # is this needed now? Or should we revert to how it was prior to change https://github.com/flyteorg/flytekit/pull/379
-        ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] = sys.executable
+        # ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] = sys.executable
+        entrypoint_path = _os.path.abspath(_flytekit.__file__)
+        if entrypoint_path.endswith(".pyc"):
+            entrypoint_path = entrypoint_path[:-1]
+
+        ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] = entrypoint_path
 
         ctx.obj[CTX_PYTHON_INTERPRETER] = sys.executable
 

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -277,7 +277,7 @@ def serialize(ctx, image, local_source_root, in_container_config_path, in_contai
         if entrypoint_path.endswith(".pyc"):
             entrypoint_path = entrypoint_path[:-1]
 
-        ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] = entrypoint_path
+        ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] = _os.path.dirname(entrypoint_path)
 
         ctx.obj[CTX_PYTHON_INTERPRETER] = sys.executable
 

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -43,6 +43,7 @@ CTX_IMAGE = "image"
 CTX_LOCAL_SRC_ROOT = "local_source_root"
 CTX_CONFIG_FILE_LOC = "config_file_loc"
 CTX_FLYTEKIT_VIRTUALENV_ROOT = "flytekit_virtualenv_root"
+CTX_PYTHON_INTERPRETER = "python_interpreter"
 
 
 class SerializationMode(_Enum):
@@ -95,6 +96,7 @@ def serialize_all(
     image: str = None,
     config_path: str = None,
     flytekit_virtualenv_root: str = None,
+    python_interpreter: str = None,
 ):
     """
     In order to register, we have to comply with Admin's endpoints. Those endpoints take the following objects. These
@@ -132,6 +134,7 @@ def serialize_all(
         image_config=flyte_context.get_image_config(img_name=image),
         env=env,
         flytekit_virtualenv_root=flytekit_virtualenv_root,
+        python_interpreter=python_interpreter,
         entrypoint_settings=flyte_context.EntrypointSettings(
             path=_os.path.join(flytekit_virtualenv_root, _DEFAULT_FLYTEKIT_RELATIVE_ENTRYPOINT_LOC)
         ),
@@ -260,11 +263,17 @@ def serialize(ctx, image, local_source_root, in_container_config_path, in_contai
             if in_container_virtualenv_root is not None
             else _DEFAULT_FLYTEKIT_VIRTUALENV_ROOT
         )
-        ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] = ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] + "/bin/python3"
+
+        # append python3
+        ctx.obj[CTX_PYTHON_INTERPRETER] = ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] + "/bin/python3"
     else:
         # For in container serialize we make sure to never accept an override the entrypoint path and determine it here
         # instead.
+
+        # is this needed now? Or should we revert to how it was prior to change https://github.com/flyteorg/flytekit/pull/379
         ctx.obj[CTX_FLYTEKIT_VIRTUALENV_ROOT] = sys.executable
+
+        ctx.obj[CTX_PYTHON_INTERPRETER] = sys.executable
 
 
 @click.command("tasks")

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -104,6 +104,7 @@ class SerializationSettings(object):
         image_config: ImageConfig,
         env: Optional[Dict[str, str]],
         flytekit_virtualenv_root: str = None,
+        python_interpreter: str = None,
         entrypoint_settings: EntrypointSettings = None,
     ):
         self._project = project
@@ -113,6 +114,7 @@ class SerializationSettings(object):
         self._env = env or {}
         self._instance_lookup = {}
         self._flytekit_virtualenv_root = flytekit_virtualenv_root
+        self._python_interpreter = python_interpreter
         self._entrypoint_settings = entrypoint_settings
 
     @property
@@ -138,6 +140,10 @@ class SerializationSettings(object):
     @property
     def flytekit_virtualenv_root(self) -> str:
         return self._flytekit_virtualenv_root
+
+    @property
+    def python_interpreter(self) -> str:
+        return self._python_interpreter
 
     @property
     def entrypoint_settings(self) -> EntrypointSettings:

--- a/plugins/spark/flytekitplugins/spark/task.py
+++ b/plugins/spark/flytekitplugins/spark/task.py
@@ -78,7 +78,7 @@ class PysparkFunctionTask(PythonFunctionTask[Spark]):
             spark_conf=self.task_config.spark_conf,
             hadoop_conf=self.task_config.hadoop_conf,
             application_file="local://" + settings.entrypoint_settings.path,
-            executor_path=settings.flytekit_virtualenv_root,
+            executor_path=settings.python_interpreter,
             main_class="",
             spark_type=SparkType.PYTHON,
         )

--- a/plugins/spark/flytekitplugins/spark/task.py
+++ b/plugins/spark/flytekitplugins/spark/task.py
@@ -78,7 +78,7 @@ class PysparkFunctionTask(PythonFunctionTask[Spark]):
             spark_conf=self.task_config.spark_conf,
             hadoop_conf=self.task_config.hadoop_conf,
             application_file="local://" + settings.entrypoint_settings.path,
-            executor_path=os.path.join(settings.flytekit_virtualenv_root, "bin/python"),
+            executor_path=settings.flytekit_virtualenv_root,
             main_class="",
             spark_type=SparkType.PYTHON,
         )


### PR DESCRIPTION
# TL;DR
Add a new variable `CTX_PYTHON_INTERPRETER` to ctx. This points to the python interpreter that should be used as part of the executor path. 
Revert back to how `CTX_FLYTE_VIRTUALENV_ROOT` was previously calculated and only use the directory. This corrects teh application file from `local:///<some_path>/flytekit/__init__.py/bin/entrypoint.py` to `local:///<some_path>/flytekit/bin/entrypoint.py`

## Type
 - [x ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
