### PR TITLE
Fix serialization of pod specs in pod plugin

### DIFF
--- a/plugins/pod/flytekitplugins/pod/task.py
+++ b/plugins/pod/flytekitplugins/pod/task.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable, Dict, Tuple, Union
 
 from flyteidl.core import tasks_pb2 as _core_task
+from kubernetes.client import ApiClient
 from kubernetes.client.models import V1Container, V1EnvVar, V1PodSpec, V1ResourceRequirements
 
 from flytekit import FlyteContext, PythonFunctionTask
@@ -76,7 +77,7 @@ class PodFunctionTask(PythonFunctionTask[Pod]):
 
         self.task_config._pod_spec.containers = final_containers
 
-        return self.task_config.pod_spec.to_dict()
+        return ApiClient().sanitize_for_serialization(self.task_config.pod_spec)
 
     def get_config(self, settings: SerializationSettings) -> Dict[str, str]:
         return {_PRIMARY_CONTAINER_NAME_FIELD: self.task_config.primary_container_name}


### PR DESCRIPTION
Signed-off-by: Jeev B <jeev.balakrishnan@freenome.com>

# TL;DR
Pod specs in the `custom` struct of `TaskTemplate` were being improperly serialized, resulting in a subsequent parsing failure by Flytepropeller.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
