### PR TITLE
Add decorator to simplify creating a reference launch plan from a function signature

### DIFF
--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -301,9 +301,11 @@ class LaunchPlan(object):
 
 class ReferenceLaunchPlan(ReferenceEntity, LaunchPlan):
     """
-    A reference launch plan serves as a pointer to a Launch Plan that already exists on your Flyte installation. This
-    object will not initiate a network call to Admin, which is why the user is asked to provide the expected interface.
-    If at registration time the interface provided causes an issue with compilation, an error will be returned.
+    A reference launch plan serves as a pointer to a Launch Plan that already exists on
+    your Flyte installation. This object will not initiate a network call to Admin,
+    which is why the user is asked to provide the expected interface. If at
+    registration time the interface provided causes an issue with compilation, an error
+    will be returned.
     """
 
     def __init__(

--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -301,11 +301,9 @@ class LaunchPlan(object):
 
 class ReferenceLaunchPlan(ReferenceEntity, LaunchPlan):
     """
-    A reference launch plan serves as a pointer to a Launch Plan that already exists on
-    your Flyte installation. This object will not initiate a network call to Admin,
-    which is why the user is asked to provide the expected interface. If at
-    registration time the interface provided causes an issue with compilation, an error
-    will be returned.
+    A reference launch plan serves as a pointer to a Launch Plan that already exists on your Flyte installation. This
+    object will not initiate a network call to Admin, which is why the user is asked to provide the expected interface.
+    If at registration time the interface provided causes an issue with compilation, an error will be returned.
     """
 
     def __init__(
@@ -321,8 +319,8 @@ def reference_launch_plan(
     version: str,
 ) -> Callable[[Callable[..., Any]], ReferenceLaunchPlan]:
     """
-    A reference launch plan is a pointer to a launch plan that already exists on your
-    Flyte installation. This object will not initiate a network call to Admin, which is why the user is asked to provide the expected interface.
+    A reference launch plan is a pointer to a launch plan that already exists on your Flyte installation. This
+    object will not initiate a network call to Admin, which is why the user is asked to provide the expected interface.
     If at registration time the interface provided causes an issue with compilation, an error will be returned.
     """
 

--- a/tests/flytekit/unit/core/test_references.py
+++ b/tests/flytekit/unit/core/test_references.py
@@ -365,6 +365,14 @@ def test_ref_lp_from_decorator():
     assert ref_lp1.python_interface.outputs == {"o0": int}
 
 
+def test_ref_lp_from_decorator_with_named_outputs():
+    @reference_launch_plan(project="project", domain="domain", name="name", version="version")
+    def ref_lp1(p1: str, p2: str) -> typing.NamedTuple("RefLPOutput", o1=int, o2=str):
+        ...
+
+    assert ref_lp1.python_interface.outputs == {"o1": int, "o2": str}
+
+
 def test_ref_dynamic():
     @reference_task(
         project="flytesnacks",

--- a/tests/flytekit/unit/core/test_references.py
+++ b/tests/flytekit/unit/core/test_references.py
@@ -8,7 +8,7 @@ from flytekit.core import context_manager
 from flytekit.core.base_task import kwtypes
 from flytekit.core.context_manager import Image, ImageConfig
 from flytekit.core.dynamic_workflow_task import dynamic
-from flytekit.core.launch_plan import LaunchPlan
+from flytekit.core.launch_plan import LaunchPlan, reference_launch_plan
 from flytekit.core.promise import VoidPromise
 from flytekit.core.reference import get_reference_entity
 from flytekit.core.reference_entity import ReferenceEntity, TaskReference
@@ -350,6 +350,19 @@ def test_lp_from_ref_wf():
     assert lp.workflow.id.project == "project"
     assert lp.workflow.id.domain == "domain"
     assert lp.workflow.id.version == "version"
+
+
+def test_ref_lp_from_decorator():
+    @reference_launch_plan(project="project", domain="domain", name="name", version="version")
+    def ref_lp1(p1: str, p2: str) -> int:
+        ...
+
+    assert ref_lp1.id.name == "name"
+    assert ref_lp1.id.project == "project"
+    assert ref_lp1.id.domain == "domain"
+    assert ref_lp1.id.version == "version"
+    assert ref_lp1.python_interface.inputs == {"p1": str, "p2": str}
+    assert ref_lp1.python_interface.outputs == {"o0": int}
 
 
 def test_ref_dynamic():


### PR DESCRIPTION
# TL;DR
Adds the `@reference_launch_plan` decorator that simplifies creating a reference launch plan from a function signature.

Currently the way to create/use reference launch plans is as follows:
```
import os

from flytekit import workflow
from flytekit.core.base_task import kwtypes
from flytekit.core.launch_plan import ReferenceLaunchPlan

rlp = ReferenceLaunchPlan(
    project=os.environ["FLYTE_INTERNAL_PROJECT"],
    domain=os.environ["FLYTE_INTERNAL_DOMAIN"],
    name="workflows.single_step.compute_square_wf",
    version="ff414a48bba9",
    inputs=kwtypes(input_integer=int),
    outputs=kwtypes(o0=int),
)


@workflow
def reference_compute_square_wf_wrapper(input_integer: int) -> int:
    return rlp(input_integer=input_integer)
```

This PR would allow us to create the reference launch plan as follows:
```
from flytekit.core.launch_plan import reference_launch_plan


@reference_launch_plan(
    project=os.environ["FLYTE_INTERNAL_PROJECT"],
    domain=os.environ["FLYTE_INTERNAL_DOMAIN"],
    name="workflows.single_step.compute_square_wf",
    version="ff414a48bba9",
)
def rlp(input_integer: int) -> int:
    ...
```

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
NA

## Follow-up issue
NA