### PR TITLE
execution classes in control plane convert flyte literals to python

### DIFF
--- a/flytekit/control_plane/nodes.py
+++ b/flytekit/control_plane/nodes.py
@@ -16,7 +16,7 @@ from flytekit.common.utils import _dnsify
 from flytekit.control_plane import component_nodes as _component_nodes
 from flytekit.control_plane import identifier as _identifier
 from flytekit.control_plane.tasks import executions as _task_executions
-from flytekit.core.context_manager import FlyteContext
+from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.promise import NodeOutput
 from flytekit.core.type_engine import TypeEngine
 from flytekit.engines.flyte import engine as _flyte_engine
@@ -203,7 +203,7 @@ class FlyteNodeExecution(_node_execution_models.NodeExecution, _artifact_mixin.E
             task_id = self.task_executions[0].id.task_id
             task = FlyteTask.fetch(task_id.project, task_id.domain, task_id.name, task_id.version)
             self._inputs = TypeEngine.literal_map_to_kwargs(
-                ctx=FlyteContext.current_context(),
+                ctx=FlyteContextManager.current_context(),
                 lm=input_map,
                 python_types=TypeEngine.guess_python_types(task.interface.inputs),
             )
@@ -244,7 +244,7 @@ class FlyteNodeExecution(_node_execution_models.NodeExecution, _artifact_mixin.E
             task_id = self.task_executions[0].id.task_id
             task = FlyteTask.fetch(task_id.project, task_id.domain, task_id.name, task_id.version)
             self._outputs = TypeEngine.literal_map_to_kwargs(
-                ctx=FlyteContext.current_context(),
+                ctx=FlyteContextManager.current_context(),
                 lm=output_map,
                 python_types=TypeEngine.guess_python_types(task.interface.outputs),
             )

--- a/flytekit/control_plane/nodes.py
+++ b/flytekit/control_plane/nodes.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 
 from flyteidl.core import literals_pb2 as _literals_pb2
 
+import flytekit
 from flytekit.clients.helpers import iterate_task_executions as _iterate_task_executions
 from flytekit.common import constants as _constants
 from flytekit.common import utils as _common_utils
@@ -15,7 +16,9 @@ from flytekit.common.utils import _dnsify
 from flytekit.control_plane import component_nodes as _component_nodes
 from flytekit.control_plane import identifier as _identifier
 from flytekit.control_plane.tasks import executions as _task_executions
+from flytekit.core.context_manager import FlyteContext
 from flytekit.core.promise import NodeOutput
+from flytekit.core.type_engine import TypeEngine
 from flytekit.engines.flyte import engine as _flyte_engine
 from flytekit.interfaces.data import data_proxy as _data_proxy
 from flytekit.models import literals as _literal_models
@@ -32,7 +35,7 @@ class FlyteNode(_hash_mixin.HashOnReferenceMixin, _workflow_model.Node):
         upstream_nodes,
         bindings,
         metadata,
-        flyte_task: "flytekit.control_plan.tasks.task.FlyteTask" = None,
+        flyte_task: "flytekit.control_plane.tasks.task.FlyteTask" = None,
         flyte_workflow: "flytekit.control_plane.workflow.FlyteWorkflow" = None,
         flyte_launch_plan=None,
         flyte_branch=None,
@@ -115,7 +118,7 @@ class FlyteNode(_hash_mixin.HashOnReferenceMixin, _workflow_model.Node):
                 return cls(
                     id=id,
                     upstream_nodes=[],  # set downstream, model doesn't contain this information
-                    bindings=models.inputs,
+                    bindings=model.inputs,
                     metadata=model.metadata,
                     flyte_launch_plan=flyte_workflow_node.flyte_launch_plan,
                 )
@@ -177,8 +180,10 @@ class FlyteNodeExecution(_node_execution_models.NodeExecution, _artifact_mixin.E
     @property
     def inputs(self) -> Dict[str, Any]:
         """
-        Returns the inputs to the execution in the standard python format as dicatated by the type engine.
+        Returns the inputs to the execution in the standard python format as dictated by the type engine.
         """
+        from flytekit.control_plane.tasks.task import FlyteTask
+
         if self._inputs is None:
             client = _flyte_engine.get_client()
             execution_data = client.get_node_execution_data(self.id)
@@ -195,9 +200,13 @@ class FlyteNodeExecution(_node_execution_models.NodeExecution, _artifact_mixin.E
                         _common_utils.load_proto_from_file(_literals_pb2.LiteralMap, tmp_name)
                     )
 
-            # TODO: need to convert flyte literals to python types. For now just use literals
-            # self._inputs = TypeEngine.literal_map_to_kwargs(ctx=FlyteContext.current_context(), lm=input_map)
-            self._inputs = input_map
+            task_id = self.task_executions[0].id.task_id
+            task = FlyteTask.fetch(task_id.project, task_id.domain, task_id.name, task_id.version)
+            self._inputs = TypeEngine.literal_map_to_kwargs(
+                ctx=FlyteContext.current_context(),
+                lm=input_map,
+                python_types=TypeEngine.guess_python_types(task.interface.inputs),
+            )
         return self._inputs
 
     @property
@@ -207,6 +216,8 @@ class FlyteNodeExecution(_node_execution_models.NodeExecution, _artifact_mixin.E
 
         :raises: ``FlyteAssertion`` error if execution is in progress or execution ended in error.
         """
+        from flytekit.control_plane.tasks.task import FlyteTask
+
         if not self.is_complete:
             raise _user_exceptions.FlyteAssertion(
                 "Please wait until the node execution has completed before requesting the outputs."
@@ -229,9 +240,14 @@ class FlyteNodeExecution(_node_execution_models.NodeExecution, _artifact_mixin.E
                     output_map = _literal_models.LiteralMap.from_flyte_idl(
                         _common_utils.load_proto_from_file(_literals_pb2.LiteralMap, tmp_name)
                     )
-            # TODO: need to convert flyte literals to python types. For now just use literals
-            # self._outputs = TypeEngine.literal_map_to_kwargs(ctx=FlyteContext.current_context(), lm=output_map)
-            self._outputs = output_map
+
+            task_id = self.task_executions[0].id.task_id
+            task = FlyteTask.fetch(task_id.project, task_id.domain, task_id.name, task_id.version)
+            self._outputs = TypeEngine.literal_map_to_kwargs(
+                ctx=FlyteContext.current_context(),
+                lm=output_map,
+                python_types=TypeEngine.guess_python_types(task.interface.outputs),
+            )
         return self._outputs
 
     @property

--- a/flytekit/control_plane/workflow.py
+++ b/flytekit/control_plane/workflow.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional
 
 from flytekit.common import constants as _constants
 from flytekit.common.exceptions import scopes as _exception_scopes
+from flytekit.common.exceptions import system as _system_exceptions
 from flytekit.common.mixins import hash as _hash_mixin
 from flytekit.control_plane import identifier as _identifier
 from flytekit.control_plane import interface as _interfaces

--- a/flytekit/control_plane/workflow_execution.py
+++ b/flytekit/control_plane/workflow_execution.py
@@ -10,7 +10,7 @@ from flytekit.common.mixins import artifact as _artifact
 from flytekit.control_plane import identifier as _core_identifier
 from flytekit.control_plane import nodes as _nodes
 from flytekit.control_plane import workflow as _workflow
-from flytekit.core.context_manager import FlyteContext
+from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.type_engine import TypeEngine
 from flytekit.engines.flyte import engine as _flyte_engine
 from flytekit.interfaces.data import data_proxy as _data_proxy
@@ -54,7 +54,7 @@ class FlyteWorkflowExecution(_execution_models.Execution, _artifact.ExecutionArt
             lp_id = self.spec.launch_plan
             workflow = _workflow.FlyteWorkflow.fetch(lp_id.project, lp_id.domain, lp_id.name, lp_id.version)
             self._inputs = TypeEngine.literal_map_to_kwargs(
-                ctx=FlyteContext.current_context(),
+                ctx=FlyteContextManager.current_context(),
                 lm=input_map,
                 python_types=TypeEngine.guess_python_types(workflow.interface.inputs),
             )
@@ -92,7 +92,7 @@ class FlyteWorkflowExecution(_execution_models.Execution, _artifact.ExecutionArt
             lp_id = self.spec.launch_plan
             workflow = _workflow.FlyteWorkflow.fetch(lp_id.project, lp_id.domain, lp_id.name, lp_id.version)
             self._outputs = TypeEngine.literal_map_to_kwargs(
-                ctx=FlyteContext.current_context(),
+                ctx=FlyteContextManager.current_context(),
                 lm=output_map,
                 python_types=TypeEngine.guess_python_types(workflow.interface.outputs),
             )

--- a/flytekit/models/interface.py
+++ b/flytekit/models/interface.py
@@ -1,3 +1,5 @@
+import typing
+
 import six as _six
 from flyteidl.core import interface_pb2 as _interface_pb2
 
@@ -95,23 +97,14 @@ class TypedInterface(_common.FlyteIdlEntity):
         self._outputs = outputs
 
     @property
-    def inputs(self):
-        """
-        :rtype: dict[Text, Variable]
-        """
+    def inputs(self) -> typing.Dict[str, Variable]:
         return self._inputs
 
     @property
-    def outputs(self):
-        """
-        :rtype: dict[Text, Variable]
-        """
+    def outputs(self) -> typing.Dict[str, Variable]:
         return self._outputs
 
-    def to_flyte_idl(self):
-        """
-        :rtype: flyteidl.core.interface_pb2.TypedInterface
-        """
+    def to_flyte_idl(self) -> _interface_pb2.TypedInterface:
         return _interface_pb2.TypedInterface(
             inputs=_interface_pb2.VariableMap(variables={k: v.to_flyte_idl() for k, v in _six.iteritems(self.inputs)}),
             outputs=_interface_pb2.VariableMap(
@@ -120,10 +113,9 @@ class TypedInterface(_common.FlyteIdlEntity):
         )
 
     @classmethod
-    def from_flyte_idl(cls, proto):
+    def from_flyte_idl(cls, proto: _interface_pb2.TypedInterface) -> "TypedInterface":
         """
-        :param flyteidl.core.interface_pb2.TypedInterface proto:
-        :rtype: TypedInterface
+        :param proto:
         """
         return cls(
             inputs={k: Variable.from_flyte_idl(v) for k, v in _six.iteritems(proto.inputs.variables)},

--- a/tests/flytekit/integration/control_plane/test_workflow.py
+++ b/tests/flytekit/integration/control_plane/test_workflow.py
@@ -36,7 +36,7 @@ def test_launch_workflow(flyteclient, flyte_workflows_register):
         PROJECT, "development", "workflows.basic.hello_world.my_wf", f"v{VERSION}"
     ).launch_with_literals(PROJECT, "development", literals.LiteralMap({}))
     execution.wait_for_completion()
-    assert execution.outputs.literals["o0"].scalar.primitive.string_value == "hello world"
+    assert execution.outputs["o0"] == "hello world"
 
 
 def test_launch_workflow_with_args(flyteclient, flyte_workflows_register):
@@ -53,8 +53,14 @@ def test_launch_workflow_with_args(flyteclient, flyte_workflows_register):
         ),
     )
     execution.wait_for_completion()
-    assert execution.outputs.literals["o0"].scalar.primitive.integer == 12
-    assert execution.outputs.literals["o1"].scalar.primitive.string_value == "foobarworld"
+    assert execution.node_executions["n0"].inputs == {"a": 10}
+    assert execution.node_executions["n0"].outputs == {"t1_int_output": 12, "c": "world"}
+    assert execution.node_executions["n1"].inputs == {"a": "world", "b": "foobar"}
+    assert execution.node_executions["n1"].outputs == {"o0": "foobarworld"}
+    assert execution.inputs["a"] == 10
+    assert execution.inputs["b"] == "foobar"
+    assert execution.outputs["o0"] == 12
+    assert execution.outputs["o1"] == "foobarworld"
 
 
 def test_monitor_workflow(flyteclient, flyte_workflows_register):
@@ -86,5 +92,6 @@ def test_monitor_workflow(flyteclient, flyte_workflows_register):
     for key in execution.node_executions:
         assert execution.node_executions[key].closure.phase == 3
 
-    assert execution.node_executions["n0"].outputs.literals["o0"].scalar.primitive.string_value == "hello world"
-    assert execution.outputs.literals["o0"].scalar.primitive.string_value == "hello world"
+    assert execution.node_executions["n0"].inputs == {}
+    assert execution.node_executions["n0"].outputs["o0"] == "hello world"
+    assert execution.outputs["o0"] == "hello world"


### PR DESCRIPTION
Signed-off-by: cosmicBboy <niels.bantilan@gmail.com>

# TL;DR

Fixes https://github.com/flyteorg/flyte/issues/974. The `inputs` and `outputs` properties of the `FlyteWorkflowExecution` and `FlyteNodeExecution` should now return python values instead of flyte literals

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
