### PR TITLE
Make extract_return_annotation compatible with 3.9 NamedTuple

### DIFF
--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -318,9 +318,10 @@ def extract_return_annotation(return_annotation: Union[Type, Tuple]) -> Dict[str
     if isinstance(return_annotation, Type) or isinstance(return_annotation, TypeVar):
         # isinstance / issubclass does not work for Namedtuple.
         # Options 1 and 2
-        if hasattr(return_annotation, "_field_types"):
+        bases = return_annotation.__bases__
+        if len(bases) == 1 and bases[0] == tuple and hasattr(return_annotation, "_fields"):
             logger.debug(f"Task returns named tuple {return_annotation}")
-            return return_annotation._field_types
+            return return_annotation.__annotations__
 
     if hasattr(return_annotation, "__origin__") and return_annotation.__origin__ is tuple:
         # Handle option 3


### PR DESCRIPTION
# TL;DR
Make `extract_return_annotation` compatible with Python 3.9 `NamedTuple`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
`_field_type` attribute was removed in Python 3.9 (see [typing.NamedTuple](https://docs.python.org/3/library/typing.html#typing.NamedTuple)). Instead, check that the type has `tuple` as a base class, and that it has the `_field` attribute (part of [namedtuple API](https://docs.python.org/3/library/collections.html#collections.somenamedtuple._fields)). Then return `__annotations__` which contains the same information as `_field_types`. 


## Tracking Issue
https://github.com/flyteorg/flyte/issues/914

## Follow-up issue
_NA_

