### PR TITLE
Early error for cases in which namedtuple usage causes compile time errors

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -228,6 +228,14 @@ class ComparisonExpression(object):
 
 
 class ConjunctionExpression(object):
+    """
+    A Conjunction Expression is an expression of the form either (A and B) or (A or B).
+    where A, B are two expressions (comparsion or conjunctions) and (and, or) are logical truth operators.
+
+    A conjunctionExpression evaluates to True or False depending on the logical operator and the truth values of
+    each of the expressions A & B
+    """
+
     def __init__(
         self,
         lhs: Union[ComparisonExpression, "ConjunctionExpression"],
@@ -420,7 +428,7 @@ class Promise(object):
 
 def create_native_named_tuple(
     ctx: FlyteContext, promises: Union[Promise, typing.List[Promise]], entity_interface: Interface
-):
+) -> Optional[Tuple]:
     """
     Creates and returns a Named tuple with all variables that match the expected named outputs. this makes
     it possible to run things locally and expect a more native behavior, i.e. address elements of a named tuple
@@ -435,6 +443,9 @@ def create_native_named_tuple(
     if isinstance(promises, Promise):
         v = [v for k, v in entity_interface.outputs.items()][0]  # get output native type
         return TypeEngine.to_python_value(ctx, promises.val, v)
+
+    if len(promises) == 0:
+        return None
 
     named_tuple_name = "DefaultNamedTupleOutput"
     if entity_interface.output_tuple_name:

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -97,6 +97,13 @@ def translate_inputs_to_literals(
             raise AssertionError(
                 f"Outputs of a non-output producing task {input_val.task_name} cannot be passed to another task."
             )
+        elif isinstance(input_val, tuple):
+            raise AssertionError(
+                "Tuples are not a supported type for individual values in Flyte - got a tuple -"
+                f" {input_val}. If using named tuple in an inner task, please, de-reference the"
+                "actual attribute that you want to use. For example, in NamedTuple('OP', x=int) then"
+                "return v.x, instead of v, even if this has a single element"
+            )
         else:
             # This handles native values, the 5 example
             return TypeEngine.to_literal(ctx, input_val, val_type, flyte_literal_type)
@@ -411,6 +418,42 @@ class Promise(object):
         return str(self.__repr__())
 
 
+def create_native_named_tuple(
+    ctx: FlyteContext, promises: Union[Promise, typing.List[Promise]], entity_interface: Interface
+):
+    """
+    Creates and returns a Named tuple with all variables that match the expected named outputs. this makes
+    it possible to run things locally and expect a more native behavior, i.e. address elements of a named tuple
+    by name.
+    """
+    if entity_interface is None:
+        raise ValueError("Interface of the entity is required to generate named outputs")
+
+    if promises is None:
+        return None
+
+    if isinstance(promises, Promise):
+        v = [v for k, v in entity_interface.outputs.items()][0]  # get output native type
+        return TypeEngine.to_python_value(ctx, promises.val, v)
+
+    named_tuple_name = "DefaultNamedTupleOutput"
+    if entity_interface.output_tuple_name:
+        named_tuple_name = entity_interface.output_tuple_name
+
+    outputs = {}
+    for p in promises:
+        if not isinstance(p, Promise):
+            raise AssertionError(
+                "Workflow outputs can only be promises that are returned by tasks. Found a value of"
+                f"type {type(p)}. Workflows cannot return local variables or constants."
+            )
+        outputs[p.var] = TypeEngine.to_python_value(ctx, p.val, entity_interface.outputs[p.var])
+
+    # Should this class be part of the Interface?
+    t = collections.namedtuple(named_tuple_name, list(outputs.keys()))
+    return t(**outputs)
+
+
 # To create a class that is a named tuple, we might have to create namedtuplemeta and manipulate the tuple
 def create_task_output(
     promises: Optional[Union[List[Promise], Promise]], entity_interface: Optional[Interface] = None
@@ -529,6 +572,14 @@ def binding_data_from_python_std(
                 }
             )
         return _literals_models.BindingData(map=m)
+
+    elif isinstance(t_value, tuple):
+        raise AssertionError(
+            "Tuples are not a supported type for individual values in Flyte - got a tuple -"
+            f" {t_value}. If using named tuple in an inner task, please, de-reference the"
+            "actual attribute that you want to use. For example, in NamedTuple('OP', x=int) then"
+            "return v.x, instead of v, even if this has a single element"
+        )
 
     # This is the scalar case - e.g. my_task(in1=5)
     scalar = TypeEngine.to_literal(ctx, t_value, t_value_type, expected_literal_type).scalar

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -33,6 +33,7 @@ from flytekit.core.promise import (
     VoidPromise,
     binding_from_python_std,
     create_and_link_node,
+    create_native_named_tuple,
     create_task_output,
     translate_inputs_to_literals,
 )
@@ -283,18 +284,7 @@ class WorkflowBase(object):
                     raise Exception(f"Workflow local execution expected 0 outputs but something received {result}")
 
             if (1 < expected_outputs == len(result)) or (result is not None and expected_outputs == 1):
-                if isinstance(result, Promise):
-                    v = [v for k, v in self.python_interface.outputs.items()][0]  # get output native type
-                    return TypeEngine.to_python_value(ctx, result.val, v)
-                else:
-                    for prom in result:
-                        if not isinstance(prom, Promise):
-                            raise Exception("should be promises")
-                        native_list = [
-                            TypeEngine.to_python_value(ctx, promise.val, self.python_interface.outputs[promise.var])
-                            for promise in result
-                        ]
-                        return tuple(native_list)
+                return create_native_named_tuple(ctx, result, self.python_interface)
 
             raise ValueError("expected outputs and actual outputs do not match")
 

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -650,10 +650,16 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
         # iterate through the list here, instead we should let the binding creation unwrap it and make a binding
         # collection/map out of it.
         if len(output_names) == 1:
-            if isinstance(workflow_outputs, tuple) and len(workflow_outputs) != 1:
-                raise AssertionError(
-                    f"The Workflow specification indicates only one return value, received {len(workflow_outputs)}"
-                )
+            if isinstance(workflow_outputs, tuple):
+                if len(workflow_outputs) != 1:
+                    raise AssertionError(
+                        f"The Workflow specification indicates only one return value, received {len(workflow_outputs)}"
+                    )
+                if self.python_interface.output_tuple_name is None:
+                    raise AssertionError(
+                        "Outputs specification for Workflow does not define a tuple, but return value is a tuple"
+                    )
+                workflow_outputs = workflow_outputs[0]
             t = self.python_interface.outputs[output_names[0]]
             b = binding_from_python_std(
                 ctx,

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -240,11 +240,13 @@ def test_wf_output_mismatch():
         def my_wf2(a: int, b: str) -> int:
             return a, b
 
-    @workflow
-    def my_wf3(a: int, b: str) -> int:
-        return (a,)
+    with pytest.raises(AssertionError):
 
-    my_wf3(a=10, b="hello")
+        @workflow
+        def my_wf3(a: int, b: str) -> int:
+            return (a,)
+
+    # my_wf3(a=10, b="hello")
     assert context_manager.FlyteContextManager.size() == 1
 
 

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -246,7 +246,6 @@ def test_wf_output_mismatch():
         def my_wf3(a: int, b: str) -> int:
             return (a,)
 
-    # my_wf3(a=10, b="hello")
     assert context_manager.FlyteContextManager.size() == 1
 
 

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -109,6 +109,27 @@ def test_sub_wf_single_named_tuple():
     assert x == (7,)
 
 
+def test_sub_wf_multi_named_tuple():
+    nt = typing.NamedTuple("Multi", named1=int, named2=int)
+
+    @task
+    def t1(a: int) -> nt:
+        a = a + 2
+        return nt(a, a)
+
+    @workflow
+    def subwf(a: int) -> nt:
+        return t1(a=a)
+
+    @workflow
+    def wf(b: int) -> nt:
+        out = subwf(a=b)
+        return t1(a=out.named1)
+
+    x = wf(b=3)
+    assert x == (7, 7)
+
+
 def test_unexpected_outputs():
     @task
     def t1(a: int) -> int:


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
The following example is incorrect
```
    nm = typing.NamedTuple("OP", greet=str)

    @task
    def say_hello() -> nm:
        return nm("hello world")

    wf_outputs = typing.NamedTuple("OP2", greet1=str, greet2=str)

    @workflow
    def my_wf() -> wf_outputs:
        # Note only Namedtuples can be created like this
        return wf_outputs(say_hello(), say_hello())
```
This fails at registration time, because Flyte does not support tuples for individual values.

It can be fixed by simply adding `.greet` to the returned value from a task - that returns a namedtuple
```
    @workflow
    def my_wf() -> wf_outputs:
        # Note only Namedtuples can be created like this
        return wf_outputs(say_hello().greet, say_hello().greet)
```
This usually is ok for cases in which you have multiple values returned as the assumption is that you need to de-reference, but for single values, this is not directly obvious. Hence we will cause early failure


## Type
 - [x] Bug Fix - not a bug
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1117
https://github.com/flyteorg/flyte/issues/1139


