### PR TITLE
[ignore] pr into #449

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -97,11 +97,12 @@ def _dispatch_execute(
         ctx.file_access.get_data(inputs_path, local_inputs_file)
         input_proto = _utils.load_proto_from_file(_literals_pb2.LiteralMap, local_inputs_file)
         idl_input_literals = _literal_models.LiteralMap.from_flyte_idl(input_proto)
+        from flytekit.core.python_third_party_task import ExecutorTask
         # Step2
         if isinstance(task_def, PythonTask):
             outputs = task_def.dispatch_execute(ctx, idl_input_literals)
-        elif isinstance(task_def, task_models.TaskTemplate):
-            outputs = executor.dispatch_execute(ctx, task_def, idl_input_literals)
+        elif isinstance(task_def, ExecutorTask):
+            outputs = task_def.dispatch_execute(ctx, idl_input_literals)
         else:
             raise Exception("Task def was neither PythonTask nor TaskTemplate")
         # Step3a

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -5,11 +5,10 @@ import os as _os
 import pathlib
 import random as _random
 import traceback as _traceback
-from typing import List, Union
+from typing import List
 
 import click as _click
 from flyteidl.core import literals_pb2 as _literals_pb2
-from flyteidl.core import tasks_pb2 as _tasks_pb2
 
 from flytekit import PythonFunctionTask
 from flytekit.common import constants as _constants
@@ -28,7 +27,6 @@ from flytekit.core.context_manager import ExecutionState, FlyteContext, Serializ
 from flytekit.core.map_task import MapPythonTask
 from flytekit.core.promise import VoidPromise
 from flytekit.core.python_auto_container import TaskResolverMixin
-from flytekit.core.python_third_party_task import TaskTemplateExecutor
 from flytekit.engines import loader as _engine_loader
 from flytekit.interfaces import random as _flyte_random
 from flytekit.interfaces.data import data_proxy as _data_proxy
@@ -36,7 +34,8 @@ from flytekit.interfaces.data.gcs import gcs_proxy as _gcs_proxy
 from flytekit.interfaces.data.s3 import s3proxy as _s3proxy
 from flytekit.interfaces.stats.taggable import get_stats as _get_stats
 from flytekit.models import dynamic_job as _dynamic_job
-from flytekit.models import literals as _literal_models, task as task_models
+from flytekit.models import literals as _literal_models
+from flytekit.models import task as task_models
 from flytekit.models.core import errors as _error_models
 from flytekit.models.core import identifier as _identifier
 from flytekit.tools.fast_registration import download_distribution as _download_distribution
@@ -75,7 +74,13 @@ def _map_job_index_to_child_index(local_input_dir, datadir, index):
     return mapping_proto.literals[index].scalar.primitive.integer
 
 
-def _dispatch_execute(ctx: FlyteContext, task_def: Union[PythonTask, task_models.TaskTemplate], inputs_path: str, output_prefix: str, executor=None):
+def _dispatch_execute(
+    ctx: FlyteContext,
+    task_def: PythonTask,
+    inputs_path: str,
+    output_prefix: str,
+    executor=None,
+):
     """
     Dispatches execute to PythonTask
         Step1: Download inputs and load into a literal map
@@ -149,18 +154,15 @@ def _dispatch_execute(ctx: FlyteContext, task_def: Union[PythonTask, task_models
     _logging.info(f"Engine folder written successfully to the output prefix {output_prefix}")
 
 
-def _handle_annotated_task(
-    task_def: PythonTask,
-    inputs: str,
-    output_prefix: str,
+import contextlib
+
+
+@contextlib.contextmanager
+def setup_execution(
     raw_output_data_prefix: str,
     dynamic_addl_distro: str = None,
     dynamic_dest_dir: str = None,
 ):
-    """
-    Entrypoint for all PythonTask extensions
-    """
-    _click.echo("Running native-typed task")
     cloud_provider = _platform_config.CLOUD_PROVIDER.get()
     log_level = _internal_config.LOGGING_LEVEL.get() or _sdk_config.LOGGING_LEVEL.get()
     _logging.getLogger().setLevel(log_level)
@@ -242,7 +244,20 @@ def _handle_annotated_task(
                 execution_params=execution_parameters,
                 additional_context={"dynamic_addl_distro": dynamic_addl_distro, "dynamic_dest_dir": dynamic_dest_dir},
             ) as ctx:
-                _dispatch_execute(ctx, task_def, inputs, output_prefix)
+                yield ctx
+
+
+def _handle_annotated_task(
+    ctx: FlyteContext,
+    task_def: PythonTask,
+    inputs: str,
+    output_prefix: str,
+):
+    """
+    Entrypoint for all PythonTask extensions
+    """
+    _click.echo("Running native-typed task")
+    _dispatch_execute(ctx, task_def, inputs, output_prefix)
 
 
 @_scopes.system_entry_point
@@ -333,18 +348,17 @@ def _execute_task(
     if len(resolver_args) < 1:
         raise Exception("cannot be <1")
 
-    resolver_obj = _load_resolver(resolver)
     with _TemporaryConfiguration(_internal_config.CONFIGURATION_PATH.get()):
-        # Use the resolver to load the actual task object
-        _task_def = resolver_obj.load_task(loader_args=resolver_args)
-        if test:
-            _click.echo(
-                f"Test detected, returning. Args were {inputs} {output_prefix} {raw_output_data_prefix} {resolver} {resolver_args}"
-            )
-            return
-        _handle_annotated_task(
-            _task_def, inputs, output_prefix, raw_output_data_prefix, dynamic_addl_distro, dynamic_dest_dir
-        )
+        with setup_execution(raw_output_data_prefix, dynamic_addl_distro, dynamic_dest_dir) as ctx:
+            resolver_obj = _load_resolver(resolver)
+            # Use the resolver to load the actual task object
+            _task_def = resolver_obj.load_task(loader_args=resolver_args)
+            if test:
+                _click.echo(
+                    f"Test detected, returning. Args were {inputs} {output_prefix} {raw_output_data_prefix} {resolver} {resolver_args}"
+                )
+                return
+            _handle_annotated_task(ctx, _task_def, inputs, output_prefix)
 
 
 @_scopes.system_entry_point
@@ -362,28 +376,27 @@ def _execute_map_task(
     if len(resolver_args) < 1:
         raise Exception(f"Resolver args cannot be <1, got {resolver_args}")
 
-    resolver_obj = _load_resolver(resolver)
     with _TemporaryConfiguration(_internal_config.CONFIGURATION_PATH.get()):
-        # Use the resolver to load the actual task object
-        _task_def = resolver_obj.load_task(loader_args=resolver_args)
-        if not isinstance(_task_def, PythonFunctionTask):
-            raise Exception("Map tasks cannot be run with instance tasks.")
-        map_task = MapPythonTask(_task_def, max_concurrency)
+        with setup_execution(raw_output_data_prefix, dynamic_addl_distro, dynamic_dest_dir) as ctx:
+            resolver_obj = _load_resolver(resolver)
+            # Use the resolver to load the actual task object
+            _task_def = resolver_obj.load_task(loader_args=resolver_args)
+            if not isinstance(_task_def, PythonFunctionTask):
+                raise Exception("Map tasks cannot be run with instance tasks.")
+            map_task = MapPythonTask(_task_def, max_concurrency)
 
-        task_index = _compute_array_job_index()
-        output_prefix = _os.path.join(output_prefix, str(task_index))
+            task_index = _compute_array_job_index()
+            output_prefix = _os.path.join(output_prefix, str(task_index))
 
-        if test:
-            _click.echo(
-                f"Test detected, returning. Inputs: {inputs} Computed task index: {task_index} "
-                f"New output prefix: {output_prefix} Raw output path: {raw_output_data_prefix} "
-                f"Resolver and args: {resolver} {resolver_args}"
-            )
-            return
+            if test:
+                _click.echo(
+                    f"Test detected, returning. Inputs: {inputs} Computed task index: {task_index} "
+                    f"New output prefix: {output_prefix} Raw output path: {raw_output_data_prefix} "
+                    f"Resolver and args: {resolver} {resolver_args}"
+                )
+                return
 
-        _handle_annotated_task(
-            map_task, inputs, output_prefix, raw_output_data_prefix, dynamic_addl_distro, dynamic_dest_dir
-        )
+            _handle_annotated_task(ctx, map_task, inputs, output_prefix)
 
 
 @_click.group()
@@ -515,145 +528,6 @@ def map_execute_task_cmd(
         resolver,
         resolver_args,
     )
-
-
-def _handle_third_party_container_task(
-    inputs: str,
-    output_prefix: str,
-    raw_output_data_prefix: str,
-    task_executor: TaskTemplateExecutor,
-    task_template_path: str,
-):
-    """
-    Entrypoint for all PythonTask extensions
-    """
-    _click.echo("Running native-typed task")
-    cloud_provider = _platform_config.CLOUD_PROVIDER.get()
-    log_level = _internal_config.LOGGING_LEVEL.get() or _sdk_config.LOGGING_LEVEL.get()
-    _logging.getLogger().setLevel(log_level)
-
-    ctx = FlyteContext.current_context()
-
-    # Create directories
-    user_workspace_dir = ctx.file_access.local_access.get_random_directory()
-    _click.echo(f"Using user directory {user_workspace_dir}")
-    pathlib.Path(user_workspace_dir).mkdir(parents=True, exist_ok=True)
-    from flytekit import __version__ as _api_version
-
-    execution_parameters = ExecutionParameters(
-        execution_id=_identifier.WorkflowExecutionIdentifier(
-            project=_internal_config.EXECUTION_PROJECT.get(),
-            domain=_internal_config.EXECUTION_DOMAIN.get(),
-            name=_internal_config.EXECUTION_NAME.get(),
-        ),
-        execution_date=_datetime.datetime.utcnow(),
-        stats=_get_stats(
-            # Stats metric path will be:
-            # registration_project.registration_domain.app.module.task_name.user_stats
-            # and it will be tagged with execution-level values for project/domain/wf/lp
-            "{}.{}.{}.user_stats".format(
-                _internal_config.TASK_PROJECT.get() or _internal_config.PROJECT.get(),
-                _internal_config.TASK_DOMAIN.get() or _internal_config.DOMAIN.get(),
-                _internal_config.TASK_NAME.get() or _internal_config.NAME.get(),
-            ),
-            tags={
-                "exec_project": _internal_config.EXECUTION_PROJECT.get(),
-                "exec_domain": _internal_config.EXECUTION_DOMAIN.get(),
-                "exec_workflow": _internal_config.EXECUTION_WORKFLOW.get(),
-                "exec_launchplan": _internal_config.EXECUTION_LAUNCHPLAN.get(),
-                "api_version": _api_version,
-            },
-        ),
-        logging=_logging,
-        tmp_dir=user_workspace_dir,
-    )
-
-    if cloud_provider == _constants.CloudProvider.AWS:
-        file_access = _data_proxy.FileAccessProvider(
-            local_sandbox_dir=_sdk_config.LOCAL_SANDBOX.get(),
-            remote_proxy=_s3proxy.AwsS3Proxy(raw_output_data_prefix),
-        )
-    elif cloud_provider == _constants.CloudProvider.GCP:
-        file_access = _data_proxy.FileAccessProvider(
-            local_sandbox_dir=_sdk_config.LOCAL_SANDBOX.get(),
-            remote_proxy=_gcs_proxy.GCSProxy(raw_output_data_prefix),
-        )
-    elif cloud_provider == _constants.CloudProvider.LOCAL:
-        # A fake remote using the local disk will automatically be created
-        file_access = _data_proxy.FileAccessProvider(local_sandbox_dir=_sdk_config.LOCAL_SANDBOX.get())
-    else:
-        raise Exception(f"Bad cloud provider {cloud_provider}")
-
-    with ctx.new_file_access_context(file_access_provider=file_access) as ctx:
-        env = {
-            _internal_config.CONFIGURATION_PATH.env_var: _internal_config.CONFIGURATION_PATH.get(),
-            _internal_config.IMAGE.env_var: _internal_config.IMAGE.get(),
-        }
-
-        serialization_settings = SerializationSettings(
-            project=_internal_config.TASK_PROJECT.get(),
-            domain=_internal_config.TASK_DOMAIN.get(),
-            version=_internal_config.TASK_VERSION.get(),
-            image_config=get_image_config(),
-            env=env,
-        )
-
-        # The reason we need this is because of dynamic tasks. Even if we move compilation all to Admin,
-        # if a dynamic task calls some task, t1, we have to write to the DJ Spec the correct task
-        # identifier for t1.
-        with ctx.new_serialization_settings(serialization_settings=serialization_settings) as ctx:
-            # Because execution states do not look up the context chain, it has to be made last
-            with ctx.new_execution_context(
-                mode=ExecutionState.Mode.TASK_EXECUTION,
-                execution_params=execution_parameters,
-            ) as ctx:
-
-                task_template_local_path = _os.path.join(ctx.execution_state.working_dir, "task_template.pb")
-                ctx.file_access.get_data(task_template_path, task_template_local_path)
-                task_template_proto = _common_utils.load_proto_from_file(
-                    _tasks_pb2.TaskTemplate, task_template_local_path
-                )
-                task_template_model = task_models.TaskTemplate.from_flyte_idl(task_template_proto)
-                _dispatch_execute(ctx, task_template_model, inputs, output_prefix, executor=task_executor)
-
-
-@_scopes.system_entry_point
-def _manual_execute_task(
-    inputs,
-    output_prefix,
-    raw_output_data_prefix,
-    task_executor,
-    task_template_path,
-):
-    # Bit of a hack, but the code is the same
-    task_executor_class = _load_resolver(task_executor)
-    with _TemporaryConfiguration(_internal_config.CONFIGURATION_PATH.get()):
-        _handle_third_party_container_task(
-            inputs, output_prefix, raw_output_data_prefix, task_executor_class, task_template_path
-        )
-
-
-@_pass_through.command("pyflyte-manual-execute")
-@_click.option("--inputs", required=True)
-@_click.option("--output-prefix", required=True)
-@_click.option("--raw-output-data-prefix", required=False)
-@_click.option("--task_executor", required=True)
-@_click.option("--task_template_path", required=False)
-def manual_execute_task_cmd(
-    inputs,
-    output_prefix,
-    raw_output_data_prefix,
-    task_executor,
-    task_template_path,
-):
-    _click.echo(_utils.get_version_message())
-    # Backwards compatibility - if Propeller hasn't filled this in, then it'll come through here as the original
-    # template string, so let's explicitly set it to None so that the downstream functions will know to fall back
-    # to the original shard formatter/prefix config.
-    if raw_output_data_prefix == "{{.rawOutputDataPrefix}}":
-        raw_output_data_prefix = None
-
-    _manual_execute_task(inputs, output_prefix, raw_output_data_prefix, task_executor, task_template_path)
 
 
 if __name__ == "__main__":

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -6,7 +6,7 @@ from abc import abstractmethod
 from typing import Dict, List, Optional, TypeVar
 
 from flytekit.common.tasks.raw_container import _get_container_definition
-from flytekit.core.base_task import PythonTask
+from flytekit.core.base_task import PythonTask, Task
 from flytekit.core.context_manager import FlyteContext, ImageConfig, SerializationSettings
 from flytekit.core.resources import Resources, ResourceSpec
 from flytekit.core.tracked_abc import FlyteTrackedABC
@@ -178,27 +178,27 @@ class TaskResolverMixin(object):
         pass
 
     @abstractmethod
-    def load_task(self, loader_args: List[str]) -> PythonAutoContainerTask:
+    def load_task(self, loader_args: List[str]) -> Task:
         """
         Given the set of identifier keys, should return one Python Task or raise an error if not found
         """
         pass
 
     @abstractmethod
-    def loader_args(self, settings: SerializationSettings, t: PythonAutoContainerTask) -> List[str]:
+    def loader_args(self, settings: SerializationSettings, t: Task) -> List[str]:
         """
         Return a list of strings that can help identify the parameter Task
         """
         pass
 
     @abstractmethod
-    def get_all_tasks(self) -> List[PythonAutoContainerTask]:
+    def get_all_tasks(self) -> List[Task]:
         """
         Future proof method. Just making it easy to access all tasks (Not required today as we auto register them)
         """
         pass
 
-    def task_name(self, t: PythonAutoContainerTask) -> Optional[str]:
+    def task_name(self, t: Task) -> Optional[str]:
         """
         Overridable function that can optionally return a custom name for a given task
         """

--- a/flytekit/core/python_third_party_task.py
+++ b/flytekit/core/python_third_party_task.py
@@ -1,24 +1,24 @@
 from __future__ import annotations
 
-from abc import abstractmethod
+import importlib
+import os
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
-from flytekit.core.context_manager import (
-    BranchEvalMode,
-    ExecutionState,
-    FlyteContext,
-    FlyteEntities,
-    SerializationSettings,
-)
-from flytekit.core.type_engine import TypeEngine
-from flytekit.loggers import logger
-from flytekit.common.tasks.sdk_runnable import ExecutionParameters
+
+from flyteidl.core import tasks_pb2 as _tasks_pb2
+
+from flytekit.common import utils as common_utils
 from flytekit.common.tasks.raw_container import _get_container_definition
-from flytekit.core.base_task import PythonTask
-from flytekit.core.context_manager import Image, ImageConfig, SerializationSettings
+from flytekit.common.tasks.sdk_runnable import ExecutionParameters
+from flytekit.core.base_task import PythonTask, Task
+from flytekit.core.context_manager import FlyteContext, Image, ImageConfig, SerializationSettings
+from flytekit.core.python_auto_container import TaskResolverMixin
 from flytekit.core.resources import Resources, ResourceSpec
 from flytekit.core.tracker import TrackedInstance
-from flytekit.models import task as _task_model, literals as _literal_models
+from flytekit.core.type_engine import TypeEngine
+from flytekit.loggers import logger
 from flytekit.models import dynamic_job as _dynamic_job
+from flytekit.models import literals as _literal_models
+from flytekit.models import task as _task_model
 from flytekit.models.core import identifier as identifier_models
 from flytekit.models.security import Secret, SecurityContext
 
@@ -121,6 +121,42 @@ class TaskTemplateExecutor(TrackedInstance, Generic[T]):
             return outputs_literal_map
 
 
+class ExecutorTask(object):
+    def __init__(self, tt: _task_model.TaskTemplate, executor: TaskTemplateExecutor):
+        self._executor = executor
+        self._task_template = tt
+
+    @property
+    def task_template(self) -> _task_model.TaskTemplate:
+        return self._task_template
+
+    @property
+    def executor(self) -> TaskTemplateExecutor:
+        return self._executor
+
+    def execute(self, **kwargs) -> Any:
+        """
+        This function overrides the default task execute behavior.
+
+        Execution for third-party tasks is different from tasks that run the user workflow container.
+        1. Serialize the task out to a TaskTemplate.
+        2. Pass the template over to the Executor to run, along with the input arguments.
+        3. Executor will reconstruct the Python task class object, before running the e
+
+        When overridden for unit testing using the patch operator, all these steps will be skipped and the mocked code,
+        which should just take in and return Python native values, will be run.
+        """
+        return self.executor.execute_from_model(self.task_template, **kwargs)
+
+    def dispatch_execute(
+        self, ctx: FlyteContext, input_literal_map: _literal_models.LiteralMap
+    ) -> Union[_literal_models.LiteralMap, _dynamic_job.DynamicJobSpec]:
+        """
+        This function overrides the default task execute behavior.
+        """
+        return self.executor.dispatch_execute(ctx, self.task_template, input_literal_map)
+
+
 class PythonThirdPartyContainerTask(PythonTask[TC]):
     SERIALIZE_SETTINGS = SerializationSettings(
         project="PLACEHOLDER_PROJECT",
@@ -136,6 +172,7 @@ class PythonThirdPartyContainerTask(PythonTask[TC]):
         task_config: TC,
         container_image: str,
         executor: TaskTemplateExecutor,
+        task_resolver: Optional[TaskTemplateResolver] = None,
         task_type="python-task",
         requests: Optional[Resources] = None,
         limits: Optional[Resources] = None,
@@ -188,6 +225,8 @@ class PythonThirdPartyContainerTask(PythonTask[TC]):
         # Because instances of these tasks rely on the task template in order to run even locally, we'll cache it
         self._task_template = None
 
+        self._task_resolver = task_resolver or default_task_template_resolver
+
     def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
         # Overriding base implementation to raise an error, force third-party task author to implement
         raise NotImplementedError
@@ -204,13 +243,13 @@ class PythonThirdPartyContainerTask(PythonTask[TC]):
     def resources(self) -> ResourceSpec:
         return self._resources
 
-    @abstractmethod
-    def get_command(self, settings: SerializationSettings) -> List[str]:
-        pass
-
     @property
     def executor(self) -> TaskTemplateExecutor:
         return self._executor
+
+    @property
+    def task_resolver(self) -> TaskTemplateResolver:
+        return self._task_resolver
 
     @property
     def task_template(self) -> Optional[_task_model.TaskTemplate]:
@@ -219,6 +258,23 @@ class PythonThirdPartyContainerTask(PythonTask[TC]):
     @property
     def container_image(self) -> str:
         return self._container_image
+
+    def get_command(self, settings: SerializationSettings) -> List[str]:
+        container_args = [
+            "pyflyte-execute",
+            "--inputs",
+            "{{.input}}",
+            "--output-prefix",
+            "{{.outputPrefix}}",
+            "--raw-output-data-prefix",
+            "{{.rawOutputDataPrefix}}",
+            "--resolver",
+            self.task_resolver.location,
+            "--",
+            *self.task_resolver.loader_args(settings, self),
+        ]
+
+        return container_args
 
     def get_container(self, settings: SerializationSettings) -> _task_model.Container:
         env = {**settings.env, **self.environment} if self.environment else settings.env
@@ -281,3 +337,42 @@ class PythonThirdPartyContainerTask(PythonTask[TC]):
         """
         tt = self.task_template or self.serialize_to_model(settings=PythonThirdPartyContainerTask.SERIALIZE_SETTINGS)
         return self.executor.dispatch_execute(ctx, tt, input_literal_map)
+
+
+def load_executor(object_location: str) -> Any:
+    """
+    Copied from entrypoint
+    """
+    class_obj = object_location.split(".")
+    class_obj_mod = class_obj[:-1]  # e.g. ['flytekit', 'core', 'python_auto_container']
+    class_obj_key = class_obj[-1]  # e.g. 'default_task_class_obj'
+    class_obj_mod = importlib.import_module(".".join(class_obj_mod))
+    return getattr(class_obj_mod, class_obj_key)
+
+
+class TaskTemplateResolver(TrackedInstance, TaskResolverMixin):
+    def __init__(self):
+        super(TaskTemplateResolver, self).__init__()
+
+    def name(self) -> str:
+        return "task template resolver"
+
+    def load_task(self, loader_args: List[str]) -> Task:
+        logger.info(f"Task template loader args: {loader_args}")
+        ctx = FlyteContext.current_context()
+        task_template_local_path = os.path.join(ctx.execution_state.working_dir, "task_template.pb")
+        ctx.file_access.get_data(loader_args[0], task_template_local_path)
+        task_template_proto = common_utils.load_proto_from_file(_tasks_pb2.TaskTemplate, task_template_local_path)
+        task_template_model = _task_model.TaskTemplate.from_flyte_idl(task_template_proto)
+
+        executor = load_executor(loader_args[1])
+        return ExecutorTask(executor, task_template_model)
+
+    def loader_args(self, settings: SerializationSettings, t: PythonThirdPartyContainerTask) -> List[str]:
+        return ["{{.taskTemplatePath}}", f"{t.executor.__module__}.{t.executor.__name__}"]
+
+    def get_all_tasks(self) -> List[Task]:
+        return []
+
+
+default_task_template_resolver = TaskTemplateResolver()

--- a/flytekit/core/python_third_party_task.py
+++ b/flytekit/core/python_third_party_task.py
@@ -366,7 +366,7 @@ class TaskTemplateResolver(TrackedInstance, TaskResolverMixin):
         task_template_model = _task_model.TaskTemplate.from_flyte_idl(task_template_proto)
 
         executor = load_executor(loader_args[1])
-        return ExecutorTask(executor, task_template_model)
+        return ExecutorTask(task_template_model, executor)
 
     def loader_args(self, settings: SerializationSettings, t: PythonThirdPartyContainerTask) -> List[str]:
         return ["{{.taskTemplatePath}}", f"{t.executor.__module__}.{t.executor.__name__}"]

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -8,7 +8,7 @@ import os
 import typing
 from abc import ABC, abstractmethod
 from typing import Type
-from flytekit.loggers import logger
+
 from dataclasses_json import DataClassJsonMixin
 from google.protobuf import json_format as _json_format
 from google.protobuf import reflection as _proto_reflection
@@ -16,8 +16,10 @@ from google.protobuf import struct_pb2 as _struct
 from google.protobuf.json_format import MessageToDict as _MessageToDict
 from google.protobuf.json_format import ParseDict as _ParseDict
 from google.protobuf.struct_pb2 import Struct
+
 from flytekit.common.types import primitives as _primitives
 from flytekit.core.context_manager import FlyteContext
+from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
 from flytekit.models import types as _type_models
 from flytekit.models.core import types as _core_types
@@ -311,7 +313,9 @@ class TypeEngine(typing.Generic[T]):
         return cls._REGISTRY.keys()
 
     @classmethod
-    def guess_python_types(cls, flyte_variable_dict: typing.Dict[str, _interface_models.Variable]) -> typing.Dict[str, type]:
+    def guess_python_types(
+        cls, flyte_variable_dict: typing.Dict[str, _interface_models.Variable]
+    ) -> typing.Dict[str, type]:
         python_types = {}
         for k, v in flyte_variable_dict.items():
             python_types[k] = cls.guess_python_type(v.type)
@@ -446,6 +450,7 @@ class DictTransformer(TypeTransformer[dict]):
             mt = TypeEngine.guess_python_type(literal_type.map_value_type)
             return typing.Dict[str, mt]
         raise ValueError(f"Dictionary transformer cannot reverse {literal_type}")
+
 
 class TextIOTransformer(TypeTransformer[typing.TextIO]):
     """

--- a/flytekit/extras/sqlite3/Dockerfile
+++ b/flytekit/extras/sqlite3/Dockerfile
@@ -4,4 +4,4 @@ ENV FLYTE_INTERNAL_IMAGE=flytecli-sqlite3:123
 
 RUN pip install awscli
 
-RUN pip install -U https://github.com/flyteorg/flytekit/archive/8f90d639d0095d17e3c6d6c92493f1e6f73b02e1.zip#egg=flytekit
+RUN pip install -U https://github.com/flyteorg/flytekit/archive/4089babbdc7797d8e12203bda4c83c172f1c5758.zip#egg=flytekit

--- a/flytekit/extras/sqlite3/Dockerfile
+++ b/flytekit/extras/sqlite3/Dockerfile
@@ -4,4 +4,4 @@ ENV FLYTE_INTERNAL_IMAGE=flytecli-sqlite3:123
 
 RUN pip install awscli
 
-RUN pip install -U https://github.com/flyteorg/flytekit/archive/6bf72ad7ce4bd9b2f04279b9b553a846315ac0a3.zip#egg=flytekit
+RUN pip install -U https://github.com/flyteorg/flytekit/archive/8f90d639d0095d17e3c6d6c92493f1e6f73b02e1.zip#egg=flytekit

--- a/flytekit/extras/sqlite3/Dockerfile
+++ b/flytekit/extras/sqlite3/Dockerfile
@@ -4,4 +4,4 @@ ENV FLYTE_INTERNAL_IMAGE=flytecli-sqlite3:123
 
 RUN pip install awscli
 
-RUN pip install -U https://github.com/flyteorg/flytekit/archive/fb701cb03fbcc4cdd1daa48db1192a45fa2bce3a.zip#egg=flytekit
+RUN pip install -U https://github.com/flyteorg/flytekit/archive/6bf72ad7ce4bd9b2f04279b9b553a846315ac0a3.zip#egg=flytekit

--- a/flytekit/extras/sqlite3/task.py
+++ b/flytekit/extras/sqlite3/task.py
@@ -97,21 +97,6 @@ class SQLite3Task(PythonThirdPartyContainerTask[SQLite3Config], SQLTask[SQLite3C
             "compressed": self.task_config.compressed,
         }
 
-    def get_command(self, settings: SerializationSettings) -> typing.List[str]:
-        return [
-            "pyflyte-manual-execute",
-            "--inputs",
-            "{{.input}}",
-            "--output-prefix",
-            "{{.outputPrefix}}",
-            "--raw-output-data-prefix",
-            "{{.rawOutputDataPrefix}}",
-            "--task_executor",
-            f"{SQLite3TaskExecutor.__module__}.{SQLite3TaskExecutor.__name__}",
-            "--task_template_path",
-            "{{.taskTemplatePath}}",
-        ]
-
 
 class SQLite3TaskExecutor(TaskTemplateExecutor[SQLite3Task]):
     @classmethod

--- a/tests/flytekit/unit/extras/sqlite3/test_task.py
+++ b/tests/flytekit/unit/extras/sqlite3/test_task.py
@@ -80,17 +80,18 @@ def test_task_serialization():
     tt = sql_task.serialize_to_model(sql_task.SERIALIZE_SETTINGS)
 
     assert tt.container.args == [
-        "pyflyte-manual-execute",
+        "pyflyte-execute",
         "--inputs",
         "{{.input}}",
         "--output-prefix",
         "{{.outputPrefix}}",
         "--raw-output-data-prefix",
         "{{.rawOutputDataPrefix}}",
-        "--task_executor",
-        "flytekit.extras.sqlite3.task.SQLite3TaskExecutor",
-        "--task_template_path",
+        "--resolver",
+        "flytekit.core.python_third_party_task.default_task_template_resolver",
+        "--",
         "{{.taskTemplatePath}}",
+        "flytekit.extras.sqlite3.task.SQLite3TaskExecutor",
     ]
 
     assert tt.custom["query_template"] == "select TrackId, Name from tracks limit {{.inputs.limit}}"


### PR DESCRIPTION
These comments are based against the `third-party-container` branch.

* The new entrypoint has been removed from `entrypoint.py` and we've reverted to using the same `pyflyte-execute`.
* `entrypoint.py` setup was put into its own function so that the task template task resolver can access aws/gcs and download the template from the cloud.
* `TaskResolverMixin` made to operate at a level higher (`Task` instead of `PythonAutoContainerTask`).
* Created a new `ExecutorTask` that has only a `TaskTemplate` and a `TaskTemplateExecutor`.  In the future, this will be the 
* Added a `TaskTemplateResolver` that will create only two strings for the loader args, the regex string for propeller to fill in the task template location, and the module and name of the executor.  At run time, the entrypoint will load the resolver.  The resolver will load the executor and download the template.  And the executor will run the template.

In the future if to replace `ExecutorTask` with `FlyteTask`, we can add an optional executor field to `FlyteTask` and add the execute and dispatch execute behavior.

# TL;DR
_Please replace this text with a description of what this PR accomplishes._

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
