### PR TITLE
Instance variable load issue.

### DIFF
--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -9,6 +9,7 @@ from typing import List
 import click
 
 import flytekit as _flytekit
+from flytekit import PythonInstanceTask
 from flytekit.clis.sdk_in_container.constants import CTX_PACKAGES
 from flytekit.common import utils as _utils
 from flytekit.common.core import identifier as _identifier
@@ -24,7 +25,7 @@ from flytekit.core.launch_plan import LaunchPlan
 from flytekit.core.workflow import Workflow
 from flytekit.tools.fast_registration import compute_digest as _compute_digest
 from flytekit.tools.fast_registration import filter_tar_file_fn as _filter_tar_file_fn
-from flytekit.tools.module_loader import iterate_registerable_entities_in_order
+from flytekit.tools.module_loader import iterate_registerable_entities_in_order, load_module_object_for_type
 
 # Identifier fields use placeholders for registration-time substitution.
 # Additional fields, such as auth and the raw output data prefix have more complex structures
@@ -152,6 +153,9 @@ def serialize_all(
                 o.resource_type, _PROJECT_PLACEHOLDER, _DOMAIN_PLACEHOLDER, name, _VERSION_PLACEHOLDER
             )
             loaded_entities.append(o)
+
+        for o, v in load_module_object_for_type(pkgs, PythonInstanceTask).items():
+            m, k = v
             ctx.serialization_settings.add_instance_var(InstanceVar(module=m, name=k, o=o))
 
         click.echo(f"Found {len(flyte_context.FlyteEntities.entities)} tasks/workflows")

--- a/flytekit/tools/module_loader.py
+++ b/flytekit/tools/module_loader.py
@@ -121,14 +121,21 @@ def _get_entity_to_module(pkgs):
     return entity_to_module_key
 
 
-def load_module_object_for_type(pkgs, t):
-    entity_to_module_key = {}
-    for m in iterate_modules(pkgs):
-        for k in dir(m):
-            o = m.__dict__[k]
-            if isinstance(o, t):
-                entity_to_module_key[o] = (m.__name__, k)
-    return entity_to_module_key
+def load_module_object_for_type(pkgs, t, additional_path=None):
+    def iterate():
+        entity_to_module_key = {}
+        for m in iterate_modules(pkgs):
+            for k in dir(m):
+                o = m.__dict__[k]
+                if isinstance(o, t):
+                    entity_to_module_key[o] = (m.__name__, k)
+        return entity_to_module_key
+
+    if additional_path is not None:
+        with add_sys_path(additional_path):
+            return iterate()
+    else:
+        return iterate()
 
 
 def iterate_registerable_entities_in_order(

--- a/flytekit/tools/module_loader.py
+++ b/flytekit/tools/module_loader.py
@@ -121,6 +121,16 @@ def _get_entity_to_module(pkgs):
     return entity_to_module_key
 
 
+def load_module_object_for_type(pkgs, t):
+    entity_to_module_key = {}
+    for m in iterate_modules(pkgs):
+        for k in dir(m):
+            o = m.__dict__[k]
+            if isinstance(o, t):
+                entity_to_module_key[o] = (m.__name__, k)
+    return entity_to_module_key
+
+
 def iterate_registerable_entities_in_order(
     pkgs, local_source_root=None, ignore_entities=None, include_entities=None, detect_unreferenced_entities=True,
 ):


### PR DESCRIPTION
# TL;DR
- AFter the refactor in which registrable entities were removed, we
  inadvertently broke instance variable lookup
- This PR resurrects it, creating a separate Path.

One problem with this PR is potentially slower serialization performance
(unnoticeable to humans), because the modules are imported twice to scan
for relevant objects

The second pass scans only for Instance Vars, and topo sort is not
needed, as automatically create a inmemory map of all the tasks loaded.


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
