### PR TITLE
Serialize directly to model classes

### DIFF
--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1759,7 +1759,6 @@ def _extract_files(
         # Where 12 indicates it is the 12 file to process in order and 1 that is of resource type 1, or TASK.
         resource_type = int(proto_file[-4])
         id, entity = _extract_pair(proto_file, resource_type, project, domain, version, patches or {})
-        print(f"Extracted {proto_file} to {id} and {entity}")
         results.append((id, entity))
 
     return results

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1759,6 +1759,7 @@ def _extract_files(
         # Where 12 indicates it is the 12 file to process in order and 1 that is of resource type 1, or TASK.
         resource_type = int(proto_file[-4])
         id, entity = _extract_pair(proto_file, resource_type, project, domain, version, patches or {})
+        print(f"Extracted {proto_file} to {id} and {entity}")
         results.append((id, entity))
 
     return results
@@ -1818,6 +1819,7 @@ def _extract_and_register(
 
     flyte_entities_list = _extract_files(project, domain, version, file_paths, patches)
     for id, flyte_entity in flyte_entities_list:
+        _click.secho(f"Registering {id}", fg="green")
         try:
             if id.resource_type == _identifier_pb2.LAUNCH_PLAN:
                 client.raw.create_launch_plan(_launch_plan_pb2.LaunchPlanCreateRequest(id=id, spec=flyte_entity.spec))
@@ -1830,7 +1832,6 @@ def _extract_and_register(
                     f"Only tasks, launch plans, and workflows can be called with this function, "
                     f"resource type {id.resource_type} was passed"
                 )
-            _click.secho(f"Registered {id}", fg="green")
         except _user_exceptions.FlyteEntityAlreadyExistsException:
             _click.secho(f"Skipping because already registered {id}", fg="cyan")
 

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1818,7 +1818,7 @@ def _extract_and_register(
 
     flyte_entities_list = _extract_files(project, domain, version, file_paths, patches)
     for id, flyte_entity in flyte_entities_list:
-        _click.secho(f"Registering {id}", fg="green")
+        _click.secho(f"\b\nRegistering {id}", fg="yellow")
         try:
             if id.resource_type == _identifier_pb2.LAUNCH_PLAN:
                 client.raw.create_launch_plan(_launch_plan_pb2.LaunchPlanCreateRequest(id=id, spec=flyte_entity.spec))

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1818,7 +1818,7 @@ def _extract_and_register(
 
     flyte_entities_list = _extract_files(project, domain, version, file_paths, patches)
     for id, flyte_entity in flyte_entities_list:
-        _click.secho(f"\b\nRegistering {id}", fg="yellow")
+        _click.secho(f"Registering {id}", fg="yellow")
         try:
             if id.resource_type == _identifier_pb2.LAUNCH_PLAN:
                 client.raw.create_launch_plan(_launch_plan_pb2.LaunchPlanCreateRequest(id=id, spec=flyte_entity.spec))

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -224,8 +224,8 @@ def serialize_all(
             elif isinstance(entity, _idl_admin_LaunchPlan):
                 fname = "{}_{}_3.pb".format(fname_index, entity.id.name)
             else:
-                raise Exception("bad format")
-            click.echo(f"  Writing type: {entity.id.resource_type_name()}, {entity.id.name} to\n    {fname}")
+                raise Exception(f"Bad format {type(entity)}")
+            click.echo(f"  Writing to file: {fname}")
             if folder:
                 fname = _os.path.join(folder, fname)
             _write_proto_to_file(entity, fname)

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -14,7 +14,6 @@ from flytekit.clis.sdk_in_container.constants import CTX_PACKAGES
 from flytekit.common import utils as _utils
 from flytekit.common.core import identifier as _identifier
 from flytekit.common.exceptions.scopes import system_entry_point
-from flytekit.common.mixins.registerable import RegisterableEntity
 from flytekit.common.tasks import task as _sdk_task
 from flytekit.common.translator import get_serializable
 from flytekit.common.utils import write_proto_to_file as _write_proto_to_file
@@ -23,6 +22,9 @@ from flytekit.core import context_manager as flyte_context
 from flytekit.core.base_task import PythonTask
 from flytekit.core.launch_plan import LaunchPlan
 from flytekit.core.workflow import WorkflowBase
+from flytekit.models import launch_plan as _launch_plan_models
+from flytekit.models import task as task_models
+from flytekit.models.admin import workflow as admin_workflow_models
 from flytekit.tools.fast_registration import compute_digest as _compute_digest
 from flytekit.tools.fast_registration import filter_tar_file_fn as _filter_tar_file_fn
 from flytekit.tools.module_loader import iterate_registerable_entities_in_order
@@ -87,6 +89,18 @@ def serialize_tasks_only(pkgs, folder=None):
         if folder:
             identifier_fname = _os.path.join(folder, identifier_fname)
         _write_proto_to_file(entity._id.to_flyte_idl(), identifier_fname)
+
+
+def _should_register_with_admin(entity) -> bool:
+    """
+    This is used in the code below. The translator.py module produces lots of objects (namely nodes and BranchNodes)
+    that do not/should not be written to .pb file to send to admin. This function filters them out.
+    """
+    return entity is not None and (
+        isinstance(entity, task_models.TaskSpec)
+        or isinstance(entity, _launch_plan_models.LaunchPlan)
+        or isinstance(entity, admin_workflow_models.WorkflowSpec)
+    )
 
 
 @system_entry_point
@@ -155,6 +169,13 @@ def serialize_all(
             )
             old_style_entities.append(o)
 
+        serialized_old_style_entities = []
+        for entity in old_style_entities:
+            if entity.has_registered:
+                _logging.info(f"Skipping entity {entity.id} because already registered")
+                continue
+            serialized_old_style_entities.append(entity.serialize())
+
         click.echo(f"Found {len(flyte_context.FlyteEntities.entities)} tasks/workflows")
 
         mode = mode if mode else SerializationMode.DEFAULT
@@ -184,30 +205,18 @@ def serialize_all(
                     lp = LaunchPlan.get_default_launch_plan(ctx, entity)
                     get_serializable(new_api_serializable_entities, ctx.serialization_settings, lp)
 
-        # This will pick up all the serializable entities, but we'll need to filter them because the process of
-        # serializing creates a lot of objects that don't need to be directly registered, namely SdkNodes and
-        # BranchNodes and other branching constructs
-        all_entities = list(new_api_serializable_entities.values())
-        registerable_entities = list(filter(lambda x: isinstance(x, RegisterableEntity), all_entities))
-        loaded_entities = old_style_entities + registerable_entities
+        new_api_model_values = list(new_api_serializable_entities.values())
+        new_api_model_values = list(filter(_should_register_with_admin, new_api_model_values))
 
-        # Preserialize registerable entities
-        #   Reference entities should be None
-        #   Non-registered things like branch nodes should be taken out by a filter in loop below
-        # Change get_serializable to get_serialized
-
+        loaded_entities = serialized_old_style_entities + new_api_model_values
         zero_padded_length = _determine_text_chars(len(loaded_entities))
         for i, entity in enumerate(loaded_entities):
-            if entity.has_registered:
-                _logging.info(f"Skipping entity {entity.id} because already registered")
-                continue
-            serialized = entity.serialize()
             fname_index = str(i).zfill(zero_padded_length)
             fname = "{}_{}_{}.pb".format(fname_index, entity.id.name, entity.id.resource_type)
             click.echo(f"  Writing type: {entity.id.resource_type_name()}, {entity.id.name} to\n    {fname}")
             if folder:
                 fname = _os.path.join(folder, fname)
-            _write_proto_to_file(serialized, fname)
+            _write_proto_to_file(entity, fname)
 
         click.secho(f"Successfully serialized {len(loaded_entities)} flyte objects", fg="green")
 

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -8,6 +8,9 @@ from enum import Enum as _Enum
 from typing import List
 
 import click
+from flyteidl.admin.launch_plan_pb2 import LaunchPlan as _idl_admin_LaunchPlan
+from flyteidl.admin.task_pb2 import TaskSpec as _idl_admin_TaskSpec
+from flyteidl.admin.workflow_pb2 import WorkflowSpec as _idl_admin_WorkflowSpec
 
 import flytekit as _flytekit
 from flytekit.clis.sdk_in_container.constants import CTX_PACKAGES
@@ -28,10 +31,6 @@ from flytekit.models.admin import workflow as admin_workflow_models
 from flytekit.tools.fast_registration import compute_digest as _compute_digest
 from flytekit.tools.fast_registration import filter_tar_file_fn as _filter_tar_file_fn
 from flytekit.tools.module_loader import iterate_registerable_entities_in_order
-
-from flyteidl.admin.launch_plan_pb2 import LaunchPlan as _idl_admin_LaunchPlan
-from flyteidl.admin.workflow_pb2 import WorkflowSpec as _idl_admin_WorkflowSpec
-from flyteidl.admin.task_pb2 import TaskSpec as _idl_admin_TaskSpec
 
 # Identifier fields use placeholders for registration-time substitution.
 # Additional fields, such as auth and the raw output data prefix have more complex structures

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -191,6 +191,11 @@ def serialize_all(
         registerable_entities = list(filter(lambda x: isinstance(x, RegisterableEntity), all_entities))
         loaded_entities = old_style_entities + registerable_entities
 
+        # Preserialize registerable entities
+        #   Reference entities should be None
+        #   Non-registered things like branch nodes should be taken out by a filter in loop below
+        # Change get_serializable to get_serialized
+
         zero_padded_length = _determine_text_chars(len(loaded_entities))
         for i, entity in enumerate(loaded_entities):
             if entity.has_registered:

--- a/flytekit/common/translator.py
+++ b/flytekit/common/translator.py
@@ -154,7 +154,7 @@ def get_serializable_workflow(
                     sub_wfs.extend(sub_wf_spec.sub_workflows)
 
     wf_id = _identifier_model.Identifier(
-        resource_type=_identifier_model.ResourceType.TASK,
+        resource_type=_identifier_model.ResourceType.WORKFLOW,
         project=settings.project,
         domain=settings.domain,
         name=entity.name,

--- a/flytekit/common/translator.py
+++ b/flytekit/common/translator.py
@@ -169,7 +169,7 @@ def get_serializable_workflow(
         outputs=entity.output_bindings,
     )
 
-    return admin_workflow_models.WorkflowSpec(template=wf_t, sub_workflows=sub_wfs)
+    return admin_workflow_models.WorkflowSpec(template=wf_t, sub_workflows=list(set(sub_wfs)))
 
 
 def get_serializable_launch_plan(

--- a/flytekit/common/translator.py
+++ b/flytekit/common/translator.py
@@ -230,6 +230,10 @@ def get_serializable_node(
 
     # Reference entities also inherit from the classes in the second if statement so address them first.
     if isinstance(entity.flyte_entity, ReferenceEntity):
+        # This is a throw away call.
+        # See the comment in compile_into_workflow in python_function_task. This is just used to place a None value
+        # in the entity_mapping.
+        get_serializable(entity_mapping, settings, entity.flyte_entity, fast)
         ref = entity.flyte_entity
         node_model = workflow_model.Node(
             id=_dnsify(entity.id),
@@ -349,7 +353,9 @@ def get_serializable(
         return entity_mapping[entity]
 
     if isinstance(entity, ReferenceEntity):
-        # cp_entity = get_serializable_references(entity_mapping, settings, entity, fast)
+        # TODO: Create a non-registerable model class comparable to TaskSpec or WorkflowSpec to replace None as a
+        #  keystone value. The purpose is only to store something so that we can check for it when compiling
+        #  dynamic tasks. See comment in compile_into_workflow.
         cp_entity = None
 
     elif isinstance(entity, PythonTask):

--- a/flytekit/common/translator.py
+++ b/flytekit/common/translator.py
@@ -191,7 +191,7 @@ def get_serializable_launch_plan(
         labels=entity.labels or _common_models.Labels({}),
         annotations=entity.annotations or _common_models.Annotations({}),
         auth_role=entity._auth_role or _common_models.AuthRole(),
-        raw_output_data_config=entity.raw_output_data_config,
+        raw_output_data_config=entity.raw_output_data_config or _common_models.RawOutputDataConfig(""),
     )
     lp_id = _identifier_model.Identifier(
         resource_type=_identifier_model.ResourceType.LAUNCH_PLAN,

--- a/flytekit/common/translator.py
+++ b/flytekit/common/translator.py
@@ -2,12 +2,8 @@ from collections import OrderedDict
 from typing import List, Optional, Union
 
 from flytekit.common import constants as _common_constants
-from flytekit.common.interface import TypedInterface
-from flytekit.common.launch_plan import SdkLaunchPlan
-from flytekit.common.nodes import SdkNode
-from flytekit.common.tasks.task import SdkTask
-from flytekit.common.workflow import SdkWorkflow
-from flytekit.core.base_task import PythonTask, TaskMetadata
+from flytekit.common.utils import _dnsify
+from flytekit.core.base_task import PythonTask
 from flytekit.core.condition import BranchNode
 from flytekit.core.context_manager import SerializationSettings
 from flytekit.core.launch_plan import LaunchPlan, ReferenceLaunchPlan
@@ -15,12 +11,12 @@ from flytekit.core.node import Node
 from flytekit.core.python_auto_container import PythonAutoContainerTask
 from flytekit.core.reference_entity import ReferenceEntity
 from flytekit.core.task import ReferenceTask
-from flytekit.core.workflow import ReferenceWorkflow, WorkflowBase, WorkflowFailurePolicy, WorkflowMetadata
+from flytekit.core.workflow import ReferenceWorkflow, WorkflowBase
 from flytekit.models import common as _common_models
 from flytekit.models import interface as interface_models
 from flytekit.models import launch_plan as _launch_plan_models
-from flytekit.models import literals as literal_models
-from flytekit.models.common import RawOutputDataConfig
+from flytekit.models import task as task_models
+from flytekit.models.admin import workflow as admin_workflow_models
 from flytekit.models.core import identifier as _identifier_model
 from flytekit.models.core import workflow as _core_wf
 from flytekit.models.core import workflow as workflow_model
@@ -37,7 +33,13 @@ FlyteLocalEntity = Union[
     ReferenceLaunchPlan,
     ReferenceEntity,
 ]
-FlyteControlPlaneEntity = Union[SdkTask, SdkLaunchPlan, SdkWorkflow, SdkNode, BranchNodeModel]
+FlyteControlPlaneEntity = Union[
+    task_models.TaskSpec,
+    _launch_plan_models.LaunchPlan,
+    admin_workflow_models.WorkflowSpec,
+    workflow_model.Node,
+    BranchNodeModel,
+]
 
 
 def to_serializable_case(
@@ -60,69 +62,21 @@ def to_serializable_cases(
     return ret_cases
 
 
-def get_serializable_references(
-    entity_mapping: OrderedDict,
-    settings: SerializationSettings,
-    entity: FlyteLocalEntity,
-    fast: bool,
-) -> FlyteControlPlaneEntity:
-    # TODO: This entire function isn't necessary. We should just return None or raise an Exception or something.
-    #   Reference entities should already exist on the Admin control plane - they should not be serialized/registered
-    #   again. Indeed we don't actually have enough information to serialize it properly.
-
-    if isinstance(entity, ReferenceTask):
-        cp_entity = SdkTask(
-            type="ignore",
-            metadata=TaskMetadata().to_taskmetadata_model(),
-            interface=entity.interface,
-            custom={},
-            container=None,
-        )
-
-    elif isinstance(entity, ReferenceWorkflow):
-        workflow_metadata = WorkflowMetadata(on_failure=WorkflowFailurePolicy.FAIL_IMMEDIATELY)
-
-        cp_entity = SdkWorkflow(
-            nodes=[],  # Fake an empty list for nodes,
-            id=entity.reference.id,
-            metadata=workflow_metadata,
-            metadata_defaults=workflow_model.WorkflowMetadataDefaults(),
-            interface=entity.interface,
-            output_bindings=[],
-        )
-
-    elif isinstance(entity, ReferenceLaunchPlan):
-        cp_entity = SdkLaunchPlan(
-            workflow_id=None,
-            entity_metadata=_launch_plan_models.LaunchPlanMetadata(schedule=None, notifications=[]),
-            default_inputs=interface_models.ParameterMap({}),
-            fixed_inputs=literal_models.LiteralMap({}),
-            labels=_common_models.Labels({}),
-            annotations=_common_models.Annotations({}),
-            auth_role=_common_models.AuthRole(assumable_iam_role="fake:role"),
-            raw_output_data_config=RawOutputDataConfig(""),
-        )
-        # Because of how SdkNodes work, it needs one of these interfaces
-        # Hopefully this is more trickery that can be cleaned up in the future
-        cp_entity._interface = TypedInterface.promote_from_model(entity.interface)
-
-    else:
-        raise Exception("Invalid reference type when serializing")
-
-    # Make sure we don't serialize this
-    cp_entity._has_registered = True
-    cp_entity.assign_name(entity.id.name)
-    cp_entity._id = entity.id
-    return cp_entity
-
-
 def get_serializable_task(
     entity_mapping: OrderedDict,
     settings: SerializationSettings,
     entity: FlyteLocalEntity,
     fast: bool,
-) -> FlyteControlPlaneEntity:
-    cp_entity = SdkTask(
+) -> task_models.TaskSpec:
+    task_id = _identifier_model.Identifier(
+        _identifier_model.ResourceType.TASK,
+        settings.project,
+        settings.domain,
+        entity.name,
+        settings.version,
+    )
+    tt = task_models.TaskTemplate(
+        id=task_id,
         type=entity.task_type,
         metadata=entity.metadata.to_taskmetadata_model(),
         interface=entity.interface,
@@ -132,11 +86,6 @@ def get_serializable_task(
         security_context=entity.security_context,
         config=entity.get_config(settings),
     )
-    # Reset just to make sure it's what we give it
-    cp_entity.id._project = settings.project
-    cp_entity.id._domain = settings.domain
-    cp_entity.id._name = entity.name
-    cp_entity.id._version = settings.version
 
     # For fast registration, we'll need to muck with the command, but only for certain kinds of tasks. Specifically,
     # tasks that rely on user code defined in the container. This should be encapsulated by the auto container
@@ -149,12 +98,12 @@ def get_serializable_task(
             "--dest-dir",
             "{{ .dest_dir }}",
             "--",
-        ] + cp_entity.container.args[:]
+        ] + tt.container.args[:]
 
-        del cp_entity._container.args[:]
-        cp_entity._container.args.extend(args)
+        del tt.container.args[:]
+        tt.container.args.extend(args)
 
-    return cp_entity
+    return task_models.TaskSpec(template=tt)
 
 
 def get_serializable_workflow(
@@ -162,43 +111,72 @@ def get_serializable_workflow(
     settings: SerializationSettings,
     entity: WorkflowBase,
     fast: bool,
-) -> FlyteControlPlaneEntity:
-    workflow_id = _identifier_model.Identifier(
-        _identifier_model.ResourceType.WORKFLOW, settings.project, settings.domain, entity.name, settings.version
-    )
-
-    # Translate nodes
-    upstream_sdk_nodes = [
+) -> admin_workflow_models.WorkflowSpec:
+    # Get node models
+    upstream_node_models = [
         get_serializable(entity_mapping, settings, n, fast)
         for n in entity.nodes
         if n.id != _common_constants.GLOBAL_INPUT_NODE_ID
     ]
 
-    cp_entity = SdkWorkflow(
-        nodes=upstream_sdk_nodes,
-        id=workflow_id,
+    sub_wfs = []
+    for n in entity.nodes:
+        if isinstance(n.flyte_entity, WorkflowBase):
+            sub_wf_spec = get_serializable(entity_mapping, settings, n.flyte_entity, fast)
+            if not isinstance(sub_wf_spec, admin_workflow_models.WorkflowSpec):
+                raise Exception(
+                    f"Serialized form of a workflow should be an admin.WorkflowSpec but {type(sub_wf_spec)} found instead"
+                )
+            sub_wfs.append(sub_wf_spec.template)
+            sub_wfs.extend(sub_wf_spec.sub_workflows)
+
+        if isinstance(n.flyte_entity, BranchNode):
+            if_else: workflow_model.IfElseBlock = n.flyte_entity._ifelse_block
+            # See comment in get_serializable_branch_node also. Again this is a List[Node] even though it's supposed
+            # to be a List[workflow_model.Node]
+            leaf_nodes: List[Node] = filter(  # noqa
+                None,
+                [
+                    if_else.case.then_node,
+                    *([] if if_else.other is None else [x.then_node for x in if_else.other]),
+                    if_else.else_node,
+                ],
+            )
+            for leaf_node in leaf_nodes:
+                if isinstance(leaf_node.flyte_entity, WorkflowBase):
+                    sub_wf_spec = get_serializable(entity_mapping, settings, leaf_node.flyte_entity, fast)
+                    sub_wfs.append(sub_wf_spec.template)
+                    sub_wfs.extend(sub_wf_spec.sub_workflows)
+
+    wf_id = _identifier_model.Identifier(
+        resource_type=_identifier_model.ResourceType.TASK,
+        project=settings.project,
+        domain=settings.domain,
+        name=entity.name,
+        version=settings.version,
+    )
+    wf_t = workflow_model.WorkflowTemplate(
+        id=wf_id,
         metadata=entity.workflow_metadata.to_flyte_model(),
         metadata_defaults=entity.workflow_metadata_defaults.to_flyte_model(),
         interface=entity.interface,
-        output_bindings=entity.output_bindings,
+        nodes=upstream_node_models,
+        outputs=entity.output_bindings,
     )
-    # Reset just to make sure it's what we give it
-    cp_entity.id._project = settings.project
-    cp_entity.id._domain = settings.domain
-    cp_entity.id._name = entity.name
-    cp_entity.id._version = settings.version
-    return cp_entity
+
+    return admin_workflow_models.WorkflowSpec(template=wf_t, sub_workflows=sub_wfs)
 
 
 def get_serializable_launch_plan(
     entity_mapping: OrderedDict,
     settings: SerializationSettings,
-    entity: FlyteLocalEntity,
+    entity: LaunchPlan,
     fast: bool,
-) -> FlyteControlPlaneEntity:
-    sdk_workflow = get_serializable(entity_mapping, settings, entity.workflow)
-    cp_entity = SdkLaunchPlan(
-        workflow_id=sdk_workflow.id,
+) -> _launch_plan_models.LaunchPlan:
+    wf_spec = get_serializable(entity_mapping, settings, entity.workflow)
+
+    lps = _launch_plan_models.LaunchPlanSpec(
+        workflow_id=wf_spec.template.id,
         entity_metadata=_launch_plan_models.LaunchPlanMetadata(
             schedule=entity.schedule,
             notifications=entity.notifications,
@@ -210,78 +188,99 @@ def get_serializable_launch_plan(
         auth_role=entity._auth_role,
         raw_output_data_config=entity.raw_output_data_config,
     )
-
-    # These two things are normally set to None in the SdkLaunchPlan constructor and filled in by
-    # SdkRunnableLaunchPlan/the registration process, so we need to set them manually. The reason is because these
-    # fields are not part of the underlying LaunchPlanSpec
-    cp_entity._interface = sdk_workflow.interface
-    cp_entity._id = _identifier_model.Identifier(
+    lp_id = _identifier_model.Identifier(
         resource_type=_identifier_model.ResourceType.LAUNCH_PLAN,
         project=settings.project,
         domain=settings.domain,
         name=entity.name,
         version=settings.version,
     )
-    return cp_entity
+    lp_model = _launch_plan_models.LaunchPlan(
+        id=lp_id,
+        spec=lps,
+        closure=_launch_plan_models.LaunchPlanClosure(
+            state=None,
+            expected_inputs=interface_models.ParameterMap({}),
+            expected_outputs=interface_models.VariableMap({}),
+        ),
+    )
+
+    return lp_model
 
 
 def get_serializable_node(
     entity_mapping: OrderedDict,
     settings: SerializationSettings,
-    entity: FlyteLocalEntity,
+    entity: Node,
     fast: bool,
-) -> FlyteControlPlaneEntity:
-    if entity._flyte_entity is None:
+) -> workflow_model.Node:
+    if entity.flyte_entity is None:
         raise Exception(f"Node {entity.id} has no flyte entity")
 
     upstream_sdk_nodes = [
         get_serializable(entity_mapping, settings, n)
-        for n in entity._upstream_nodes
+        for n in entity.upstream_nodes
         if n.id != _common_constants.GLOBAL_INPUT_NODE_ID
     ]
 
-    if isinstance(entity._flyte_entity, PythonTask):
-        cp_entity = SdkNode(
-            entity._id,
-            upstream_nodes=upstream_sdk_nodes,
-            bindings=entity._bindings,
-            metadata=entity._metadata,
-            sdk_task=get_serializable(entity_mapping, settings, entity._flyte_entity, fast),
-            parameter_mapping=False,
+    if isinstance(entity.flyte_entity, PythonTask):
+        task_spec = get_serializable(entity_mapping, settings, entity.flyte_entity, fast)
+        node_model = workflow_model.Node(
+            id=_dnsify(entity.id),
+            metadata=entity.metadata,
+            inputs=entity.bindings,
+            upstream_node_ids=[n.id for n in upstream_sdk_nodes],
+            output_aliases=[],
+            task_node=workflow_model.TaskNode(reference_id=task_spec.template.id),
         )
         if entity._aliases:
-            cp_entity._output_aliases = entity._aliases
-    elif isinstance(entity._flyte_entity, WorkflowBase):
-        cp_entity = SdkNode(
-            entity._id,
-            upstream_nodes=upstream_sdk_nodes,
-            bindings=entity._bindings,
-            metadata=entity._metadata,
-            sdk_workflow=get_serializable(entity_mapping, settings, entity._flyte_entity),
-            parameter_mapping=False,
+            node_model._output_aliases = entity._aliases
+
+    elif isinstance(entity.flyte_entity, WorkflowBase):
+        wf_spec = get_serializable(entity_mapping, settings, entity.flyte_entity, fast)
+        node_model = workflow_model.Node(
+            id=_dnsify(entity.id),
+            metadata=entity.metadata,
+            inputs=entity.bindings,
+            upstream_node_ids=[n.id for n in upstream_sdk_nodes],
+            output_aliases=[],
+            workflow_node=workflow_model.WorkflowNode(sub_workflow_ref=wf_spec.template.id),
         )
-    elif isinstance(entity._flyte_entity, BranchNode):
-        cp_entity = SdkNode(
-            entity._id,
-            upstream_nodes=upstream_sdk_nodes,
-            bindings=entity._bindings,
-            metadata=entity._metadata,
-            sdk_branch=get_serializable(entity_mapping, settings, entity._flyte_entity),
-            parameter_mapping=False,
+
+    elif isinstance(entity.flyte_entity, BranchNode):
+        node_model = workflow_model.Node(
+            id=_dnsify(entity.id),
+            metadata=entity.metadata,
+            inputs=entity.bindings,
+            upstream_node_ids=[n.id for n in upstream_sdk_nodes],
+            output_aliases=[],
+            branch_node=get_serializable(entity_mapping, settings, entity.flyte_entity),
         )
-    elif isinstance(entity._flyte_entity, LaunchPlan):
-        cp_entity = SdkNode(
-            entity._id,
-            upstream_nodes=upstream_sdk_nodes,
-            bindings=entity._bindings,
-            metadata=entity._metadata,
-            sdk_launch_plan=get_serializable(entity_mapping, settings, entity._flyte_entity),
-            parameter_mapping=False,
+
+        # cp_entity = SdkNode(
+        #     entity._id,
+        #     upstream_nodes=upstream_sdk_nodes,
+        #     bindings=entity._bindings,
+        #     metadata=entity._metadata,
+        #     sdk_branch=get_serializable(entity_mapping, settings, entity.flyte_entity),
+        #     parameter_mapping=False,
+        # )
+
+    elif isinstance(entity.flyte_entity, LaunchPlan):
+        lp_spec = get_serializable(entity_mapping, settings, entity.flyte_entity, fast)
+
+        node_model = workflow_model.Node(
+            id=_dnsify(entity.id),
+            metadata=entity.metadata,
+            inputs=entity.bindings,
+            upstream_node_ids=[n.id for n in upstream_sdk_nodes],
+            output_aliases=[],
+            workflow_node=workflow_model.WorkflowNode(launchplan_ref=lp_spec.id),
         )
     else:
         raise Exception(f"Node contained non-serializable entity {entity._flyte_entity}")
 
-    return cp_entity
+    return node_model
 
 
 def get_serializable_branch_node(
@@ -289,17 +288,21 @@ def get_serializable_branch_node(
     settings: SerializationSettings,
     entity: FlyteLocalEntity,
     fast: bool,
-) -> FlyteControlPlaneEntity:
-    # We have to iterate through the blocks to convert the nodes from their current type to SDKNode
+) -> BranchNodeModel:
+    # We have to iterate through the blocks to convert the nodes from the internal Node type to the Node model type.
+    # This was done to avoid having to create our own IfElseBlock object (i.e. condition.py just uses the model
+    # directly) even though the node there is of the wrong type (our type instead of the model type).
     # TODO this should be cleaned up instead of mutation, we probaby should just create a new object
     first = to_serializable_case(entity_mapping, settings, entity._ifelse_block.case)
     other = to_serializable_cases(entity_mapping, settings, entity._ifelse_block.other)
-    else_node = None
+    else_node_model = None
     if entity._ifelse_block.else_node:
-        else_node = get_serializable(entity_mapping, settings, entity._ifelse_block.else_node)
+        else_node_model = get_serializable(entity_mapping, settings, entity._ifelse_block.else_node)
 
     return BranchNodeModel(
-        if_else=_core_wf.IfElseBlock(case=first, other=other, else_node=else_node, error=entity._ifelse_block.error)
+        if_else=_core_wf.IfElseBlock(
+            case=first, other=other, else_node=else_node_model, error=entity._ifelse_block.error
+        )
     )
 
 
@@ -330,7 +333,8 @@ def get_serializable(
         return entity_mapping[entity]
 
     if isinstance(entity, ReferenceEntity):
-        cp_entity = get_serializable_references(entity_mapping, settings, entity, fast)
+        # cp_entity = get_serializable_references(entity_mapping, settings, entity, fast)
+        cp_entity = None
 
     elif isinstance(entity, PythonTask):
         cp_entity = get_serializable_task(entity_mapping, settings, entity, fast)

--- a/flytekit/common/translator.py
+++ b/flytekit/common/translator.py
@@ -190,7 +190,7 @@ def get_serializable_launch_plan(
         fixed_inputs=entity.fixed_inputs,
         labels=entity.labels or _common_models.Labels({}),
         annotations=entity.annotations or _common_models.Annotations({}),
-        auth_role=entity._auth_role,
+        auth_role=entity._auth_role or _common_models.AuthRole(),
         raw_output_data_config=entity.raw_output_data_config,
     )
     lp_id = _identifier_model.Identifier(

--- a/flytekit/core/condition.py
+++ b/flytekit/core/condition.py
@@ -25,7 +25,6 @@ from flytekit.models.types import Error
 class BranchNode(object):
     def __init__(self, name: str, ifelse_block: _core_wf.IfElseBlock):
         self._name = name
-        self._registerable_entity = None
         self._ifelse_block = ifelse_block
 
     @property

--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -67,6 +67,10 @@ class Node(object):
     def flyte_entity(self) -> Any:
         return self._flyte_entity
 
+    @property
+    def metadata(self) -> _workflow_model.NodeMetadata:
+        return self._metadata
+
     def with_overrides(self, *args, **kwargs):
         if "node_name" in kwargs:
             self._id = kwargs["node_name"]

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -216,25 +216,6 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):
 
             return dj_spec
 
-    # @staticmethod
-    # def aggregate(tasks, workflows, node) -> None:
-    #     if node.task_node is not None:
-    #         tasks.add(node.task_node.sdk_task)
-    #     if node.workflow_node is not None:
-    #         if node.workflow_node.sdk_workflow is not None:
-    #             workflows.add(node.workflow_node.sdk_workflow)
-    #             for sub_node in node.workflow_node.sdk_workflow.nodes:
-    #                 PythonFunctionTask.aggregate(tasks, workflows, sub_node)
-    #     if node.branch_node is not None:
-    #         if node.branch_node.if_else.case.then_node is not None:
-    #             PythonFunctionTask.aggregate(tasks, workflows, node.branch_node.if_else.case.then_node)
-    #         if node.branch_node.if_else.other:
-    #             for oth in node.branch_node.if_else.other:
-    #                 if oth.then_node:
-    #                     PythonFunctionTask.aggregate(tasks, workflows, oth.then_node)
-    #         if node.branch_node.if_else.else_node is not None:
-    #             PythonFunctionTask.aggregate(tasks, workflows, node.branch_node.if_else.else_node)
-
     def dynamic_execute(self, task_function: Callable, **kwargs) -> Any:
         """
         By the time this function is invoked, the _local_execute function should have unwrapped the Promises and Flyte

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -18,6 +18,8 @@ from flytekit.core.workflow import (
 from flytekit.loggers import logger
 from flytekit.models import dynamic_job as _dynamic_job
 from flytekit.models import literals as _literal_models
+from flytekit.models import task as task_models
+from flytekit.models.admin import workflow as admin_workflow_models
 
 T = TypeVar("T")
 
@@ -150,19 +152,29 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):
             self._wf.compile(**kwargs)
 
             wf = self._wf
-            sdk_workflow = get_serializable(OrderedDict(), ctx.serialization_settings, wf, is_fast_execution)
+            model_entities = OrderedDict()
+            workflow_spec: admin_workflow_models.WorkflowSpec = get_serializable(
+                model_entities, ctx.serialization_settings, wf, is_fast_execution
+            )
 
             # If no nodes were produced, let's just return the strict outputs
-            if len(sdk_workflow.nodes) == 0:
+            if len(workflow_spec.template.nodes) == 0:
                 return _literal_models.LiteralMap(
-                    literals={binding.var: binding.binding.to_literal_model() for binding in sdk_workflow._outputs}
+                    literals={
+                        binding.var: binding.binding.to_literal_model() for binding in workflow_spec.template.outputs
+                    }
                 )
 
-            # Gather underlying tasks/workflows that get referenced. Launch plans are handled by propeller.
-            tasks = set()
-            sub_workflows = set()
-            for n in sdk_workflow.nodes:
-                self.aggregate(tasks, sub_workflows, n)
+            # Gather underlying TaskTemplates that get referenced. Launch plans are handled by propeller. Subworkflows
+            # should already be in the workflow spec.
+            # import ipdb; ipdb.set_trace()
+            tts = [v.template for v in model_entities.values() if isinstance(v, task_models.TaskSpec)]
+            for tt in tts:
+                if tt is None:
+                    raise Exception(
+                        "Reference tasks are not allowed in the dynamic - a network call is necessary "
+                        "in order to retrieve the structure of the reference task."
+                    )
 
             if is_fast_execution:
                 if (
@@ -175,50 +187,46 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):
                         "distribution could be retrieved"
                     )
                 logger.warn(f"ctx.execution_state.additional_context {ctx.execution_state.additional_context}")
-                sanitized_tasks = set()
-                for task in tasks:
+                for task_template in tts:
                     sanitized_args = []
-                    for arg in task.container.args:
+                    for arg in task_template.container.args:
                         if arg == "{{ .remote_package_path }}":
                             sanitized_args.append(ctx.execution_state.additional_context.get("dynamic_addl_distro"))
                         elif arg == "{{ .dest_dir }}":
                             sanitized_args.append(ctx.execution_state.additional_context.get("dynamic_dest_dir", "."))
                         else:
                             sanitized_args.append(arg)
-                    del task.container.args[:]
-                    task.container.args.extend(sanitized_args)
-                    sanitized_tasks.add(task)
-
-                tasks = sanitized_tasks
+                    del task_template.container.args[:]
+                    task_template.container.args.extend(sanitized_args)
 
             dj_spec = _dynamic_job.DynamicJobSpec(
-                min_successes=len(sdk_workflow.nodes),
-                tasks=list(tasks),
-                nodes=sdk_workflow.nodes,
-                outputs=sdk_workflow._outputs,
-                subworkflows=list(sub_workflows),
+                min_successes=len(workflow_spec.template.nodes),
+                tasks=tts,
+                nodes=workflow_spec.template.nodes,
+                outputs=workflow_spec.template.outputs,
+                subworkflows=workflow_spec.sub_workflows,
             )
 
             return dj_spec
 
-    @staticmethod
-    def aggregate(tasks, workflows, node) -> None:
-        if node.task_node is not None:
-            tasks.add(node.task_node.sdk_task)
-        if node.workflow_node is not None:
-            if node.workflow_node.sdk_workflow is not None:
-                workflows.add(node.workflow_node.sdk_workflow)
-                for sub_node in node.workflow_node.sdk_workflow.nodes:
-                    PythonFunctionTask.aggregate(tasks, workflows, sub_node)
-        if node.branch_node is not None:
-            if node.branch_node.if_else.case.then_node is not None:
-                PythonFunctionTask.aggregate(tasks, workflows, node.branch_node.if_else.case.then_node)
-            if node.branch_node.if_else.other:
-                for oth in node.branch_node.if_else.other:
-                    if oth.then_node:
-                        PythonFunctionTask.aggregate(tasks, workflows, oth.then_node)
-            if node.branch_node.if_else.else_node is not None:
-                PythonFunctionTask.aggregate(tasks, workflows, node.branch_node.if_else.else_node)
+    # @staticmethod
+    # def aggregate(tasks, workflows, node) -> None:
+    #     if node.task_node is not None:
+    #         tasks.add(node.task_node.sdk_task)
+    #     if node.workflow_node is not None:
+    #         if node.workflow_node.sdk_workflow is not None:
+    #             workflows.add(node.workflow_node.sdk_workflow)
+    #             for sub_node in node.workflow_node.sdk_workflow.nodes:
+    #                 PythonFunctionTask.aggregate(tasks, workflows, sub_node)
+    #     if node.branch_node is not None:
+    #         if node.branch_node.if_else.case.then_node is not None:
+    #             PythonFunctionTask.aggregate(tasks, workflows, node.branch_node.if_else.case.then_node)
+    #         if node.branch_node.if_else.other:
+    #             for oth in node.branch_node.if_else.other:
+    #                 if oth.then_node:
+    #                     PythonFunctionTask.aggregate(tasks, workflows, oth.then_node)
+    #         if node.branch_node.if_else.else_node is not None:
+    #             PythonFunctionTask.aggregate(tasks, workflows, node.branch_node.if_else.else_node)
 
     def dynamic_execute(self, task_function: Callable, **kwargs) -> Any:
         """

--- a/plugins/tests/hive/test_hive_task.py
+++ b/plugins/tests/hive/test_hive_task.py
@@ -38,17 +38,17 @@ def test_serialization():
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
         env={},
     )
-    sdk_task = get_serializable(OrderedDict(), serialization_settings, hive_task)
-    assert "{{ .rawOutputDataPrefix" in sdk_task.custom["query"]["query"]
-    assert "insert overwrite directory" in sdk_task.custom["query"]["query"]
-    assert len(sdk_task.interface.inputs) == 2
-    assert len(sdk_task.interface.outputs) == 1
+    task_spec = get_serializable(OrderedDict(), serialization_settings, hive_task)
+    assert "{{ .rawOutputDataPrefix" in task_spec.template.custom["query"]["query"]
+    assert "insert overwrite directory" in task_spec.template.custom["query"]["query"]
+    assert len(task_spec.template.interface.inputs) == 2
+    assert len(task_spec.template.interface.outputs) == 1
 
-    sdk_wf = get_serializable(OrderedDict(), serialization_settings, my_wf)
-    assert sdk_wf.interface.outputs["o0"].type.schema is not None
-    assert sdk_wf.outputs[0].var == "o0"
-    assert sdk_wf.outputs[0].binding.promise.node_id == "n0"
-    assert sdk_wf.outputs[0].binding.promise.var == "results"
+    admin_workflow_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    assert admin_workflow_spec.template.interface.outputs["o0"].type.schema is not None
+    assert admin_workflow_spec.template.outputs[0].var == "o0"
+    assert admin_workflow_spec.template.outputs[0].binding.promise.node_id == "n0"
+    assert admin_workflow_spec.template.outputs[0].binding.promise.var == "results"
 
 
 def test_local_exec():
@@ -110,9 +110,9 @@ def test_query_no_inputs_or_outputs():
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
         env={},
     )
-    sdk_task = get_serializable(OrderedDict(), serialization_settings, hive_task)
-    assert len(sdk_task.interface.inputs) == 0
-    assert len(sdk_task.interface.outputs) == 0
+    task_spec = get_serializable(OrderedDict(), serialization_settings, hive_task)
+    assert len(task_spec.template.interface.inputs) == 0
+    assert len(task_spec.template.interface.outputs) == 0
 
     get_serializable(OrderedDict(), serialization_settings, my_wf)
 

--- a/plugins/tests/pod/test_pod.py
+++ b/plugins/tests/pod/test_pod.py
@@ -267,5 +267,5 @@ def test_pod_task_serialized():
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
     serialized = get_serializable(OrderedDict(), ssettings, simple_pod_task)
-    assert serialized.task_type_version == 1
-    assert serialized.config["primary_container_name"] == "an undefined container"
+    assert serialized.template.task_type_version == 1
+    assert serialized.template.config["primary_container_name"] == "an undefined container"

--- a/plugins/tests/sqlalchemy/test_sql_tracker.py
+++ b/plugins/tests/sqlalchemy/test_sql_tracker.py
@@ -20,7 +20,7 @@ def test_sql_command():
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
     srz_t = get_serializable(OrderedDict(), serialization_settings, not_tk)
-    assert srz_t.container.args[-7:] == [
+    assert srz_t.template.container.args[-7:] == [
         "--resolver",
         "flytekit.core.python_auto_container.default_task_resolver",
         "--",

--- a/tests/flytekit/unit/common_tests/test_translator.py
+++ b/tests/flytekit/unit/common_tests/test_translator.py
@@ -22,16 +22,16 @@ serialization_settings = context_manager.SerializationSettings(
 
 def test_references():
     rlp = ReferenceLaunchPlan("media", "stg", "some.name", "cafe", inputs=kwtypes(in1=str), outputs=kwtypes())
-    sdk_lp = get_serializable(OrderedDict(), serialization_settings, rlp)
-    assert sdk_lp.has_registered
+    lp_model = get_serializable(OrderedDict(), serialization_settings, rlp)
+    assert lp_model is None
 
     rt = ReferenceTask("media", "stg", "some.name", "cafe", inputs=kwtypes(in1=str), outputs=kwtypes())
-    sdk_task = get_serializable(OrderedDict(), serialization_settings, rt)
-    assert sdk_task.has_registered
+    task_spec = get_serializable(OrderedDict(), serialization_settings, rt)
+    assert task_spec is None
 
     rw = ReferenceWorkflow("media", "stg", "some.name", "cafe", inputs=kwtypes(in1=str), outputs=kwtypes())
-    sdk_wf = get_serializable(OrderedDict(), serialization_settings, rw)
-    assert sdk_wf.has_registered
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, rw)
+    assert wf_spec is None
 
 
 def test_basics():
@@ -49,21 +49,21 @@ def test_basics():
         d = t2(a=y, b=b)
         return x, d
 
-    sdk_wf = get_serializable(OrderedDict(), serialization_settings, my_wf, False)
-    assert len(sdk_wf.interface.inputs) == 2
-    assert len(sdk_wf.interface.outputs) == 2
-    assert len(sdk_wf.nodes) == 2
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf, False)
+    assert len(wf_spec.template.interface.inputs) == 2
+    assert len(wf_spec.template.interface.outputs) == 2
+    assert len(wf_spec.template.nodes) == 2
 
     # Gets cached the first time around so it's not actually fast.
-    sdk_task = get_serializable(OrderedDict(), serialization_settings, t1, True)
-    assert "pyflyte-execute" in sdk_task.container.args
+    task_spec = get_serializable(OrderedDict(), serialization_settings, t1, True)
+    assert "pyflyte-execute" in task_spec.template.container.args
 
     lp = LaunchPlan.create(
         "testlp",
         my_wf,
     )
-    sdk_lp = get_serializable(OrderedDict(), serialization_settings, lp)
-    assert sdk_lp.id.name == "testlp"
+    lp_model = get_serializable(OrderedDict(), serialization_settings, lp)
+    assert lp_model.id.name == "testlp"
 
 
 def test_fast():
@@ -75,8 +75,8 @@ def test_fast():
     def t2(a: str, b: str) -> str:
         return b + a
 
-    sdk_task = get_serializable(OrderedDict(), serialization_settings, t1, True)
-    assert "pyflyte-fast-execute" in sdk_task.container.args
+    task_spec = get_serializable(OrderedDict(), serialization_settings, t1, True)
+    assert "pyflyte-fast-execute" in task_spec.template.container.args
 
 
 def test_container():
@@ -95,5 +95,5 @@ def test_container():
         requests=Resources(mem="400Mi", cpu="1"),
     )
 
-    sdk_task = get_serializable(OrderedDict(), serialization_settings, t2, fast=True)
-    assert "pyflyte" not in sdk_task.container.args
+    task_spec = get_serializable(OrderedDict(), serialization_settings, t2, fast=True)
+    assert "pyflyte" not in task_spec.template.container.args

--- a/tests/flytekit/unit/common_tests/test_translator.py
+++ b/tests/flytekit/unit/common_tests/test_translator.py
@@ -9,6 +9,7 @@ from flytekit.core.context_manager import Image, ImageConfig
 from flytekit.core.launch_plan import LaunchPlan, ReferenceLaunchPlan
 from flytekit.core.task import ReferenceTask, task
 from flytekit.core.workflow import ReferenceWorkflow, workflow
+from flytekit.models.core import identifier as identifier_models
 
 default_img = Image(name="default", fqn="test", tag="tag")
 serialization_settings = context_manager.SerializationSettings(
@@ -53,6 +54,7 @@ def test_basics():
     assert len(wf_spec.template.interface.inputs) == 2
     assert len(wf_spec.template.interface.outputs) == 2
     assert len(wf_spec.template.nodes) == 2
+    assert wf_spec.template.id.resource_type == identifier_models.ResourceType.WORKFLOW
 
     # Gets cached the first time around so it's not actually fast.
     task_spec = get_serializable(OrderedDict(), serialization_settings, t1, True)

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -117,9 +117,12 @@ def test_condition_tuple_branches():
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
 
-    sdk_wf = get_serializable(OrderedDict(), serialization_settings, math_ops)
-    assert len(sdk_wf.nodes) == 1
-    assert sdk_wf.nodes[0].branch_node.if_else.case.then_node.task_node.reference_id.name == "test_conditions.sum_sub"
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, math_ops)
+    assert len(wf_spec.template.nodes) == 1
+    assert (
+        wf_spec.template.nodes[0].branch_node.if_else.case.then_node.task_node.reference_id.name
+        == "test_conditions.sum_sub"
+    )
 
 
 def test_condition_unary_bool():

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -236,7 +236,9 @@ def test_subworkflow_condition_serialization():
         wf_spec = get_serializable(OrderedDict(), serialization_settings, wf)
         subworkflows = wf_spec.sub_workflows
 
-        assert [sub_wf.id.name for sub_wf in subworkflows] == expected_subworkflows
+        for sub_wf in subworkflows:
+            assert sub_wf.id.name in expected_subworkflows
+        assert len(subworkflows) == len(expected_subworkflows)
 
 
 def test_subworkflow_condition():

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -8,7 +8,6 @@ from flytekit.common.translator import get_serializable
 from flytekit.core import context_manager
 from flytekit.core.condition import conditional
 from flytekit.core.context_manager import Image, ImageConfig, SerializationSettings
-from flytekit.models.admin import workflow as admin_workflow_models
 
 
 @task

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -8,6 +8,7 @@ from flytekit.common.translator import get_serializable
 from flytekit.core import context_manager
 from flytekit.core.condition import conditional
 from flytekit.core.context_manager import Image, ImageConfig, SerializationSettings
+from flytekit.models.admin import workflow as admin_workflow_models
 
 
 @task
@@ -195,7 +196,7 @@ def test_subworkflow_condition_serialization():
 
     @workflow
     def if_elif_else_branching(x: int) -> int:
-        return (
+        return (  # noqa
             conditional("test")
             .if_(x == 2)
             .then(wf1())
@@ -230,8 +231,8 @@ def test_subworkflow_condition_serialization():
         (if_elif_else_branching, ["test_conditions.{}".format(x) for x in ("wf1", "wf2", "wf3", "wf4")]),
         (nested_branching, ["test_conditions.{}".format(x) for x in ("ifelse_branching", "wf1", "wf2", "wf5")]),
     ]:
-        serializable_wf = get_serializable(OrderedDict(), serialization_settings, wf)
-        subworkflows = serializable_wf.get_sub_workflows()
+        wf_spec = get_serializable(OrderedDict(), serialization_settings, wf)
+        subworkflows = wf_spec.sub_workflows
 
         assert [sub_wf.id.name for sub_wf in subworkflows] == expected_subworkflows
 

--- a/tests/flytekit/unit/core/test_dynamic_conditional.py
+++ b/tests/flytekit/unit/core/test_dynamic_conditional.py
@@ -96,3 +96,4 @@ def test_dynamic_conditional():
                 ctx, False, merge_sort_remotely._task_function, in1=[2, 3, 4, 5]
             )
             assert len(dynamic_job_spec.tasks) == 5
+            assert len(dynamic_job_spec.subworkflows) == 1

--- a/tests/flytekit/unit/core/test_imperative.py
+++ b/tests/flytekit/unit/core/test_imperative.py
@@ -39,18 +39,18 @@ def test_imperative():
 
     assert wb(in1="hello") == "hello world"
 
-    srz_wf = get_serializable(OrderedDict(), serialization_settings, wb)
-    assert len(srz_wf.nodes) == 2
-    assert srz_wf.nodes[0].task_node is not None
-    assert len(srz_wf.outputs) == 1
-    assert srz_wf.outputs[0].var == "from_n0t1"
-    assert len(srz_wf.interface.inputs) == 1
-    assert len(srz_wf.interface.outputs) == 1
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, wb)
+    assert len(wf_spec.template.nodes) == 2
+    assert wf_spec.template.nodes[0].task_node is not None
+    assert len(wf_spec.template.outputs) == 1
+    assert wf_spec.template.outputs[0].var == "from_n0t1"
+    assert len(wf_spec.template.interface.inputs) == 1
+    assert len(wf_spec.template.interface.outputs) == 1
 
     # Create launch plan from wf, that can also be serialized.
     lp = LaunchPlan.create("test_wb", wb)
-    srz_lp = get_serializable(OrderedDict(), serialization_settings, lp)
-    assert srz_lp.workflow_id.name == "my.workflow"
+    lp_model = get_serializable(OrderedDict(), serialization_settings, lp)
+    assert lp_model.spec.workflow_id.name == "my.workflow"
 
 
 def test_imperative_list_bound():
@@ -116,9 +116,9 @@ def test_imperative_wf_list_input():
 
     assert wb(in1=[5, 6, 7]) == 24
 
-    srz_wf = get_serializable(OrderedDict(), serialization_settings, wb)
-    assert len(srz_wf.nodes) == 2
-    assert srz_wf.nodes[0].task_node is not None
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, wb)
+    assert len(wf_spec.template.nodes) == 2
+    assert wf_spec.template.nodes[0].task_node is not None
 
 
 def test_imperative_scalar_bindings():
@@ -132,9 +132,9 @@ def test_imperative_scalar_bindings():
 
     assert wb() == {"a": 7, "b": 11}
 
-    srz_wf = get_serializable(OrderedDict(), serialization_settings, wb)
-    assert len(srz_wf.nodes) == 1
-    assert srz_wf.nodes[0].task_node is not None
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, wb)
+    assert len(wf_spec.template.nodes) == 1
+    assert wf_spec.template.nodes[0].task_node is not None
 
 
 def test_imperative_list_bound_output():

--- a/tests/flytekit/unit/core/test_map_task.py
+++ b/tests/flytekit/unit/core/test_map_task.py
@@ -39,11 +39,11 @@ def test_serialization():
         env=None,
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
-    serialized = get_serializable(OrderedDict(), serialization_settings, maptask)
+    task_spec = get_serializable(OrderedDict(), serialization_settings, maptask)
 
-    assert serialized.type == "container_array"
-    assert serialized.task_type_version == 1
-    assert serialized.container.args == [
+    assert task_spec.template.type == "container_array"
+    assert task_spec.template.task_type_version == 1
+    assert task_spec.template.container.args == [
         "pyflyte-map-execute",
         "--inputs",
         "{{.input}}",
@@ -86,13 +86,13 @@ def test_serialization_workflow_def():
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
     serialized_control_plane_entities = OrderedDict()
-    wf1_serialized = get_serializable(serialized_control_plane_entities, serialization_settings, w1)
-    assert wf1_serialized is not None
-    assert len(wf1_serialized.nodes) == 1
+    wf1_spec = get_serializable(serialized_control_plane_entities, serialization_settings, w1)
+    assert wf1_spec.template is not None
+    assert len(wf1_spec.template.nodes) == 1
 
-    wf2_serialized = get_serializable(serialized_control_plane_entities, serialization_settings, w2)
-    assert wf2_serialized is not None
-    assert len(wf2_serialized.nodes) == 1
+    wf2_spec = get_serializable(serialized_control_plane_entities, serialization_settings, w2)
+    assert wf2_spec.template is not None
+    assert len(wf2_spec.template.nodes) == 1
 
     flyte_entities = list(serialized_control_plane_entities.keys())
 

--- a/tests/flytekit/unit/core/test_node_creation.py
+++ b/tests/flytekit/unit/core/test_node_creation.py
@@ -42,9 +42,9 @@ def test_normal_task():
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
         env={},
     )
-    sdk_wf = get_serializable(OrderedDict(), serialization_settings, my_wf)
-    assert len(sdk_wf.nodes) == 2
-    assert len(sdk_wf.outputs) == 2
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    assert len(wf_spec.template.nodes) == 2
+    assert len(wf_spec.template.outputs) == 2
 
     @task
     def t2():
@@ -76,13 +76,13 @@ def test_normal_task():
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
         env={},
     )
-    sdk_wf = get_serializable(OrderedDict(), serialization_settings, empty_wf)
-    assert sdk_wf.nodes[0].upstream_node_ids[0] == "n1"
-    assert sdk_wf.nodes[0].id == "n0"
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, empty_wf)
+    assert wf_spec.template.nodes[0].upstream_node_ids[0] == "n1"
+    assert wf_spec.template.nodes[0].id == "n0"
 
-    sdk_wf = get_serializable(OrderedDict(), serialization_settings, empty_wf2)
-    assert sdk_wf.nodes[0].upstream_node_ids[0] == "n1"
-    assert sdk_wf.nodes[0].id == "n0"
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, empty_wf2)
+    assert wf_spec.template.nodes[0].upstream_node_ids[0] == "n1"
+    assert wf_spec.template.nodes[0].id == "n0"
 
     with pytest.raises(FlyteAssertion):
 

--- a/tests/flytekit/unit/core/test_resolver.py
+++ b/tests/flytekit/unit/core/test_resolver.py
@@ -53,16 +53,16 @@ def test_wf_resolving():
 
     # The tasks should get the location the workflow was assigned to as the resolver.
     # The args are the index.
-    srz_t0 = get_serializable(OrderedDict(), serialization_settings, workflows_tasks[0])
-    assert srz_t0.container.args[-4:] == [
+    srz_t0_spec = get_serializable(OrderedDict(), serialization_settings, workflows_tasks[0])
+    assert srz_t0_spec.template.container.args[-4:] == [
         "--resolver",
         "example.module.example_var_name",
         "--",
         "0",
     ]
 
-    srz_t1 = get_serializable(OrderedDict(), serialization_settings, workflows_tasks[1])
-    assert srz_t1.container.args[-4:] == [
+    srz_t1_spec = get_serializable(OrderedDict(), serialization_settings, workflows_tasks[1])
+    assert srz_t1_spec.template.container.args[-4:] == [
         "--resolver",
         "example.module.example_var_name",
         "--",

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -55,13 +55,14 @@ def test_serialization():
         env=None,
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
-    wf = get_serializable(OrderedDict(), serialization_settings, raw_container_wf)
-    assert wf is not None
-    assert len(wf.nodes) == 3
-    sqn = get_serializable(OrderedDict(), serialization_settings, square)
-    assert sqn.container.image == "alpine"
-    sumn = get_serializable(OrderedDict(), serialization_settings, sum)
-    assert sumn.container.image == "alpine"
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, raw_container_wf)
+    assert wf_spec is not None
+    assert wf_spec.template is not None
+    assert len(wf_spec.template.nodes) == 3
+    sqn_spec = get_serializable(OrderedDict(), serialization_settings, square)
+    assert sqn_spec.template.container.image == "alpine"
+    sumn_spec = get_serializable(OrderedDict(), serialization_settings, sum)
+    assert sumn_spec.template.container.image == "alpine"
 
 
 def test_serialization_branch_complex():
@@ -88,19 +89,11 @@ def test_serialization_branch_complex():
         f = conditional("test2").if_(d == "hello ").then(t2(a="It is hello")).else_().then(t2(a="Not Hello!"))
         return x, f
 
-    default_img = Image(name="default", fqn="test", tag="tag")
-    serialization_settings = context_manager.SerializationSettings(
-        project="project",
-        domain="domain",
-        version="version",
-        env=None,
-        image_config=ImageConfig(default_image=default_img, images=[default_img]),
-    )
-    wf = get_serializable(OrderedDict(), serialization_settings, my_wf)
-    assert wf is not None
-    assert len(wf.nodes) == 3
-    assert wf.nodes[1].branch_node is not None
-    assert wf.nodes[2].branch_node is not None
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    assert wf_spec is not None
+    assert len(wf_spec.template.nodes) == 3
+    assert wf_spec.template.nodes[1].branch_node is not None
+    assert wf_spec.template.nodes[2].branch_node is not None
 
 
 def test_serialization_branch_sub_wf():
@@ -117,19 +110,11 @@ def test_serialization_branch_sub_wf():
         d = conditional("test1").if_(a > 3).then(t1(a=a)).else_().then(my_sub_wf(a=a))
         return d
 
-    default_img = Image(name="default", fqn="test", tag="tag")
-    serialization_settings = context_manager.SerializationSettings(
-        project="project",
-        domain="domain",
-        version="version",
-        env=None,
-        image_config=ImageConfig(default_image=default_img, images=[default_img]),
-    )
-    wf = get_serializable(OrderedDict(), serialization_settings, my_wf)
-    assert wf is not None
-    assert len(wf.nodes[0].inputs) == 1
-    assert wf.nodes[0].inputs[0].var == ".a"
-    assert wf.nodes[0] is not None
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    assert wf_spec is not None
+    assert len(wf_spec.template.nodes[0].inputs) == 1
+    assert wf_spec.template.nodes[0].inputs[0].var == ".a"
+    assert wf_spec.template.nodes[0] is not None
 
 
 def test_serialization_branch_compound_conditions():
@@ -158,10 +143,10 @@ def test_serialization_branch_compound_conditions():
         env=None,
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
-    wf = get_serializable(OrderedDict(), serialization_settings, my_wf)
-    assert wf is not None
-    assert len(wf.nodes[0].inputs) == 1
-    assert wf.nodes[0].inputs[0].var == ".a"
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    assert wf_spec is not None
+    assert len(wf_spec.template.nodes[0].inputs) == 1
+    assert wf_spec.template.nodes[0].inputs[0].var == ".a"
 
 
 def test_serialization_branch_complex_2():
@@ -196,9 +181,9 @@ def test_serialization_branch_complex_2():
         env=None,
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
-    wf = get_serializable(OrderedDict(), serialization_settings, my_wf)
-    assert wf is not None
-    assert wf.nodes[1].inputs[0].var == "n0.t1_int_output"
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    assert wf_spec is not None
+    assert wf_spec.template.nodes[1].inputs[0].var == "n0.t1_int_output"
 
 
 def test_serialization_branch():
@@ -230,10 +215,10 @@ def test_serialization_branch():
         env=None,
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
-    wf = get_serializable(OrderedDict(), serialization_settings, my_wf)
-    assert wf is not None
-    assert len(wf.nodes) == 2
-    assert wf.nodes[1].branch_node is not None
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    assert wf_spec is not None
+    assert len(wf_spec.template.nodes) == 2
+    assert wf_spec.template.nodes[1].branch_node is not None
 
 
 def test_serialization_images():
@@ -266,21 +251,21 @@ def test_serialization_images():
         env=None,
         image_config=get_image_config(),
     )
-    t1_ser = get_serializable(OrderedDict(), rs, t1)
-    assert t1_ser.container.image == "docker.io/xyz:version"
-    t1_ser.to_flyte_idl()
+    t1_spec = get_serializable(OrderedDict(), rs, t1)
+    assert t1_spec.template.container.image == "docker.io/xyz:version"
+    t1_spec.to_flyte_idl()
 
-    t2_ser = get_serializable(OrderedDict(), rs, t2)
-    assert t2_ser.container.image == "docker.io/default:version"
+    t2_spec = get_serializable(OrderedDict(), rs, t2)
+    assert t2_spec.template.container.image == "docker.io/default:version"
 
-    t3_ser = get_serializable(OrderedDict(), rs, t3)
-    assert t3_ser.container.image == "docker.io/default:version"
+    t3_spec = get_serializable(OrderedDict(), rs, t3)
+    assert t3_spec.template.container.image == "docker.io/default:version"
 
-    t4_ser = get_serializable(OrderedDict(), rs, t4)
-    assert t4_ser.container.image == "docker.io/org/myimage:latest"
+    t4_spec = get_serializable(OrderedDict(), rs, t4)
+    assert t4_spec.template.container.image == "docker.io/org/myimage:latest"
 
-    t5_ser = get_serializable(OrderedDict(), rs, t5)
-    assert t5_ser.container.image == "docker.io/org/myimage:version"
+    t5_spec = get_serializable(OrderedDict(), rs, t5)
+    assert t5_spec.template.container.image == "docker.io/org/myimage:version"
 
 
 def test_serialization_command1():
@@ -288,8 +273,8 @@ def test_serialization_command1():
     def t1(a: str) -> str:
         return a
 
-    srz_t = get_serializable(OrderedDict(), serialization_settings, t1)
-    assert srz_t.container.args[-7:] == [
+    task_spec = get_serializable(OrderedDict(), serialization_settings, t1)
+    assert task_spec.template.container.args[-7:] == [
         "--resolver",
         "flytekit.core.python_auto_container.default_task_resolver",
         "--",
@@ -312,10 +297,10 @@ def test_serialization_types():
         compute_square_result = squared(value=input_integer)
         return compute_square_result
 
-    wf = get_serializable(OrderedDict(), serialization_settings, compute_square_wf)
-    assert wf.interface.outputs["o0"].type.collection_type.map_value_type.simple == SimpleType.INTEGER
-    ser = get_serializable(OrderedDict(), serialization_settings, squared)
-    assert ser.interface.outputs["o0"].type.collection_type.map_value_type.simple == SimpleType.INTEGER
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, compute_square_wf)
+    assert wf_spec.template.interface.outputs["o0"].type.collection_type.map_value_type.simple == SimpleType.INTEGER
+    task_spec = get_serializable(OrderedDict(), serialization_settings, squared)
+    assert task_spec.template.interface.outputs["o0"].type.collection_type.map_value_type.simple == SimpleType.INTEGER
 
 
 def test_serialization_named_return():
@@ -327,7 +312,6 @@ def test_serialization_named_return():
     def wf() -> typing.NamedTuple("OP", a=str, b=str):
         return t1(), t1()
 
-    print(wf())
     default_img = Image(name="default", fqn="test", tag="tag")
     serialization_settings = context_manager.SerializationSettings(
         project="project",
@@ -336,6 +320,6 @@ def test_serialization_named_return():
         env=None,
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
-    ser_wf = get_serializable(OrderedDict(), serialization_settings, wf)
-    assert len(ser_wf.interface.outputs) == 2
-    assert list(ser_wf.interface.outputs.keys()) == ["a", "b"]
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, wf)
+    assert len(wf_spec.template.interface.outputs) == 2
+    assert list(wf_spec.template.interface.outputs.keys()) == ["a", "b"]

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -727,22 +727,22 @@ def test_lp_serialize():
         image_config=ImageConfig(Image(name="name", fqn="asdf/fdsa", tag="123")),
         env={},
     )
-    sdk_lp = get_serializable(OrderedDict(), serialization_settings, lp)
-    assert len(sdk_lp.default_inputs.parameters) == 1
-    assert sdk_lp.default_inputs.parameters["a"].required
-    assert len(sdk_lp.fixed_inputs.literals) == 0
+    lp_model = get_serializable(OrderedDict(), serialization_settings, lp)
+    assert len(lp_model.spec.default_inputs.parameters) == 1
+    assert lp_model.spec.default_inputs.parameters["a"].required
+    assert len(lp_model.spec.fixed_inputs.literals) == 0
 
-    sdk_lp = get_serializable(OrderedDict(), serialization_settings, lp_with_defaults)
-    assert len(sdk_lp.default_inputs.parameters) == 1
-    assert not sdk_lp.default_inputs.parameters["a"].required
-    assert sdk_lp.default_inputs.parameters["a"].default == _literal_models.Literal(
+    lp_model = get_serializable(OrderedDict(), serialization_settings, lp_with_defaults)
+    assert len(lp_model.spec.default_inputs.parameters) == 1
+    assert not lp_model.spec.default_inputs.parameters["a"].required
+    assert lp_model.spec.default_inputs.parameters["a"].default == _literal_models.Literal(
         scalar=_literal_models.Scalar(primitive=_literal_models.Primitive(integer=3))
     )
-    assert len(sdk_lp.fixed_inputs.literals) == 0
+    assert len(lp_model.spec.fixed_inputs.literals) == 0
 
     # Adding a check to make sure oneof is respected. Tricky with booleans... if a default is specified, the
     # required field needs to be None, not False.
-    parameter_a = sdk_lp.default_inputs.parameters["a"]
+    parameter_a = lp_model.spec.default_inputs.parameters["a"]
     parameter_a = Parameter.from_flyte_idl(parameter_a.to_flyte_idl())
     assert parameter_a.default is not None
 
@@ -1048,8 +1048,8 @@ def test_environment():
     with context_manager.FlyteContextManager.with_context(
         context_manager.FlyteContextManager.current_context().with_new_compilation_state()
     ):
-        sdk_task = get_serializable(OrderedDict(), serialization_settings, t1)
-        assert sdk_task.container.env == {"FOO": "foofoo", "BAR": "bar", "BAZ": "baz"}
+        task_spec = get_serializable(OrderedDict(), serialization_settings, t1)
+        assert task_spec.template.container.env == {"FOO": "foofoo", "BAR": "bar", "BAZ": "baz"}
 
 
 def test_resources():
@@ -1078,20 +1078,20 @@ def test_resources():
     with context_manager.FlyteContextManager.with_context(
         context_manager.FlyteContextManager.current_context().with_new_compilation_state()
     ):
-        sdk_task = get_serializable(OrderedDict(), serialization_settings, t1)
-        assert sdk_task.container.resources.requests == [
+        task_spec = get_serializable(OrderedDict(), serialization_settings, t1)
+        assert task_spec.template.container.resources.requests == [
             _resource_models.ResourceEntry(_resource_models.ResourceName.CPU, "1")
         ]
-        assert sdk_task.container.resources.limits == [
+        assert task_spec.template.container.resources.limits == [
             _resource_models.ResourceEntry(_resource_models.ResourceName.CPU, "2"),
             _resource_models.ResourceEntry(_resource_models.ResourceName.MEMORY, "400M"),
         ]
 
-        sdk_task2 = get_serializable(OrderedDict(), serialization_settings, t2)
-        assert sdk_task2.container.resources.requests == [
+        task_spec2 = get_serializable(OrderedDict(), serialization_settings, t2)
+        assert task_spec2.template.container.resources.requests == [
             _resource_models.ResourceEntry(_resource_models.ResourceName.CPU, "3")
         ]
-        assert sdk_task2.container.resources.limits == []
+        assert task_spec2.template.container.resources.limits == []
 
 
 def test_wf_explicitly_returning_empty_task():

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -443,6 +443,7 @@ def test_wf1_with_dynamic():
         with context_manager.FlyteContextManager.with_context(ctx.with_execution_state(new_exc_state)) as ctx:
             dynamic_job_spec = my_subwf.compile_into_workflow(ctx, False, my_subwf._task_function, a=5)
             assert len(dynamic_job_spec._nodes) == 5
+            assert len(dynamic_job_spec.tasks) == 1
 
     assert context_manager.FlyteContextManager.size() == 1
 

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -49,9 +49,9 @@ def test_workflow_values():
         u, v = t1(a=x)
         return y, v
 
-    sdk_wf = get_serializable(OrderedDict(), serialization_settings, wf)
-    assert sdk_wf.metadata_defaults.interruptible
-    assert sdk_wf.metadata.on_failure == 1
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, wf)
+    assert wf_spec.template.metadata_defaults.interruptible
+    assert wf_spec.template.metadata.on_failure == 1
 
 
 def test_default_values():
@@ -162,9 +162,9 @@ def test_wf_nested_comp():
     assert (8, 10) == outer()
     entity_mapping = OrderedDict()
 
-    sdk_wf = get_serializable(entity_mapping, serialization_settings, outer)
-    model_wf = sdk_wf.serialize()
-    assert len(model_wf.template.interface.outputs.variables) == 2
+    model_wf = get_serializable(entity_mapping, serialization_settings, outer)
+
+    assert len(model_wf.template.interface.outputs) == 2
     assert len(model_wf.template.nodes) == 2
     assert model_wf.template.nodes[1].workflow_node is not None
 

--- a/tests/flytekit/unit/extras/sqlite3/test_sql_tracker.py
+++ b/tests/flytekit/unit/extras/sqlite3/test_sql_tracker.py
@@ -20,7 +20,7 @@ def test_sql_command():
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
     srz_t = get_serializable(OrderedDict(), serialization_settings, not_tk)
-    assert srz_t.container.args[-7:] == [
+    assert srz_t.template.container.args[-7:] == [
         "--resolver",
         "flytekit.core.python_auto_container.default_task_resolver",
         "--",

--- a/tests/flytekit/unit/models/test_common.py
+++ b/tests/flytekit/unit/models/test_common.py
@@ -88,3 +88,12 @@ def test_raw_output_data_config():
     assert obj.output_location_prefix == "s3://bucket"
     obj2 = _common.RawOutputDataConfig.from_flyte_idl(obj.to_flyte_idl())
     assert obj2 == obj
+
+
+def test_auth_role_empty():
+    # This test is here to ensure we can serialize launch plans with an empty auth role.
+    # Auth roles are empty because they are filled in at registration time.
+    obj = _common.AuthRole()
+    x = obj.to_flyte_idl()
+    y = _common.AuthRole.from_flyte_idl(x)
+    assert y == obj


### PR DESCRIPTION
# TL;DR
Gets rid of the Sdk... classes in the `translator.py` module. This should be the last place flytekit is explicitly using the old classes.

Previously the `translator` module converted from the new Python classes (PythonFunctionTask, PythonFunctionWorkflow, LaunchPlan) into the `SdkXyz` classes, and then relied on the `serialize()` call within each of those Sdk classes, invoked by `serialize.py` to convert them into model objects.  Now `translator` will go directly to the model, and the serialization step will just call `to_flyte_idl()`

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
* Remove most of the `common` dependencies in `translator.py` and replace with the model classes.
* Python objects get converted to the same model classes as the output of their respective serialize calls earlier, namely
  * Tasks -> `flytekit.models.task.TaskSpec`
  * Launch Plans -> `flytekit.models.launch_plan.LaunchPlan`
  * Workflows -> `flytekit.models.admin.WorkflowSpec`
* Realized that we were actually still relying on the two `AuthRole` settings in the serialization step. These were being read in the property field for `auth_role` in the `SdkLaunchPlan` class itself.
* Handling for reference tasks/workflows is actually not great when it comes to getting the model representation. I'm currently using `None`.  That is, whenever a reference entity is run through `translator.py`, a `None` is returned and cached in the ordered dict.  This is useful because the translator is used in one other place - in dynamic tasks.  The runtime dynamic task compilation will look for these `None`s and reject them.  Using `None` as a sentinel value is not good, but I think this PR has enough going on so will address that in a future PR.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/822

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
