### PR TITLE
Add PythonInstanceTask to core flytekit import

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ copyright = "2021, Flyte"
 author = "Flyte"
 
 # The full version, including alpha/beta/rc tags
-release = "0.16.0b7"
+release = "0.16.0b9"
 
 
 # -- General configuration ---------------------------------------------------

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -105,6 +105,7 @@ Core Task Types
    SQLTask
    ContainerTask
    PythonFunctionTask
+   PythonInstanceTask
    LaunchPlan
 
 """
@@ -120,7 +121,7 @@ from flytekit.core.dynamic_workflow_task import dynamic
 from flytekit.core.launch_plan import LaunchPlan
 from flytekit.core.map_task import maptask
 from flytekit.core.notification import Email, PagerDuty, Slack
-from flytekit.core.python_function_task import PythonFunctionTask
+from flytekit.core.python_function_task import PythonFunctionTask, PythonInstanceTask
 from flytekit.core.reference import get_reference_entity
 from flytekit.core.reference_entity import LaunchPlanReference, TaskReference, WorkflowReference
 from flytekit.core.resources import Resources


### PR DESCRIPTION
# TL;DR
In an earlier [PR](https://github.com/flyteorg/flytekit/pull/356/files) we inadvertently removed the `PythonInstanceTask` object from the core flytekit import.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Adding it back.

