### PR TITLE
fix default value for flyte config

### DIFF
--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -9,7 +9,7 @@ IMAGE = _common_config.FlyteRequiredStringConfigurationEntry("internal", "image"
 # The default, if you want to use it, should be a file called flytekit.config, located in wherever your python
 # interpreter originates.
 CONFIGURATION_PATH = _common_config.FlyteStringConfigurationEntry(
-    "internal", "configuration_path", default="flytekit.config"
+    "internal", "configuration_path", default="flyte.config"
 )
 
 # Project, Domain and Version represent the values at registration time.


### PR DESCRIPTION
Signed-off-by: cosmicBboy <niels.bantilan@gmail.com>

# TL;DR

`flytekit.config` default value renamed to `flyte.config` to correctly read config file from `pyflyte`

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
