### PR TITLE
Add a lot more user friendly launch plan creating function

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,6 @@
 ignore:
   - "flytekit/bin"
   - "test_*.py"
-  - "tests/flytekit/unit/core/test_node_creation.py"
   - "flytekit/__init__.py"
   - "flytekit/extend/__init__.py"
   - "flytekit/testing/__init__.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,4 @@ ignore:
   - "flytekit/__init__.py"
   - "flytekit/extend/__init__.py"
   - "flytekit/testing/__init__.py"
+  - "tests/*"

--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -139,7 +139,7 @@ class LaunchPlan(object):
             or auth_role is not None
         ):
             raise ValueError(
-                "When get_or_create'ing the default launch plan, no arguments other than the workflow may be specified"
+                "Only named launchplans can be created that have other properties. Drop the name if you want to create a default launchplan. Default launchplans cannot have any other associations"
             )
 
         if name is not None and name in LaunchPlan.CACHE:

--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -20,6 +20,15 @@ class LaunchPlan(object):
 
     @staticmethod
     def get_default_launch_plan(ctx: FlyteContext, workflow: _annotated_workflow.WorkflowBase) -> LaunchPlan:
+        """
+        Users should probably call the get_or_create function defined below instead. A default launch plan is the one
+        that will just pick up whatever default values are defined in the workflow function signature (if any) and
+        use the default auth information supplied during serialization, with no notifications or schedules.
+
+        :param ctx: This is not flytekit.current_context(). This is an internal context object. Users familiar with
+          flytekit should feel free to use this however.
+        :param workflow: The workflow to create a launch plan for.
+        """
         if workflow.name in LaunchPlan.CACHE:
             return LaunchPlan.CACHE[workflow.name]
 

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -562,7 +562,9 @@ class ImperativeWorkflow(WorkflowBase):
 
 class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
     """
-    More comments to come.
+    Please read :std:ref:`flyte:divedeep-workflows` first for a high-level understanding of what workflows are in Flyte.
+    This Python object represents a workflow  defined by a function and decorated with the
+    :py:func:`@workflow <flytekit.workflow>` decorator. Please see notes on that object for additional information.
     """
 
     def __init__(

--- a/tests/flytekit/unit/core/test_launch_plan.py
+++ b/tests/flytekit/unit/core/test_launch_plan.py
@@ -1,0 +1,39 @@
+import typing
+
+import pytest
+
+from flytekit.core import launch_plan
+from flytekit.core.task import task
+from flytekit.core.workflow import workflow
+
+
+def test_lp():
+    @task
+    def t1(a: int) -> typing.NamedTuple("OutputsBC", t1_int_output=int, c=str):
+        a = a + 2
+        return a, "world-" + str(a)
+
+    @task
+    def t2(a: str, b: str) -> str:
+        return b + a
+
+    @workflow
+    def wf(a: int) -> (str, str):
+        x, y = t1(a=a)
+        u, v = t1(a=x)
+        return y, v
+
+    lp = launch_plan.LaunchPlan.get_or_create(wf, "get_or_create1")
+    lp2 = launch_plan.LaunchPlan.get_or_create(wf, "get_or_create1")
+    assert lp.name == "get_or_create1"
+    assert lp is lp2
+
+    default_lp = launch_plan.LaunchPlan.get_or_create(wf)
+    default_lp2 = launch_plan.LaunchPlan.get_or_create(wf)
+    assert default_lp is default_lp2
+
+    with pytest.raises(ValueError):
+        launch_plan.LaunchPlan.get_or_create(wf, default_inputs={"a": 3})
+
+    lp_with_defaults = launch_plan.LaunchPlan.create("get_or_create2", wf, default_inputs={"a": 3})
+    assert lp_with_defaults.parameters.parameters["a"].default.scalar.primitive.integer == 3


### PR DESCRIPTION
Signed-off-by: wild-endeavor <wild-endeavor@users.noreply.github.com>

# TL;DR
It was decided that the existing functions for creating launch plans were not user-friendly.  The `get_default_launch_plan` function required a context, but it's supposed to be the `FlyteContext` not the user-facing context (`ExecutionParameters`). The regular `create` function requires a name all the time. This PR introduces a new function that is
* cached by default
* Doesn't need the name. If no name is provided, it's assumed the default launch plan is what you're after.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
See code.

## Follow-up issue
https://github.com/flyteorg/flyte/issues/892
