### PR TITLE
Implement fast register for pod tasks v2

### DIFF
--- a/flytekit/common/translator.py
+++ b/flytekit/common/translator.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import List, Optional, Union
+from typing import Callable, List, Optional, Union
 
 from flytekit.common import constants as _common_constants
 from flytekit.common.utils import _dnsify
@@ -62,6 +62,24 @@ def to_serializable_cases(
     return ret_cases
 
 
+def _fast_serialize_command_fn(
+    settings: SerializationSettings, task: PythonAutoContainerTask
+) -> Callable[[SerializationSettings], List[str]]:
+    default_command = task.get_default_command(settings)
+
+    def fn(settings: SerializationSettings) -> List[str]:
+        return [
+            "pyflyte-fast-execute",
+            "--additional-distribution",
+            "{{ .remote_package_path }}",
+            "--dest-dir",
+            "{{ .dest_dir }}",
+            "--",
+        ] + default_command
+
+    return fn
+
+
 def get_serializable_task(
     entity_mapping: OrderedDict,
     settings: SerializationSettings,
@@ -75,6 +93,11 @@ def get_serializable_task(
         entity.name,
         settings.version,
     )
+    if fast and isinstance(entity, PythonAutoContainerTask):
+        # For fast registration, we'll need to muck with the command, but only for certain kinds of tasks. Specifically,
+        # tasks that rely on user code defined in the container. This should be encapsulated by the auto container
+        # parent class
+        entity.set_command_fn(_fast_serialize_command_fn(settings, entity))
     tt = task_models.TaskTemplate(
         id=task_id,
         type=entity.task_type,
@@ -87,22 +110,8 @@ def get_serializable_task(
         config=entity.get_config(settings),
         k8s_pod=entity.get_k8s_pod(settings),
     )
-
-    # For fast registration, we'll need to muck with the command, but only for certain kinds of tasks. Specifically,
-    # tasks that rely on user code defined in the container. This should be encapsulated by the auto container
-    # parent class
     if fast and isinstance(entity, PythonAutoContainerTask):
-        args = [
-            "pyflyte-fast-execute",
-            "--additional-distribution",
-            "{{ .remote_package_path }}",
-            "--dest-dir",
-            "{{ .dest_dir }}",
-            "--",
-        ] + tt.container.args[:]
-
-        del tt.container.args[:]
-        tt.container.args.extend(args)
+        entity.reset_command_fn()
 
     return task_models.TaskSpec(template=tt)
 

--- a/flytekit/common/translator.py
+++ b/flytekit/common/translator.py
@@ -75,7 +75,8 @@ def _fast_serialize_command_fn(
             "--dest-dir",
             "{{ .dest_dir }}",
             "--",
-        ] + default_command
+            *default_command,
+        ]
 
     return fn
 

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -129,7 +129,7 @@ class PythonAutoContainerTask(PythonTask[T], metaclass=FlyteTrackedABC):
         """
         By default, the task will run on the Flyte platform using the pyflyte-execute command.
         However, it can be useful to update the command with which the task is serialized for specific cases like
-        running map tasks ("pyflyte-map-execute") or for fast-registered tasks.
+        running map tasks ("pyflyte-map-execute") or for fast-executed tasks.
         """
         self._get_command_fn = get_command_fn
 

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import importlib
 import re
-from functools import partial
 from typing import Callable, Dict, List, Optional, TypeVar
 
 from flytekit.common.tasks.raw_container import _get_container_definition


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Pod tasks now write the pod spec to the task target directly. In order to fast-execute them, we must modify the primary container command to first run `pyflyte-fast-execute...`

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
User reported bug (thank you @jeevb)

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1050

## Follow-up issue
_NA_
