### PR TITLE
Adding a pointer to the docs for filter option

### DIFF
--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -350,7 +350,9 @@ _filter_option = _click.option(
     "-f",
     "--filter",
     multiple=True,
-    help="Filter to be applied.  Multiple filters can be applied and they will be ANDed together. Filtery may be supllied as strings such as test",
+    help="""Filter to be applied.  Multiple filters can be applied and they will be ANDed together. 
+    Filters may be supllied as strings such as 'eq(name, workflow_name)'. Additionnal documentation on filter
+    syntax can be found here: https://docs.flyte.org/en/latest/dive_deep/admin_service.html#adding-request-filters""",
 )
 _state_choice = _click.option(
     "--state",

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -350,7 +350,7 @@ _filter_option = _click.option(
     "-f",
     "--filter",
     multiple=True,
-    help="Filter to be applied.  Multiple filters can be applied and they will be ANDed together.",
+    help="Filter to be applied.  Multiple filters can be applied and they will be ANDed together. Filtery may be supllied as strings such as test",
 )
 _state_choice = _click.option(
     "--state",

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -350,7 +350,7 @@ _filter_option = _click.option(
     "-f",
     "--filter",
     multiple=True,
-    help="""Filter to be applied.  Multiple filters can be applied and they will be ANDed together. 
+    help="""Filter to be applied.  Multiple filters can be applied and they will be ANDed together.
     Filters may be supllied as strings such as 'eq(name, workflow_name)'. Additionnal documentation on filter
     syntax can be found here: https://docs.flyte.org/en/latest/dive_deep/admin_service.html#adding-request-filters""",
 )

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -350,7 +350,7 @@ _filter_option = _click.option(
     "-f",
     "--filter",
     multiple=True,
-    help="""Filter to be applied.  Multiple filters can be applied and they will be ANDed together. 
+    help="""Filter to be applied.  Multiple filters can be applied and they will be ANDed together.
     Filters may be supplied as strings such as 'eq(name, workflow_name)'. Additional documentation on filter
     syntax can be found here: https://docs.flyte.org/en/latest/dive_deep/admin_service.html#adding-request-filters""",
 )


### PR DESCRIPTION
# TL;DR
Adding a pointer to the documentation for [FlyteAdmin Service](https://docs.flyte.org/en/latest/dive_deep/admin_service.html#adding-request-filters) to help users understand the '--filter' option

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin
 - [x] Documentation fix

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Adding a link and an example.
