### PR TITLE
Raw output prefix takes precedence for remote proxy creation in entrypoint

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -243,7 +243,9 @@ def setup_execution(
             local_sandbox_dir=_sdk_config.LOCAL_SANDBOX.get(),
             remote_proxy=_gcs_proxy.GCSProxy(raw_output_data_prefix),
         )
-    elif raw_output_data_prefix.startswith("file") or raw_output_data_prefix.startswith("/"):
+    elif raw_output_data_prefix and (
+        raw_output_data_prefix.startswith("file") or raw_output_data_prefix.startswith("/")
+    ):
         # A fake remote using the local disk will automatically be created
         file_access = _data_proxy.FileAccessProvider(local_sandbox_dir=_sdk_config.LOCAL_SANDBOX.get())
     else:

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -186,7 +186,6 @@ def setup_execution(
     dynamic_addl_distro: str = None,
     dynamic_dest_dir: str = None,
 ):
-    cloud_provider = _platform_config.CLOUD_PROVIDER.get()
     log_level = _internal_config.LOGGING_LEVEL.get() or _sdk_config.LOGGING_LEVEL.get()
     _logging.getLogger().setLevel(log_level)
 
@@ -226,17 +225,17 @@ def setup_execution(
         tmp_dir=user_workspace_dir,
     )
 
-    if cloud_provider == _constants.CloudProvider.AWS:
+    if raw_output_data_prefix.startswith("s3:/"):
         file_access = _data_proxy.FileAccessProvider(
             local_sandbox_dir=_sdk_config.LOCAL_SANDBOX.get(),
             remote_proxy=_s3proxy.AwsS3Proxy(raw_output_data_prefix),
         )
-    elif cloud_provider == _constants.CloudProvider.GCP:
+    elif raw_output_data_prefix.startswith("gs:/"):
         file_access = _data_proxy.FileAccessProvider(
             local_sandbox_dir=_sdk_config.LOCAL_SANDBOX.get(),
             remote_proxy=_gcs_proxy.GCSProxy(raw_output_data_prefix),
         )
-    elif cloud_provider == _constants.CloudProvider.LOCAL:
+    elif raw_output_data_prefix.startswith("file") or raw_output_data_prefix.startswith("/"):
         # A fake remote using the local disk will automatically be created
         file_access = _data_proxy.FileAccessProvider(local_sandbox_dir=_sdk_config.LOCAL_SANDBOX.get())
     else:

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -226,7 +226,8 @@ def setup_execution(
         tmp_dir=user_workspace_dir,
     )
 
-    # This rather ugly hack will be going away with #559. The reason we have to check for the existence of the
+    # This rather ugly condition will be going away with #559. We first check the raw output prefix, and if missing,
+    # we fall back to the logic of checking the cloud provider. The reason we have to check for the existence of the
     # raw_output_data_prefix arg first is because it may be set to None by execute_task_cmd. That is there to support
     # the corner case of a really old propeller that is still not filling in the raw output prefix template.
     if raw_output_data_prefix:

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -229,23 +229,31 @@ def setup_execution(
     # This rather ugly hack will be going away with #559. The reason we have to check for the existence of the
     # raw_output_data_prefix arg first is because it may be set to None by execute_task_cmd. That is there to support
     # the corner case of a really old propeller that is still not filling in the raw output prefix template.
-    if (
-        raw_output_data_prefix and raw_output_data_prefix.startswith("s3:/")
-    ) or cloud_provider == _constants.CloudProvider.AWS:
+    if raw_output_data_prefix:
+        if raw_output_data_prefix.startswith("s3:/"):
+            file_access = _data_proxy.FileAccessProvider(
+                local_sandbox_dir=_sdk_config.LOCAL_SANDBOX.get(),
+                remote_proxy=_s3proxy.AwsS3Proxy(raw_output_data_prefix),
+            )
+        elif raw_output_data_prefix.startswith("gs:/"):
+            file_access = _data_proxy.FileAccessProvider(
+                local_sandbox_dir=_sdk_config.LOCAL_SANDBOX.get(),
+                remote_proxy=_gcs_proxy.GCSProxy(raw_output_data_prefix),
+            )
+        elif raw_output_data_prefix.startswith("file") or raw_output_data_prefix.startswith("/"):
+            # A fake remote using the local disk will automatically be created
+            file_access = _data_proxy.FileAccessProvider(local_sandbox_dir=_sdk_config.LOCAL_SANDBOX.get())
+    elif cloud_provider == _constants.CloudProvider.AWS:
         file_access = _data_proxy.FileAccessProvider(
             local_sandbox_dir=_sdk_config.LOCAL_SANDBOX.get(),
             remote_proxy=_s3proxy.AwsS3Proxy(raw_output_data_prefix),
         )
-    elif (
-        raw_output_data_prefix and raw_output_data_prefix.startswith("gs:/")
-    ) or cloud_provider == _constants.CloudProvider.GCP:
+    elif cloud_provider == _constants.CloudProvider.GCP:
         file_access = _data_proxy.FileAccessProvider(
             local_sandbox_dir=_sdk_config.LOCAL_SANDBOX.get(),
             remote_proxy=_gcs_proxy.GCSProxy(raw_output_data_prefix),
         )
-    elif raw_output_data_prefix and (
-        raw_output_data_prefix.startswith("file") or raw_output_data_prefix.startswith("/")
-    ):
+    elif cloud_provider == _constants.CloudProvider.LOCAL:
         # A fake remote using the local disk will automatically be created
         file_access = _data_proxy.FileAccessProvider(local_sandbox_dir=_sdk_config.LOCAL_SANDBOX.get())
     else:


### PR DESCRIPTION
# TL;DR
When running in GCP without a config file present, flytekit uses the wrong setting to try to determine what environment it's running in.  We should base the decision on the offloaded data location, not the cloud provider setting, which defaults to AWS.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Add an extra conditional to first check the `raw_output_data_prefix`.  Not too worried about the increased complexity becase this section of the code will soon be removed by #559, which should be going in within a week and change.

