### PR TITLE
Bump urllib3 dependency in inner repo

### DIFF
--- a/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
+++ b/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
@@ -28,7 +28,7 @@ docker-image-py==0.1.10
     # via flytekit
 flyteidl==0.19.11
     # via flytekit
-flytekit==0.20.0
+flytekit==0.20.1
     # via -r requirements.in
 grpcio==1.38.1
     # via flytekit
@@ -40,7 +40,7 @@ keyring==23.0.1
     # via flytekit
 kiwisolver==1.3.1
     # via matplotlib
-marshmallow==3.12.1
+marshmallow==3.12.2
     # via
     #   dataclasses-json
     #   marshmallow-enum
@@ -67,7 +67,7 @@ pandas==1.3.0
     # via flytekit
 pathspec==0.8.1
     # via scantree
-pillow==8.3.0
+pillow==8.3.1
     # via matplotlib
 protobuf==3.17.3
     # via
@@ -124,7 +124,7 @@ typing-extensions==3.10.0.0
     # via typing-inspect
 typing-inspect==0.7.1
     # via dataclasses-json
-urllib3==1.25.11
+urllib3==1.26.6
     # via
     #   flytekit
     #   requests


### PR DESCRIPTION
Signed-off-by: wild-endeavor <wild-endeavor@users.noreply.github.com>

Previous PR didn't work because flytekit itself wasn't released.