### PR TITLE
Allow statsd tags to be disabled through config

### DIFF
--- a/flytekit/configuration/statsd.py
+++ b/flytekit/configuration/statsd.py
@@ -3,3 +3,4 @@ from flytekit.configuration import common as _common_config
 HOST = _common_config.FlyteStringConfigurationEntry("statsd", "host", default="localhost")
 PORT = _common_config.FlyteIntegerConfigurationEntry("statsd", "port", default=8125)
 DISABLED = _common_config.FlyteBoolConfigurationEntry("statsd", "disabled", default=False)
+DISABLE_TAGS = _common_config.FlyteBoolConfigurationEntry("statsd", "disable_tagging", default=False)

--- a/flytekit/configuration/statsd.py
+++ b/flytekit/configuration/statsd.py
@@ -1,5 +1,8 @@
 from flytekit.configuration import common as _common_config
 
+# StatsD Config flags should ideally be controlled at the platform level and not through flytekit's config file.
+# They are meant to allow administrators to control certain behavior according to how the system is configured.
+
 HOST = _common_config.FlyteStringConfigurationEntry("statsd", "host", default="localhost")
 PORT = _common_config.FlyteIntegerConfigurationEntry("statsd", "port", default=8125)
 DISABLED = _common_config.FlyteBoolConfigurationEntry("statsd", "disabled", default=False)

--- a/flytekit/configuration/statsd.py
+++ b/flytekit/configuration/statsd.py
@@ -3,4 +3,4 @@ from flytekit.configuration import common as _common_config
 HOST = _common_config.FlyteStringConfigurationEntry("statsd", "host", default="localhost")
 PORT = _common_config.FlyteIntegerConfigurationEntry("statsd", "port", default=8125)
 DISABLED = _common_config.FlyteBoolConfigurationEntry("statsd", "disabled", default=False)
-DISABLE_TAGS = _common_config.FlyteBoolConfigurationEntry("statsd", "disable_tagging", default=False)
+DISABLE_TAGS = _common_config.FlyteBoolConfigurationEntry("statsd", "disable_tags", default=False)

--- a/flytekit/interfaces/stats/taggable.py
+++ b/flytekit/interfaces/stats/taggable.py
@@ -1,3 +1,4 @@
+from flytekit.configuration.statsd import DISABLE_TAGS
 from flytekit.interfaces.stats import client as _stats_client
 
 
@@ -19,7 +20,7 @@ class TaggableStats(_stats_client.ScopeableStatsProxy):
                 if kwargs.pop("per_host", False):
                     tags["_f"] = "i"
 
-                if bool(tags):
+                if bool(tags) and not DISABLE_TAGS.get():
                     stat = self._serialize_tags(stat, tags)
                 return base_func(self._p_with_prefix(stat), *args, **kwargs)
 
@@ -31,7 +32,7 @@ class TaggableStats(_stats_client.ScopeableStatsProxy):
                 if kwargs.pop("per_host", False):
                     tags["_f"] = "i"
 
-                if bool(tags):
+                if bool(tags) and not DISABLE_TAGS.get():
                     stat = self._serialize_tags(stat, tags)
                 return base_func(stat, *args, **kwargs)
 
@@ -82,4 +83,9 @@ def get_stats(prefix, tags=None):
     """
     :rtype: TaggableStats
     """
+
+    # If tagging is disabled, do not pass tags to the constructor.
+    if DISABLE_TAGS.get():
+        tags = None
+
     return TaggableStats(_stats_client.get_base_stats(prefix.lower()), prefix.lower(), tags=tags)


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Statsd Library used by flytekit [doesn't support tagging](https://statsd.readthedocs.io/en/v3.3/tags.html). This PR adds a flag to allow disabling of the tagging functionality in the flytekit's statsd wrapper.

The main concern with the way tagging is implementing is the huge cardinality it can potentially produce which can overwhelm the metrics system or incur high costs.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

# Tracking issue
fixes https://github.com/flyteorg/flyte/issues/1204