### PR TITLE
List workflow outputs

### DIFF
--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -181,9 +181,9 @@ class Task(object):
         #  Also alongwith promises and constants, there could be dictionary or list of promises or constants
         kwargs = translate_inputs_to_literals(
             ctx,
-            input_kwargs=kwargs,
-            flyte_interface_inputs=self.interface.inputs,
-            native_input_types=self.get_input_types(),
+            incoming_values=kwargs,
+            flyte_interface_types=self.interface.inputs,
+            native_types=self.get_input_types(),
         )
         input_literal_map = _literal_models.LiteralMap(literals=kwargs)
 

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -180,7 +180,10 @@ class Task(object):
         #  native constants are just bound to this specific task (default values for a task input)
         #  Also alongwith promises and constants, there could be dictionary or list of promises or constants
         kwargs = translate_inputs_to_literals(
-            ctx, input_kwargs=kwargs, interface=self.interface, native_input_types=self.get_input_types()
+            ctx,
+            input_kwargs=kwargs,
+            flyte_interface_inputs=self.interface.inputs,
+            native_input_types=self.get_input_types(),
         )
         input_literal_map = _literal_models.LiteralMap(literals=kwargs)
 

--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -66,9 +66,9 @@ class LaunchPlan(object):
         # it'll be taken out from defaults in the LaunchPlan constructor
         fixed_literals = translate_inputs_to_literals(
             ctx,
-            input_kwargs=fixed_inputs,
-            flyte_interface_inputs=workflow.interface.inputs,
-            native_input_types=workflow._native_interface.inputs,
+            incoming_values=fixed_inputs,
+            flyte_interface_types=workflow.interface.inputs,
+            native_types=workflow._native_interface.inputs,
         )
         fixed_lm = _literal_models.LiteralMap(literals=fixed_literals)
 

--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -67,7 +67,7 @@ class LaunchPlan(object):
         fixed_literals = translate_inputs_to_literals(
             ctx,
             input_kwargs=fixed_inputs,
-            interface=workflow.interface,
+            flyte_interface_inputs=workflow.interface.inputs,
             native_input_types=workflow._native_interface.inputs,
         )
         fixed_lm = _literal_models.LiteralMap(literals=fixed_literals)

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -26,11 +26,14 @@ from flytekit.models.literals import Primitive
 
 def translate_inputs_to_literals(
     ctx: FlyteContext,
-    input_kwargs: Dict[str, Any],
-    flyte_interface_inputs: Dict[str, _interface_models.Variable],
-    native_input_types: Dict[str, type],
+    incoming_values: Dict[str, Any],
+    flyte_interface_types: Dict[str, _interface_models.Variable],
+    native_types: Dict[str, type],
 ) -> Dict[str, _literal_models.Literal]:
     """
+    The point of this function is to extract out Literals from a collection of either Python native values (which would
+    be converted into Flyte literals) or Promises (the literals in which would just get extracted).
+
     When calling a task inside a workflow, a user might do something like this.
 
         def my_wf(in1: int) -> int:
@@ -50,6 +53,13 @@ def translate_inputs_to_literals(
 
     Here, in task_2, during execution we'd have a list of Promises. We have to make sure to give task2 a Flyte
     LiteralCollection (Flyte's name for list), not a Python list of Flyte literals.
+
+    This helper function is used both when sorting out inputs to a task, as well as outputs of a function.
+
+    :param ctx: Context needed in case a non-primitive literal needs to be translated to a Flyte literal (like a file)
+    :param incoming_values: This is a map of your task's input kwargs basically
+    :param flyte_interface_types: One side of an :py:class:`flytekit.models.interface.TypedInterface` basically.
+    :param native_types: Map to native Python type.
     """
 
     def extract_value(
@@ -92,11 +102,11 @@ def translate_inputs_to_literals(
             return TypeEngine.to_literal(ctx, input_val, val_type, flyte_literal_type)
 
     result = {}  # So as to not overwrite the input_kwargs
-    for k, v in input_kwargs.items():
-        if k not in flyte_interface_inputs:
+    for k, v in incoming_values.items():
+        if k not in flyte_interface_types:
             raise ValueError(f"Received unexpected keyword argument {k}")
-        var = flyte_interface_inputs[k]
-        t = native_input_types[k]
+        var = flyte_interface_types[k]
+        t = native_types[k]
         result[k] = extract_value(ctx, v, t, var.type)
 
     return result

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -57,7 +57,7 @@ def translate_inputs_to_literals(
     This helper function is used both when sorting out inputs to a task, as well as outputs of a function.
 
     :param ctx: Context needed in case a non-primitive literal needs to be translated to a Flyte literal (like a file)
-    :param incoming_values: This is a map of your task's input kwargs basically
+    :param incoming_values: This is a map of your task's input or wf's output kwargs basically
     :param flyte_interface_types: One side of an :py:class:`flytekit.models.interface.TypedInterface` basically.
     :param native_types: Map to native Python type.
     """
@@ -100,6 +100,9 @@ def translate_inputs_to_literals(
         else:
             # This handles native values, the 5 example
             return TypeEngine.to_literal(ctx, input_val, val_type, flyte_literal_type)
+
+    if incoming_values is None:
+        raise ValueError("Incoming values cannot be None, must be a dict")
 
     result = {}  # So as to not overwrite the input_kwargs
     for k, v in incoming_values.items():

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -27,7 +27,7 @@ from flytekit.models.literals import Primitive
 def translate_inputs_to_literals(
     ctx: FlyteContext,
     input_kwargs: Dict[str, Any],
-    interface: _interface_models.TypedInterface,
+    flyte_interface_inputs: Dict[str, _interface_models.Variable],
     native_input_types: Dict[str, type],
 ) -> Dict[str, _literal_models.Literal]:
     """
@@ -93,9 +93,9 @@ def translate_inputs_to_literals(
 
     result = {}  # So as to not overwrite the input_kwargs
     for k, v in input_kwargs.items():
-        if k not in interface.inputs:
+        if k not in flyte_interface_inputs:
             raise ValueError(f"Received unexpected keyword argument {k}")
-        var = interface.inputs[k]
+        var = flyte_interface_inputs[k]
         t = native_input_types[k]
         result[k] = extract_value(ctx, v, t, var.type)
 
@@ -369,7 +369,7 @@ class Promise(object):
 
     def __repr__(self):
         if self._promise_ready:
-            return f"Var({self._var}={self._val})"
+            return f"Resolved({self._var}={self._val})"
         return f"Promise(node:{self.ref.node_id}.{self._var})"
 
     def __str__(self):

--- a/flytekit/core/reference_entity.py
+++ b/flytekit/core/reference_entity.py
@@ -156,7 +156,10 @@ class ReferenceEntity(object):
         #  native constants are just bound to this specific task (default values for a task input)
         #  Also alongwith promises and constants, there could be dictionary or list of promises or constants
         kwargs = translate_inputs_to_literals(
-            ctx, input_kwargs=kwargs, interface=self.typed_interface, native_input_types=self.interface.inputs
+            ctx,
+            input_kwargs=kwargs,
+            flyte_interface_inputs=self.typed_interface.inputs,
+            native_input_types=self.interface.inputs,
         )
         input_literal_map = _literal_models.LiteralMap(literals=kwargs)
 

--- a/flytekit/core/reference_entity.py
+++ b/flytekit/core/reference_entity.py
@@ -157,9 +157,9 @@ class ReferenceEntity(object):
         #  Also alongwith promises and constants, there could be dictionary or list of promises or constants
         kwargs = translate_inputs_to_literals(
             ctx,
-            input_kwargs=kwargs,
-            flyte_interface_inputs=self.typed_interface.inputs,
-            native_input_types=self.interface.inputs,
+            incoming_values=kwargs,
+            flyte_interface_types=self.typed_interface.inputs,
+            native_types=self.interface.inputs,
         )
         input_literal_map = _literal_models.LiteralMap(literals=kwargs)
 

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -252,8 +252,8 @@ class Workflow(object):
         wf_outputs_as_literal_dict = translate_inputs_to_literals(
             ctx,
             wf_outputs_as_map,
-            flyte_interface_inputs=self.interface.outputs,
-            native_input_types=self.python_interface.outputs,
+            flyte_interface_types=self.interface.outputs,
+            native_types=self.python_interface.outputs,
         )
 
         new_promises = [Promise(var, wf_outputs_as_literal_dict[var]) for var in expected_output_names]

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-import typing
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -317,10 +317,7 @@ class Workflow(object):
             ):
                 if isinstance(result, Promise):
                     v = [v for k, v in self._native_interface.outputs.items()][0]
-                    # import ipdb;
-                    # ipdb.set_trace()
-                    xx = TypeEngine.to_python_value(ctx, result.val, v)
-                    return xx
+                    return TypeEngine.to_python_value(ctx, result.val, v)
                 else:
                     for prom in result:
                         if not isinstance(prom, Promise):

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -16,7 +16,7 @@ from flytekit.core.type_engine import (
 )
 from flytekit.models import types as model_types
 from flytekit.models.core.types import BlobType
-from flytekit.models.literals import Blob, BlobMetadata, Literal, LiteralMap, Primitive, Scalar
+from flytekit.models.literals import Blob, BlobMetadata, Literal, LiteralCollection, LiteralMap, Primitive, Scalar
 from flytekit.models.types import LiteralType, SimpleType
 from flytekit.types.file.file import FlyteFile
 from flytekit.types.schema import FlyteSchema, SchemaFormat
@@ -167,3 +167,14 @@ def test_dict_transformer():
         Literal(map=LiteralMap(literals={"x": Literal(scalar=Scalar(primitive=Primitive(integer=1)))})),
         typing.Dict[str, int],
     )
+
+
+def test_list_transformer():
+    l0 = Literal(scalar=Scalar(primitive=Primitive(integer=3)))
+    l1 = Literal(scalar=Scalar(primitive=Primitive(integer=4)))
+    lc = LiteralCollection(literals=[l0, l1])
+    lit = Literal(collection=lc)
+
+    ctx = FlyteContext.current_context()
+    xx = TypeEngine.to_python_value(ctx, lit, typing.List[int])
+    assert xx == [3, 4]

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -88,7 +88,7 @@ def test_sub_wf_single_named_tuple():
     assert x == (7,)
 
 
-def test_fdsjaf():
+def test_unexpected_outputs():
     @task
     def t1(a: int) -> int:
         a = a + 5

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -48,3 +48,25 @@ def test_workflow_values():
     sdk_wf = get_serializable(serialization_settings, wf)
     assert sdk_wf.metadata_defaults.interruptible
     assert sdk_wf.metadata.on_failure == 1
+
+
+def test_fdsafdsa():
+    @task
+    def t1(a: int) -> int:
+        a = a + 5
+        return a
+
+    @workflow
+    def list_output_wf() -> typing.List[int]:
+        v = []
+        for i in range(2):
+            v.append(t1(a=i))
+        return v
+
+        o1 = t2()  # list of ints
+
+        return o1[2:5]
+
+    x = list_output_wf()
+    # import ipdb; ipdb.set_trace()
+    print(x)

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -50,7 +50,7 @@ def test_workflow_values():
     assert sdk_wf.metadata.on_failure == 1
 
 
-def test_fdsafdsa():
+def test_list_output_wf():
     @task
     def t1(a: int) -> int:
         a = a + 5
@@ -63,10 +63,26 @@ def test_fdsafdsa():
             v.append(t1(a=i))
         return v
 
-        o1 = t2()  # list of ints
-
-        return o1[2:5]
-
     x = list_output_wf()
-    # import ipdb; ipdb.set_trace()
-    print(x)
+    assert x == [5, 6]
+
+
+def test_sub_wf_single_named_tuple():
+    nt = typing.NamedTuple("SingleNamedOutput", named1=int)
+
+    @task
+    def t1(a: int) -> nt:
+        a = a + 2
+        return (a,)
+
+    @workflow
+    def subwf(a: int) -> nt:
+        return t1(a=a)
+
+    @workflow
+    def wf(b: int) -> nt:
+        out = subwf(a=b)
+        return t1(a=out.named1)
+
+    x = wf(b=3)
+    assert x == (7,)


### PR DESCRIPTION
# TL;DR
This previously didn't work

```
    @task
    def t1(a: int) -> int:
        a = a + 5
        return a

    @workflow
    def list_output_wf() -> typing.List[int]:
        v = []
        for i in range(2):
            v.append(t1(a=i))
        return v
```

What was happening was that `Promise` objects were getting wrapped twice.  Coming out of the workflow function call, it was already a list of Promises.  What the workflow function should return is a `LiteralCollection` rather than attempting to rewrap. The end result was that `type(result.val.collection.literals[0].scalar.primitive.integer)` was again a `Promise` rather than a proper Python integer. (`result` here is the output of [`_local_execute`](https://github.com/flyteorg/flytekit/pull/388/files#diff-b1a8538044c80e14d7998344a528dccb59cf54c9735de724f39d345e5f8dfcf5R306))

## Type
 - [x] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
* Removed the `_workflow_fn_outputs_to_promise` function.  I never understood why this function existed.
* Changed the `promise.translate_inputs_to_literals` function to just accept one side of an interface, either inputs or outputs.
* Then `translate_inputs_to_literals` can be used on the outputs of a workflow as well.
* Changed the string template for promises to say "Resolved" instead of "Var".

## Tracking Issue
NA

## Follow-up issue
NA
