### PR TITLE
[WIP] feature/975: support subworkflow input/output inspection in control plane

### DIFF
--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -670,16 +670,18 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         token=None,
         filters=None,
         sort_by=None,
+        unique_parent_id: str = None,
     ):
-        """
-        TODO: Comment
+        """Get node executions associated with a given workflow execution.
+
         :param flytekit.models.core.identifier.WorkflowExecutionIdentifier workflow_execution_identifier:
         :param int limit:
         :param Text token: [Optional] If specified, this specifies where in the rows of results to skip before reading.
-        If you previously retrieved a page response with token="foo" and you want the next page,
-        specify token="foo".
+            If you previously retrieved a page response with token="foo" and you want the next page,
+            specify token="foo".
         :param list[flytekit.models.filters.Filter] filters:
         :param flytekit.models.admin.common.Sort sort_by: [Optional] If provided, the results will be sorted.
+        :param unique_parent_id:
         :rtype: list[flytekit.models.node_execution.NodeExecution], Text
         """
         exec_list = super(SynchronousFlyteClient, self).list_node_executions_paginated(
@@ -689,6 +691,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
                 token=token,
                 filters=_filters.FilterList(filters or []).to_flyte_idl(),
                 sort_by=None if sort_by is None else sort_by.to_flyte_idl(),
+                unique_parent_id=unique_parent_id,
             )
         )
         return (

--- a/flytekit/clients/helpers.py
+++ b/flytekit/clients/helpers.py
@@ -1,9 +1,16 @@
+import typing
+
+from flytekit.clients.friendly import SynchronousFlyteClient
+from flytekit.models.core.identifier import NodeExecutionIdentifier
+
+
 def iterate_node_executions(
     client,
     workflow_execution_identifier=None,
     task_execution_identifier=None,
     limit=None,
     filters=None,
+    unique_parent_id=None,
 ):
     """
     This returns a generator for node executions.
@@ -26,6 +33,7 @@ def iterate_node_executions(
                 limit=num_to_fetch,
                 token=token,
                 filters=filters,
+                unique_parent_id=unique_parent_id,
             )
         else:
             node_execs, next_token = client.list_node_executions_for_task_paginated(

--- a/flytekit/control_plane/component_nodes.py
+++ b/flytekit/control_plane/component_nodes.py
@@ -112,7 +112,7 @@ class FlyteWorkflowNode(_workflow_model.WorkflowNode):
             base_model.reference.version,
         )
 
-        if base_model.launch_plan_ref is not None:
+        if base_model.launchplan_ref is not None:
             return cls(flyte_launch_plan=_launch_plan.FlyteLaunchPlan.fetch(*fetch_args))
         elif base_model.sub_workflow_ref is not None:
             # the workflow tempaltes for sub-workflows should have been included in the original response

--- a/flytekit/control_plane/tasks/executions.py
+++ b/flytekit/control_plane/tasks/executions.py
@@ -1,10 +1,16 @@
+import os
 from typing import Any, Dict, Optional
+
+from flyteidl.core import literals_pb2 as _literals_pb2
 
 from flytekit.clients.helpers import iterate_node_executions as _iterate_node_executions
 from flytekit.common import utils as _common_utils
 from flytekit.common.exceptions import user as _user_exceptions
 from flytekit.common.mixins import artifact as _artifact_mixin
+from flytekit.core.context_manager import FlyteContextManager
+from flytekit.core.type_engine import TypeEngine
 from flytekit.engines.flyte import engine as _flyte_engine
+from flytekit.interfaces.data import data_proxy as _data_proxy
 from flytekit.models import literals as _literal_models
 from flytekit.models.admin import task_execution as _task_execution_model
 from flytekit.models.core import execution as _execution_models
@@ -31,6 +37,8 @@ class FlyteTaskExecution(_task_execution_model.TaskExecution, _artifact_mixin.Ex
         Returns the inputs of the task execution in the standard Python format that is produced by
         the type engine.
         """
+        from flytekit.control_plane.tasks.task import FlyteTask
+
         if self._inputs is None:
             client = _flyte_engine.get_client()
             execution_data = client.get_task_execution_data(self.id)
@@ -41,15 +49,20 @@ class FlyteTaskExecution(_task_execution_model.TaskExecution, _artifact_mixin.Ex
                 input_map = execution_data.full_inputs
             elif execution_data.inputs.bytes > 0:
                 with _common_utils.AutoDeletingTempDir() as tmp_dir:
-                    tmp_name = _os.path.join(tmp_dir.name, "inputs.pb")
+                    tmp_name = os.path.join(tmp_dir.name, "inputs.pb")
                     _data_proxy.Data.get_data(execution_data.inputs.url, tmp_name)
                     input_map = _literal_models.LiteralMap.from_flyte_idl(
                         _common_utils.load_proto_from_file(_literals_pb2.LiteralMap, tmp_name)
                     )
 
-            # TODO: need to convert flyte literals to python types. For now just use literals
-            # self._inputs = TypeEngine.literal_map_to_kwargs(ctx=FlyteContext.current_context(), lm=input_map)
-            self._inputs = input_map
+            task = FlyteTask.fetch(
+                self.id.task_id.project, self.id.task_id.domain, self.id.task_id.name, self.id.task_id.version
+            )
+            self._inputs = TypeEngine.literal_map_to_kwargs(
+                ctx=FlyteContextManager.current_context(),
+                lm=input_map,
+                python_types=TypeEngine.guess_python_types(task.interface.inputs),
+            )
         return self._inputs
 
     @property
@@ -60,6 +73,8 @@ class FlyteTaskExecution(_task_execution_model.TaskExecution, _artifact_mixin.Ex
 
         :raises: ``FlyteAssertion`` error if execution is in progress or execution ended in error.
         """
+        from flytekit.control_plane.tasks.task import FlyteTask
+
         if not self.is_complete:
             raise _user_exceptions.FlyteAssertion(
                 "Please what until the task execution has completed before requesting the outputs."
@@ -77,15 +92,20 @@ class FlyteTaskExecution(_task_execution_model.TaskExecution, _artifact_mixin.Ex
                 output_map = execution_data.full_outputs
             elif execution_data.outputs.bytes > 0:
                 with _common_utils.AutoDeletingTempDir() as t:
-                    tmp_name = _os.path.join(t.name, "outputs.pb")
+                    tmp_name = os.path.join(t.name, "outputs.pb")
                     _data_proxy.Data.get_data(execution_data.outputs.url, tmp_name)
                     output_map = _literal_models.LiteralMap.from_flyte_idl(
                         _common_utils.load_proto_from_file(_literals_pb2.LiteralMap, tmp_name)
                     )
 
-            # TODO: need to convert flyte literals to python types. For now just use literals
-            # self._outputs = TypeEngine.literal_map_to_kwargs(ctx=FlyteContext.current_context(), lm=output_map)
-            self._outputs = output_map
+            task = FlyteTask.fetch(
+                self.id.task_id.project, self.id.task_id.domain, self.id.task_id.name, self.id.task_id.version
+            )
+            self._outputs = TypeEngine.literal_map_to_kwargs(
+                ctx=FlyteContextManager.current_context(),
+                lm=output_map,
+                python_types=TypeEngine.guess_python_types(task.interface.outputs),
+            )
         return self._outputs
 
     @property

--- a/flytekit/control_plane/tasks/task.py
+++ b/flytekit/control_plane/tasks/task.py
@@ -1,4 +1,5 @@
 from flytekit.common.exceptions import scopes as _exception_scopes
+from flytekit.common.exceptions import user as _user_exceptions
 from flytekit.common.mixins import hash as _hash_mixin
 from flytekit.control_plane import identifier as _identifier
 from flytekit.control_plane import interface as _interfaces

--- a/flytekit/control_plane/workflow.py
+++ b/flytekit/control_plane/workflow.py
@@ -3,12 +3,15 @@ from typing import Dict, List, Optional
 from flytekit.common import constants as _constants
 from flytekit.common.exceptions import scopes as _exception_scopes
 from flytekit.common.exceptions import system as _system_exceptions
+from flytekit.common.exceptions import user as _user_exceptions
 from flytekit.common.mixins import hash as _hash_mixin
 from flytekit.control_plane import identifier as _identifier
 from flytekit.control_plane import interface as _interfaces
 from flytekit.control_plane import nodes as _nodes
 from flytekit.engines.flyte import engine as _flyte_engine
+from flytekit.models import common as _common_model
 from flytekit.models import task as _task_models
+from flytekit.models.admin import common as _admin_common
 from flytekit.models.core import identifier as _identifier_model
 from flytekit.models.core import workflow as _workflow_models
 

--- a/flytekit/models/node_execution.py
+++ b/flytekit/models/node_execution.py
@@ -1,3 +1,4 @@
+import flyteidl
 import flyteidl.admin.node_execution_pb2 as _node_execution_pb2
 import pytz as _pytz
 
@@ -84,8 +85,42 @@ class NodeExecutionClosure(_common_models.FlyteIdlEntity):
         )
 
 
+class NodeExecutionMetaData(_common_models.FlyteIdlEntity):
+    def __init__(self, retry_group: str, is_parent_node: bool, spec_node_id: str):
+        self._retry_group = retry_group
+        self._is_parent_node = is_parent_node
+        self._spec_node_id = spec_node_id
+
+    @property
+    def retry_group(self):
+        return self._retry_group
+
+    @property
+    def is_parent_node(self):
+        return self._is_parent_node
+
+    @property
+    def spec_node_id(self):
+        return self._spec_node_id
+
+    def to_flyte_idl(self) -> _node_execution_pb2.NodeExecutionMetaData:
+        return _node_execution_pb2.NodeExecutionMetaData(
+            retry_group=self.retry_group,
+            is_parent_node=self.is_parent_node,
+            spec_node_id=self.spec_node_id,
+        )
+
+    @classmethod
+    def from_flyte_idl(cls, p: _node_execution_pb2.NodeExecutionMetaData) -> "NodeExecutionMetaData":
+        return cls(
+            retry_group=p.retry_group,
+            is_parent_node=p.is_parent_node,
+            spec_node_id=p.spec_node_id,
+        )
+
+
 class NodeExecution(_common_models.FlyteIdlEntity):
-    def __init__(self, id, input_uri, closure):
+    def __init__(self, id, input_uri, closure, metadata):
         """
         :param flytekit.models.core.identifier.NodeExecutionIdentifier id:
         :param Text input_uri:
@@ -94,6 +129,7 @@ class NodeExecution(_common_models.FlyteIdlEntity):
         self._id = id
         self._input_uri = input_uri
         self._closure = closure
+        self._metadata = metadata
 
     @property
     def id(self):
@@ -116,10 +152,11 @@ class NodeExecution(_common_models.FlyteIdlEntity):
         """
         return self._closure
 
-    def to_flyte_idl(self):
-        """
-        :rtype: flyteidl.admin.node_execution_pb2.NodeExecution
-        """
+    @property
+    def metadata(self):
+        return self._metadata
+
+    def to_flyte_idl(self) -> _node_execution_pb2.NodeExecution:
         return _node_execution_pb2.NodeExecution(
             id=self.id.to_flyte_idl(),
             input_uri=self.input_uri,
@@ -127,13 +164,10 @@ class NodeExecution(_common_models.FlyteIdlEntity):
         )
 
     @classmethod
-    def from_flyte_idl(cls, p):
-        """
-        :param flyteidl.admin.node_execution_pb2.NodeExecution p:
-        :rtype: NodeExecution
-        """
+    def from_flyte_idl(cls, p: _node_execution_pb2.NodeExecution) -> "NodeExecution":
         return cls(
             id=_identifier.NodeExecutionIdentifier.from_flyte_idl(p.id),
             input_uri=p.input_uri,
             closure=NodeExecutionClosure.from_flyte_idl(p.closure),
+            metadata=NodeExecutionMetaData.from_flyte_idl(p.metadata),
         )

--- a/tests/flytekit/integration/control_plane/mock_flyte_repo/workflows/basic/subworkflows.py
+++ b/tests/flytekit/integration/control_plane/mock_flyte_repo/workflows/basic/subworkflows.py
@@ -1,0 +1,26 @@
+import typing
+
+from flytekit import task, workflow
+
+
+@task
+def t1(a: int) -> typing.NamedTuple("OutputsBC", t1_int_output=int, c=str):
+    return a + 2, "world"
+
+
+@workflow
+def my_subwf(a: int = 42) -> (str, str):
+    x, y = t1(a=a)
+    u, v = t1(a=x)
+    return y, v
+
+
+@workflow
+def parent_wf(a: int) -> (int, str, str):
+    x, y = t1(a=a)
+    u, v = my_subwf(a=x)
+    return x, u, v
+
+
+if __name__ == "__main__":
+    print(f"Running my_wf(a=3) {parent_wf(a=3)}")

--- a/tests/flytekit/integration/control_plane/test_workflow.py
+++ b/tests/flytekit/integration/control_plane/test_workflow.py
@@ -57,6 +57,10 @@ def test_launch_workflow_with_args(flyteclient, flyte_workflows_register):
     assert execution.node_executions["n0"].outputs == {"t1_int_output": 12, "c": "world"}
     assert execution.node_executions["n1"].inputs == {"a": "world", "b": "foobar"}
     assert execution.node_executions["n1"].outputs == {"o0": "foobarworld"}
+    assert execution.node_executions["n0"].task_executions[0].inputs == {"a": 10}
+    assert execution.node_executions["n0"].task_executions[0].outputs == {"t1_int_output": 12, "c": "world"}
+    assert execution.node_executions["n1"].task_executions[0].inputs == {"a": "world", "b": "foobar"}
+    assert execution.node_executions["n1"].task_executions[0].outputs == {"o0": "foobarworld"}
     assert execution.inputs["a"] == 10
     assert execution.inputs["b"] == "foobar"
     assert execution.outputs["o0"] == 12
@@ -94,4 +98,7 @@ def test_monitor_workflow(flyteclient, flyte_workflows_register):
 
     assert execution.node_executions["n0"].inputs == {}
     assert execution.node_executions["n0"].outputs["o0"] == "hello world"
+    assert execution.node_executions["n0"].task_executions[0].inputs == {}
+    assert execution.node_executions["n0"].task_executions[0].outputs["o0"] == "hello world"
+    assert execution.inputs == {}
     assert execution.outputs["o0"] == "hello world"


### PR DESCRIPTION
# TL;DR

fixes https://github.com/flyteorg/flyte/issues/975. This PR adds support for the use case of inspecting sub-workflow inputs and outputs in the `NodeExecution` class.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/975

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
