### PR TITLE
handle Asymmetric return values from tasks within a conditional block

### DIFF
--- a/flytekit/core/condition.py
+++ b/flytekit/core/condition.py
@@ -215,6 +215,11 @@ class SkippedConditionalSection(ConditionalSection):
         """
         if self._last_case:
             FlyteContextManager.pop_context()
+            curr = self.compute_output_set()
+            if curr is None:
+                return VoidPromise(self.name)
+            promises = [Promise(var=x, val=None) for x in curr]
+            return create_task_output(promises)
         return self._condition
 
 

--- a/flytekit/core/condition.py
+++ b/flytekit/core/condition.py
@@ -114,13 +114,16 @@ class ConditionalSection:
     def if_(self, expr: bool) -> Case:
         return self._condition._if(expr)
 
-    def _compute_outputs(self, n: Node) -> Union[Promise, Tuple[Promise], VoidPromise]:
+    def compute_output_set(self) -> typing.Optional[typing.Set[str]]:
+        """
+        Computes and returns the minimum set of outputs for this conditional block, based on all the cases that have
+        been registered
+        """
         output_var_sets: typing.List[typing.Set[str]] = []
         for c in self._cases:
             if c.output_promise is None and c.err is None:
-                # One node returns a void output and no error, we will default to a
-                # Void output
-                return VoidPromise(n.id)
+                # One node returns a void output and no error, we will default to None return
+                return None
             if c.output_promise is not None:
                 if isinstance(c.output_promise, tuple):
                     output_var_sets.append(set([i.var for i in c.output_promise]))
@@ -130,6 +133,12 @@ class ConditionalSection:
         if len(output_var_sets) > 1:
             for x in output_var_sets[1:]:
                 curr = curr.intersection(x)
+        return curr
+
+    def _compute_outputs(self, n: Node) -> Union[Promise, Tuple[Promise], VoidPromise]:
+        curr = self.compute_output_set()
+        if curr is None:
+            return VoidPromise(n.id)
         promises = [Promise(var=x, val=NodeOutput(node=n, var=x)) for x in curr]
         # TODO: Is there a way to add the Python interface here? Currently, it's an optional arg.
         return create_task_output(promises)
@@ -174,9 +183,21 @@ class LocalExecutedConditionalSection(ConditionalSection):
             if self._selected_case.output_promise is None and self._selected_case.err is None:
                 raise AssertionError("Bad conditional statements, did not resolve in a promise")
             elif self._selected_case.output_promise is not None:
-                return self._selected_case.output_promise
+                return self._compute_outputs(self._selected_case.output_promise)
             raise ValueError(self._selected_case.err)
         return self._condition
+
+    def _compute_outputs(self, selected_output_promise) -> Union[Promise, Tuple[Promise], VoidPromise]:
+        """
+        For the local execution case only returns the least common set of outputs
+        """
+        curr = self.compute_output_set()
+        if curr is None:
+            return VoidPromise(self.name)
+        if not isinstance(selected_output_promise, tuple):
+            selected_output_promise = (selected_output_promise,)
+        promises = [Promise(var=x, val=v.val) for x, v in zip(curr, selected_output_promise)]
+        return create_task_output(promises)
 
 
 class SkippedConditionalSection(ConditionalSection):

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -262,11 +262,12 @@ class WorkflowBase(object):
             ctx.execution_state is not None and ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION
         ):
             if ctx.execution_state.branch_eval_mode == BranchEvalMode.BRANCH_SKIPPED:
-                if self.python_interface and self.python_interface.output_tuple_name:
-                    variables = [k for k in self.python_interface.outputs.keys()]
-                    output_tuple = collections.namedtuple(self.python_interface.output_tuple_name, variables)
-                    nones = [None for _ in self.python_interface.outputs.keys()]
-                    return output_tuple(*nones)
+                if self.interface:
+                    output_names = list(self.interface.outputs.keys())
+                    if len(output_names) == 0:
+                        return VoidPromise(self.name)
+                    vals = [Promise(var, None) for var in output_names]
+                    return create_task_output(vals, self.python_interface)
                 else:
                     return None
             # We are already in a local execution, just continue the execution context

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import collections
 import inspect
 from dataclasses import dataclass
 from enum import Enum


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
Flyte conditionals support asymmetric return values for the tasks in each of the case statements. The behavior is to truncate the outputs to only the minimal set that match across all outputs. this mostly affected local execution

```python
    @task
    def square(n: int) -> int:
        return n * n

    @task
    def double(n: int) -> int:
        return 2 * n

    @task
    def coin_toss(seed: int) -> bool:
        """
        Mimic some condition checking to see if something ran correctly
        """
        r = random.Random(seed)
        if r.random() < 0.5:
            return True
        return False

    @task
    def sum_diff(a: int, b: int) -> (int, int):
        return a + b, a - b

    @workflow
    def consume_outputs(my_input: int, seed: int = 5) -> int:
        is_heads = coin_toss(seed=seed)
        res = (
            conditional("double_or_square")
            .if_(is_heads.is_true())
            .then(square(n=my_input))
            .else_()
            .then(sum_diff(a=my_input, b=my_input))
        )

        return double(n=res)
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
The base task did not return Promises in the case of skipped conditional sections. This also resulted in a case that the Conditional section when executed locally, ignored outputs from other tasks and thus would simply return outputs from the selected block. This output may not match the expected interface. So now just like in compilation, the outputs are matched and truncated in the cases when the task returns more outputs than expected.

