### PR TITLE
Prefix command with SDK_PYTHON_VENV if available

### DIFF
--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -119,19 +119,21 @@ class PythonAutoContainerTask(PythonTask[T], metaclass=FlyteTrackedABC):
         if SDK_PYTHON_VENV.get():
             container_args.extend(SDK_PYTHON_VENV.get())
 
-        container_args.extend([
-            "pyflyte-execute",
-            "--inputs",
-            "{{.input}}",
-            "--output-prefix",
-            "{{.outputPrefix}}",
-            "--raw-output-data-prefix",
-            "{{.rawOutputDataPrefix}}",
-            "--resolver",
-            self.task_resolver.location,
-            "--",
-            *self.task_resolver.loader_args(settings, self),
-        ])
+        container_args.extend(
+            [
+                "pyflyte-execute",
+                "--inputs",
+                "{{.input}}",
+                "--output-prefix",
+                "{{.outputPrefix}}",
+                "--raw-output-data-prefix",
+                "{{.rawOutputDataPrefix}}",
+                "--resolver",
+                self.task_resolver.location,
+                "--",
+                *self.task_resolver.loader_args(settings, self),
+            ]
+        )
 
         return container_args
 

--- a/tests/flytekit/unit/core/test_python_auto_container.py
+++ b/tests/flytekit/unit/core/test_python_auto_container.py
@@ -1,21 +1,23 @@
 from typing import List
 
-from flytekit.core.context_manager import SerializationSettings
-from flytekit.core.python_auto_container import PythonAutoContainerTask
 import mock
 
+from flytekit.core.context_manager import SerializationSettings
+from flytekit.core.python_auto_container import PythonAutoContainerTask
 
-@mock.patch('flytekit.core.python_auto_container.SDK_PYTHON_VENV')
+
+@mock.patch("flytekit.core.python_auto_container.SDK_PYTHON_VENV")
 def test_get_default_command_prefix_sdk_python_venv(mock_venv):
 
     mock_venv.get.return_value = ["service_venv"]
 
     task = PythonAutoContainerTask(
-        "test", None,
+        "test",
+        None,
     )
 
-    task._task_resolver._location = 'location'
-    task._task_resolver.loader_args = lambda a, b: ['a', 'b']
+    task._task_resolver._location = "location"
+    task._task_resolver.loader_args = lambda a, b: ["a", "b"]
 
-    cmd: List[str] = task.get_default_command(SerializationSettings('p', 'd', 'v', None))
+    cmd: List[str] = task.get_default_command(SerializationSettings("p", "d", "v", None))
     assert cmd[0] == "service_venv"

--- a/tests/flytekit/unit/core/test_python_auto_container.py
+++ b/tests/flytekit/unit/core/test_python_auto_container.py
@@ -21,3 +21,7 @@ def test_get_default_command_prefix_sdk_python_venv(mock_venv):
 
     cmd: List[str] = task.get_default_command(SerializationSettings("p", "d", "v", None))
     assert cmd[0] == "service_venv"
+
+    mock_venv.get.return_value = []
+    cmd: List[str] = task.get_default_command(SerializationSettings("p", "d", "v", None))
+    assert cmd[0] == "pyflyte-execute"

--- a/tests/flytekit/unit/core/test_python_auto_container.py
+++ b/tests/flytekit/unit/core/test_python_auto_container.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from flytekit.core.context_manager import SerializationSettings
+from flytekit.core.python_auto_container import PythonAutoContainerTask
+import mock
+
+
+@mock.patch('flytekit.core.python_auto_container.SDK_PYTHON_VENV')
+def test_get_default_command_prefix_sdk_python_venv(mock_venv):
+
+    mock_venv.get.return_value = ["service_venv"]
+
+    task = PythonAutoContainerTask(
+        "test", None,
+    )
+
+    task._task_resolver._location = 'location'
+    task._task_resolver.loader_args = lambda a, b: ['a', 'b']
+
+    cmd: List[str] = task.get_default_command(SerializationSettings('p', 'd', 'v', None))
+    assert cmd[0] == "service_venv"

--- a/tests/flytekit/unit/core/test_python_auto_container.py
+++ b/tests/flytekit/unit/core/test_python_auto_container.py
@@ -16,6 +16,8 @@ def test_get_default_command_prefix_sdk_python_venv(mock_venv):
         None,
     )
 
+    task._task_resolver = mock.Mock()
+
     task._task_resolver._location = "location"
     task._task_resolver.loader_args = lambda a, b: ["a", "b"]
 


### PR DESCRIPTION
# TL;DR
Prefix the command with `SDK_PYTHON_VENV` if it is present. This ensures feature parity with https://github.com/flyteorg/flytekit/blob/68cd7beb1800bd32e7bb6b7b77fad7fecec01998/flytekit/common/tasks/sdk_runnable.py#L266

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
