### PR TITLE
Simplify map tasks and also respect map_task kwargs

### DIFF
--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -580,7 +580,6 @@ class TaskResolverMixin(object):
     def resolution_behavior(self) -> ResolutionBehavior:
         return self._resolution_behavior
 
-    # a setter function
     @resolution_behavior.setter
     def resolution_behavior(self, resolution_behavior: ResolutionBehavior):
         self._resolution_behavior = resolution_behavior

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -2,6 +2,7 @@ import collections
 import datetime
 from abc import abstractmethod
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Dict, Generic, List, Optional, Tuple, Type, TypeVar, Union
 
 from flytekit.common.exceptions import user as _user_exceptions
@@ -532,6 +533,13 @@ class TaskResolverMixin(object):
     This is just the default behavior. Users should feel free to implement their own resolvers.
     """
 
+    class ResolutionBehavior(Enum):
+        DEFAULT = 1
+        MAP = 2
+
+    def __init__(self):
+        self._resolution_behavior = self.ResolutionBehavior.DEFAULT
+
     @property
     @abstractmethod
     def location(self) -> str:
@@ -567,3 +575,12 @@ class TaskResolverMixin(object):
         Overridable function that can optionally return a custom name for a given task
         """
         return None
+
+    @property
+    def resolution_behavior(self) -> ResolutionBehavior:
+        return self._resolution_behavior
+
+    # a setter function
+    @resolution_behavior.setter
+    def resolution_behavior(self, resolution_behavior: ResolutionBehavior):
+        self._resolution_behavior = resolution_behavior

--- a/flytekit/core/map_task.py
+++ b/flytekit/core/map_task.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Type
 
 from flytekit import SecurityContext
 from flytekit.common.constants import SdkTaskType
-from flytekit.core.base_task import PythonTask
+from flytekit.core.base_task import PythonTask, TaskResolverMixin
 from flytekit.core.context_manager import ExecutionState, FlyteContext, FlyteContextManager, SerializationSettings
 from flytekit.core.interface import transform_interface_to_list_interface
 from flytekit.core.python_function_task import PythonFunctionTask
@@ -60,6 +60,8 @@ class MapPythonTask(PythonTask):
         # The run task in this case refers to a doctored copy of the user-provided task with map-task kwargs.
         # At registration time, the doctored task settings (e.g. environment, resources, etc) from the map task
         # declaration are used, rather than underlying run_task settings.
+        task_resolver = python_function_task.task_resolver
+        task_resolver.resolution_behavior = TaskResolverMixin.ResolutionBehavior.MAP
         self._run_task = type(python_function_task)(
             python_function_task.task_config,
             python_function_task.task_function,

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -83,7 +83,11 @@ class PythonAutoContainerTask(PythonTask[T], metaclass=FlyteTrackedABC):
         self._environment = environment
 
         compilation_state = FlyteContextManager.current_context().compilation_state
-        if compilation_state and compilation_state.task_resolver:
+        if (
+            compilation_state
+            and compilation_state.task_resolver
+            and (task_resolver is None or task_resolver.resolution_behavior != TaskResolverMixin.ResolutionBehavior.MAP)
+        ):
             if task_resolver:
                 logger.info(
                     f"Not using the passed in task resolver {task_resolver} because one found in compilation context"


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Instantiate a separate run_task (inner task) for map tasks that respects the map task kwargs (e.g. environment, resources, etc) but uses the input run_task resolver.

Tested on flytesandbox.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description


## Tracking Issue
https://github.com/flyteorg/flyte/issues/1170

## Follow-up issue
_NA_
