### PR TITLE
Make image config param optional

### DIFF
--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -279,8 +279,6 @@ def serialize(ctx, image, local_source_root, in_container_config_path, in_contai
     """
     if not image:
         image = _internal_config.IMAGE.get()
-    if not image:
-        raise click.UsageError("Could not find image from config, please specify a value for ``--image``")
     ctx.obj[CTX_IMAGE] = image
 
     if local_source_root is None:

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -2,7 +2,7 @@ import re
 
 from flytekit.configuration import common as _common_config
 
-IMAGE = _common_config.FlyteRequiredStringConfigurationEntry("internal", "image")
+IMAGE = _common_config.FlyteStringConfigurationEntry("internal", "image")
 # This configuration option specifies the path to the file that holds the configuration options.  Don't worry,
 # there will not be cycles because the parsing of the configuration file intentionally will not read and settings
 # in the [internal] section.

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -42,7 +42,7 @@ class Image(object):
 
 @dataclass(init=True, repr=True, eq=True, frozen=True)
 class ImageConfig(object):
-    default_image: Image
+    default_image: Image = None
     images: List[Image] = None
 
     def find_image(self, name) -> Optional[Image]:
@@ -79,7 +79,7 @@ def look_up_image_info(name: str, tag: str, optional_tag: bool = False) -> Image
 
 def get_image_config(img_name: str = None) -> ImageConfig:
     image_name = img_name if img_name else internal.IMAGE.get()
-    default_img = look_up_image_info("default", image_name)
+    default_img = look_up_image_info("default", image_name) if image_name is not None and image_name != "" else None
     other_images = [look_up_image_info(k, tag=v, optional_tag=True) for k, v in images.get_specified_images().items()]
     other_images.append(default_img)
     return ImageConfig(default_image=default_img, images=other_images)

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -77,7 +77,7 @@ def look_up_image_info(name: str, tag: str, optional_tag: bool = False) -> Image
         return Image(name=name, fqn=ref["name"], tag=ref["tag"])
 
 
-def get_image_config(img_name: str = None) -> ImageConfig:
+def get_image_config(img_name: Optional[str] = None) -> ImageConfig:
     image_name = img_name if img_name else internal.IMAGE.get()
     default_img = look_up_image_info("default", image_name) if image_name is not None and image_name != "" else None
     other_images = [look_up_image_info(k, tag=v, optional_tag=True) for k, v in images.get_specified_images().items()]

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -217,7 +217,7 @@ def get_registerable_container_image(img: Optional[str], cfg: ImageConfig) -> st
                 raise AssertionError(f"Only fqn and version are supported replacements, {attr} is not supported")
         return img
     if cfg.default_image is None:
-        raise ValueError(f"An image is required for PythonAutoContainer tasks")
+        raise ValueError("An image is required for PythonAutoContainer tasks")
     return f"{cfg.default_image.fqn}:{cfg.default_image.tag}"
 
 

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -216,6 +216,8 @@ def get_registerable_container_image(img: Optional[str], cfg: ImageConfig) -> st
             else:
                 raise AssertionError(f"Only fqn and version are supported replacements, {attr} is not supported")
         return img
+    if cfg.default_image is None:
+        raise ValueError(f"An image is required for PythonAutoContainer tasks")
     return f"{cfg.default_image.fqn}:{cfg.default_image.tag}"
 
 

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -65,6 +65,13 @@ def test_container_image_conversion():
     assert get_registerable_container_image("{{.image.default}}", cfg) == "xyz.com/abc:tag1"
 
 
+def test_get_registerable_container_image_no_images():
+    cfg = ImageConfig()
+
+    with pytest.raises(ValueError):
+        assert get_registerable_container_image("", cfg) == "xyz.com/abc:tag1"
+
+
 def test_py_func_task_get_container():
     def foo(i: int):
         pass

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -69,7 +69,7 @@ def test_get_registerable_container_image_no_images():
     cfg = ImageConfig()
 
     with pytest.raises(ValueError):
-        assert get_registerable_container_image("", cfg) == "xyz.com/abc:tag1"
+        get_registerable_container_image("", cfg)
 
 
 def test_py_func_task_get_container():


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
In light of containerless tasks it no longer makes sense to have image be a required configuration parameter. Rather, PythonAutoContainer tasks should validate that the image config is provided at serialization

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1031

## Follow-up issue
_NA_
