### PR TITLE
local sandbox tmp dir supports windows

### DIFF
--- a/flytekit/configuration/sdk.py
+++ b/flytekit/configuration/sdk.py
@@ -1,5 +1,4 @@
-import os
-import platform
+import tempfile
 
 from flytekit.configuration import common as _config_common
 
@@ -26,7 +25,7 @@ TODO: Explain how this would be used to extend the SDK
 LOCAL_SANDBOX = _config_common.FlyteStringConfigurationEntry(
     "sdk",
     "local_sandbox",
-    default=str(os.path.join(os.getenv("TEMP") if platform.system() == "Windows" else "/tmp", "flyte")),
+    default=tempfile.mkdtemp(prefix="flyte"),
 )
 """
 This is the path where SDK will place files during local executions and testing.  The SDK will not automatically

--- a/flytekit/configuration/sdk.py
+++ b/flytekit/configuration/sdk.py
@@ -1,3 +1,6 @@
+import os
+import platform
+
 from flytekit.configuration import common as _config_common
 
 WORKFLOW_PACKAGES = _config_common.FlyteStringListConfigurationEntry("sdk", "workflow_packages", default=[])
@@ -20,7 +23,11 @@ This is a comma-delimited list of package strings, in order, for resolving type 
 TODO: Explain how this would be used to extend the SDK
 """
 
-LOCAL_SANDBOX = _config_common.FlyteStringConfigurationEntry("sdk", "local_sandbox", default="/tmp/flyte")
+LOCAL_SANDBOX = _config_common.FlyteStringConfigurationEntry(
+    "sdk",
+    "local_sandbox",
+    default=str(os.path.join(os.getenv("TEMP") if platform.system() == "Windows" else "/tmp", "flyte")),
+)
 """
 This is the path where SDK will place files during local executions and testing.  The SDK will not automatically
 clean up data in these directories.


### PR DESCRIPTION
Signed-off-by: cosmicBboy <niels.bantilan@gmail.com>

# TL;DR
fixes https://github.com/flyteorg/flyte/issues/782

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

The default filepath defined in by `LOCAL_SANDBOX` resulted in an usable tmp-dir path when invoking `flytekit.current_context().working_directory`

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/782

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
