### PR TITLE
Pass through FlyteFile and FlyteDirectory if created from a remote source

### DIFF
--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -168,6 +168,11 @@ class FlyteDirToMultipartBlobTransformer(TypeTransformer[FlyteDirectory]):
         # There are two kinds of literals we handle, either an actual FlyteDirectory, or a string path to a directory.
         # Handle the FlyteDirectory case
         if isinstance(python_val, FlyteDirectory):
+            # If the object has a remote source, then we just convert it back.
+            if python_val._remote_source is not None:
+                meta = BlobMetadata(type=self._blob_type(format=self.get_format(python_type)))
+                return Literal(scalar=Scalar(blob=Blob(metadata=meta, uri=python_val._remote_source)))
+
             source_path = python_val.path
             if python_val.remote_directory is False:
                 # If the user specified the remote_path to be False, that means no matter what, do not upload

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -217,6 +217,11 @@ class FlyteFilePathTransformer(TypeTransformer[FlyteFile]):
         if python_val is None:
             raise AssertionError("None value cannot be converted to a file.")
         if isinstance(python_val, FlyteFile):
+            # If the object has a remote source, then we just convert it back.
+            if python_val._remote_source is not None:
+                meta = BlobMetadata(type=self._blob_type(format=self.get_format(python_type)))
+                return Literal(scalar=Scalar(blob=Blob(metadata=meta, uri=python_val._remote_source)))
+
             source_path = python_val.path
             if python_val.remote_path is False:
                 # If the user specified the remote_path to be False, that means no matter what, do not upload

--- a/tests/flytekit/unit/core/test_flyte_directory.py
+++ b/tests/flytekit/unit/core/test_flyte_directory.py
@@ -2,17 +2,18 @@ import os
 import pathlib
 import shutil
 
-import pytest
-
 import flytekit
+import pytest
 from flytekit.core import context_manager
+from flytekit.core.context_manager import ExecutionState, Image, ImageConfig
+from flytekit.core.dynamic_workflow_task import dynamic
 from flytekit.core.task import task
 from flytekit.core.type_engine import TypeEngine
 from flytekit.core.workflow import workflow
 from flytekit.interfaces.data.data_proxy import FileAccessProvider
 from flytekit.models.core.types import BlobType
 from flytekit.types.directory.types import FlyteDirectory, FlyteDirToMultipartBlobTransformer
-
+from flytekit.models.literals import Literal, LiteralMap, Scalar, Blob
 
 def test_engine():
     t = FlyteDirectory
@@ -133,3 +134,32 @@ def test_wf():
 
     x = wf2()
     assert x == 5
+
+
+def test_dont_convert_remotes():
+
+    @task
+    def t1(in1: FlyteDirectory):
+        print(in1)
+
+    @dynamic
+    def dyn(in1: FlyteDirectory):
+        t1(in1=in1)
+
+    fd = FlyteDirectory("s3://anything")
+
+    with context_manager.FlyteContext.current_context().new_serialization_settings(
+        serialization_settings=context_manager.SerializationSettings(
+            project="test_proj",
+            domain="test_domain",
+            version="abc",
+            image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
+            env={},
+        )
+    ) as ctx:
+        with ctx.new_execution_context(mode=ExecutionState.Mode.TASK_EXECUTION) as ctx:
+            lit = TypeEngine.to_literal(ctx, fd, FlyteDirectory, BlobType("", dimensionality=BlobType.BlobDimensionality.MULTIPART))
+            lm = LiteralMap(literals={"in1": lit})
+            wf = dyn.dispatch_execute(ctx, lm)
+            print(wf)
+

--- a/tests/flytekit/unit/core/test_flyte_directory.py
+++ b/tests/flytekit/unit/core/test_flyte_directory.py
@@ -2,8 +2,9 @@ import os
 import pathlib
 import shutil
 
-import flytekit
 import pytest
+
+import flytekit
 from flytekit.core import context_manager
 from flytekit.core.context_manager import ExecutionState, Image, ImageConfig
 from flytekit.core.dynamic_workflow_task import dynamic
@@ -12,8 +13,9 @@ from flytekit.core.type_engine import TypeEngine
 from flytekit.core.workflow import workflow
 from flytekit.interfaces.data.data_proxy import FileAccessProvider
 from flytekit.models.core.types import BlobType
+from flytekit.models.literals import Blob, Literal, LiteralMap, Scalar
 from flytekit.types.directory.types import FlyteDirectory, FlyteDirToMultipartBlobTransformer
-from flytekit.models.literals import Literal, LiteralMap, Scalar, Blob
+
 
 def test_engine():
     t = FlyteDirectory
@@ -137,7 +139,6 @@ def test_wf():
 
 
 def test_dont_convert_remotes():
-
     @task
     def t1(in1: FlyteDirectory):
         print(in1)
@@ -158,8 +159,9 @@ def test_dont_convert_remotes():
         )
     ) as ctx:
         with ctx.new_execution_context(mode=ExecutionState.Mode.TASK_EXECUTION) as ctx:
-            lit = TypeEngine.to_literal(ctx, fd, FlyteDirectory, BlobType("", dimensionality=BlobType.BlobDimensionality.MULTIPART))
+            lit = TypeEngine.to_literal(
+                ctx, fd, FlyteDirectory, BlobType("", dimensionality=BlobType.BlobDimensionality.MULTIPART)
+            )
             lm = LiteralMap(literals={"in1": lit})
             wf = dyn.dispatch_execute(ctx, lm)
-            print(wf)
-
+            assert wf.nodes[0].inputs[0].binding.scalar.blob.uri == "s3://anything"

--- a/tests/flytekit/unit/core/test_flyte_directory.py
+++ b/tests/flytekit/unit/core/test_flyte_directory.py
@@ -13,7 +13,7 @@ from flytekit.core.type_engine import TypeEngine
 from flytekit.core.workflow import workflow
 from flytekit.interfaces.data.data_proxy import FileAccessProvider
 from flytekit.models.core.types import BlobType
-from flytekit.models.literals import Blob, Literal, LiteralMap, Scalar
+from flytekit.models.literals import LiteralMap
 from flytekit.types.directory.types import FlyteDirectory, FlyteDirToMultipartBlobTransformer
 
 


### PR DESCRIPTION
Signed-off-by: wild-endeavor <wild-endeavor@users.noreply.github.com>

# TL;DR
In converting a workflow from the old api to the new one, @samhita-alla found a bug in the flytefile/directory objects.  Basically, there was a [dynamic task](https://github.com/flyteorg/flytesnacks/blob/master/legacy/demos/gaic-2020/demo/multiregion_house_price_predictor.py#L32) that would unpack a list of blobs and then call another task on each element.

However in doing so, the s3 location that was bound to the tasks in the dynamicjobspec was different than the s3 locations that came in.  Basically there was an unnecessary conversion happening.

This PR adds an early return to File/Directory so that if the object to be converted into a literal was tagged as having been created from a remote source, then we just use the remote source field.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Add an early return to the to_literal call.  In debugging the [workflow](https://demo.nuclyde.io/console/projects/flytesnacks/domains/development/executions/xkxdevxv0m), we noticed that all the inputs to the child tasks pointed to empty S3 locations.  This is because of the conversion.  The files/folders themselves were empty because the dynamic task just reassigned them, they were never `open`ed so the contents were never downloaded.

## Tracking Issue
NA
