### PR TITLE
Pin ipykernel

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -38,7 +38,7 @@ cffi==1.14.6
     #   bcrypt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.3
+charset-normalizer==2.0.4
     # via
     #   -c requirements.txt
     #   requests
@@ -73,7 +73,7 @@ dirhash==0.2.1
     # via
     #   -c requirements.txt
     #   flytekit
-distro==1.5.0
+distro==1.6.0
     # via docker-compose
 docker[ssh]==5.0.0
     # via docker-compose
@@ -81,7 +81,7 @@ docker-compose==1.29.2
     # via
     #   pytest-docker
     #   pytest-flyte
-docker-image-py==0.1.10
+docker-image-py==0.1.12
     # via
     #   -c requirements.txt
     #   flytekit
@@ -89,7 +89,7 @@ dockerpty==0.4.1
     # via docker-compose
 docopt==0.6.2
     # via docker-compose
-docstring-parser==0.9.1
+docstring-parser==0.10
     # via
     #   -c requirements.txt
     #   flytekit
@@ -102,11 +102,11 @@ flake8-black==0.2.3
     # via -r dev-requirements.in
 flake8-isort==4.0.0
     # via -r dev-requirements.in
-flyteidl==0.19.14
+flyteidl==0.19.19
     # via
     #   -c requirements.txt
     #   flytekit
-grpcio==1.38.1
+grpcio==1.39.0
     # via
     #   -c requirements.txt
     #   flytekit
@@ -114,13 +114,13 @@ idna==3.2
     # via
     #   -c requirements.txt
     #   requests
-importlib-metadata==4.6.1
+importlib-metadata==4.6.3
     # via
     #   -c requirements.txt
     #   keyring
 iniconfig==1.1.1
     # via pytest
-isort==5.9.2
+isort==5.9.3
     # via
     #   -r dev-requirements.in
     #   flake8-isort
@@ -179,7 +179,7 @@ packaging==21.0
     # via
     #   -c requirements.txt
     #   pytest
-pandas==1.3.0
+pandas==1.3.1
     # via
     #   -c requirements.txt
     #   flytekit
@@ -243,9 +243,9 @@ python-dateutil==2.8.1
     #   croniter
     #   flytekit
     #   pandas
-python-dotenv==0.18.0
+python-dotenv==0.19.0
     # via docker-compose
-python-json-logger==2.0.1
+python-json-logger==2.0.2
     # via
     #   -c requirements.txt
     #   flytekit
@@ -262,7 +262,7 @@ pyyaml==5.4.1
     # via
     #   -c requirements.txt
     #   docker-compose
-regex==2021.7.6
+regex==2021.8.3
     # via
     #   -c requirements.txt
     #   black
@@ -322,7 +322,7 @@ toml==0.10.2
     #   flake8-black
     #   mypy
     #   pytest
-tomli==1.0.4
+tomli==1.2.0
     # via
     #   -c requirements.txt
     #   black

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -16,7 +16,7 @@ appnope==0.1.2
     # via
     #   ipykernel
     #   ipython
-astroid==2.6.5
+astroid==2.6.6
     # via sphinx-autoapi
 async-generator==1.10
     # via nbclient
@@ -37,11 +37,11 @@ beautifulsoup4==4.9.3
     #   sphinx-material
 black==21.7b0
     # via papermill
-bleach==3.3.1
+bleach==4.0.0
     # via nbconvert
-boto3==1.18.6
+boto3==1.18.14
     # via sagemaker-training
-botocore==1.21.6
+botocore==1.21.14
     # via
     #   boto3
     #   s3transfer
@@ -52,7 +52,7 @@ cffi==1.14.6
     #   bcrypt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.3
+charset-normalizer==2.0.4
     # via requests
 click==7.1.2
     # via
@@ -70,8 +70,6 @@ css-html-js-minify==2.5.5
     # via sphinx-material
 dataclasses-json==0.5.4
     # via flytekit
-debugpy==1.4.1
-    # via ipykernel
 decorator==5.0.9
     # via
     #   ipython
@@ -82,9 +80,9 @@ deprecated==1.2.12
     # via flytekit
 dirhash==0.2.1
     # via flytekit
-docker-image-py==0.1.11
+docker-image-py==0.1.12
     # via flytekit
-docstring-parser==0.9.1
+docstring-parser==0.10
     # via flytekit
 docutils==0.17.1
     # via sphinx
@@ -92,7 +90,7 @@ entrypoints==0.3
     # via
     #   nbconvert
     #   papermill
-flyteidl==0.19.14
+flyteidl==0.19.19
     # via flytekit
 git+git://github.com/flyteorg/furo@main
     # via -r doc-requirements.in
@@ -110,13 +108,13 @@ idna==3.2
     # via requests
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==4.6.1
+importlib-metadata==4.6.3
     # via keyring
 inotify_simple==1.2.1
     # via sagemaker-training
-ipykernel==6.0.3
+ipykernel==5.5.5
     # via flytekit
-ipython==7.25.0
+ipython==7.26.0
     # via ipykernel
 ipython-genutils==0.2.0
     # via
@@ -166,9 +164,7 @@ marshmallow-enum==1.5.1
 marshmallow-jsonschema==0.12.0
     # via flytekit
 matplotlib-inline==0.1.2
-    # via
-    #   ipykernel
-    #   ipython
+    # via ipython
 mistune==0.8.4
     # via nbconvert
 mypy-extensions==0.4.3
@@ -261,7 +257,7 @@ python-dateutil==2.8.1
     #   flytekit
     #   jupyter-client
     #   pandas
-python-json-logger==2.0.1
+python-json-logger==2.0.2
     # via flytekit
 python-slugify[unidecode]==5.0.2
     # via sphinx-material
@@ -276,9 +272,9 @@ pyyaml==5.4.1
     # via
     #   papermill
     #   sphinx-autoapi
-pyzmq==22.1.0
+pyzmq==22.2.1
     # via jupyter-client
-regex==2021.7.6
+regex==2021.8.3
     # via
     #   black
     #   docker-image-py
@@ -300,7 +296,7 @@ sagemaker-training==3.9.2
     # via flytekit
 scantree==0.0.1
     # via dirhash
-scipy==1.7.0
+scipy==1.7.1
     # via sagemaker-training
 six==1.16.0
     # via
@@ -335,7 +331,7 @@ sphinx==4.1.2
     #   sphinx-gallery
     #   sphinx-material
     #   sphinx-prompt
-sphinx-autoapi==1.8.1
+sphinx-autoapi==1.8.3
     # via -r doc-requirements.in
 sphinx-code-include==1.1.1
     # via -r doc-requirements.in
@@ -375,13 +371,13 @@ textwrap3==0.9.2
     # via ansiwrap
 thrift==0.13.0
     # via hmsclient
-tomli==1.1.0
+tomli==1.2.0
     # via black
 tornado==6.1
     # via
     #   ipykernel
     #   jupyter-client
-tqdm==4.61.2
+tqdm==4.62.0
     # via papermill
 traitlets==5.0.5
     # via

--- a/requirements-spark2.txt
+++ b/requirements-spark2.txt
@@ -27,11 +27,11 @@ bcrypt==3.2.0
     # via paramiko
 black==21.7b0
     # via papermill
-bleach==3.3.1
+bleach==4.0.0
     # via nbconvert
-boto3==1.18.4
+boto3==1.18.14
     # via sagemaker-training
-botocore==1.21.4
+botocore==1.21.14
     # via
     #   boto3
     #   s3transfer
@@ -42,7 +42,7 @@ cffi==1.14.6
     #   bcrypt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.3
+charset-normalizer==2.0.4
     # via requests
 click==7.1.2
     # via
@@ -56,8 +56,6 @@ cryptography==3.4.7
     # via paramiko
 dataclasses-json==0.5.4
     # via flytekit
-debugpy==1.4.0
-    # via ipykernel
 decorator==5.0.9
     # via
     #   ipython
@@ -68,33 +66,33 @@ deprecated==1.2.12
     # via flytekit
 dirhash==0.2.1
     # via flytekit
-docker-image-py==0.1.10
+docker-image-py==0.1.12
     # via flytekit
-docstring-parser==0.9.1
+docstring-parser==0.10
     # via flytekit
 entrypoints==0.3
     # via
     #   nbconvert
     #   papermill
-flyteidl==0.19.14
+flyteidl==0.19.19
     # via flytekit
 gevent==21.1.2
     # via sagemaker-training
 greenlet==1.1.0
     # via gevent
-grpcio==1.38.1
+grpcio==1.39.0
     # via flytekit
 hmsclient==0.1.1
     # via flytekit
 idna==3.2
     # via requests
-importlib-metadata==4.6.1
+importlib-metadata==4.6.3
     # via keyring
 inotify_simple==1.2.1
     # via sagemaker-training
-ipykernel==6.0.3
+ipykernel==5.5.5
     # via flytekit
-ipython==7.25.0
+ipython==7.26.0
     # via ipykernel
 ipython-genutils==0.2.0
     # via
@@ -137,9 +135,7 @@ marshmallow-enum==1.5.1
 marshmallow-jsonschema==0.12.0
     # via flytekit
 matplotlib-inline==0.1.2
-    # via
-    #   ipykernel
-    #   ipython
+    # via ipython
 mistune==0.8.4
     # via nbconvert
 mypy-extensions==0.4.3
@@ -170,7 +166,7 @@ numpy==1.21.1
     #   scipy
 packaging==21.0
     # via bleach
-pandas==1.3.0
+pandas==1.3.1
     # via flytekit
 pandocfilters==1.4.3
     # via nbconvert
@@ -228,7 +224,7 @@ python-dateutil==2.8.1
     #   flytekit
     #   jupyter-client
     #   pandas
-python-json-logger==2.0.1
+python-json-logger==2.0.2
     # via flytekit
 pytimeparse==1.1.8
     # via flytekit
@@ -238,9 +234,9 @@ pytz==2018.4
     #   pandas
 pyyaml==5.4.1
     # via papermill
-pyzmq==22.1.0
+pyzmq==22.2.1
     # via jupyter-client
-regex==2021.7.6
+regex==2021.8.3
     # via
     #   black
     #   docker-image-py
@@ -261,7 +257,7 @@ sagemaker-training==3.9.2
     # via flytekit
 scantree==0.0.1
     # via dirhash
-scipy==1.7.0
+scipy==1.7.1
     # via sagemaker-training
 six==1.16.0
     # via
@@ -292,13 +288,13 @@ textwrap3==0.9.2
     # via ansiwrap
 thrift==0.13.0
     # via hmsclient
-tomli==1.0.4
+tomli==1.2.0
     # via black
 tornado==6.1
     # via
     #   ipykernel
     #   jupyter-client
-tqdm==4.61.2
+tqdm==4.62.0
     # via papermill
 traitlets==5.0.5
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,11 +27,11 @@ bcrypt==3.2.0
     # via paramiko
 black==21.7b0
     # via papermill
-bleach==3.3.1
+bleach==4.0.0
     # via nbconvert
-boto3==1.18.4
+boto3==1.18.14
     # via sagemaker-training
-botocore==1.21.4
+botocore==1.21.14
     # via
     #   boto3
     #   s3transfer
@@ -42,7 +42,7 @@ cffi==1.14.6
     #   bcrypt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.3
+charset-normalizer==2.0.4
     # via requests
 click==7.1.2
     # via
@@ -56,8 +56,6 @@ cryptography==3.4.7
     # via paramiko
 dataclasses-json==0.5.4
     # via flytekit
-debugpy==1.4.0
-    # via ipykernel
 decorator==5.0.9
     # via
     #   ipython
@@ -68,33 +66,33 @@ deprecated==1.2.12
     # via flytekit
 dirhash==0.2.1
     # via flytekit
-docker-image-py==0.1.10
+docker-image-py==0.1.12
     # via flytekit
-docstring-parser==0.9.1
+docstring-parser==0.10
     # via flytekit
 entrypoints==0.3
     # via
     #   nbconvert
     #   papermill
-flyteidl==0.19.14
+flyteidl==0.19.19
     # via flytekit
 gevent==21.1.2
     # via sagemaker-training
 greenlet==1.1.0
     # via gevent
-grpcio==1.38.1
+grpcio==1.39.0
     # via flytekit
 hmsclient==0.1.1
     # via flytekit
 idna==3.2
     # via requests
-importlib-metadata==4.6.1
+importlib-metadata==4.6.3
     # via keyring
 inotify_simple==1.2.1
     # via sagemaker-training
-ipykernel==6.0.3
+ipykernel==5.5.5
     # via flytekit
-ipython==7.25.0
+ipython==7.26.0
     # via ipykernel
 ipython-genutils==0.2.0
     # via
@@ -137,9 +135,7 @@ marshmallow-enum==1.5.1
 marshmallow-jsonschema==0.12.0
     # via flytekit
 matplotlib-inline==0.1.2
-    # via
-    #   ipykernel
-    #   ipython
+    # via ipython
 mistune==0.8.4
     # via nbconvert
 mypy-extensions==0.4.3
@@ -170,7 +166,7 @@ numpy==1.21.1
     #   scipy
 packaging==21.0
     # via bleach
-pandas==1.3.0
+pandas==1.3.1
     # via flytekit
 pandocfilters==1.4.3
     # via nbconvert
@@ -228,7 +224,7 @@ python-dateutil==2.8.1
     #   flytekit
     #   jupyter-client
     #   pandas
-python-json-logger==2.0.1
+python-json-logger==2.0.2
     # via flytekit
 pytimeparse==1.1.8
     # via flytekit
@@ -238,9 +234,9 @@ pytz==2018.4
     #   pandas
 pyyaml==5.4.1
     # via papermill
-pyzmq==22.1.0
+pyzmq==22.2.1
     # via jupyter-client
-regex==2021.7.6
+regex==2021.8.3
     # via
     #   black
     #   docker-image-py
@@ -261,7 +257,7 @@ sagemaker-training==3.9.2
     # via flytekit
 scantree==0.0.1
     # via dirhash
-scipy==1.7.0
+scipy==1.7.1
     # via sagemaker-training
 six==1.16.0
     # via
@@ -292,13 +288,13 @@ textwrap3==0.9.2
     # via ansiwrap
 thrift==0.13.0
     # via hmsclient
-tomli==1.0.4
+tomli==1.2.0
     # via black
 tornado==6.1
     # via
     #   ipykernel
     #   jupyter-client
-tqdm==4.61.2
+tqdm==4.62.0
     # via papermill
 traitlets==5.0.5
     # via

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ spark3 = ["pyspark>=3.0.0"]
 sidecar = ["k8s-proto>=0.0.3,<1.0.0"]
 schema = ["numpy>=1.14.0,<2.0.0", "pandas>=0.22.0,<2.0.0", "pyarrow>2.0.0,<4.0.0"]
 hive_sensor = ["hmsclient>=0.0.1,<1.0.0"]
-notebook = ["papermill>=1.2.0", "nbconvert>=6.0.7", "ipykernel>=5.0.0"]
+notebook = ["papermill>=1.2.0", "nbconvert>=6.0.7", "ipykernel>=5.0.0,<6.0.0"]
 sagemaker = ["sagemaker-training>=3.6.2,<4.0.0"]
 
 all_but_spark = sidecar + schema + hive_sensor + notebook + sagemaker


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Pin ipykernel since commits on master now fail to install dependencies with

```
The conflict is caused by:
    The user requested importlib-metadata==4.6.1
    flake8 3.9.2 depends on importlib-metadata; python_version < "3.8"
    ipykernel 6.0.3 depends on importlib-metadata<4; python_version < "3.8.0"
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
