### PR TITLE
Remove kwargs

### DIFF
--- a/flytekit/core/dynamic_workflow_task.py
+++ b/flytekit/core/dynamic_workflow_task.py
@@ -4,12 +4,6 @@ Dynamic Workflows
 Dynamic workflows are one of the powerful aspects of Flyte. Please take a look at the :py:func:`flytekit.dynamic` documentation first to get started.
 
 
-Declaring a dynamic workflow
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. autoclass:: flytekit.core.dynamic_workflow_task.DynamicWorkflowTask
-
-
 Caveats when using a dynamic workflow
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Because of the dynamic nature of the workflow generated, it can easily be abused. Keep in mind that the workflow

--- a/flytekit/core/resources.py
+++ b/flytekit/core/resources.py
@@ -3,6 +3,19 @@ from dataclasses import dataclass
 
 @dataclass
 class Resources(object):
+    """
+    This class is used to specify both resource requests and resource limits. ::
+
+        Resources(cpu="1", mem="2048")  # This is 1 CPU and 2 KB of memory
+        Resources(cpu="100m", mem="2Gi")  # This is 1/10th of a CPU and 2 gigabytes of memory
+
+    .. note::
+        Storage is not currently supported on the Flyte backend.
+
+    Please see :std:doc:`cookbook:auto_core_remote_flyte/customizing_resources` for detailed examples.
+    Also refer to the `K8s conventions. <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes>`__
+    """
+
     cpu: str = None
     mem: str = None
     gpu: str = None

--- a/flytekit/core/task.py
+++ b/flytekit/core/task.py
@@ -137,8 +137,10 @@ def task(
                     def foo2():
                         ...
     :param environment: Environment variables that should be added for this tasks execution
-    :param requests: Compute requests.
-    :param limits: Compute limits.
+    :param requests: Specify compute resource requests for your task. For Pod-plugin tasks, these values will apply only
+      to the primary container.
+    :param limits: Compute limits. Specify compute resource limits for your task. For Pod-plugin tasks, these values
+      will apply only to the primary container. For more information, please see :py:class:`flytekit.Resources`.
     :param execution_mode: This is mainly for internal use. Please ignore. It is filled in automatically.
     """
 

--- a/tests/flytekit/unit/core/test_realworld_examples.py
+++ b/tests/flytekit/unit/core/test_realworld_examples.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 
 import pandas as pd
 
+from flytekit import Resources
 from flytekit.core.task import task
 from flytekit.core.workflow import workflow
 from flytekit.types.file.file import FlyteFile
@@ -76,7 +77,7 @@ def test_diabetes():
 
     # load data
     # Example file: https://raw.githubusercontent.com/jbrownlee/Datasets/master/pima-indians-diabetes.data.csv
-    @task(cache_version="1.0", cache=True, memory_limit="200Mi")
+    @task(cache_version="1.0", cache=True, limits=Resources(mem="200Mi"))
     def split_traintest_dataset(
         dataset: FlyteFile[typing.TypeVar("csv")], seed: int, test_split_ratio: float
     ) -> (
@@ -105,7 +106,7 @@ def test_diabetes():
 
     nt = typing.NamedTuple("Outputs", model=FlyteFile[MODELSER_JOBLIB])
 
-    @task(cache_version="1.0", cache=True, memory_limit="200Mi")
+    @task(cache_version="1.0", cache=True, limits=Resources(mem="200Mi"))
     def fit(x: FlyteSchema[FEATURE_COLUMNS], y: FlyteSchema[CLASSES_COLUMNS], hyperparams: dict) -> nt:
         """
         This function takes the given input features and their corresponding classes to train a XGBClassifier.
@@ -126,7 +127,7 @@ def test_diabetes():
             f.write("Some binary data")
         return nt(model=fname)
 
-    @task(cache_version="1.0", cache=True, memory_limit="200Mi")
+    @task(cache_version="1.0", cache=True, limits=Resources(mem="200Mi"))
     def predict(x: FlyteSchema[FEATURE_COLUMNS], model_ser: FlyteFile[MODELSER_JOBLIB]) -> FlyteSchema[CLASSES_COLUMNS]:
         """
         Given a any trained model, serialized using joblib (this method can be shared!) and features, this method returns
@@ -140,7 +141,7 @@ def test_diabetes():
         y_pred_df.round(0)
         return y_pred_df
 
-    @task(cache_version="1.0", cache=True, memory_limit="200Mi")
+    @task(cache_version="1.0", cache=True, limits=Resources(mem="200Mi"))
     def score(predictions: FlyteSchema[CLASSES_COLUMNS], y: FlyteSchema[CLASSES_COLUMNS]) -> float:
         """
         Compares the predictions with the actuals and returns the accuracy score.


### PR DESCRIPTION
# TL;DR
Instead of kwargs, at the task decorator level, specify explicitly everything that can be passed.  Indeterminate kwargs led to user confusion.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
* Also fix a test that wasn't specifying things resources correctly.
