### PR TITLE
Add recover-execution flyte-cli command

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,7 +23,7 @@ bcrypt==3.2.0
     # via
     #   -c requirements.txt
     #   paramiko
-black==21.6b0
+black==21.7b0
     # via
     #   -c requirements.txt
     #   -r dev-requirements.in
@@ -32,13 +32,13 @@ certifi==2021.5.30
     # via
     #   -c requirements.txt
     #   requests
-cffi==1.14.5
+cffi==1.14.6
     # via
     #   -c requirements.txt
     #   bcrypt
     #   cryptography
     #   pynacl
-chardet==4.0.0
+charset-normalizer==2.0.3
     # via
     #   -c requirements.txt
     #   requests
@@ -94,11 +94,11 @@ flake8==3.9.2
     #   -r dev-requirements.in
     #   flake8-black
     #   flake8-isort
-flake8-black==0.2.1
+flake8-black==0.2.2
     # via -r dev-requirements.in
 flake8-isort==4.0.0
     # via -r dev-requirements.in
-flyteidl==0.19.11
+flyteidl==0.19.14
     # via
     #   -c requirements.txt
     #   flytekit
@@ -106,7 +106,7 @@ grpcio==1.38.1
     # via
     #   -c requirements.txt
     #   flytekit
-idna==2.10
+idna==3.2
     # via
     #   -c requirements.txt
     #   requests
@@ -116,7 +116,7 @@ importlib-metadata==4.6.1
     #   keyring
 iniconfig==1.1.1
     # via pytest
-isort==5.9.1
+isort==5.9.2
     # via
     #   -r dev-requirements.in
     #   flake8-isort
@@ -136,7 +136,7 @@ markupsafe==2.0.1
     # via
     #   -c requirements.txt
     #   jinja2
-marshmallow==3.12.1
+marshmallow==3.12.2
     # via
     #   -c requirements.txt
     #   dataclasses-json
@@ -263,7 +263,7 @@ regex==2021.7.6
     #   -c requirements.txt
     #   black
     #   docker-image-py
-requests==2.25.1
+requests==2.26.0
     # via
     #   -c requirements.txt
     #   docker
@@ -308,17 +308,19 @@ stringcase==1.2.0
     # via
     #   -c requirements.txt
     #   dataclasses-json
-testfixtures==6.17.1
+testfixtures==6.18.0
     # via flake8-isort
-texttable==1.6.3
+texttable==1.6.4
     # via docker-compose
 toml==0.10.2
     # via
-    #   -c requirements.txt
-    #   black
     #   coverage
     #   mypy
     #   pytest
+tomli==1.0.4
+    # via
+    #   -c requirements.txt
+    #   black
 typing-extensions==3.10.0.0
     # via
     #   -c requirements.txt

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -13,7 +13,9 @@ ansiwrap==0.8.4
 appdirs==1.4.4
     # via black
 appnope==0.1.2
-    # via ipython
+    # via
+    #   ipykernel
+    #   ipython
 astroid==2.6.2
     # via sphinx-autoapi
 async-generator==1.10
@@ -33,24 +35,24 @@ beautifulsoup4==4.9.3
     #   furo
     #   sphinx-code-include
     #   sphinx-material
-black==21.6b0
+black==21.7b0
     # via papermill
-bleach==3.3.0
+bleach==3.3.1
     # via nbconvert
-boto3==1.17.105
+boto3==1.18.1
     # via sagemaker-training
-botocore==1.20.105
+botocore==1.21.1
     # via
     #   boto3
     #   s3transfer
 certifi==2021.5.30
     # via requests
-cffi==1.14.5
+cffi==1.14.6
     # via
     #   bcrypt
     #   cryptography
     #   pynacl
-chardet==4.0.0
+charset-normalizer==2.0.3
     # via requests
 click==7.1.2
     # via
@@ -88,7 +90,7 @@ entrypoints==0.3
     # via
     #   nbconvert
     #   papermill
-flyteidl==0.19.11
+flyteidl==0.19.14
     # via flytekit
 git+git://github.com/flyteorg/furo@main
     # via -r doc-requirements.in
@@ -102,7 +104,7 @@ grpcio==1.38.1
     #   flytekit
 hmsclient==0.1.1
     # via flytekit
-idna==2.10
+idna==3.2
     # via requests
 imagesize==1.2.0
     # via sphinx
@@ -110,7 +112,7 @@ importlib-metadata==4.6.1
     # via keyring
 inotify_simple==1.2.1
     # via sagemaker-training
-ipykernel==6.0.1
+ipykernel==6.0.2
     # via flytekit
 ipython==7.25.0
     # via ipykernel
@@ -152,7 +154,7 @@ lxml==4.6.3
     # via sphinx-material
 markupsafe==2.0.1
     # via jinja2
-marshmallow==3.12.1
+marshmallow==3.12.2
     # via
     #   dataclasses-json
     #   marshmallow-enum
@@ -278,7 +280,7 @@ regex==2021.7.6
     # via
     #   black
     #   docker-image-py
-requests==2.25.1
+requests==2.26.0
     # via
     #   flytekit
     #   papermill
@@ -290,7 +292,7 @@ retry==0.9.2
     # via flytekit
 retrying==1.3.3
     # via sagemaker-training
-s3transfer==0.4.2
+s3transfer==0.5.0
     # via boto3
 sagemaker-training==3.9.2
     # via flytekit
@@ -313,7 +315,6 @@ six==1.16.0
     #   sagemaker-training
     #   scantree
     #   sphinx-code-include
-    #   tenacity
     #   thrift
 snowballstemmer==2.1.0
     # via sphinx
@@ -362,7 +363,7 @@ statsd==3.3.0
     # via flytekit
 stringcase==1.2.0
     # via dataclasses-json
-tenacity==7.0.0
+tenacity==8.0.1
     # via papermill
 testpath==0.5.0
     # via nbconvert
@@ -372,7 +373,7 @@ textwrap3==0.9.2
     # via ansiwrap
 thrift==0.13.0
     # via hmsclient
-toml==0.10.2
+tomli==1.0.4
     # via black
 tornado==6.1
     # via

--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -558,6 +558,17 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
             .id
         )
 
+    def recover_execution(self, id, name: str = None):
+        """
+        :param flytekit.common.core.identifier.WorkflowExecutionIdentifier id:
+        :rtype: flytekit.models.core.identifier.WorkflowExecutionIdentifier
+        """
+        return _identifier.WorkflowExecutionIdentifier.from_flyte_idl(
+            super(SynchronousFlyteClient, self)
+            .recover_execution(_execution_pb2.ExecutionRecoverRequest(id=id.to_flyte_idl(), name=name))
+            .id
+        )
+
     def get_execution(self, id):
         """
         :param flytekit.common.core.identifier.WorkflowExecutionIdentifier id:

--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -560,7 +560,9 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
 
     def recover_execution(self, id, name: str = None):
         """
+        Recreates a previously-run workflow execution that will only start executing from the last known failure point.
         :param flytekit.common.core.identifier.WorkflowExecutionIdentifier id:
+        :param name str: Optional name to assign to the newly created execution.
         :rtype: flytekit.models.core.identifier.WorkflowExecutionIdentifier
         """
         return _identifier.WorkflowExecutionIdentifier.from_flyte_idl(

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -524,7 +524,7 @@ class RawSynchronousFlyteClient(object):
     @_handle_rpc_error()
     def recover_execution(self, recover_execution_request):
         """
-        This will create an execution for the given execution spec.
+        This will recreate an execution with the same spec as the one belonging to the given execution identifier.
         :param flyteidl.admin.execution_pb2.ExecutionRecoverRequest recover_execution_request:
         :rtype: flyteidl.admin.execution_pb2.ExecutionRecoverResponse
         """

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -521,6 +521,15 @@ class RawSynchronousFlyteClient(object):
         """
         return self._stub.CreateExecution(create_execution_request, metadata=self._metadata)
 
+    @_handle_rpc_error()
+    def recover_execution(self, recover_execution_request):
+        """
+        This will create an execution for the given execution spec.
+        :param flyteidl.admin.execution_pb2.ExecutionRecoverRequest recover_execution_request:
+        :rtype: flyteidl.admin.execution_pb2.ExecutionRecoverResponse
+        """
+        return self._stub.RecoverExecution(recover_execution_request, metadata=self._metadata)
+
     @_handle_rpc_error(retry=True)
     def get_execution(self, get_object_request):
         """

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1255,6 +1255,44 @@ def relaunch_execution(project, domain, name, host, insecure, urn, principal, ve
     _click.echo("")
 
 
+@_flyte_cli.command("recover-execution", cls=_FlyteSubCommand)
+@_urn_option
+@_optional_name_option
+@_host_option
+@_insecure_option
+def recover_execution(urn, name, host, insecure):
+    """
+    Recreates a previously-run workflow execution that will only start executing from the last known failure point.
+
+    In Recover mode, users cannot change any input parameters or update the version of the execution.
+    This is extremely useful to recover from system errors and byzantine faults like
+        - loss of K8s cluster
+        - bugs in platform or instability
+        - machine failures
+        - downstream system failures (downstream services)
+        - or simply to recover executions that failed because of retry exhaustion and should complete if tried again.
+
+    You can optionally assign a name to the recreated execution you trigger or let the system assing one.
+
+    Usage:
+        $ flyte-cli recover-execution -u ex:flyteexamples:development:some-workflow:abc123 -n my_retry_name
+
+    These arguments are then collected, and passed into the `lp_args` variable as a Tuple[Text].
+    Users should use the get-execution and get-launch-plan commands to ascertain the names of inputs to use.
+    """
+    _welcome_message()
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+
+    _click.echo("Recovering execution {}\n".format(_tt(urn)))
+
+    original_workflow_execution_identifier = _identifier.WorkflowExecutionIdentifier.from_python_std(urn)
+
+    execution_identifier_resp = client.recover_execution(id=original_workflow_execution_identifier, name=name)
+    execution_identifier = _identifier.WorkflowExecutionIdentifier.promote_from_model(execution_identifier_resp)
+    _click.secho("Launched execution: {}".format(execution_identifier), fg="blue")
+    _click.echo("")
+
+
 @_flyte_cli.command("terminate-execution", cls=_FlyteSubCommand)
 @_host_option
 @_insecure_option

--- a/requirements-spark2.txt
+++ b/requirements-spark2.txt
@@ -11,7 +11,9 @@ ansiwrap==0.8.4
 appdirs==1.4.4
     # via black
 appnope==0.1.2
-    # via ipython
+    # via
+    #   ipykernel
+    #   ipython
 async-generator==1.10
     # via nbclient
 attrs==20.3.0
@@ -23,24 +25,24 @@ backcall==0.2.0
     # via ipython
 bcrypt==3.2.0
     # via paramiko
-black==21.6b0
+black==21.7b0
     # via papermill
-bleach==3.3.0
+bleach==3.3.1
     # via nbconvert
-boto3==1.17.105
+boto3==1.18.1
     # via sagemaker-training
-botocore==1.20.105
+botocore==1.21.1
     # via
     #   boto3
     #   s3transfer
 certifi==2021.5.30
     # via requests
-cffi==1.14.5
+cffi==1.14.6
     # via
     #   bcrypt
     #   cryptography
     #   pynacl
-chardet==4.0.0
+charset-normalizer==2.0.3
     # via requests
 click==7.1.2
     # via
@@ -72,7 +74,7 @@ entrypoints==0.3
     # via
     #   nbconvert
     #   papermill
-flyteidl==0.19.11
+flyteidl==0.19.14
     # via flytekit
 gevent==21.1.2
     # via sagemaker-training
@@ -82,13 +84,13 @@ grpcio==1.38.1
     # via flytekit
 hmsclient==0.1.1
     # via flytekit
-idna==2.10
+idna==3.2
     # via requests
 importlib-metadata==4.6.1
     # via keyring
 inotify_simple==1.2.1
     # via sagemaker-training
-ipykernel==6.0.1
+ipykernel==6.0.2
     # via flytekit
 ipython==7.25.0
     # via ipykernel
@@ -123,7 +125,7 @@ keyring==23.0.1
     # via flytekit
 markupsafe==2.0.1
     # via jinja2
-marshmallow==3.12.1
+marshmallow==3.12.2
     # via
     #   dataclasses-json
     #   marshmallow-enum
@@ -240,7 +242,7 @@ regex==2021.7.6
     # via
     #   black
     #   docker-image-py
-requests==2.25.1
+requests==2.26.0
     # via
     #   flytekit
     #   papermill
@@ -251,7 +253,7 @@ retry==0.9.2
     # via flytekit
 retrying==1.3.3
     # via sagemaker-training
-s3transfer==0.4.2
+s3transfer==0.5.0
     # via boto3
 sagemaker-training==3.9.2
     # via flytekit
@@ -273,7 +275,6 @@ six==1.16.0
     #   retrying
     #   sagemaker-training
     #   scantree
-    #   tenacity
     #   thrift
 sortedcontainers==2.4.0
     # via flytekit
@@ -281,7 +282,7 @@ statsd==3.3.0
     # via flytekit
 stringcase==1.2.0
     # via dataclasses-json
-tenacity==7.0.0
+tenacity==8.0.1
     # via papermill
 testpath==0.5.0
     # via nbconvert
@@ -289,7 +290,7 @@ textwrap3==0.9.2
     # via ansiwrap
 thrift==0.13.0
     # via hmsclient
-toml==0.10.2
+tomli==1.0.4
     # via black
 tornado==6.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,9 @@ ansiwrap==0.8.4
 appdirs==1.4.4
     # via black
 appnope==0.1.2
-    # via ipython
+    # via
+    #   ipykernel
+    #   ipython
 async-generator==1.10
     # via nbclient
 attrs==20.3.0
@@ -23,24 +25,24 @@ backcall==0.2.0
     # via ipython
 bcrypt==3.2.0
     # via paramiko
-black==21.6b0
+black==21.7b0
     # via papermill
-bleach==3.3.0
+bleach==3.3.1
     # via nbconvert
-boto3==1.17.105
+boto3==1.18.1
     # via sagemaker-training
-botocore==1.20.105
+botocore==1.21.1
     # via
     #   boto3
     #   s3transfer
 certifi==2021.5.30
     # via requests
-cffi==1.14.5
+cffi==1.14.6
     # via
     #   bcrypt
     #   cryptography
     #   pynacl
-chardet==4.0.0
+charset-normalizer==2.0.3
     # via requests
 click==7.1.2
     # via
@@ -72,7 +74,7 @@ entrypoints==0.3
     # via
     #   nbconvert
     #   papermill
-flyteidl==0.19.11
+flyteidl==0.19.14
     # via flytekit
 gevent==21.1.2
     # via sagemaker-training
@@ -82,13 +84,13 @@ grpcio==1.38.1
     # via flytekit
 hmsclient==0.1.1
     # via flytekit
-idna==2.10
+idna==3.2
     # via requests
 importlib-metadata==4.6.1
     # via keyring
 inotify_simple==1.2.1
     # via sagemaker-training
-ipykernel==6.0.1
+ipykernel==6.0.2
     # via flytekit
 ipython==7.25.0
     # via ipykernel
@@ -123,7 +125,7 @@ keyring==23.0.1
     # via flytekit
 markupsafe==2.0.1
     # via jinja2
-marshmallow==3.12.1
+marshmallow==3.12.2
     # via
     #   dataclasses-json
     #   marshmallow-enum
@@ -240,7 +242,7 @@ regex==2021.7.6
     # via
     #   black
     #   docker-image-py
-requests==2.25.1
+requests==2.26.0
     # via
     #   flytekit
     #   papermill
@@ -251,7 +253,7 @@ retry==0.9.2
     # via flytekit
 retrying==1.3.3
     # via sagemaker-training
-s3transfer==0.4.2
+s3transfer==0.5.0
     # via boto3
 sagemaker-training==3.9.2
     # via flytekit
@@ -273,7 +275,6 @@ six==1.16.0
     #   retrying
     #   sagemaker-training
     #   scantree
-    #   tenacity
     #   thrift
 sortedcontainers==2.4.0
     # via flytekit
@@ -281,7 +282,7 @@ statsd==3.3.0
     # via flytekit
 stringcase==1.2.0
     # via dataclasses-json
-tenacity==7.0.0
+tenacity==8.0.1
     # via papermill
 testpath==0.5.0
     # via nbconvert
@@ -289,7 +290,7 @@ textwrap3==0.9.2
     # via ansiwrap
 thrift==0.13.0
     # via hmsclient
-toml==0.10.2
+tomli==1.0.4
     # via black
 tornado==6.1
     # via

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         ]
     },
     install_requires=[
-        "flyteidl>=0.19.5,<1.0.0",
+        "flyteidl>=0.19.14,<1.0.0",
         "wheel>=0.30.0,<1.0.0",
         "pandas>=1.0.0,<2.0.0",
         "pyarrow>=2.0.0,<4.0.0",


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Allows users to recreate a previously-run workflow execution that will only start executing from the last known failure point.

In keeping with existing execution commands `relaunch-execution` and `terminate-execution` as separate commands I made this one an additional command for consistency.


## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1151

## Follow-up issue
_NA_