### PR TITLE
Validate All Arguments While Using the Cached LaunchPlan

### DIFF
--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -143,7 +143,22 @@ class LaunchPlan(object):
             )
 
         if name is not None and name in LaunchPlan.CACHE:
-            # TODO: Add checking of the other arguments (default_inputs, fixed_inputs, etc.) to make sure they match
+            cached_outputs = vars(LaunchPlan.CACHE[name])
+
+            notifications = notifications or []
+            default_inputs = default_inputs or {}
+            fixed_inputs = fixed_inputs or {}
+
+            default_inputs.update(fixed_inputs)
+            if (
+                workflow != cached_outputs["_workflow"]
+                or schedule != cached_outputs["_schedule"]
+                or notifications != cached_outputs["_notifications"]
+                or auth_role != cached_outputs["_auth_role"]
+                or default_inputs != cached_outputs["_saved_inputs"]
+            ):
+                return AssertionError("The cached values aren't the same as the current call arguments")
+
             return LaunchPlan.CACHE[name]
         elif name is None and workflow.name in LaunchPlan.CACHE:
             return LaunchPlan.CACHE[workflow.name]

--- a/tests/flytekit/unit/core/test_launch_plan.py
+++ b/tests/flytekit/unit/core/test_launch_plan.py
@@ -2,9 +2,12 @@ import typing
 
 import pytest
 
-from flytekit.core import launch_plan
+from flytekit.core import launch_plan, notification
+from flytekit.core.schedule import CronSchedule
 from flytekit.core.task import task
 from flytekit.core.workflow import workflow
+from flytekit.models.common import AuthRole
+from flytekit.models.core import execution as _execution_model
 
 
 def test_lp():
@@ -12,10 +15,6 @@ def test_lp():
     def t1(a: int) -> typing.NamedTuple("OutputsBC", t1_int_output=int, c=str):
         a = a + 2
         return a, "world-" + str(a)
-
-    @task
-    def t2(a: str, b: str) -> str:
-        return b + a
 
     @workflow
     def wf(a: int) -> (str, str):
@@ -37,3 +36,62 @@ def test_lp():
 
     lp_with_defaults = launch_plan.LaunchPlan.create("get_or_create2", wf, default_inputs={"a": 3})
     assert lp_with_defaults.parameters.parameters["a"].default.scalar.primitive.integer == 3
+
+
+def test_lp_all_parameters():
+    @task
+    def t1(a: int) -> typing.NamedTuple("OutputsBC", t1_int_output=int, c=str):
+        a = a + 2
+        return a, "world-" + str(a)
+
+    @task
+    def t2(a: str, b: str, c: str) -> str:
+        return b + a + c
+
+    @workflow
+    def wf(a: int, c: str) -> str:
+        x, y = t1(a=a)
+        u = t2(a=x, b=y, c=c)
+        return u
+
+    obj = CronSchedule("* * ? * * *", kickoff_time_input_arg="abc")
+    obj1 = CronSchedule("10 * ? * * *", kickoff_time_input_arg="abc")
+    slack_notif = notification.Slack(
+        phases=[_execution_model.WorkflowExecutionPhase.SUCCEEDED], recipients_email=["my-team@slack.com"]
+    )
+    auth_role_model = AuthRole(assumable_iam_role="my:iam:role")
+
+    lp = launch_plan.LaunchPlan.get_or_create(
+        workflow=wf,
+        name="get_or_create",
+        default_inputs={"a": 3},
+        fixed_inputs={"c": "4"},
+        schedule=obj,
+        notifications=slack_notif,
+        auth_role=auth_role_model,
+    )
+    lp2 = launch_plan.LaunchPlan.get_or_create(
+        workflow=wf,
+        name="get_or_create",
+        default_inputs={"a": 3},
+        fixed_inputs={"c": "4"},
+        schedule=obj,
+        notifications=slack_notif,
+        auth_role=auth_role_model,
+    )
+
+    assert lp is lp2
+
+    # Check for assertion error when a different scheduler is used
+    lp3 = launch_plan.LaunchPlan.get_or_create(
+        workflow=wf,
+        name="get_or_create",
+        default_inputs={"a": 3},
+        fixed_inputs={"c": "4"},
+        schedule=obj1,
+        notifications=slack_notif,
+        auth_role=auth_role_model,
+    )
+
+    with pytest.raises(AssertionError):
+        assert lp is lp3

--- a/tests/flytekit/unit/core/test_launch_plan.py
+++ b/tests/flytekit/unit/core/test_launch_plan.py
@@ -1,6 +1,7 @@
 import typing
 
 import pytest
+from flyteidl.admin import launch_plan_pb2 as _launch_plan_idl
 
 from flytekit.core import launch_plan, notification
 from flytekit.core.schedule import CronSchedule
@@ -8,7 +9,6 @@ from flytekit.core.task import task
 from flytekit.core.workflow import workflow
 from flytekit.models.common import AuthRole
 from flytekit.models.core import execution as _execution_model
-from flyteidl.admin import launch_plan_pb2 as _launch_plan_idl
 
 
 def test_lp():
@@ -38,6 +38,7 @@ def test_lp():
     lp_with_defaults = launch_plan.LaunchPlan.create("get_or_create2", wf, default_inputs={"a": 3})
     assert lp_with_defaults.parameters.parameters["a"].default.scalar.primitive.integer == 3
 
+
 def test_lp_each_parameter():
     @task
     def t1(a: int) -> typing.NamedTuple("OutputsBC", t1_int_output=int, c=str):
@@ -50,7 +51,9 @@ def test_lp_each_parameter():
         return x, y
 
     # Fixed Inputs Parameter
-    fixed_lp = launch_plan.LaunchPlan.get_or_create(workflow=wf, name="get_or_create_fixed", fixed_inputs={"a": 1, "c": "4"})
+    fixed_lp = launch_plan.LaunchPlan.get_or_create(
+        workflow=wf, name="get_or_create_fixed", fixed_inputs={"a": 1, "c": "4"}
+    )
     fixed_lp1 = launch_plan.LaunchPlan.get_or_create(workflow=wf, name="get_or_create_fixed")
 
     with pytest.raises(AssertionError):
@@ -64,17 +67,27 @@ def test_lp_each_parameter():
     assert schedule_lp is schedule_lp1
 
     # Default Inputs Parameter
-    default_lp = launch_plan.LaunchPlan.get_or_create(workflow=wf, name="get_or_create_schedule", default_inputs={"a": 9})
-    default_lp1 = launch_plan.LaunchPlan.get_or_create(workflow=wf, name="get_or_create_schedule", default_inputs={"a": 19})
+    default_lp = launch_plan.LaunchPlan.get_or_create(
+        workflow=wf, name="get_or_create_schedule", default_inputs={"a": 9}
+    )
+    default_lp1 = launch_plan.LaunchPlan.get_or_create(
+        workflow=wf, name="get_or_create_schedule", default_inputs={"a": 19}
+    )
 
     # Validates both schedule and default inputs owing to the same launch plan
     with pytest.raises(AssertionError):
         assert default_lp is default_lp1
 
     # Notifications Parameter
-    email_notif = notification.Email(phases=[_execution_model.WorkflowExecutionPhase.SUCCEEDED], recipients_email=["my-team@email.com"])
-    notification_lp = launch_plan.LaunchPlan.get_or_create(workflow=wf, name="get_or_create_notification", notifications=email_notif)
-    notification_lp1 = launch_plan.LaunchPlan.get_or_create(workflow=wf, name="get_or_create_notification", notifications=email_notif)
+    email_notif = notification.Email(
+        phases=[_execution_model.WorkflowExecutionPhase.SUCCEEDED], recipients_email=["my-team@email.com"]
+    )
+    notification_lp = launch_plan.LaunchPlan.get_or_create(
+        workflow=wf, name="get_or_create_notification", notifications=email_notif
+    )
+    notification_lp1 = launch_plan.LaunchPlan.get_or_create(
+        workflow=wf, name="get_or_create_notification", notifications=email_notif
+    )
 
     assert notification_lp is notification_lp1
 
@@ -92,6 +105,7 @@ def test_lp_each_parameter():
     name_lp1 = launch_plan.LaunchPlan.get_or_create(workflow=wf)
 
     assert name_lp is name_lp1
+
 
 def test_lp_all_parameters():
     @task


### PR DESCRIPTION
Signed-off-by: Samhita Alla <aallasamhita@gmail.com>

# TL;DR
Verify if the cached outputs are the same as the arguments passed in the further repeat calls.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue
https://github.com/lyft/flyte/issues/892

## Complete Description
In flytekit's `core/launch_plan.py::LaunchPlan` object, the `get_or_create` function creates a launch plan. The user can supply things like a schedule or fixed or default inputs to it. The resultant launch plan is cached. On repeat calls, the cached version (based on the name) is returned. We should add a check to make sure that these repeat calls raise an error if any of the other arguments have changed.

## Follow-up issue
_NA_