### PR TITLE
Allow {{image.sagemaker}} to substitute for the entire image

### DIFF
--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -28,6 +28,10 @@ class Image(object):
     fqn: str
     tag: str
 
+    @property
+    def full(self):
+        return f"{self.fqn}:{self.tag}"
+
 
 @dataclass(init=True, repr=True, eq=True, frozen=True)
 class ImageConfig(object):

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -16,6 +16,12 @@ from flytekit.models import literals as _literal_models
 from flytekit.models import task as _task_model
 
 
+# Matches {{.image.<name>.<attr>}}. A name can be either 'default' indicating the default image passed during
+# serialization or it can be a custom name for an image that must be defined in the config section Images. An attribute
+# can be either 'fqn', 'version' or non-existent.
+# fqn will access the fully qualified name of the image (e.g. registry/imagename:version -> registry/imagename)
+# version will access the version part of the image (e.g. registry/imagename:version -> version)
+# With empty attribute, it'll access the full image path (e.g. registry/imagename:version -> registry/imagename:version)
 _IMAGE_REPLACE_REGEX = re.compile(r"({{\s*\.image[s]?(?:\.([a-zA-Z]+))(?:\.([a-zA-Z]+))?\s*}})", re.IGNORECASE)
 
 

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -15,7 +15,6 @@ from flytekit.models import dynamic_job as _dynamic_job
 from flytekit.models import literals as _literal_models
 from flytekit.models import task as _task_model
 
-
 # Matches {{.image.<name>.<attr>}}. A name can be either 'default' indicating the default image passed during
 # serialization or it can be a custom name for an image that must be defined in the config section Images. An attribute
 # can be either 'fqn', 'version' or non-existent.

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -65,6 +65,9 @@ def test_container_image_conversion():
     with pytest.raises(AssertionError):
         get_registerable_container_image("{{.image.blah}}", cfg)
 
+    assert (
+        get_registerable_container_image("{{.image.default}}", cfg) == "xyz.com/abc:tag1"
+    )
 
 def test_py_func_task_get_container():
     def foo(i: int):

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -65,9 +65,8 @@ def test_container_image_conversion():
     with pytest.raises(AssertionError):
         get_registerable_container_image("{{.image.blah}}", cfg)
 
-    assert (
-        get_registerable_container_image("{{.image.default}}", cfg) == "xyz.com/abc:tag1"
-    )
+    assert get_registerable_container_image("{{.image.default}}", cfg) == "xyz.com/abc:tag1"
+
 
 def test_py_func_task_get_container():
     def foo(i: int):


### PR DESCRIPTION
# TL;DR
Allow users to specify {{image.sagemaker}} (or others) into their `container_image` attribute of a task to substitute for the entire image path... instead of forcing them to write `{{image.sagemaker.fqn}}:{{image.sagemaker.version}}`.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
https://github.com/flyteorg/flyte/issues/734