### PR TITLE
Use default arguments in addition to kwargs in local wf execution

### DIFF
--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -226,7 +226,7 @@ class WorkflowBase(object):
         # Get default agruements and override with kwargs passed in
         input_kwargs = self.python_interface.default_inputs_as_kwargs
         input_kwargs.update(kwargs)
-        
+
         # The first condition is compilation.
         if ctx.compilation_state is not None:
             return create_and_link_node(ctx, entity=self, interface=self.python_interface, **input_kwargs)

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -223,10 +223,12 @@ class WorkflowBase(object):
 
         ctx = FlyteContext.current_context()
 
+        # Get default agruements and override with kwargs passed in
+        input_kwargs = self.python_interface.default_inputs_as_kwargs
+        input_kwargs.update(kwargs)
+        
         # The first condition is compilation.
         if ctx.compilation_state is not None:
-            input_kwargs = self.python_interface.default_inputs_as_kwargs
-            input_kwargs.update(kwargs)
             return create_and_link_node(ctx, entity=self, interface=self.python_interface, **input_kwargs)
 
         # This condition is hit when this workflow (self) is being called as part of a parent's workflow local run.
@@ -243,7 +245,7 @@ class WorkflowBase(object):
                 else:
                     return None
             # We are already in a local execution, just continue the execution context
-            return self._local_execute(ctx, **kwargs)
+            return self._local_execute(ctx, **input_kwargs)
 
         # Last is starting a local workflow execution
         else:
@@ -251,14 +253,14 @@ class WorkflowBase(object):
             # Even though the _local_execute call generally expects inputs to be Promises, we don't have to do the
             # conversion here in this loop. The reason is because we don't prevent users from specifying inputs
             # as direct scalars, which means there's another Promise-generating loop inside _local_execute too
-            for k, v in kwargs.items():
+            for k, v in input_kwargs.items():
                 if k not in self.interface.inputs:
                     raise ValueError(f"Received unexpected keyword argument {k}")
                 if isinstance(v, Promise):
                     raise ValueError(f"Received a promise for a workflow call, when expecting a native value for {k}")
 
             with ctx.new_execution_context(mode=ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION) as ctx:
-                result = self._local_execute(ctx, **kwargs)
+                result = self._local_execute(ctx, **input_kwargs)
 
             expected_outputs = len(self.python_interface.outputs)
             if expected_outputs == 0:

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -63,13 +63,7 @@ def test_default_values():
 
     @workflow
     def wf(a: bool = True) -> bool:
-        return (
-            conditional("bool")
-            .if_(a.is_true())
-            .then(t())
-            .else_()
-            .then(f())
-        )
+        return conditional("bool").if_(a.is_true()).then(t()).else_().then(f())
 
     assert wf() is True
     assert wf(a=False) is False

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -6,6 +6,7 @@ import pytest
 from flytekit.common.exceptions.user import FlyteValidationException, FlyteValueException
 from flytekit.common.translator import get_serializable
 from flytekit.core import context_manager
+from flytekit.core.condition import conditional
 from flytekit.core.context_manager import Image, ImageConfig
 from flytekit.core.task import task
 from flytekit.core.workflow import WorkflowFailurePolicy, WorkflowMetadata, WorkflowMetadataDefaults, workflow
@@ -50,6 +51,28 @@ def test_workflow_values():
     assert sdk_wf.metadata_defaults.interruptible
     assert sdk_wf.metadata.on_failure == 1
 
+def test_default_values():
+    @task
+    def t() -> bool:
+        return True
+
+    @task
+    def f() -> bool:
+        return False
+
+    @workflow
+    def wf(a: bool = True) -> bool:
+        return (
+            conditional("bool")
+            .if_(a.is_true())
+            .then(t())
+            .else_()
+            .then(f())
+        )
+    
+    assert wf() == True
+    assert wf(a=False) == False
+    
 
 def test_list_output_wf():
     @task

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -51,6 +51,7 @@ def test_workflow_values():
     assert sdk_wf.metadata_defaults.interruptible
     assert sdk_wf.metadata.on_failure == 1
 
+
 def test_default_values():
     @task
     def t() -> bool:
@@ -69,10 +70,10 @@ def test_default_values():
             .else_()
             .then(f())
         )
-    
-    assert wf() == True
-    assert wf(a=False) == False
-    
+
+    assert wf() is True
+    assert wf(a=False) is False
+
 
 def test_list_output_wf():
     @task


### PR DESCRIPTION
# TL;DR
Previously `_local_execute` would be called without checking for default arguments. See https://github.com/flyteorg/flyte/issues/951 for more details.

## Type
 - [ X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue


## Tracking Issue
https://github.com/flyteorg/flyte/issues/951
