### PR TITLE
Update readme to fix square function argument passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ def sum(x: int, y: int) -> int:
     return x + y
 
 @task(cache=True, cache_version="1", retries=3)
-def square(x: int) -> int:
-    return x*x
+def square(z: int) -> int:
+    return z*z
 
 @workflow
 def my_workflow(x: int, y: int) -> int:
-    return sum(x=square(x=x),y=square(y=y))
+    return sum(x=square(z=x),y=square(z=y))
 ```
 
 ### Learn Flytekit by example using


### PR DESCRIPTION
Updates the readme with a minor change to argument passing

# TL;DR
Updates the readme with a minor fix to change `square(y=y)` while square accepts `x`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Follow-up issue
_NA_