### PR TITLE
collapse coverage run into single command

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -43,9 +43,7 @@ jobs:
       uses: ludeeus/action-shellcheck@master
     - name: Test with coverage
       run: |
-        coverage run -m pytest tests/flytekit/unit
-        coverage run -m pytest tests/scripts
-        coverage run -m pytest plugins/tests
+        coverage run -m pytest tests/flytekit/unit tests/scripts plugins/tests
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:


### PR DESCRIPTION
# TL;DR
Coverage report is on the fritz, try collapsing pytest run in one `coverage run` invocation

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
