### PR TITLE
Propagate required envs to executors and fix bug to set configs in Spark task

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -137,7 +137,7 @@ class RestrictedType(TypeTransformer[T], ABC):
         super().__init__(name, t)
 
     def get_literal_type(self, t: Type[T] = None) -> LiteralType:
-        raise RestrictedTypeError(f"Transformer for type{self.python_type} is restricted currently")
+        raise RestrictedTypeError(f"Transformer for type {self.python_type} is restricted currently")
 
 
 class DataclassTransformer(TypeTransformer[object]):

--- a/plugins/spark/flytekitplugins/spark/task.py
+++ b/plugins/spark/flytekitplugins/spark/task.py
@@ -53,10 +53,11 @@ def new_spark_session(name: str, conf: typing.Dict[str, str] = None):
     if "FLYTE_INTERNAL_EXECUTION_ID" not in os.environ and conf is not None:
         # If either of above cases is not true, then we are in local execution of this task
         # Add system spark-conf for local/notebook based execution.
+        sess_builder = sess_builder.master("local[*]")
         spark_conf = _pyspark.SparkConf()
         for k, v in conf.items():
             spark_conf.set(k, v)
-        spark_conf.set("spark.master", "local")
+        spark_conf.set("spark.driver.bindAddress", "127.0.0.1")
         # In local execution, propagate PYTHONPATH to executors too. This makes the spark
         # execution hermetic to the execution environment. For example, it allows running
         # Spark applications using Bazel, without major changes.

--- a/plugins/spark/flytekitplugins/spark/task.py
+++ b/plugins/spark/flytekitplugins/spark/task.py
@@ -64,7 +64,10 @@ def new_spark_session(name: str, conf: typing.Dict[str, str] = None):
         if "PYTHONPATH" in os.environ:
             spark_conf.setExecutorEnv("PYTHONPATH", os.environ["PYTHONPATH"])
         sess_builder = sess_builder.config(conf=spark_conf)
-
+        
+    # If there is a global SparkSession available, get it and try to stop it.
+    _pyspark.sql.SparkSession.builder.getOrCreate().stop()
+    
     return sess_builder.getOrCreate()
     # SparkSession.Stop does not work correctly, as it stops the session before all the data is written
     # sess.stop()

--- a/plugins/spark/flytekitplugins/spark/task.py
+++ b/plugins/spark/flytekitplugins/spark/task.py
@@ -34,8 +34,9 @@ class Spark(object):
             self.hadoop_conf = {}
 
 
-# This method does not work properly. It's a bit hard to handle multiple Spark sessions
-# as described in https://stackoverflow.com/questions/41491972/how-can-i-tear-down-a-sparksession-and-create-a-new-one-within-one-application.
+# This method does not reset the SparkSession since it's a bit hard to handle multiple
+# Spark sessions in a single application as it's described in:
+# https://stackoverflow.com/questions/41491972/how-can-i-tear-down-a-sparksession-and-create-a-new-one-within-one-application.
 def new_spark_session(name: str, conf: typing.Dict[str, str] = None):
     """
     Optionally creates a new spark session and returns it.

--- a/plugins/spark/flytekitplugins/spark/task.py
+++ b/plugins/spark/flytekitplugins/spark/task.py
@@ -87,6 +87,7 @@ class PysparkFunctionTask(PythonFunctionTask[Spark]):
             task_function=task_function,
             **kwargs,
         )
+        self.sess = None
 
     def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
         job = _task_model.SparkJob(
@@ -117,8 +118,8 @@ class PysparkFunctionTask(PythonFunctionTask[Spark]):
                 spark_conf.setExecutorEnv("PYTHONPATH", os.environ["PYTHONPATH"])
             sess_builder = sess_builder.config(conf=spark_conf)
 
-        sess = sess_builder.getOrCreate()
-        return user_params.builder().add_attr("SPARK_SESSION", sess).build()
+        self.sess = sess_builder.getOrCreate()
+        return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 
 
 # Inject the Spark plugin into flytekits dynamic plugin loading system

--- a/plugins/spark/flytekitplugins/spark/task.py
+++ b/plugins/spark/flytekitplugins/spark/task.py
@@ -64,10 +64,10 @@ def new_spark_session(name: str, conf: typing.Dict[str, str] = None):
         if "PYTHONPATH" in os.environ:
             spark_conf.setExecutorEnv("PYTHONPATH", os.environ["PYTHONPATH"])
         sess_builder = sess_builder.config(conf=spark_conf)
-        
+
     # If there is a global SparkSession available, get it and try to stop it.
     _pyspark.sql.SparkSession.builder.getOrCreate().stop()
-    
+
     return sess_builder.getOrCreate()
     # SparkSession.Stop does not work correctly, as it stops the session before all the data is written
     # sess.stop()

--- a/plugins/spark/flytekitplugins/spark/task.py
+++ b/plugins/spark/flytekitplugins/spark/task.py
@@ -34,6 +34,8 @@ class Spark(object):
             self.hadoop_conf = {}
 
 
+# This method does not work properly. It's a bit hard to handle multiple Spark sessions
+# as described in https://stackoverflow.com/questions/41491972/how-can-i-tear-down-a-sparksession-and-create-a-new-one-within-one-application.
 def new_spark_session(name: str, conf: typing.Dict[str, str] = None):
     """
     Optionally creates a new spark session and returns it.
@@ -85,7 +87,7 @@ class PysparkFunctionTask(PythonFunctionTask[Spark]):
         job = _task_model.SparkJob(
             spark_conf=self.task_config.spark_conf,
             hadoop_conf=self.task_config.hadoop_conf,
-            application_file="local://" + settings.entrypoint_settings.path,
+            application_file="local://" + settings.entrypoint_settings.path if settings.entrypoint_settings else "",
             executor_path=settings.python_interpreter,
             main_class="",
             spark_type=SparkType.PYTHON,

--- a/plugins/tests/spark/test_spark_task.py
+++ b/plugins/tests/spark/test_spark_task.py
@@ -39,8 +39,8 @@ def test_spark_task():
 
 
 def test_new_spark_session():
-    name = 'SessionName'
-    spark_conf = {'spark1': '1', 'spark2': '2'}
+    name = "SessionName"
+    spark_conf = {"spark1": "1", "spark2": "2"}
     new_sess = new_spark_session(name, spark_conf)
     assert new_sess is not None
     assert ("spark.driver.bindAddress", "127.0.0.1") in new_sess.sparkContext.getConf().getAll()

--- a/plugins/tests/spark/test_spark_task.py
+++ b/plugins/tests/spark/test_spark_task.py
@@ -1,5 +1,4 @@
 from flytekitplugins.spark import Spark
-from flytekitplugins.spark.task import new_spark_session
 
 import flytekit
 from flytekit import task

--- a/plugins/tests/spark/test_spark_task.py
+++ b/plugins/tests/spark/test_spark_task.py
@@ -47,6 +47,9 @@ def test_new_spark_session():
     name = "SessionName"
     spark_conf = {"spark1": "1", "spark2": "2"}
     new_sess = new_spark_session(name, spark_conf)
+    configs = new_sess.sparkContext.getConf().getAll()
     assert new_sess is not None
-    assert ("spark.driver.bindAddress", "127.0.0.1") in new_sess.sparkContext.getConf().getAll()
-    assert ("spark.master", "local[*]") in new_sess.sparkContext.getConf().getAll()
+    assert ("spark.driver.bindAddress", "127.0.0.1") in configs
+    assert ("spark.master", "local[*]") in configs
+    assert ("spark1", "1") in configs
+    assert ("spark2", "2") in configs

--- a/plugins/tests/spark/test_spark_task.py
+++ b/plugins/tests/spark/test_spark_task.py
@@ -1,10 +1,10 @@
 from flytekitplugins.spark import Spark
+from flytekitplugins.spark.task import new_spark_session
 
 import flytekit
 from flytekit import task
-from flytekit.extend import Image, ImageConfig, SerializationSettings
 from flytekit.common.tasks.sdk_runnable import ExecutionParameters
-from flytekitplugins.spark.task import new_spark_session
+from flytekit.extend import Image, ImageConfig, SerializationSettings
 
 
 def test_spark_task():
@@ -31,7 +31,7 @@ def test_spark_task():
 
     pb = ExecutionParameters.new_builder()
     pb.working_dir = "/tmp"
-    pb.execution_id = 'ex:local:local:local'
+    pb.execution_id = "ex:local:local:local"
     p = pb.build()
     new_p = my_spark.pre_execute(p)
     assert new_p is not None

--- a/plugins/tests/spark/test_spark_task.py
+++ b/plugins/tests/spark/test_spark_task.py
@@ -3,6 +3,8 @@ from flytekitplugins.spark import Spark
 import flytekit
 from flytekit import task
 from flytekit.extend import Image, ImageConfig, SerializationSettings
+from flytekit.common.tasks.sdk_runnable import ExecutionParameters
+from flytekitplugins.spark.task import new_spark_session
 
 
 def test_spark_task():
@@ -26,3 +28,11 @@ def test_spark_task():
 
     retrieved_settings = my_spark.get_custom(settings)
     assert retrieved_settings["sparkConf"] == {"spark": "1"}
+
+    pb = ExecutionParameters.new_builder()
+    pb.working_dir = "/tmp"
+    pb.execution_id = 'ex:local:local:local'
+    p = pb.build()
+    new_p = my_spark.pre_execute(p)
+    assert new_p is not None
+    assert new_p.has_attr("SPARK_SESSION")

--- a/plugins/tests/spark/test_spark_task.py
+++ b/plugins/tests/spark/test_spark_task.py
@@ -1,4 +1,5 @@
 from flytekitplugins.spark import Spark
+from flytekitplugins.spark.task import new_spark_session
 
 import flytekit
 from flytekit import task
@@ -35,3 +36,12 @@ def test_spark_task():
     new_p = my_spark.pre_execute(p)
     assert new_p is not None
     assert new_p.has_attr("SPARK_SESSION")
+
+
+def test_new_spark_session():
+    name = 'SessionName'
+    spark_conf = {'spark1': '1', 'spark2': '2'}
+    new_sess = new_spark_session(name, spark_conf)
+    assert new_sess is not None
+    assert ("spark.driver.bindAddress", "127.0.0.1") in new_sess.sparkContext.getConf().getAll()
+    assert ("spark.master", "local[*]") in new_sess.sparkContext.getConf().getAll()

--- a/plugins/tests/spark/test_spark_task.py
+++ b/plugins/tests/spark/test_spark_task.py
@@ -37,6 +37,11 @@ def test_spark_task():
     assert new_p is not None
     assert new_p.has_attr("SPARK_SESSION")
 
+    assert my_spark.sess is not None
+    configs = my_spark.sess.sparkContext.getConf().getAll()
+    assert ("spark", "1") in configs
+    assert ("spark.app.name", "FlyteSpark: ex:local:local:local") in configs
+
 
 def test_new_spark_session():
     name = "SessionName"

--- a/plugins/tests/spark/test_wf.py
+++ b/plugins/tests/spark/test_wf.py
@@ -1,5 +1,3 @@
-import typing
-
 import pandas
 import pyspark
 from flytekitplugins.spark.task import Spark

--- a/plugins/tests/spark/test_wf.py
+++ b/plugins/tests/spark/test_wf.py
@@ -11,7 +11,7 @@ from flytekit.types.schema import FlyteSchema
 
 def test_wf1_with_spark():
     @task(task_config=Spark())
-    def my_spark(a: int) -> typing.NamedTuple("OutputsBC", t1_int_output=int, c=str):
+    def my_spark(a: int) -> (int, str):
         session = flytekit.current_context().spark_session
         assert session.sparkContext.appName == "FlyteSpark: ex:local:local:local"
         return a + 2, "world"


### PR DESCRIPTION
# TL;DR
This PR has two goals: 1) introduce a feature to propagate python configurations to Spark executors, and 2) fix a bug in how Spark configs are set in `SparkContext`/`SparkSession`. In addition, fixed other minor bugs as part of this PR.

## Type
 - [x] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
1. [Feature] Propagate `PYTHONPATH` to executors. If the variable is found in the system, means we already have a setup already prepared, so convey that env to the `SparkSession` to propagate the configuration in executors.
2. [Bug] Fix how configs are set to the `SparkSession`. Changed the way it's set with a `SparkConfig` and introduced it to the 'SparkSession' before creating.

## Tracking Issue
NA

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
