### PR TITLE
Fast register: move destination dir as part of serialization settings

### DIFF
--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -147,6 +147,12 @@ def serialize_all(
         _internal_config.IMAGE.env_var: image,
     }
 
+    if not (mode == SerializationMode.DEFAULT or mode == SerializationMode.FAST):
+        raise AssertionError(f"Unrecognized serialization mode: {mode}")
+    fast_serialization_settings = flyte_context.FastSerializationSettings(
+        enabled=mode == SerializationMode.FAST,
+        # TODO: if we want to move the destination dir as a serialization argument, we should initialize it here
+    )
     serialization_settings = flyte_context.SerializationSettings(
         project=_PROJECT_PLACEHOLDER,
         domain=_DOMAIN_PLACEHOLDER,
@@ -158,6 +164,7 @@ def serialize_all(
         entrypoint_settings=flyte_context.EntrypointSettings(
             path=_os.path.join(flytekit_virtualenv_root, _DEFAULT_FLYTEKIT_RELATIVE_ENTRYPOINT_LOC)
         ),
+        fast_serialization_settings=fast_serialization_settings,
     )
     ctx = flyte_context.FlyteContextManager.current_context().with_serialization_settings(serialization_settings)
     with flyte_context.FlyteContextManager.with_context(ctx) as ctx:
@@ -194,15 +201,7 @@ def serialize_all(
             #  Also a user may import dir_b.workflows from dir_a.workflows but workflow packages might only
             #  specify dir_a
             if isinstance(entity, PythonTask) or isinstance(entity, WorkflowBase) or isinstance(entity, LaunchPlan):
-                if isinstance(entity, PythonTask):
-                    if mode == SerializationMode.DEFAULT:
-                        get_serializable(new_api_serializable_entities, ctx.serialization_settings, entity)
-                    elif mode == SerializationMode.FAST:
-                        get_serializable(new_api_serializable_entities, ctx.serialization_settings, entity, fast=True)
-                    else:
-                        raise AssertionError(f"Unrecognized serialization mode: {mode}")
-                else:
-                    get_serializable(new_api_serializable_entities, ctx.serialization_settings, entity)
+                get_serializable(new_api_serializable_entities, ctx.serialization_settings, entity)
 
                 if isinstance(entity, WorkflowBase):
                     lp = LaunchPlan.get_default_launch_plan(ctx, entity)

--- a/flytekit/common/translator.py
+++ b/flytekit/common/translator.py
@@ -68,7 +68,9 @@ def _fast_serialize_command_fn(
 ) -> Callable[[SerializationSettings], List[str]]:
     default_command = task.get_default_command(settings)
 
-    dest_dir = settings.fast_serialization_settings.destination_dir
+    dest_dir = (
+        settings.fast_serialization_settings.destination_dir if settings.fast_serialization_settings is not None else ""
+    )
     if dest_dir is None or dest_dir == "":
         dest_dir = "{{ .dest_dir }}"
 

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -173,9 +173,6 @@ class SerializationSettings(object):
             fast_serialization_settings=self.fast_serialization_settings,
         )
 
-    def with_fast_serialization_settings(self, fss: fast_serialization_settings) -> Builder:
-        return self.new_builder().with_fast_serialization_settings(fss)
-
     def should_fast_serialize(self) -> bool:
         return self.fast_serialization_settings is not None and self.fast_serialization_settings.enabled
 

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -104,6 +104,16 @@ class EntrypointSettings(object):
     version: int = 0
 
 
+@dataclass
+class FastSerializationSettings(object):
+    """
+    This object hold information about settings necessary to serialize an object so that it can be fast-registered.
+    """
+
+    enabled: bool = False
+    destination_dir: str = False
+
+
 @dataclass(frozen=True)
 class SerializationSettings(object):
     """
@@ -119,6 +129,7 @@ class SerializationSettings(object):
     flytekit_virtualenv_root: Optional[str] = None
     python_interpreter: Optional[str] = None
     entrypoint_settings: Optional[EntrypointSettings] = None
+    fast_serialization_settings: Optional[FastSerializationSettings] = None
 
 
 @dataclass(frozen=True)

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -111,7 +111,7 @@ class FastSerializationSettings(object):
     """
 
     enabled: bool = False
-    destination_dir: str = False
+    destination_dir: str = None
 
 
 @dataclass(frozen=True)
@@ -130,6 +130,54 @@ class SerializationSettings(object):
     python_interpreter: Optional[str] = None
     entrypoint_settings: Optional[EntrypointSettings] = None
     fast_serialization_settings: Optional[FastSerializationSettings] = None
+
+    @dataclass
+    class Builder(object):
+        project: str
+        domain: str
+        version: str
+        image_config: ImageConfig
+        env: Optional[Dict[str, str]] = None
+        flytekit_virtualenv_root: Optional[str] = None
+        python_interpreter: Optional[str] = None
+        entrypoint_settings: Optional[EntrypointSettings] = None
+        fast_serialization_settings: Optional[FastSerializationSettings] = None
+
+        def with_fast_serialization_settings(self, fss: fast_serialization_settings) -> "Builder":
+            self.fast_serialization_settings = fss
+            return self
+
+        def build(self) -> SerializationSettings:
+            return SerializationSettings(
+                project=self.project,
+                domain=self.domain,
+                version=self.version,
+                image_config=self.image_config,
+                env=self.env,
+                flytekit_virtualenv_root=self.flytekit_virtualenv_root,
+                python_interpreter=self.python_interpreter,
+                entrypoint_settings=self.entrypoint_settings,
+                fast_serialization_settings=self.fast_serialization_settings,
+            )
+
+    def new_builder(self) -> Builder:
+        return SerializationSettings.Builder(
+            project=self.project,
+            domain=self.domain,
+            version=self.version,
+            image_config=self.image_config,
+            env=self.env,
+            flytekit_virtualenv_root=self.flytekit_virtualenv_root,
+            python_interpreter=self.python_interpreter,
+            entrypoint_settings=self.entrypoint_settings,
+            fast_serialization_settings=self.fast_serialization_settings,
+        )
+
+    def with_fast_serialization_settings(self, fss: fast_serialization_settings) -> Builder:
+        return self.new_builder().with_fast_serialization_settings(fss)
+
+    def should_fast_serialize(self) -> bool:
+        return self.fast_serialization_settings is not None and self.fast_serialization_settings.enabled
 
 
 @dataclass(frozen=True)

--- a/plugins/tests/pod/test_pod.py
+++ b/plugins/tests/pod/test_pod.py
@@ -9,6 +9,7 @@ from kubernetes.client.models import V1Container, V1EnvVar, V1PodSpec, V1Resourc
 from flytekit import Resources, TaskMetadata, dynamic, map_task, task
 from flytekit.common.translator import get_serializable
 from flytekit.core import context_manager
+from flytekit.core.context_manager import FastSerializationSettings
 from flytekit.extend import ExecutionState, Image, ImageConfig, SerializationSettings
 from plugins.pod.flytekitplugins.pod.task import Pod, PodFunctionTask
 
@@ -207,7 +208,7 @@ def test_dynamic_pod_task():
         with context_manager.FlyteContextManager.with_context(
             ctx.with_execution_state(ctx.execution_state.with_params(mode=ExecutionState.Mode.TASK_EXECUTION))
         ) as ctx:
-            dynamic_job_spec = dynamic_pod_task.compile_into_workflow(ctx, False, dynamic_pod_task._task_function, a=5)
+            dynamic_job_spec = dynamic_pod_task.compile_into_workflow(ctx, dynamic_pod_task._task_function, a=5)
             assert len(dynamic_job_spec._nodes) == 5
 
 
@@ -340,8 +341,9 @@ def test_fast_pod_task_serialization():
         version="version",
         env={"FOO": "baz"},
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
+        fast_serialization_settings=FastSerializationSettings(enabled=True),
     )
-    serialized = get_serializable(OrderedDict(), serialization_settings, simple_pod_task, fast=True)
+    serialized = get_serializable(OrderedDict(), serialization_settings, simple_pod_task)
 
     assert serialized.template.k8s_pod.pod_spec["containers"][0]["args"] == [
         "pyflyte-fast-execute",

--- a/tests/flytekit/unit/common_tests/test_translator.py
+++ b/tests/flytekit/unit/common_tests/test_translator.py
@@ -57,8 +57,10 @@ def test_basics():
     assert wf_spec.template.id.resource_type == identifier_models.ResourceType.WORKFLOW
 
     # Gets cached the first time around so it's not actually fast.
-    ssettings = serialization_settings.new_builder().with_fast_serialization_settings(
-        FastSerializationSettings(enabled=True)
+    ssettings = (
+        serialization_settings.new_builder()
+        .with_fast_serialization_settings(FastSerializationSettings(enabled=True))
+        .build()
     )
     task_spec = get_serializable(OrderedDict(), ssettings, t1)
     assert "pyflyte-execute" in task_spec.template.container.args
@@ -80,8 +82,10 @@ def test_fast():
     def t2(a: str, b: str) -> str:
         return b + a
 
-    ssettings = serialization_settings.new_builder().with_fast_serialization_settings(
-        FastSerializationSettings(enabled=True)
+    ssettings = (
+        serialization_settings.new_builder()
+        .with_fast_serialization_settings(FastSerializationSettings(enabled=True))
+        .build()
     )
     task_spec = get_serializable(OrderedDict(), ssettings, t1)
     assert "pyflyte-fast-execute" in task_spec.template.container.args
@@ -103,8 +107,10 @@ def test_container():
         requests=Resources(mem="400Mi", cpu="1"),
     )
 
-    ssettings = serialization_settings.new_builder().with_fast_serialization_settings(
-        FastSerializationSettings(enabled=True)
+    ssettings = (
+        serialization_settings.new_builder()
+        .with_fast_serialization_settings(FastSerializationSettings(enabled=True))
+        .build()
     )
     task_spec = get_serializable(OrderedDict(), ssettings, t2)
     assert "pyflyte" not in task_spec.template.container.args

--- a/tests/flytekit/unit/core/test_dynamic_conditional.py
+++ b/tests/flytekit/unit/core/test_dynamic_conditional.py
@@ -93,7 +93,7 @@ def test_dynamic_conditional():
             ctx.with_execution_state(ctx.execution_state.with_params(mode=ExecutionState.Mode.TASK_EXECUTION))
         ) as ctx:
             dynamic_job_spec = merge_sort_remotely.compile_into_workflow(
-                ctx, False, merge_sort_remotely._task_function, in1=[2, 3, 4, 5]
+                ctx, merge_sort_remotely._task_function, in1=[2, 3, 4, 5]
             )
             assert len(dynamic_job_spec.tasks) == 5
             assert len(dynamic_job_spec.subworkflows) == 1


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
For fast registered entities, the destination dir specifies where to untar the fast-registered code archive. Currently the destination dir is a registration time attribute, however considering that the code location is specified in the Dockerfile, this actually ought to be a serialization attribute. This change enables that for future `pyflyte package` work.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
