### PR TITLE
DictTrasformer works when LiteralMap is empty

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -424,12 +424,12 @@ class DictTransformer(TypeTransformer[dict]):
         return Literal(map=LiteralMap(literals=lit_map))
 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[dict]) -> dict:
-        if lv and lv.map and lv.map.literals:
+        if lv and lv.map and lv.map.literals is not None:
             tp = self.get_dict_types(expected_python_type)
             if tp is None or tp[0] is None:
                 raise TypeError(
                     "TypeMismatch: Cannot convert to python dictionary from Flyte Literal Dictionary as the given "
-                    "dictionary ddoes not have sub-type hints or they do not match with the originating dictionary "
+                    "dictionary does not have sub-type hints or they do not match with the originating dictionary "
                     "source. Flytekit does not currently support implicit conversions"
                 )
             if tp[0] != str:

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -145,6 +145,10 @@ def test_dict_transformer():
     pv = d.to_python_value(ctx, lit, typing.Dict)
     assert pv == {}
 
+    lit_empty = Literal(map=LiteralMap(literals={}))
+    pv_empty = d.to_python_value(ctx, lit_empty, typing.Dict[str, str])
+    assert pv_empty == {}
+
     # Literal to python
     with pytest.raises(TypeError):
         d.to_python_value(ctx, Literal(scalar=Scalar(primitive=Primitive(integer=10))), dict)


### PR DESCRIPTION
# TL;DR
Allow passing an empty dictionary as input. 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Tried to execute the following task:

```
@task
def test_empty(d: Dict[str, str]) -> int:
    return len(d)


@workflow
def my_wf() -> int:
    res = test_empty(d={})
    return res
```

which would fail with:

```
  File "/root/flytekit/core/type_engine.py", line 447, in to_python_value
    raise TypeError(f"Cannot convert from {lv} to {expected_python_type}")
TypeError: Cannot convert from map {
}
 to typing.Dict[str, str]
```

## Tracking Issue
https://github.com/flyteorg/flyte/issues/918

## Follow-up issue
_NA_
