### PR TITLE
Use JSON logging formatter

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -224,7 +224,7 @@ pyrsistent==0.17.3
     # via
     #   -c requirements.txt
     #   jsonschema
-pytest-docker==0.10.1
+pytest-docker==0.10.3
     # via pytest-flyte
 git+git://github.com/flyteorg/pytest-flyte@main#egg=pytest-flyte
     # via -r dev-requirements.in
@@ -241,6 +241,10 @@ python-dateutil==2.8.1
     #   pandas
 python-dotenv==0.17.1
     # via docker-compose
+python-json-logger==2.0.1
+    # via
+    #   -c requirements.txt
+    #   flytekit
 pytimeparse==1.1.8
     # via
     #   -c requirements.txt

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -39,9 +39,9 @@ black==21.6b0
     # via papermill
 bleach==3.3.0
     # via nbconvert
-boto3==1.17.92
+boto3==1.17.94
     # via sagemaker-training
-botocore==1.20.92
+botocore==1.20.94
     # via
     #   boto3
     #   s3transfer
@@ -255,6 +255,8 @@ python-dateutil==2.8.1
     #   flytekit
     #   jupyter-client
     #   pandas
+python-json-logger==2.0.1
+    # via flytekit
 python-slugify[unidecode]==5.0.2
     # via sphinx-material
 pytimeparse==1.1.8
@@ -323,7 +325,7 @@ sphinx-autoapi==1.8.1
     # via -r doc-requirements.in
 sphinx-code-include==1.1.1
     # via -r doc-requirements.in
-sphinx-copybutton==0.3.1
+sphinx-copybutton==0.3.3
     # via -r doc-requirements.in
 sphinx-fontawesome==0.0.6
     # via -r doc-requirements.in
@@ -376,7 +378,7 @@ tornado==6.1
     # via
     #   ipykernel
     #   jupyter-client
-tqdm==4.61.0
+tqdm==4.61.1
     # via papermill
 traitlets==5.0.5
     # via

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -1,5 +1,6 @@
 import logging as _logging
 import os as _os
+from pythonjsonlogger import jsonlogger
 
 logger = _logging.getLogger("flytekit")
 # Always set the root logger to debug until we can add more user based controls
@@ -23,7 +24,7 @@ else:
     ch.setLevel(_logging.DEBUG)
 
 # create formatter
-formatter = _logging.Formatter("%(asctime)s-%(name)s-%(levelname)s$ %(message)s")
+formatter = jsonlogger.JsonFormatter(fmt="%(asctime)s %(name)s %(levelname)s %(message)s")
 
 # add formatter to ch
 ch.setFormatter(formatter)

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -1,5 +1,6 @@
 import logging as _logging
 import os as _os
+
 from pythonjsonlogger import jsonlogger
 
 logger = _logging.getLogger("flytekit")

--- a/requirements-spark2.txt
+++ b/requirements-spark2.txt
@@ -29,9 +29,9 @@ black==21.6b0
     # via papermill
 bleach==3.3.0
     # via nbconvert
-boto3==1.17.92
+boto3==1.17.94
     # via sagemaker-training
-botocore==1.20.92
+botocore==1.20.94
     # via
     #   boto3
     #   s3transfer
@@ -222,6 +222,8 @@ python-dateutil==2.8.1
     #   flytekit
     #   jupyter-client
     #   pandas
+python-json-logger==2.0.1
+    # via flytekit
 pytimeparse==1.1.8
     # via flytekit
 pytz==2018.4
@@ -291,7 +293,7 @@ tornado==6.1
     # via
     #   ipykernel
     #   jupyter-client
-tqdm==4.61.0
+tqdm==4.61.1
     # via papermill
 traitlets==5.0.5
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,9 +29,9 @@ black==21.6b0
     # via papermill
 bleach==3.3.0
     # via nbconvert
-boto3==1.17.92
+boto3==1.17.94
     # via sagemaker-training
-botocore==1.20.92
+botocore==1.20.94
     # via
     #   boto3
     #   s3transfer
@@ -222,6 +222,8 @@ python-dateutil==2.8.1
     #   flytekit
     #   jupyter-client
     #   pandas
+python-json-logger==2.0.1
+    # via flytekit
 pytimeparse==1.1.8
     # via flytekit
 pytz==2018.4
@@ -291,7 +293,7 @@ tornado==6.1
     # via
     #   ipykernel
     #   jupyter-client
-tqdm==4.61.0
+tqdm==4.61.1
     # via papermill
 traitlets==5.0.5
     # via

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         "python-dateutil<=2.8.1,>=2.1",
         "grpcio>=1.3.0,<2.0",
         "protobuf>=3.6.1,<4",
+        "python-json-logger>=2.0.0",
         "pytimeparse>=1.1.8,<2.0.0",
         "pytz>=2017.2,<2018.5",
         "keyring>=18.0.1",


### PR DESCRIPTION
# TL;DR
Use JSON logging formatter.  Logs will now look like:

```
{"asctime": "2021-06-15 19:30:58,474", "name": "flytekit", "levelname": "INFO", "message": "This is the base logger - UTC: 19:30:58"}
{"asctime": "2021-06-15 19:30:58,474", "name": "flytekit.auth", "levelname": "DEBUG", "message": "This is a debug auth logger 19:30:58"}
```

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Added a JSON formatter for logging and set the formatter in the main handler to use it.
The reason for this is because json logs are easier to parse, esp by third party log search providers.
