### PR TITLE
Clean up scopes and exception handling for new tasks

### DIFF
--- a/docs/source/design/authoring.rst
+++ b/docs/source/design/authoring.rst
@@ -65,6 +65,31 @@ There is also only one :py:class:`LaunchPlan <flytekit.core.launch_plan.LaunchPl
 .. autoclass:: flytekit.core.launch_plan.LaunchPlan
    :noindex:
 
+******************
+Exception Handling
+******************
+Exception handling is done along two dimensions
+
+* System vs User: We try to differentiate between user exceptions and flytekit/system level exceptions. For instance, if flytekit
+  fails to upload its outputs, that's a system exception. If you the user raise a ``ValueError`` because of unexpected input
+  in the task code, that's a user exception.
+* Recoverable vs Non-recoverable: Recoverable errors will be retried and count against your task's retry count. Non-recoverable errors will just fail. System exceptions are by default recoverable (since there's a good chance it was just a blip).
+
+This is the user exception tree. Feel free to raise any of these exception classes. Note that the ``FlyteRecoverableException`` is the only recoverable one. All others, along with all non-flytekit defined exceptions, are non-recoverable.
+
+.. inheritance-diagram:: flytekit.common.exceptions.user.FlyteValidationException flytekit.common.exceptions.user.FlyteEntityAlreadyExistsException flytekit.common.exceptions.user.FlyteValueException flytekit.common.exceptions.user.FlyteTimeout flytekit.common.exceptions.user.FlyteAuthenticationException flytekit.common.exceptions.user.FlyteRecoverableException
+   :parts: 1
+   :top-classes: Exception
+
+Implementation
+==============
+For those that want to dig a bit deeper, take a look at the :py:class:`flytekit.common.exceptions.scopes.FlyteScopedException` classes.
+There are also two decorators which you'll find interspersed througout the codebase.
+
+.. autofunction:: flytekit.common.exceptions.scopes.system_entry_point
+
+.. autofunction:: flytekit.common.exceptions.scopes.user_entry_point
+
 **************
 Call Patterns
 **************

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -42,7 +42,8 @@ from flytekit.interfaces.stats.taggable import get_stats as _get_stats
 from flytekit.models import dynamic_job as _dynamic_job
 from flytekit.models import literals as _literal_models
 from flytekit.models.core import errors as _error_models
-from flytekit.models.core import identifier as _identifier, execution as _execution_models
+from flytekit.models.core import execution as _execution_models
+from flytekit.models.core import identifier as _identifier
 from flytekit.tools.fast_registration import download_distribution as _download_distribution
 from flytekit.tools.module_loader import load_object_from_module
 
@@ -132,8 +133,9 @@ def _dispatch_execute(
             _logging.warning(f"User-scoped IgnoreOutputs received! Outputs.pb will not be uploaded. reason {e}!!")
             return
         output_file_dict[_constants.ERROR_FILE_NAME] = _error_models.ErrorDocument(
-            _error_models.ContainerError(e.error_code, e.verbose_message, e.kind,
-                                         _execution_models.ExecutionError.ErrorKind.USER)
+            _error_models.ContainerError(
+                e.error_code, e.verbose_message, e.kind, _execution_models.ExecutionError.ErrorKind.USER
+            )
         )
         _logging.error("!! Begin User Error Captured by Flyte !!")
         _logging.error(e.verbose_message)
@@ -145,8 +147,9 @@ def _dispatch_execute(
             _logging.warning(f"System-scoped IgnoreOutputs received! Outputs.pb will not be uploaded. reason {e}!!")
             return
         output_file_dict[_constants.ERROR_FILE_NAME] = _error_models.ErrorDocument(
-            _error_models.ContainerError(e.error_code, e.verbose_message, e.kind,
-                                         _execution_models.ExecutionError.ErrorKind.SYSTEM)
+            _error_models.ContainerError(
+                e.error_code, e.verbose_message, e.kind, _execution_models.ExecutionError.ErrorKind.SYSTEM
+            )
         )
         _logging.error("!! Begin System Error Captured by Flyte !!")
         _logging.error(e.verbose_message)

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -120,6 +120,7 @@ def _dispatch_execute(
                     "UNKNOWN_OUTPUT",
                     f"Type of output received not handled {type(outputs)} outputs: {outputs}",
                     _error_models.ContainerError.Kind.RECOVERABLE,
+                    0
                 )
             )
     except _scoped_exceptions.FlyteScopedException as e:
@@ -143,6 +144,7 @@ def _dispatch_execute(
                 "SYSTEM:Unknown",
                 exc_str,
                 _error_models.ContainerError.Kind.RECOVERABLE,
+                2
             )
         )
         _logging.error(exc_str)

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -135,7 +135,7 @@ def _dispatch_execute(
             _error_models.ContainerError(e.error_code, e.verbose_message, e.kind,
                                          _execution_models.ExecutionError.ErrorKind.USER)
         )
-        _logging.error("!! Begin Error Captured by Flyte !!")
+        _logging.error("!! Begin User Error Captured by Flyte !!")
         _logging.error(e.verbose_message)
         _logging.error("!! End Error Captured by Flyte !!")
 
@@ -148,17 +148,13 @@ def _dispatch_execute(
             _error_models.ContainerError(e.error_code, e.verbose_message, e.kind,
                                          _execution_models.ExecutionError.ErrorKind.SYSTEM)
         )
-        _logging.error("!! Begin Error Captured by Flyte !!")
+        _logging.error("!! Begin System Error Captured by Flyte !!")
         _logging.error(e.verbose_message)
         _logging.error("!! End Error Captured by Flyte !!")
 
     # Interpret all other exceptions (some of which may be caused by the code in the try block outside of
     # dispatch_execute) as recoverable system exceptions.
     except Exception as e:
-        if isinstance(e, IgnoreOutputs):
-            # Step 3b
-            _logging.warning(f"IgnoreOutputs received! Outputs.pb will not be uploaded. reason {e}")
-            return
         # Step 3c
         exc_str = _traceback.format_exc()
         output_file_dict[_constants.ERROR_FILE_NAME] = _error_models.ErrorDocument(

--- a/flytekit/common/exceptions/scopes.py
+++ b/flytekit/common/exceptions/scopes.py
@@ -152,6 +152,8 @@ def system_entry_point(wrapped, instance, args, kwargs):
         else:
             try:
                 return wrapped(*args, **kwargs)
+            except FlyteScopedException as scoped:
+                raise scoped
             except _user_exceptions.FlyteUserException as ee:
                 # Re-raise from here.
                 raise FlyteScopedUserException(*_exc_info())
@@ -183,6 +185,8 @@ def user_entry_point(wrapped, instance, args, kwargs):
         else:
             try:
                 return wrapped(*args, **kwargs)
+            except FlyteScopedException as scoped:
+                raise scoped
             except _user_exceptions.FlyteUserException:
                 raise FlyteScopedUserException(*_exc_info())
             except _system_exceptions.FlyteSystemException:

--- a/flytekit/common/exceptions/scopes.py
+++ b/flytekit/common/exceptions/scopes.py
@@ -154,7 +154,7 @@ def system_entry_point(wrapped, instance, args, kwargs):
                 return wrapped(*args, **kwargs)
             except FlyteScopedException as scoped:
                 raise scoped
-            except _user_exceptions.FlyteUserException as ee:
+            except _user_exceptions.FlyteUserException:
                 # Re-raise from here.
                 raise FlyteScopedUserException(*_exc_info())
             except Exception:

--- a/flytekit/common/exceptions/scopes.py
+++ b/flytekit/common/exceptions/scopes.py
@@ -202,8 +202,6 @@ def user_entry_point(wrapped, instance, args, kwargs):
                 return wrapped(*args, **kwargs)
             except FlyteScopedException as scoped:
                 raise scoped
-            except _user_exceptions.FlyteRecoverableException:
-                raise FlyteScopedUserException(*_exc_info(), kind=)
             except _user_exceptions.FlyteUserException:
                 raise FlyteScopedUserException(*_exc_info())
             except _system_exceptions.FlyteSystemException:

--- a/flytekit/common/exceptions/scopes.py
+++ b/flytekit/common/exceptions/scopes.py
@@ -140,14 +140,15 @@ def system_entry_point(wrapped, instance, args, kwargs):
     The reason these two (see the user one below) decorators exist is to categorize non-Flyte exceptions at arbitrary
     locations. For example, while there is a separate ecosystem of Flyte-defined user and system exceptions
     (see the FlyteException hierarchy), and we can easily understand and categorize those, if flytekit comes upon
-    a random ValueError or other non-flytekit defined error, how would we know if it was a bug in flytekit versus an
+    a random ``ValueError`` or other non-flytekit defined error, how would we know if it was a bug in flytekit versus an
     error with user code or something the user called? The purpose of these decorators is to categorize those (see
     the last case in the nested try/catch below.
 
-    Decorator for wrapping functions that enter a system context. This should decorate every method a user might
-    call.  This will allow us to add differentiation between what is a user error and what is a system failure.
-    Furthermore, we will clean the exception trace so as to make more sense to the user--allowing them to know if they
-    should take action themselves or pass on to the platform owners.  We will dispatch metrics and such appropriately.
+    Decorator for wrapping functions that enter a system context. This should decorate every method that may invoke some
+    user code later on down the line. This will allow us to add differentiation between what is a user error and
+    what is a system failure. Furthermore, we will clean the exception trace so as to make more sense to the
+    user -- allowing them to know if they should take action themselves or pass on to the platform owners.
+    We will dispatch metrics and such appropriately.
     """
     try:
         _CONTEXT_STACK.append(_SYSTEM_CONTEXT)

--- a/flytekit/common/exceptions/scopes.py
+++ b/flytekit/common/exceptions/scopes.py
@@ -76,7 +76,7 @@ class FlyteScopedException(Exception):
         return "{}:Unknown".format(self._context)
 
     @property
-    def kind(self):
+    def kind(self) -> int:
         """
         :rtype: int
         """
@@ -132,14 +132,6 @@ _CONTEXT_STACK = [_NULL_CONTEXT]
 
 def _is_base_context():
     return _CONTEXT_STACK[-2] == _NULL_CONTEXT
-
-
-def reraise(tp, value, tb=None):
-    if value is None:
-        value = tp()
-    # if value.__traceback__ is not tb:
-    #     raise value.with_traceback(tb)
-    raise value
 
 
 @_decorator

--- a/flytekit/common/exceptions/scopes.py
+++ b/flytekit/common/exceptions/scopes.py
@@ -145,37 +145,19 @@ def system_entry_point(wrapped, instance, args, kwargs):
     try:
         _CONTEXT_STACK.append(_SYSTEM_CONTEXT)
         if _is_base_context():
-            # return wrapped(*args, **kwargs)
             try:
                 return wrapped(*args, **kwargs)
             except FlyteScopedException as ex:
                 raise ex.value
-                # reraise(ex.type, ex.value, ex.traceback)
         else:
             try:
                 return wrapped(*args, **kwargs)
-            # except FlyteScopedException:
-            #     # Just pass-on the exception that is already wrapped and scoped
-            #     _reraise(*_exc_info())
             except _user_exceptions.FlyteUserException as ee:
                 # Re-raise from here.
                 raise FlyteScopedUserException(*_exc_info())
-                # import ipdb; ipdb.set_trace()
-                # ex_type, ex_value, ex_tb = _exc_info()
-                # raise FlyteScopedUserException(ex_type, ex_value, ex_tb)
-                # reraise(
-                #     FlyteScopedUserException,
-                #     FlyteScopedUserException(ex_type, ex_value, ex_tb),
-                #     ex_tb,
-                # )
             except Exception:
                 # System error, raise full stack-trace all the way up the chain.
                 raise FlyteScopedSystemException(*_exc_info(), kind=_error_model.ContainerError.Kind.RECOVERABLE)
-                # _reraise(
-                #     FlyteScopedSystemException,
-                #     FlyteScopedSystemException(*_exc_info(), kind=_error_model.ContainerError.Kind.RECOVERABLE),
-                #     _exc_info()[2],
-                # )
     finally:
         _CONTEXT_STACK.pop()
 
@@ -194,40 +176,20 @@ def user_entry_point(wrapped, instance, args, kwargs):
     try:
         _CONTEXT_STACK.append(_USER_CONTEXT)
         if _is_base_context():
-            # return wrapped(*args, **kwargs)
             try:
                 return wrapped(*args, **kwargs)
             except FlyteScopedException as ex:
                 raise ex.value
-                # _reraise(ex.type, ex.value, ex.traceback)
         else:
             try:
                 return wrapped(*args, **kwargs)
-            # except FlyteScopedException:
-            #     # Just pass on the already wrapped and scoped exception
-            #     _reraise(*_exc_info())
             except _user_exceptions.FlyteUserException:
                 raise FlyteScopedUserException(*_exc_info())
-                # _reraise(
-                #     FlyteScopedUserException,
-                #     FlyteScopedUserException(*_exc_info()),
-                #     _exc_info()[2],
-                # )
             except _system_exceptions.FlyteSystemException:
                 raise FlyteScopedSystemException(*_exc_info())
-                # _reraise(
-                #     FlyteScopedSystemException,
-                #     FlyteScopedSystemException(*_exc_info()),
-                #     _exc_info()[2],
-                # )
             except Exception:
                 # Any non-platform raised exception is a user exception.
                 # This will also catch FlyteUserException re-raised by the system_entry_point handler
                 raise FlyteScopedUserException(*_exc_info())
-                # _reraise(
-                #     FlyteScopedUserException,
-                #     FlyteScopedUserException(*_exc_info()),
-                #     _exc_info()[2],
-                # )
     finally:
         _CONTEXT_STACK.pop()

--- a/flytekit/core/map_task.py
+++ b/flytekit/core/map_task.py
@@ -2,6 +2,8 @@
 Flytekit map tasks specify how to run a single task across a list of inputs. Map tasks themselves are constructed with
 a reference task as well as run-time parameters that limit execution concurrency and failure tolerations.
 """
+
+from flytekit.common.exceptions import scopes as exception_scopes
 import os
 from contextlib import contextmanager
 from itertools import count
@@ -168,7 +170,7 @@ class MapPythonTask(PythonTask):
         map_task_inputs = {}
         for k in self.interface.inputs.keys():
             map_task_inputs[k] = kwargs[k][task_index]
-        return self._run_task.execute(**map_task_inputs)
+        return exception_scopes.user_entry_point(self._run_task.execute)(**map_task_inputs)
 
     def _raw_execute(self, **kwargs) -> Any:
         """
@@ -190,7 +192,7 @@ class MapPythonTask(PythonTask):
             single_instance_inputs = {}
             for k in self.interface.inputs.keys():
                 single_instance_inputs[k] = kwargs[k][i]
-            o = self._run_task.execute(**single_instance_inputs)
+            o = exception_scopes.user_entry_point(self._run_task.execute)(**single_instance_inputs)
             if outputs_expected:
                 outputs.append(o)
 

--- a/flytekit/core/map_task.py
+++ b/flytekit/core/map_task.py
@@ -3,13 +3,13 @@ Flytekit map tasks specify how to run a single task across a list of inputs. Map
 a reference task as well as run-time parameters that limit execution concurrency and failure tolerations.
 """
 
-from flytekit.common.exceptions import scopes as exception_scopes
 import os
 from contextlib import contextmanager
 from itertools import count
 from typing import Any, Dict, List, Optional, Type
 
 from flytekit.common.constants import SdkTaskType
+from flytekit.common.exceptions import scopes as exception_scopes
 from flytekit.core.base_task import PythonTask
 from flytekit.core.context_manager import ExecutionState, FlyteContext, FlyteContextManager, SerializationSettings
 from flytekit.core.interface import transform_interface_to_list_interface

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -19,6 +19,7 @@ from abc import ABC
 from collections import OrderedDict
 from enum import Enum
 from typing import Any, Callable, List, Optional, TypeVar, Union
+
 from flytekit.common.exceptions import scopes as exception_scopes
 from flytekit.core.base_task import TaskResolverMixin
 from flytekit.core.context_manager import (

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -19,7 +19,7 @@ from abc import ABC
 from collections import OrderedDict
 from enum import Enum
 from typing import Any, Callable, List, Optional, TypeVar, Union
-
+from flytekit.common.exceptions import scopes as exception_scopes
 from flytekit.core.base_task import TaskResolverMixin
 from flytekit.core.context_manager import (
     ExecutionState,
@@ -156,7 +156,7 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):
         handle dynamic tasks or you will no longer be able to use the task as a dynamic task generator.
         """
         if self.execution_mode == self.ExecutionBehavior.DEFAULT:
-            return self._task_function(**kwargs)
+            return exception_scopes.user_entry_point(self._task_function)(**kwargs)
         elif self.execution_mode == self.ExecutionBehavior.DYNAMIC:
             return self.dynamic_execute(self._task_function, **kwargs)
 
@@ -267,7 +267,7 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):
             updated_exec_state = ctx.execution_state.with_params(mode=ExecutionState.Mode.TASK_EXECUTION)
             with FlyteContextManager.with_context(ctx.with_execution_state(updated_exec_state)):
                 logger.info("Executing Dynamic workflow, using raw inputs")
-                return task_function(**kwargs)
+                return exception_scopes.user_entry_point(task_function)(**kwargs)
 
         if ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
             is_fast_execution = bool(

--- a/flytekit/core/resources.py
+++ b/flytekit/core/resources.py
@@ -15,7 +15,7 @@ class Resources(object):
 
         Storage is not currently supported on the Flyte backend.
 
-    Please see the :std:ref:`User Guide <cookbook:sphx_glr_auto_deployment_workflow_customizing_resources.py>` for detailed examples.
+    Please see the :std:ref:`User Guide <cookbook:customizing task resources>` for detailed examples.
     Also refer to the `K8s conventions. <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes>`__
     """
 

--- a/flytekit/core/schedule.py
+++ b/flytekit/core/schedule.py
@@ -24,7 +24,7 @@ class CronSchedule(_schedule_models.Schedule):
             cron_expression="0 10 * * ? *",
         )
 
-    See the :std:ref:`User Guide <cookbook:sphx_glr_auto_deployment_workflow_lp_schedules.py>` for further examples.
+    See the :std:ref:`User Guide <cookbook:cron schedules>` for further examples.
     """
 
     _VALID_CRON_ALIASES = [

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -7,10 +7,10 @@ from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from flytekit.common import constants as _common_constants
+from flytekit.common.exceptions import scopes as exception_scopes
 from flytekit.common.exceptions.user import FlyteValidationException, FlyteValueException
 from flytekit.core.base_task import PythonTask
 from flytekit.core.class_based_resolver import ClassStorageTaskResolver
-from flytekit.common.exceptions import scopes as exception_scopes
 from flytekit.core.condition import ConditionalSection
 from flytekit.core.context_manager import (
     BranchEvalMode,

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -385,11 +385,21 @@ class ImperativeWorkflow(WorkflowBase):
 
     .. literalinclude:: ../../../tests/flytekit/unit/core/test_imperative.py
        :start-after: # docs_start
-       :end-before: # docs_start
+       :end-before: # docs_end
        :language: python
        :dedent: 4
 
-    This workflow would be identical on the backed to the
+    This workflow would be identical on the back-end to
+
+    .. literalinclude:: ../../../tests/flytekit/unit/core/test_imperative.py
+       :start-after: # docs_equivalent_start
+       :end-before: # docs_equivalent_end
+       :language: python
+       :dedent: 4
+
+    Note that the only reason we need the ``NamedTuple`` is so we can name the output the same thing as in the
+    imperative example. The imperative paradigm makes the naming of workflow outputs easier, but this isn't a big
+    deal in function-workflows because names tend to not be necessary.
     """
 
     def __init__(

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -10,6 +10,7 @@ from flytekit.common import constants as _common_constants
 from flytekit.common.exceptions.user import FlyteValidationException, FlyteValueException
 from flytekit.core.base_task import PythonTask
 from flytekit.core.class_based_resolver import ClassStorageTaskResolver
+from flytekit.common.exceptions import scopes as exception_scopes
 from flytekit.core.condition import ConditionalSection
 from flytekit.core.context_manager import (
     BranchEvalMode,
@@ -668,7 +669,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
             # Construct the default input promise bindings, but then override with the provided inputs, if any
             input_kwargs = construct_input_promises([k for k in self.interface.inputs.keys()])
             input_kwargs.update(kwargs)
-            workflow_outputs = self._workflow_function(**input_kwargs)
+            workflow_outputs = exception_scopes.user_entry_point(self._workflow_function)(**input_kwargs)
             all_nodes.extend(comp_ctx.compilation_state.nodes)
 
             # This little loop was added as part of the task resolver change. The task resolver interface itself is
@@ -740,7 +741,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
         call execute from dispatch_execute which is in _local_execute, workflows should also call an execute inside
         _local_execute. This makes mocking cleaner.
         """
-        return self._workflow_function(**kwargs)
+        return exception_scopes.user_entry_point(self._workflow_function)(**kwargs)
 
 
 def workflow(

--- a/flytekit/engines/flyte/engine.py
+++ b/flytekit/engines/flyte/engine.py
@@ -387,10 +387,7 @@ class FlyteTask(_common_engine.BaseTaskExecutor):
                             exc_str = _traceback.format_exc()
                             output_file_dict[_constants.ERROR_FILE_NAME] = _error_models.ErrorDocument(
                                 _error_models.ContainerError(
-                                    "SYSTEM:Unknown",
-                                    exc_str,
-                                    _error_models.ContainerError.Kind.RECOVERABLE,
-                                    0
+                                    "SYSTEM:Unknown", exc_str, _error_models.ContainerError.Kind.RECOVERABLE, 0
                                 )
                             )
                             _logging.error(exc_str)

--- a/flytekit/engines/flyte/engine.py
+++ b/flytekit/engines/flyte/engine.py
@@ -378,7 +378,7 @@ class FlyteTask(_common_engine.BaseTaskExecutor):
                         except _exception_scopes.FlyteScopedException as e:
                             _logging.error("!!! Begin Error Captured by Flyte !!!")
                             output_file_dict[_constants.ERROR_FILE_NAME] = _error_models.ErrorDocument(
-                                _error_models.ContainerError(e.error_code, e.verbose_message, e.kind)
+                                _error_models.ContainerError(e.error_code, e.verbose_message, e.kind, 0)
                             )
                             _logging.error(e.verbose_message)
                             _logging.error("!!! End Error Captured by Flyte !!!")
@@ -390,6 +390,7 @@ class FlyteTask(_common_engine.BaseTaskExecutor):
                                     "SYSTEM:Unknown",
                                     exc_str,
                                     _error_models.ContainerError.Kind.RECOVERABLE,
+                                    0
                                 )
                             )
                             _logging.error(exc_str)

--- a/flytekit/models/core/errors.py
+++ b/flytekit/models/core/errors.py
@@ -8,15 +8,18 @@ class ContainerError(_common.FlyteIdlEntity):
         NON_RECOVERABLE = _errors_pb2.ContainerError.NON_RECOVERABLE
         RECOVERABLE = _errors_pb2.ContainerError.RECOVERABLE
 
-    def __init__(self, code, message, kind):
+    def __init__(self, code: str, message: str, kind: int, origin: int):
         """
-        :param Text code: A succinct code about the error
-        :param Text message: Whatever message you want to surface about the error
-        :param int kind: A value from the ContainerError.Kind enum.
+        :param code: A succinct code about the error
+        :param message: Whatever message you want to surface about the error
+        :param kind: A value from the ContainerError.Kind enum.
+        :param origin: A value from ExecutionError.ErrorKind. Don't confuse this with error kind, even though
+          both are called kind.
         """
         self._code = code
         self._message = message
         self._kind = kind
+        self._origin = origin
 
     @property
     def code(self):
@@ -39,11 +42,18 @@ class ContainerError(_common.FlyteIdlEntity):
         """
         return self._kind
 
+    @property
+    def origin(self) -> int:
+        """
+        The origin of the error, an enum value from ExecutionError.ErrorKind
+        """
+        return self._origin
+
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.core.errors_pb2.ContainerError
         """
-        return _errors_pb2.ContainerError(code=self.code, message=self.message, kind=self.kind)
+        return _errors_pb2.ContainerError(code=self.code, message=self.message, kind=self.kind, origin=self.origin)
 
     @classmethod
     def from_flyte_idl(cls, proto):
@@ -51,7 +61,7 @@ class ContainerError(_common.FlyteIdlEntity):
         :param flyteidl.core.errors_pb2.ContainerError proto:
         :rtype: ContainerError
         """
-        return cls(proto.code, proto.message, proto.kind)
+        return cls(proto.code, proto.message, proto.kind, proto.origin)
 
 
 class ErrorDocument(_common.FlyteIdlEntity):

--- a/flytekit/models/core/execution.py
+++ b/flytekit/models/core/execution.py
@@ -112,15 +112,22 @@ class TaskExecutionPhase(object):
 
 
 class ExecutionError(_common.FlyteIdlEntity):
-    def __init__(self, code, message, error_uri):
+    class ErrorKind(object):
+        UNKNOWN = _execution_pb2.ExecutionError.ErrorKind.UNKNOWN
+        USER = _execution_pb2.ExecutionError.ErrorKind.USER
+        SYSTEM = _execution_pb2.ExecutionError.ErrorKind.SYSTEM
+
+    def __init__(self, code: str, message: str, error_uri: str, kind: int):
         """
-        :param Text code:
-        :param Text message:
-        :param Text uri:
+        :param code:
+        :param message:
+        :param uri:
+        :param kind:
         """
         self._code = code
         self._message = message
         self._error_uri = error_uri
+        self._kind = kind
 
     @property
     def code(self):
@@ -143,6 +150,13 @@ class ExecutionError(_common.FlyteIdlEntity):
         """
         return self._error_uri
 
+    @property
+    def kind(self) -> int:
+        """
+        Enum value from ErrorKind
+        """
+        return self._kind
+
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.core.execution_pb2.ExecutionError
@@ -151,6 +165,7 @@ class ExecutionError(_common.FlyteIdlEntity):
             code=self.code,
             message=self.message,
             error_uri=self.error_uri,
+            kind=self.kind,
         )
 
     @classmethod
@@ -159,11 +174,7 @@ class ExecutionError(_common.FlyteIdlEntity):
         :param flyteidl.core.execution_pb2.ExecutionError p:
         :rtype: ExecutionError
         """
-        return cls(
-            code=p.code,
-            message=p.message,
-            error_uri=p.error_uri,
-        )
+        return cls(code=p.code, message=p.message, error_uri=p.error_uri, kind=p.kind)
 
 
 class TaskLog(_common.FlyteIdlEntity):

--- a/flytekit/models/literals.py
+++ b/flytekit/models/literals.py
@@ -1,7 +1,6 @@
 from datetime import datetime as _datetime
 
 import pytz as _pytz
-import six as _six
 from flyteidl.core import literals_pb2 as _literals_pb2
 from google.protobuf.struct_pb2 import Struct
 
@@ -310,7 +309,7 @@ class BindingDataMap(_common.FlyteIdlEntity):
         """
         :rtype: flyteidl.core.literals_pb2.BindingDataMap
         """
-        return _literals_pb2.BindingDataMap(bindings={k: v.to_flyte_idl() for (k, v) in _six.iteritems(self.bindings)})
+        return _literals_pb2.BindingDataMap(bindings={k: v.to_flyte_idl() for (k, v) in self.bindings.items()})
 
     @classmethod
     def from_flyte_idl(cls, pb2_object):
@@ -319,7 +318,7 @@ class BindingDataMap(_common.FlyteIdlEntity):
         :rtype: flytekit.models.literals.BindingDataMap
         """
 
-        return cls({k: BindingData.from_flyte_idl(v) for (k, v) in _six.iteritems(pb2_object.bindings)})
+        return cls({k: BindingData.from_flyte_idl(v) for (k, v) in pb2_object.bindings.items()})
 
 
 class BindingDataCollection(_common.FlyteIdlEntity):
@@ -588,7 +587,7 @@ class LiteralMap(_common.FlyteIdlEntity):
         """
         :rtype: flyteidl.core.literals_pb2.LiteralMap
         """
-        return _literals_pb2.LiteralMap(literals={k: v.to_flyte_idl() for k, v in _six.iteritems(self.literals)})
+        return _literals_pb2.LiteralMap(literals={k: v.to_flyte_idl() for k, v in self.literals.items()})
 
     @classmethod
     def from_flyte_idl(cls, pb2_object):
@@ -596,7 +595,7 @@ class LiteralMap(_common.FlyteIdlEntity):
         :param flyteidl.core.literals_pb2.LiteralMap pb2_object:
         :rtype: LiteralMap
         """
-        return cls({k: Literal.from_flyte_idl(v) for k, v in _six.iteritems(pb2_object.literals)})
+        return cls({k: Literal.from_flyte_idl(v) for k, v in pb2_object.literals.items()})
 
 
 class Scalar(_common.FlyteIdlEntity):

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -1,27 +1,30 @@
 import os
+import typing
 from collections import OrderedDict
-from flytekit.common.exceptions.scopes import system_entry_point
+
 import mock
 import six
 from click.testing import CliRunner
 from flyteidl.core import literals_pb2 as _literals_pb2
 from flyteidl.core.errors_pb2 import ErrorDocument
-from flytekit.core.task import task
-from flytekit.core.type_engine import TypeEngine
-import typing
+
 from flytekit.bin.entrypoint import _dispatch_execute, _legacy_execute_task, execute_task_cmd
 from flytekit.common import constants as _constants
 from flytekit.common import utils as _utils
+from flytekit.common.exceptions import user as user_exceptions
+from flytekit.common.exceptions.scopes import system_entry_point
 from flytekit.common.types import helpers as _type_helpers
 from flytekit.configuration import TemporaryConfiguration as _TemporaryConfiguration
 from flytekit.core import context_manager
 from flytekit.core.base_task import IgnoreOutputs
-from flytekit.core.promise import VoidPromise
 from flytekit.core.dynamic_workflow_task import dynamic
+from flytekit.core.promise import VoidPromise
+from flytekit.core.task import task
+from flytekit.core.type_engine import TypeEngine
 from flytekit.models import literals as _literal_models
+from flytekit.models.core import errors as error_models
+from flytekit.models.core import execution as execution_models
 from tests.flytekit.common import task_definitions as _task_defs
-from flytekit.models.core import errors as error_models, execution as execution_models
-from flytekit.common.exceptions import user as user_exceptions
 
 
 def _type_map_from_variable_map(variable_map):
@@ -115,7 +118,9 @@ def test_arrayjob_entrypoint_in_proc():
             _utils.write_proto_to_file(literal_map.to_flyte_idl(), input_file)
 
             # construct indexlookup.pb which has array: [1]
-            mapped_index = _literal_models.Literal(_literal_models.Scalar(primitive=_literal_models.Primitive(integer=1)))
+            mapped_index = _literal_models.Literal(
+                _literal_models.Scalar(primitive=_literal_models.Primitive(integer=1))
+            )
             index_lookup_collection = _literal_models.LiteralCollection([mapped_index])
             index_lookup_file = os.path.join(dir.name, "indexlookup.pb")
             _utils.write_proto_to_file(index_lookup_collection.to_flyte_idl(), index_lookup_file)
@@ -269,6 +274,7 @@ def test_dispatch_execute_exception(mock_write_to_file, mock_upload_dir, mock_ge
 def get_output_collector(results: OrderedDict):
     def output_collector(proto, path):
         results[path] = proto
+
     return output_collector
 
 

--- a/tests/flytekit/unit/core/test_imperative.py
+++ b/tests/flytekit/unit/core/test_imperative.py
@@ -46,7 +46,7 @@ def test_imperative():
     # docs_start
     # Create the workflow with a name. This needs to be unique within the project and takes the place of the function
     # name that's used for regular decorated function-based workflows.
-    wb = Workflow(name="my.workflow")
+    wb = Workflow(name="my_workflow")
     # Adds a top level input to the workflow. This is like an input to a workflow function.
     wb.add_workflow_input("in1", str)
     # Call your tasks.
@@ -54,7 +54,7 @@ def test_imperative():
     wb.add_entity(t2)
     # This is analagous to a return statement
     wb.add_workflow_output("from_n0t1", node.outputs["o0"])
-    # docs_start
+    # docs_end
 
     assert wb(in1="hello") == "hello world"
 
@@ -66,10 +66,20 @@ def test_imperative():
     assert len(wf_spec.template.interface.inputs) == 1
     assert len(wf_spec.template.interface.outputs) == 1
 
+    # docs_equivalent_start
+    nt = typing.NamedTuple("wf_output", from_n0t1=str)
+
+    @workflow
+    def my_workflow(in1: str) -> nt:
+        x = t1(a=in1)
+        t2()
+        return x,
+    # docs_equivalent_end
+
     # Create launch plan from wf, that can also be serialized.
     lp = LaunchPlan.create("test_wb", wb)
     lp_model = get_serializable(OrderedDict(), serialization_settings, lp)
-    assert lp_model.spec.workflow_id.name == "my.workflow"
+    assert lp_model.spec.workflow_id.name == "my_workflow"
 
     wb2 = ImperativeWorkflow(name="parent.imperative")
     p_in1 = wb2.add_workflow_input("p_in1", str)
@@ -81,7 +91,7 @@ def test_imperative():
     assert wb2_spec.template.interface.inputs["p_in1"].type.simple is not None
     assert len(wb2_spec.template.interface.outputs) == 1
     assert wb2_spec.template.interface.outputs["parent_wf_output"].type.simple is not None
-    assert wb2_spec.template.nodes[0].workflow_node.sub_workflow_ref.name == "my.workflow"
+    assert wb2_spec.template.nodes[0].workflow_node.sub_workflow_ref.name == "my_workflow"
     assert len(wb2_spec.sub_workflows) == 1
 
     wb3 = ImperativeWorkflow(name="parent.imperative")

--- a/tests/flytekit/unit/core/test_imperative.py
+++ b/tests/flytekit/unit/core/test_imperative.py
@@ -73,7 +73,8 @@ def test_imperative():
     def my_workflow(in1: str) -> nt:
         x = t1(a=in1)
         t2()
-        return x,
+        return (x,)
+
     # docs_equivalent_end
 
     # Create launch plan from wf, that can also be serialized.

--- a/tests/flytekit/unit/models/core/test_errors.py
+++ b/tests/flytekit/unit/models/core/test_errors.py
@@ -1,21 +1,27 @@
-from flytekit.models.core import errors
+from flytekit.models.core import errors, execution
 
 
 def test_container_error():
-    obj = errors.ContainerError("code", "my message", errors.ContainerError.Kind.RECOVERABLE)
+    obj = errors.ContainerError(
+        "code", "my message", errors.ContainerError.Kind.RECOVERABLE, execution.ExecutionError.ErrorKind.SYSTEM
+    )
     assert obj.code == "code"
     assert obj.message == "my message"
     assert obj.kind == errors.ContainerError.Kind.RECOVERABLE
+    assert obj.origin == 2
 
     obj2 = errors.ContainerError.from_flyte_idl(obj.to_flyte_idl())
     assert obj == obj2
     assert obj2.code == "code"
     assert obj2.message == "my message"
     assert obj2.kind == errors.ContainerError.Kind.RECOVERABLE
+    assert obj2.origin == 2
 
 
 def test_error_document():
-    ce = errors.ContainerError("code", "my message", errors.ContainerError.Kind.RECOVERABLE)
+    ce = errors.ContainerError(
+        "code", "my message", errors.ContainerError.Kind.RECOVERABLE, execution.ExecutionError.ErrorKind.USER
+    )
     obj = errors.ErrorDocument(ce)
     assert obj.error == ce
 

--- a/tests/flytekit/unit/models/core/test_execution.py
+++ b/tests/flytekit/unit/models/core/test_execution.py
@@ -19,13 +19,15 @@ def test_task_logs():
 
 
 def test_execution_error():
-    obj = execution.ExecutionError("code", "message", "uri")
+    obj = execution.ExecutionError("code", "message", "uri", execution.ExecutionError.ErrorKind.UNKNOWN)
     assert obj.code == "code"
     assert obj.message == "message"
     assert obj.error_uri == "uri"
+    assert obj.kind == 0
 
     obj2 = execution.ExecutionError.from_flyte_idl(obj.to_flyte_idl())
     assert obj == obj2
     assert obj2.code == "code"
     assert obj2.message == "message"
     assert obj2.error_uri == "uri"
+    assert obj2.kind == 0


### PR DESCRIPTION
# TL;DR
This cleans up the exception handling of new tasks and workflows.  Currently there is no differentiation of recoverable or non-recoverable errors and all errors were system errors.

## Type
 - [x] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
* Remove six from the scopes handling, no Python 2 anymore.  This makes the scopes code slightly easier to read.
* Add in [`kind`](https://github.com/flyteorg/flyteidl/blob/f4809c1a52073ec80de41be109bccc6331cdbac3/protos/flyteidl/core/execution.proto#L68) into the `ExecutionError` model.
* Add in [`origin`](https://github.com/flyteorg/flyteidl/blob/f4809c1a52073ec80de41be109bccc6331cdbac3/protos/flyteidl/core/errors.proto#L27) into the `ContainerError`.
* Use the user scope decorator where user-code is invoked (see https://github.com/flyteorg/flytekit/pull/540/files which this PR originally came from).
* Add the system scope decorator to `_dispatch_execute` in the entrypoint.py.
