### PR TITLE
Protobuf transformer did not consider empty generic

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -271,7 +271,7 @@ class ProtobufTransformer(TypeTransformer[_proto_reflection.GeneratedProtocolMes
 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
         if not (lv and lv.scalar and lv.scalar.generic is not None):
-            raise AssertionError("Can only covert a generic literal to a Protobuf")
+            raise AssertionError("Can only convert a generic literal to a Protobuf")
 
         pb_obj = expected_python_type()
         dictionary = _MessageToDict(lv.scalar.generic)

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -270,7 +270,7 @@ class ProtobufTransformer(TypeTransformer[_proto_reflection.GeneratedProtocolMes
         return Literal(scalar=Scalar(generic=struct))
 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
-        if not (lv and lv.scalar and lv.scalar.generic):
+        if not (lv and lv.scalar and lv.scalar.generic is not None):
             raise AssertionError("Can only covert a generic literal to a Protobuf")
 
         pb_obj = expected_python_type()
@@ -797,6 +797,7 @@ def _register_default_type_transformers():
     TypeEngine.register(PathLikeTransformer())
     TypeEngine.register(BinaryIOTransformer())
     TypeEngine.register(EnumTransformer())
+    TypeEngine.register(ProtobufTransformer())
 
     # inner type is. Also unsupported are typing's Tuples. Even though you can look inside them, Flyte's type system
     # doesn't support these currently.
@@ -810,5 +811,3 @@ def _register_default_type_transformers():
 
 
 _register_default_type_transformers()
-
-TypeEngine.register(ProtobufTransformer())

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -198,6 +198,13 @@ def test_protos():
     with pytest.raises(AssertionError):
         TypeEngine.to_python_value(ctx, l0, errors_pb2.ContainerError)
 
+    default_proto = errors_pb2.ContainerError()
+    lit = TypeEngine.to_literal(ctx, default_proto, errors_pb2.ContainerError, lt)
+    assert lit.scalar
+    assert lit.scalar.generic is not None
+    new_python_val = TypeEngine.to_python_value(ctx, lit, errors_pb2.ContainerError)
+    assert new_python_val == default_proto
+
 
 def test_guessing_basic():
     b = model_types.LiteralType(simple=model_types.SimpleType.BOOLEAN)


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
 - Zero value protobufs, become empty json (or empty dictionaries).
 - empty dictionaries currently result in an exception, when it should
result in empty proto
 - This needs a simple change in the condition

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1325


