### PR TITLE
[wip] do not review

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -36,7 +36,8 @@ from flytekit.interfaces.data.gcs import gcs_proxy as _gcs_proxy
 from flytekit.interfaces.data.s3 import s3proxy as _s3proxy
 from flytekit.interfaces.stats.taggable import get_stats as _get_stats
 from flytekit.models import dynamic_job as _dynamic_job
-from flytekit.models import literals as _literal_models, task as task_models
+from flytekit.models import literals as _literal_models
+from flytekit.models import task as task_models
 from flytekit.models.core import errors as _error_models
 from flytekit.models.core import identifier as _identifier
 from flytekit.tools.fast_registration import download_distribution as _download_distribution
@@ -75,7 +76,13 @@ def _map_job_index_to_child_index(local_input_dir, datadir, index):
     return mapping_proto.literals[index].scalar.primitive.integer
 
 
-def _dispatch_execute(ctx: FlyteContext, task_def: Union[PythonTask, task_models.TaskTemplate], inputs_path: str, output_prefix: str, executor=None):
+def _dispatch_execute(
+    ctx: FlyteContext,
+    task_def: Union[PythonTask, task_models.TaskTemplate],
+    inputs_path: str,
+    output_prefix: str,
+    executor=None,
+):
     """
     Dispatches execute to PythonTask
         Step1: Download inputs and load into a literal map

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -9,7 +9,6 @@ from typing import List
 
 import click as _click
 from flyteidl.core import literals_pb2 as _literals_pb2
-from flyteidl.core import tasks_pb2 as _tasks_pb2
 
 from flytekit import PythonFunctionTask
 from flytekit.common import constants as _constants
@@ -28,7 +27,6 @@ from flytekit.core.context_manager import ExecutionState, FlyteContext, Serializ
 from flytekit.core.map_task import MapPythonTask
 from flytekit.core.promise import VoidPromise
 from flytekit.core.python_auto_container import TaskResolverMixin
-from flytekit.core.python_third_party_task import TaskTemplateExecutor
 from flytekit.engines import loader as _engine_loader
 from flytekit.interfaces import random as _flyte_random
 from flytekit.interfaces.data import data_proxy as _data_proxy

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -178,27 +178,27 @@ class TaskResolverMixin(object):
         pass
 
     @abstractmethod
-    def load_task(self, loader_args: List[str]) -> PythonAutoContainerTask:
+    def load_task(self, loader_args: List[str]) -> PythonTask:
         """
         Given the set of identifier keys, should return one Python Task or raise an error if not found
         """
         pass
 
     @abstractmethod
-    def loader_args(self, settings: SerializationSettings, t: PythonAutoContainerTask) -> List[str]:
+    def loader_args(self, settings: SerializationSettings, t: PythonTask) -> List[str]:
         """
         Return a list of strings that can help identify the parameter Task
         """
         pass
 
     @abstractmethod
-    def get_all_tasks(self) -> List[PythonAutoContainerTask]:
+    def get_all_tasks(self) -> List[PythonTask]:
         """
         Future proof method. Just making it easy to access all tasks (Not required today as we auto register them)
         """
         pass
 
-    def task_name(self, t: PythonAutoContainerTask) -> Optional[str]:
+    def task_name(self, t: PythonTask) -> Optional[str]:
         """
         Overridable function that can optionally return a custom name for a given task
         """

--- a/flytekit/core/python_third_party_task.py
+++ b/flytekit/core/python_third_party_task.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
+from typing import Any, Dict, List, Optional, TypeVar, Union
 
 from flytekit.common.tasks.raw_container import _get_container_definition
-from flytekit.common.tasks.sdk_runnable import ExecutionParameters
 from flytekit.core.base_task import PythonTask
 from flytekit.core.context_manager import FlyteContext, Image, ImageConfig, SerializationSettings
 from flytekit.core.python_auto_container import TaskResolverMixin
 from flytekit.core.resources import Resources, ResourceSpec
-from flytekit.core.tracker import TrackedInstance
 from flytekit.core.type_engine import TypeEngine
 from flytekit.loggers import logger
 from flytekit.models import dynamic_job as _dynamic_job

--- a/flytekit/core/python_third_party_task.py
+++ b/flytekit/core/python_third_party_task.py
@@ -1,124 +1,24 @@
 from __future__ import annotations
 
-from abc import abstractmethod
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
-from flytekit.core.context_manager import (
-    BranchEvalMode,
-    ExecutionState,
-    FlyteContext,
-    FlyteEntities,
-    SerializationSettings,
-)
-from flytekit.core.type_engine import TypeEngine
-from flytekit.loggers import logger
-from flytekit.common.tasks.sdk_runnable import ExecutionParameters
+
 from flytekit.common.tasks.raw_container import _get_container_definition
+from flytekit.common.tasks.sdk_runnable import ExecutionParameters
 from flytekit.core.base_task import PythonTask
-from flytekit.core.context_manager import Image, ImageConfig, SerializationSettings
+from flytekit.core.context_manager import FlyteContext, Image, ImageConfig, SerializationSettings
+from flytekit.core.python_auto_container import TaskResolverMixin
 from flytekit.core.resources import Resources, ResourceSpec
 from flytekit.core.tracker import TrackedInstance
-from flytekit.models import task as _task_model, literals as _literal_models
+from flytekit.core.type_engine import TypeEngine
+from flytekit.loggers import logger
 from flytekit.models import dynamic_job as _dynamic_job
+from flytekit.models import literals as _literal_models
+from flytekit.models import task as _task_model
 from flytekit.models.core import identifier as identifier_models
 from flytekit.models.security import Secret, SecurityContext
 
 T = TypeVar("T")
 TC = TypeVar("TC")
-
-
-class TaskTemplateExecutor(TrackedInstance, Generic[T]):
-    @classmethod
-    def execute_from_model(cls, tt: _task_model.TaskTemplate, **kwargs) -> Any:
-        raise NotImplementedError
-
-    @classmethod
-    def pre_execute(cls, user_params: ExecutionParameters) -> ExecutionParameters:
-        """
-        This function is a stub, just here to keep dispatch_execute compatibility between this class and PythonTask.
-        """
-        return user_params
-
-    @classmethod
-    def post_execute(cls, user_params: ExecutionParameters, rval: Any) -> Any:
-        """
-        This function is a stub, just here to keep dispatch_execute compatibility between this class and PythonTask.
-        """
-        return rval
-
-    @classmethod
-    def dispatch_execute(
-        cls, ctx: FlyteContext, tt: _task_model.TaskTemplate, input_literal_map: _literal_models.LiteralMap
-    ) -> Union[_literal_models.LiteralMap, _dynamic_job.DynamicJobSpec]:
-        """
-        This function is copied from PythonTask.dispatch_execute. Will need to make it a mixin and refactor in the
-        future.
-        """
-
-        # Invoked before the task is executed
-        new_user_params = cls.pre_execute(ctx.user_space_params)
-
-        # Create another execution context with the new user params, but let's keep the same working dir
-        with ctx.new_execution_context(
-            mode=ctx.execution_state.mode,
-            execution_params=new_user_params,
-            working_dir=ctx.execution_state.working_dir,
-        ) as exec_ctx:
-            # Added: Have to reverse the Python interface from the task template Flyte interface
-            #  This will be moved into the FlyteTask promote logic instead
-            guessed_python_input_types = TypeEngine.guess_python_types(tt.interface.inputs)
-            native_inputs = TypeEngine.literal_map_to_kwargs(exec_ctx, input_literal_map, guessed_python_input_types)
-
-            logger.info(f"Invoking FlyteTask executor {tt.id.name} with inputs: {native_inputs}")
-            try:
-                native_outputs = cls.execute_from_model(tt, **native_inputs)
-            except Exception as e:
-                logger.exception(f"Exception when executing {e}")
-                raise e
-
-            logger.info(f"Task executed successfully in user level, outputs: {native_outputs}")
-            # Lets run the post_execute method. This may result in a IgnoreOutputs Exception, which is
-            # bubbled up to be handled at the callee layer.
-            native_outputs = cls.post_execute(new_user_params, native_outputs)
-
-            # Short circuit the translation to literal map because what's returned may be a dj spec (or an
-            # already-constructed LiteralMap if the dynamic task was a no-op), not python native values
-            if isinstance(native_outputs, _literal_models.LiteralMap) or isinstance(
-                native_outputs, _dynamic_job.DynamicJobSpec
-            ):
-                return native_outputs
-
-            expected_output_names = list(tt.interface.outputs.keys())
-            if len(expected_output_names) == 1:
-                # Here we have to handle the fact that the task could've been declared with a typing.NamedTuple of
-                # length one. That convention is used for naming outputs - and single-length-NamedTuples are
-                # particularly troublesome but elegant handling of them is not a high priority
-                # Again, we're using the output_tuple_name as a proxy.
-                # Deleted some stuff
-                native_outputs_as_map = {expected_output_names[0]: native_outputs}
-            elif len(expected_output_names) == 0:
-                native_outputs_as_map = {}
-            else:
-                native_outputs_as_map = {
-                    expected_output_names[i]: native_outputs[i] for i, _ in enumerate(native_outputs)
-                }
-
-            # We manually construct a LiteralMap here because task inputs and outputs actually violate the assumption
-            # built into the IDL that all the values of a literal map are of the same type.
-            literals = {}
-            for k, v in native_outputs_as_map.items():
-                literal_type = tt.interface.outputs[k].type
-                py_type = type(v)
-
-                if isinstance(v, tuple):
-                    raise AssertionError(f"Output({k}) in task{tt.id.name} received a tuple {v}, instead of {py_type}")
-                try:
-                    literals[k] = TypeEngine.to_literal(exec_ctx, v, py_type, literal_type)
-                except Exception as e:
-                    raise AssertionError(f"failed to convert return value for var {k}") from e
-
-            outputs_literal_map = _literal_models.LiteralMap(literals=literals)
-            # After the execute has been successfully completed
-            return outputs_literal_map
 
 
 class PythonThirdPartyContainerTask(PythonTask[TC]):
@@ -135,7 +35,7 @@ class PythonThirdPartyContainerTask(PythonTask[TC]):
         name: str,
         task_config: TC,
         container_image: str,
-        executor: TaskTemplateExecutor,
+        resolver: TaskResolverMixin,
         task_type="python-task",
         requests: Optional[Resources] = None,
         limits: Optional[Resources] = None,
@@ -182,7 +82,7 @@ class PythonThirdPartyContainerTask(PythonTask[TC]):
             requests=requests if requests else Resources(), limits=limits if limits else Resources()
         )
         self._environment = environment
-        self._executor = executor
+        self._task_resolver = resolver
 
         self._container_image = container_image
         # Because instances of these tasks rely on the task template in order to run even locally, we'll cache it
@@ -204,13 +104,9 @@ class PythonThirdPartyContainerTask(PythonTask[TC]):
     def resources(self) -> ResourceSpec:
         return self._resources
 
-    @abstractmethod
-    def get_command(self, settings: SerializationSettings) -> List[str]:
-        pass
-
     @property
-    def executor(self) -> TaskTemplateExecutor:
-        return self._executor
+    def task_resolver(self) -> TaskResolverMixin:
+        return self._task_resolver
 
     @property
     def task_template(self) -> Optional[_task_model.TaskTemplate]:
@@ -258,6 +154,26 @@ class PythonThirdPartyContainerTask(PythonTask[TC]):
         self._task_template = obj
         return obj
 
+    def get_command(self, settings: SerializationSettings) -> List[str]:
+        container_args = [
+            "pyflyte-execute",
+            "--inputs",
+            "{{.input}}",
+            "--output-prefix",
+            "{{.outputPrefix}}",
+            "--raw-output-data-prefix",
+            "{{.rawOutputDataPrefix}}",
+            "--resolver",
+            self.task_resolver.location,
+            "--",
+            *self.task_resolver.loader_args(settings, self),
+        ]
+
+        return container_args
+
+    def execute_from_model(self, tt: _task_model.TaskTemplate, **kwargs) -> Any:
+        raise NotImplementedError
+
     def execute(self, **kwargs) -> Any:
         """
         This function overrides the default task execute behavior.
@@ -271,7 +187,7 @@ class PythonThirdPartyContainerTask(PythonTask[TC]):
         which should just take in and return Python native values, will be run.
         """
         tt = self.task_template or self.serialize_to_model(settings=PythonThirdPartyContainerTask.SERIALIZE_SETTINGS)
-        return self.executor.execute_from_model(tt, **kwargs)
+        return self.execute_from_model(tt, **kwargs)
 
     def dispatch_execute(
         self, ctx: FlyteContext, input_literal_map: _literal_models.LiteralMap
@@ -280,4 +196,69 @@ class PythonThirdPartyContainerTask(PythonTask[TC]):
         This function overrides the default task execute behavior.
         """
         tt = self.task_template or self.serialize_to_model(settings=PythonThirdPartyContainerTask.SERIALIZE_SETTINGS)
-        return self.executor.dispatch_execute(ctx, tt, input_literal_map)
+
+        # Invoked before the task is executed
+        new_user_params = self.pre_execute(ctx.user_space_params)
+
+        # Create another execution context with the new user params, but let's keep the same working dir
+        with ctx.new_execution_context(
+            mode=ctx.execution_state.mode,
+            execution_params=new_user_params,
+            working_dir=ctx.execution_state.working_dir,
+        ) as exec_ctx:
+            # Added: Have to reverse the Python interface from the task template Flyte interface
+            #  This will be moved into the FlyteTask promote logic instead
+            guessed_python_input_types = TypeEngine.guess_python_types(tt.interface.inputs)
+            native_inputs = TypeEngine.literal_map_to_kwargs(exec_ctx, input_literal_map, guessed_python_input_types)
+
+            logger.info(f"Invoking FlyteTask executor {tt.id.name} with inputs: {native_inputs}")
+            try:
+                native_outputs = self.execute(**native_inputs)
+            except Exception as e:
+                logger.exception(f"Exception when executing {e}")
+                raise e
+
+            logger.info(f"Task executed successfully in user level, outputs: {native_outputs}")
+            # Lets run the post_execute method. This may result in a IgnoreOutputs Exception, which is
+            # bubbled up to be handled at the callee layer.
+            native_outputs = self.post_execute(new_user_params, native_outputs)
+
+            # Short circuit the translation to literal map because what's returned may be a dj spec (or an
+            # already-constructed LiteralMap if the dynamic task was a no-op), not python native values
+            if isinstance(native_outputs, _literal_models.LiteralMap) or isinstance(
+                native_outputs, _dynamic_job.DynamicJobSpec
+            ):
+                return native_outputs
+
+            expected_output_names = list(tt.interface.outputs.keys())
+            if len(expected_output_names) == 1:
+                # Here we have to handle the fact that the task could've been declared with a typing.NamedTuple of
+                # length one. That convention is used for naming outputs - and single-length-NamedTuples are
+                # particularly troublesome but elegant handling of them is not a high priority
+                # Again, we're using the output_tuple_name as a proxy.
+                # Deleted some stuff
+                native_outputs_as_map = {expected_output_names[0]: native_outputs}
+            elif len(expected_output_names) == 0:
+                native_outputs_as_map = {}
+            else:
+                native_outputs_as_map = {
+                    expected_output_names[i]: native_outputs[i] for i, _ in enumerate(native_outputs)
+                }
+
+            # We manually construct a LiteralMap here because task inputs and outputs actually violate the assumption
+            # built into the IDL that all the values of a literal map are of the same type.
+            literals = {}
+            for k, v in native_outputs_as_map.items():
+                literal_type = tt.interface.outputs[k].type
+                py_type = type(v)
+
+                if isinstance(v, tuple):
+                    raise AssertionError(f"Output({k}) in task{tt.id.name} received a tuple {v}, instead of {py_type}")
+                try:
+                    literals[k] = TypeEngine.to_literal(exec_ctx, v, py_type, literal_type)
+                except Exception as e:
+                    raise AssertionError(f"failed to convert return value for var {k}") from e
+
+            outputs_literal_map = _literal_models.LiteralMap(literals=literals)
+            # After the execute has been successfully completed
+            return outputs_literal_map

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -8,7 +8,7 @@ import os
 import typing
 from abc import ABC, abstractmethod
 from typing import Type
-from flytekit.loggers import logger
+
 from dataclasses_json import DataClassJsonMixin
 from google.protobuf import json_format as _json_format
 from google.protobuf import reflection as _proto_reflection
@@ -16,8 +16,10 @@ from google.protobuf import struct_pb2 as _struct
 from google.protobuf.json_format import MessageToDict as _MessageToDict
 from google.protobuf.json_format import ParseDict as _ParseDict
 from google.protobuf.struct_pb2 import Struct
+
 from flytekit.common.types import primitives as _primitives
 from flytekit.core.context_manager import FlyteContext
+from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
 from flytekit.models import types as _type_models
 from flytekit.models.core import types as _core_types
@@ -311,7 +313,9 @@ class TypeEngine(typing.Generic[T]):
         return cls._REGISTRY.keys()
 
     @classmethod
-    def guess_python_types(cls, flyte_variable_dict: typing.Dict[str, _interface_models.Variable]) -> typing.Dict[str, type]:
+    def guess_python_types(
+        cls, flyte_variable_dict: typing.Dict[str, _interface_models.Variable]
+    ) -> typing.Dict[str, type]:
         python_types = {}
         for k, v in flyte_variable_dict.items():
             python_types[k] = cls.guess_python_type(v.type)
@@ -446,6 +450,7 @@ class DictTransformer(TypeTransformer[dict]):
             mt = TypeEngine.guess_python_type(literal_type.map_value_type)
             return typing.Dict[str, mt]
         raise ValueError(f"Dictionary transformer cannot reverse {literal_type}")
+
 
 class TextIOTransformer(TypeTransformer[typing.TextIO]):
     """

--- a/flytekit/extras/sqlite3/Dockerfile
+++ b/flytekit/extras/sqlite3/Dockerfile
@@ -4,4 +4,4 @@ ENV FLYTE_INTERNAL_IMAGE=flytecli-sqlite3:123
 
 RUN pip install awscli
 
-RUN pip install -U https://github.com/flyteorg/flytekit/archive/fb701cb03fbcc4cdd1daa48db1192a45fa2bce3a.zip#egg=flytekit
+RUN pip install -U https://github.com/flyteorg/flytekit/archive/d3d3a97cb1e5bf67638e7f45270fb354a51606af.zip#egg=flytekit

--- a/flytekit/extras/sqlite3/Dockerfile
+++ b/flytekit/extras/sqlite3/Dockerfile
@@ -4,4 +4,4 @@ ENV FLYTE_INTERNAL_IMAGE=flytecli-sqlite3:123
 
 RUN pip install awscli
 
-RUN pip install -U https://github.com/flyteorg/flytekit/archive/d3d3a97cb1e5bf67638e7f45270fb354a51606af.zip#egg=flytekit
+RUN pip install -U https://github.com/flyteorg/flytekit/archive/052b1adc185c48dd260450c6b22a20fea88fbbac.zip#egg=flytekit

--- a/flytekit/extras/sqlite3/Dockerfile
+++ b/flytekit/extras/sqlite3/Dockerfile
@@ -4,4 +4,4 @@ ENV FLYTE_INTERNAL_IMAGE=flytecli-sqlite3:123
 
 RUN pip install awscli
 
-RUN pip install -U https://github.com/flyteorg/flytekit/archive/052b1adc185c48dd260450c6b22a20fea88fbbac.zip#egg=flytekit
+RUN pip install -U https://github.com/flyteorg/flytekit/archive/e941fca66b8df526e0ea339a19ec62c84a84f911.zip#egg=flytekit

--- a/flytekit/extras/sqlite3/task.py
+++ b/flytekit/extras/sqlite3/task.py
@@ -5,13 +5,19 @@ import sqlite3
 import tempfile
 import typing
 from dataclasses import dataclass
+from typing import List, Optional, Type
 
 import pandas as pd
+from flyteidl.core import tasks_pb2 as _tasks_pb2
 
 from flytekit import FlyteContext, kwtypes
+from flytekit.common import utils as _common_utils
 from flytekit.core.base_sql_task import SQLTask
+from flytekit.core.base_task import PythonTask
 from flytekit.core.context_manager import SerializationSettings
-from flytekit.core.python_third_party_task import PythonThirdPartyContainerTask, TaskTemplateExecutor
+from flytekit.core.python_auto_container import TaskResolverMixin
+from flytekit.core.python_third_party_task import PythonThirdPartyContainerTask
+from flytekit.core.tracker import TrackedInstance
 from flytekit.models import task as task_models
 from flytekit.types.schema import FlyteSchema
 
@@ -49,6 +55,29 @@ class SQLite3Config(object):
     compressed: bool = False
 
 
+class TaskTemplateResolver(TrackedInstance, TaskResolverMixin):
+    def __init__(self, task_class: Type[PythonThirdPartyContainerTask]):
+        self._task_class = task_class
+        super(TaskTemplateResolver, self).__init__()
+
+    def name(self) -> str:
+        return "task template resolver"
+
+    def load_task(self, loader_args: List[str]) -> PythonTask:
+        ctx = FlyteContext.current_context()
+        task_template_local_path = os.path.join(ctx.execution_state.working_dir, "task_template.pb")
+        ctx.file_access.get_data(loader_args[0], task_template_local_path)
+        task_template_proto = _common_utils.load_proto_from_file(_tasks_pb2.TaskTemplate, task_template_local_path)
+        task_template_model = task_models.TaskTemplate.from_flyte_idl(task_template_proto)
+        return self._task_class(task_template=task_template_model)
+
+    def loader_args(self, settings: SerializationSettings, t: PythonTask) -> List[str]:
+        return ["{{.taskTemplatePath}}"]
+
+    def get_all_tasks(self) -> List[PythonTask]:
+        return []
+
+
 class SQLite3Task(PythonThirdPartyContainerTask[SQLite3Config], SQLTask[SQLite3Config]):
     """
     Makes it possible to run client side SQLite3 queries that optionally return a FlyteSchema object
@@ -61,13 +90,24 @@ class SQLite3Task(PythonThirdPartyContainerTask[SQLite3Config], SQLTask[SQLite3C
 
     def __init__(
         self,
-        name: str,
-        query_template: str,
+        task_template: Optional[task_models.TaskTemplate] = None,
+        name: Optional[str] = None,
+        query_template: Optional[str] = None,
         inputs: typing.Optional[typing.Dict[str, typing.Type]] = None,
         task_config: typing.Optional[SQLite3Config] = None,
         output_schema_type: typing.Optional[typing.Type[FlyteSchema]] = None,
         **kwargs,
     ):
+        # Because in the task template case, we skip the rest of instantiation, unless we want the task template loading
+        # behavior to also be present in all parent classes. Or we can just promote_from_model
+        # self._task_type = "python-task"
+        # self._name = name
+
+        if task_template is not None:
+            self._task_template = task_template
+            print("Task template specified, skipping all other constructor logic...")
+            return
+
         if task_config is None or task_config.uri is None:
             raise ValueError("SQLite DB uri is required.")
         outputs = kwtypes(results=output_schema_type if output_schema_type else FlyteSchema)
@@ -75,7 +115,7 @@ class SQLite3Task(PythonThirdPartyContainerTask[SQLite3Config], SQLTask[SQLite3C
             name=name,
             task_config=task_config,
             container_image="flytekit-sqlite3:123",
-            executor=SQLite3TaskExecutor,
+            resolver=sqlite3_task_resolver,
             task_type=self._SQLITE_TASK_TYPE,
             query_template=query_template,
             inputs=inputs,
@@ -97,25 +137,7 @@ class SQLite3Task(PythonThirdPartyContainerTask[SQLite3Config], SQLTask[SQLite3C
             "compressed": self.task_config.compressed,
         }
 
-    def get_command(self, settings: SerializationSettings) -> typing.List[str]:
-        return [
-            "pyflyte-manual-execute",
-            "--inputs",
-            "{{.input}}",
-            "--output-prefix",
-            "{{.outputPrefix}}",
-            "--raw-output-data-prefix",
-            "{{.rawOutputDataPrefix}}",
-            "--task_executor",
-            f"{SQLite3TaskExecutor.__module__}.{SQLite3TaskExecutor.__name__}",
-            "--task_template_path",
-            "{{.taskTemplatePath}}",
-        ]
-
-
-class SQLite3TaskExecutor(TaskTemplateExecutor[SQLite3Task]):
-    @classmethod
-    def execute_from_model(cls, tt: task_models.TaskTemplate, **kwargs) -> typing.Any:
+    def execute_from_model(self, tt: task_models.TaskTemplate, **kwargs) -> typing.Any:
         with tempfile.TemporaryDirectory() as temp_dir:
             ctx = FlyteContext.current_context()
             file_ext = os.path.basename(tt.custom["uri"])
@@ -130,3 +152,6 @@ class SQLite3TaskExecutor(TaskTemplateExecutor[SQLite3Task]):
             with contextlib.closing(sqlite3.connect(local_path)) as con:
                 df = pd.read_sql_query(interpolated_query, con)
                 return df
+
+
+sqlite3_task_resolver = TaskTemplateResolver(task_class=SQLite3Task)

--- a/flytekit/extras/sqlite3/task.py
+++ b/flytekit/extras/sqlite3/task.py
@@ -56,6 +56,7 @@ class SQLite3Config(object):
 
 
 class TaskTemplateResolver(TrackedInstance, TaskResolverMixin):
+    # This should be hidden from the task plugin author
     def __init__(self, task_class: Type[PythonThirdPartyContainerTask]):
         self._task_class = task_class
         super(TaskTemplateResolver, self).__init__()
@@ -98,11 +99,6 @@ class SQLite3Task(PythonThirdPartyContainerTask[SQLite3Config], SQLTask[SQLite3C
         output_schema_type: typing.Optional[typing.Type[FlyteSchema]] = None,
         **kwargs,
     ):
-        # Because in the task template case, we skip the rest of instantiation, unless we want the task template loading
-        # behavior to also be present in all parent classes. Or we can just promote_from_model
-        # self._task_type = "python-task"
-        # self._name = name
-
         if task_template is not None:
             self._task_template = task_template
             print("Task template specified, skipping all other constructor logic...")

--- a/tests/flytekit/unit/extras/sqlite3/test_task.py
+++ b/tests/flytekit/unit/extras/sqlite3/test_task.py
@@ -10,7 +10,7 @@ EXAMPLE_DB = "https://cdn.sqlitetutorial.net/wp-content/uploads/2018/03/chinook.
 
 # This task belongs to test_task_static but is intentionally here to help test tracking
 tk = SQLite3Task(
-    "test",
+    name="test",
     query_template="select * from tracks",
     task_config=SQLite3Config(
         uri=EXAMPLE_DB,
@@ -28,7 +28,7 @@ def test_task_static():
 
 def test_task_schema():
     sql_task = SQLite3Task(
-        "test",
+        name="test",
         query_template="select TrackId, Name from tracks limit {{.inputs.limit}}",
         inputs=kwtypes(limit=int),
         output_schema_type=FlyteSchema[kwtypes(TrackId=int, Name=str)],
@@ -49,7 +49,7 @@ def test_workflow():
         return len(df[df.columns[0]])
 
     sql_task = SQLite3Task(
-        "test",
+        name="test",
         query_template="select * from tracks limit {{.inputs.limit}}",
         inputs=kwtypes(limit=int),
         task_config=SQLite3Config(
@@ -67,7 +67,7 @@ def test_workflow():
 
 def test_task_serialization():
     sql_task = SQLite3Task(
-        "test",
+        name="test",
         query_template="select TrackId, Name from tracks limit {{.inputs.limit}}",
         inputs=kwtypes(limit=int),
         output_schema_type=FlyteSchema[kwtypes(TrackId=int, Name=str)],
@@ -80,16 +80,16 @@ def test_task_serialization():
     tt = sql_task.serialize_to_model(sql_task.SERIALIZE_SETTINGS)
 
     assert tt.container.args == [
-        "pyflyte-manual-execute",
+        "pyflyte-execute",
         "--inputs",
         "{{.input}}",
         "--output-prefix",
         "{{.outputPrefix}}",
         "--raw-output-data-prefix",
         "{{.rawOutputDataPrefix}}",
-        "--task_executor",
-        "flytekit.extras.sqlite3.task.SQLite3TaskExecutor",
-        "--task_template_path",
+        "--resolver",
+        "flytekit.extras.sqlite3.task.sqlite3_task_resolver",
+        "--",
         "{{.taskTemplatePath}}",
     ]
 


### PR DESCRIPTION
These comments are based against the `third-party-container` branch.

* The new entrypoint has been removed from `entrypoint.py` and we've reverted to using the same `pyflyte-execute`
* `entrypoint.py` setup was put into its own function so that the task template task resolver can access aws/gcs and download the template from the cloud.
* `TaskResolverMixin` made to operate at a level higher (`PythonTask` instead of `PythonAutoContainerTask`)
* The execution flow differs from regular task flow by overriding:
  * `dispatch_execute` - (search for "Added:") - `dispatch_execute` has been moved from the Executor into the base class instead and is an instance method instead of a classmethod.  (For more background: the reason we can't rely on the base `dispatch_execute` is because we need to guess at Python interface using the task template, rather than relying on the local Python interface, to translate between Flyte literals and Python native values.)
  * `execute` is overridden to call `execute_from_model` directly instead of through the executor.
* The `task_template` has been made an optional field in the `SQLite3Task` constructor along with all the existing args, since the constructor is used in two different ways, either by specifying the `task_template` or by specifying all the values.  In the former case, all parent constructor logic is skipped.
* The "Executor" concept has been removed and replaced with a custom `TaskTemplateResolver`.  This resolver is instantiated with the task type that the resolver should create at execution time.
  