### PR TITLE
Fix subworkflow branch skip return

### DIFF
--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections
 import inspect
 from dataclasses import dataclass
 from enum import Enum
@@ -8,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 from flytekit.common import constants as _common_constants
 from flytekit.common.exceptions.user import FlyteValidationException, FlyteValueException
 from flytekit.core.condition import ConditionalSection
-from flytekit.core.context_manager import ExecutionState, FlyteContext, FlyteEntities
+from flytekit.core.context_manager import BranchEvalMode, ExecutionState, FlyteContext, FlyteEntities
 from flytekit.core.interface import (
     Interface,
     transform_inputs_to_parameters,
@@ -118,6 +119,10 @@ class Workflow(object):
         #    we can re-evaluate.
         self._input_parameters = None
         FlyteEntities.entities.append(self)
+
+    def define(self, nodes: List[Node]):
+        def placeholder():
+            raise Exception("This should never be called")
 
     @property
     def function(self):
@@ -293,6 +298,14 @@ class Workflow(object):
         elif (
             ctx.execution_state is not None and ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION
         ):
+            if ctx.execution_state.branch_eval_mode == BranchEvalMode.BRANCH_SKIPPED:
+                if self.python_interface and self.python_interface.output_tuple_name:
+                    variables = [k for k in self.python_interface.outputs.keys()]
+                    output_tuple = collections.namedtuple(self.python_interface.output_tuple_name, variables)
+                    nones = [None for _ in self.python_interface.outputs.keys()]
+                    return output_tuple(*nones)
+                else:
+                    return None
             # We are already in a local execution, just continue the execution context
             return self._local_execute(ctx, **kwargs)
 

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -120,10 +120,6 @@ class Workflow(object):
         self._input_parameters = None
         FlyteEntities.entities.append(self)
 
-    def define(self, nodes: List[Node]):
-        def placeholder():
-            raise Exception("This should never be called")
-
     @property
     def function(self):
         return self._workflow_function

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -206,10 +206,10 @@ def test_subworkflow_condition_single_named_tuple():
 
     @workflow
     def wf1() -> nt:
-        return (t(),)
+        return t()
 
     @workflow
     def branching(x: int) -> int:
         return conditional("test").if_(x == 2).then(t().b).else_().then(wf1().b)
 
-    branching(x=2)
+    assert branching(x=2) == 5

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -159,3 +159,57 @@ def test_condition_unary_bool():
         return conditional("test").if_(result.is_true()).then(success()).else_().then(failed())
 
     assert decompose() == 20
+
+
+def test_subworkflow_condition():
+    @task
+    def t() -> int:
+        return 5
+
+    @workflow
+    def wf1() -> int:
+        return t()
+
+    @workflow
+    def branching(x: int) -> int:
+        return conditional("test").if_(x == 2).then(t()).else_().then(wf1())
+
+    assert branching(x=2) == 5
+    assert branching(x=3) == 5
+
+
+def test_subworkflow_condition_named_tuple():
+    nt = typing.NamedTuple("SampleNamedTuple", b=int, c=str)
+
+    @task
+    def t() -> nt:
+        return 5, "foo"
+
+    @workflow
+    def wf1() -> nt:
+        return 3, "bar"
+
+    @workflow
+    def branching(x: int) -> nt:
+        return conditional("test").if_(x == 2).then(t()).else_().then(wf1())
+
+    assert branching(x=2) == (5, "foo")
+    assert branching(x=3) == (3, "bar")
+
+
+def test_subworkflow_condition_single_named_tuple():
+    nt = typing.NamedTuple("SampleNamedTuple", b=int)
+
+    @task
+    def t() -> nt:
+        return (5,)
+
+    @workflow
+    def wf1() -> nt:
+        return (t(),)
+
+    @workflow
+    def branching(x: int) -> int:
+        return conditional("test").if_(x == 2).then(t().b).else_().then(wf1().b)
+
+    branching(x=2)


### PR DESCRIPTION
# TL;DR
Please see https://github.com/flyteorg/flyte/issues/807
Basically when a `then()` block ran a task, but wasn't in the true condition case, we'd skip execution but we never did that for subworkflows.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Basically we're copying this section https://github.com/flyteorg/flytekit/blob/master/flytekit/core/base_task.py#L238-L246 which will skip the branches not taken when running locally.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/807
