### PR TITLE
Consistent launch plan initialization interfaces.

### DIFF
--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -53,6 +53,9 @@ class LaunchPlan(object):
         fixed_inputs: Dict[str, Any] = None,
         schedule: _schedule_model.Schedule = None,
         notifications: List[_common_models.Notification] = None,
+        labels: _common_models.Labels = None,
+        annotations: _common_models.Annotations = None,
+        raw_output_data_config: _common_models.RawOutputDataConfig = None,
         auth_role: _common_models.AuthRole = None,
     ) -> LaunchPlan:
         ctx = FlyteContextManager.current_context()
@@ -88,6 +91,9 @@ class LaunchPlan(object):
             fixed_inputs=fixed_lm,
             schedule=schedule,
             notifications=notifications,
+            labels=labels,
+            annotations=annotations,
+            raw_output_data_config=raw_output_data_config,
             auth_role=auth_role,
         )
 
@@ -111,6 +117,9 @@ class LaunchPlan(object):
         fixed_inputs: Dict[str, Any] = None,
         schedule: _schedule_model.Schedule = None,
         notifications: List[_common_models.Notification] = None,
+        labels: _common_models.Labels = None,
+        annotations: _common_models.Annotations = None,
+        raw_output_data_config: _common_models.RawOutputDataConfig = None,
         auth_role: _common_models.AuthRole = None,
     ) -> LaunchPlan:
         """
@@ -129,6 +138,9 @@ class LaunchPlan(object):
         :param fixed_inputs: Fixed inputs, expressed as Python values. At call time, these cannot be changed.
         :param schedule: Optional schedule to run on.
         :param notifications: Notifications to send.
+        :param labels: Optional labels to attach to executions created by this launch plan.
+        :param annotations: Optional annotations to attach to executions created by this launch plan.
+        :param raw_output_data_config: Optional location of offloaded data for things like S3, etc.
         :param auth_role: Add an auth role if necessary.
         """
         if name is None and (
@@ -136,6 +148,9 @@ class LaunchPlan(object):
             or fixed_inputs is not None
             or schedule is not None
             or notifications is not None
+            or labels is not None
+            or annotations is not None
+            or raw_output_data_config is not None
             or auth_role is not None
         ):
             raise ValueError(
@@ -156,6 +171,9 @@ class LaunchPlan(object):
                 or notifications != cached_outputs["_notifications"]
                 or auth_role != cached_outputs["_auth_role"]
                 or default_inputs != cached_outputs["_saved_inputs"]
+                or labels != cached_outputs["_labels"]
+                or annotations != cached_outputs["_annotations"]
+                or raw_output_data_config != cached_outputs["_raw_output_data_config"]
             ):
                 return AssertionError("The cached values aren't the same as the current call arguments")
 
@@ -168,7 +186,18 @@ class LaunchPlan(object):
             ctx = FlyteContext.current_context()
             lp = cls.get_default_launch_plan(ctx, workflow)
         else:
-            lp = cls.create(name, workflow, default_inputs, fixed_inputs, schedule, notifications, auth_role)
+            lp = cls.create(
+                name,
+                workflow,
+                default_inputs,
+                fixed_inputs,
+                schedule,
+                notifications,
+                labels,
+                annotations,
+                raw_output_data_config,
+                auth_role,
+            )
         LaunchPlan.CACHE[name or workflow.name] = lp
         return lp
 

--- a/tests/flytekit/unit/core/test_launch_plan.py
+++ b/tests/flytekit/unit/core/test_launch_plan.py
@@ -10,7 +10,7 @@ from flytekit.core.context_manager import Image, ImageConfig
 from flytekit.core.schedule import CronSchedule
 from flytekit.core.task import task
 from flytekit.core.workflow import workflow
-from flytekit.models.common import AuthRole
+from flytekit.models.common import Annotations, AuthRole, Labels, RawOutputDataConfig
 from flytekit.models.core import execution as _execution_model
 from flytekit.models.core import identifier as identifier_models
 
@@ -113,6 +113,35 @@ def test_lp_each_parameter():
     with pytest.raises(AssertionError):
         assert auth_lp is auth_lp1
 
+    # Labels parameters
+    labels_model1 = Labels({"label": "foo"})
+    labels_model2 = Labels({"label": "foo"})
+    labels_lp1 = launch_plan.LaunchPlan.get_or_create(workflow=wf, name="get_or_create_labels", labels=labels_model1)
+    labels_lp2 = launch_plan.LaunchPlan.get_or_create(workflow=wf, name="get_or_create_labels", labels=labels_model2)
+    assert labels_lp1 is labels_lp2
+
+    # Annotations parameters
+    annotations_model1 = Annotations({"anno": "bar"})
+    annotations_model2 = Annotations({"anno": "bar"})
+    annotations_lp1 = launch_plan.LaunchPlan.get_or_create(
+        workflow=wf, name="get_or_create_annotations", annotations=annotations_model1
+    )
+    annotations_lp2 = launch_plan.LaunchPlan.get_or_create(
+        workflow=wf, name="get_or_create_annotations", annotations=annotations_model2
+    )
+    assert annotations_lp1 is annotations_lp2
+
+    # Raw output prefix parameters
+    raw_output_data_config1 = RawOutputDataConfig("s3://foo/output")
+    raw_output_data_config2 = RawOutputDataConfig("s3://foo/output")
+    raw_output_data_config_lp1 = launch_plan.LaunchPlan.get_or_create(
+        workflow=wf, name="get_or_create_raw_output_prefix", raw_output_data_config=raw_output_data_config1
+    )
+    raw_output_data_config_lp2 = launch_plan.LaunchPlan.get_or_create(
+        workflow=wf, name="get_or_create_raw_output_prefix", raw_output_data_config=raw_output_data_config2
+    )
+    assert raw_output_data_config_lp1 is raw_output_data_config_lp2
+
     # Default LaunchPlan
     name_lp = launch_plan.LaunchPlan.get_or_create(workflow=wf)
     name_lp1 = launch_plan.LaunchPlan.get_or_create(workflow=wf)
@@ -142,6 +171,9 @@ def test_lp_all_parameters():
         phases=[_execution_model.WorkflowExecutionPhase.SUCCEEDED], recipients_email=["my-team@slack.com"]
     )
     auth_role_model = AuthRole(assumable_iam_role="my:iam:role")
+    labels = Labels({"label": "foo"})
+    annotations = Annotations({"anno": "bar"})
+    raw_output_data_config = RawOutputDataConfig("s3://foo/output")
 
     lp = launch_plan.LaunchPlan.get_or_create(
         workflow=wf,
@@ -151,6 +183,9 @@ def test_lp_all_parameters():
         schedule=obj,
         notifications=slack_notif,
         auth_role=auth_role_model,
+        labels=labels,
+        annotations=annotations,
+        raw_output_data_config=raw_output_data_config,
     )
     lp2 = launch_plan.LaunchPlan.get_or_create(
         workflow=wf,
@@ -160,6 +195,9 @@ def test_lp_all_parameters():
         schedule=obj,
         notifications=slack_notif,
         auth_role=auth_role_model,
+        labels=labels,
+        annotations=annotations,
+        raw_output_data_config=raw_output_data_config,
     )
 
     assert lp is lp2
@@ -173,6 +211,9 @@ def test_lp_all_parameters():
         schedule=obj1,
         notifications=slack_notif,
         auth_role=auth_role_model,
+        labels=labels,
+        annotations=annotations,
+        raw_output_data_config=raw_output_data_config,
     )
 
     with pytest.raises(AssertionError):


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Consistent launch plan initialization interfaces. Get and get_or_create now accept labels, annotations, and raw_output_data_config parameters just like `__init__`

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
User reported bug.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1086

## Follow-up issue
_NA_
