### PR TITLE
[wip] Add caching to local execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,3 +88,8 @@ update_version:
 
 	grep "$(PLACEHOLDER)" "setup.py"
 	sed -i "s/$(PLACEHOLDER)/__version__ = \"${VERSION}\"/g" "setup.py"
+
+# TODO
+.PHONY: clear-cache
+clear-cache:
+	python -m 'from flytekit.core.local_cache import LocalCache; LocalCache.clear()'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -128,6 +128,10 @@ jinja2==3.0.1
     # via
     #   -c requirements.txt
     #   pytest-flyte
+joblib==1.0.1
+    # via
+    #   -c requirements.txt
+    #   flytekit
 jsonschema==3.2.0
     # via
     #   -c requirements.txt
@@ -274,7 +278,7 @@ requests==2.26.0
     #   docker-compose
     #   flytekit
     #   responses
-responses==0.13.3
+responses==0.13.4
     # via
     #   -c requirements.txt
     #   flytekit
@@ -345,7 +349,7 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wheel==0.36.2
+wheel==0.37.0
     # via
     #   -c requirements.txt
     #   flytekit

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -39,9 +39,9 @@ black==21.7b0
     # via papermill
 bleach==4.0.0
     # via nbconvert
-boto3==1.18.15
+boto3==1.18.19
     # via sagemaker-training
-botocore==1.21.15
+botocore==1.21.19
     # via
     #   boto3
     #   s3transfer
@@ -96,7 +96,7 @@ git+git://github.com/flyteorg/furo@main
     # via -r doc-requirements.in
 gevent==21.8.0
     # via sagemaker-training
-greenlet==1.1.0
+greenlet==1.1.1
     # via gevent
 grpcio==1.39.0
     # via
@@ -131,6 +131,8 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
+joblib==1.0.1
+    # via flytekit
 jsonschema==3.2.0
     # via nbformat
 jupyter-client==6.1.12
@@ -284,7 +286,7 @@ requests==2.26.0
     #   papermill
     #   responses
     #   sphinx
-responses==0.13.3
+responses==0.13.4
     # via flytekit
 retry==0.9.2
     # via flytekit
@@ -343,7 +345,7 @@ sphinx-gallery==0.9.0
     # via -r doc-requirements.in
 sphinx-material==0.0.34
     # via -r doc-requirements.in
-sphinx-prompt==1.4.0
+sphinx-prompt==1.5.0
     # via -r doc-requirements.in
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
@@ -409,7 +411,7 @@ webencodings==0.5.1
     # via bleach
 werkzeug==2.0.1
     # via sagemaker-training
-wheel==0.36.2
+wheel==0.37.0
     # via flytekit
 wrapt==1.12.1
     # via

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -253,8 +253,6 @@ class Task(object):
         # TODO: improve comment
         # if metadata.cache is set, check memoized version including cache_version
         if self._metadata.cache:
-            # TODO: do I need to ignore self?
-            # TODO: probably need a wrapper to indicate it's going to pull from the cache. A log message here might be enough?
             dispatch_execute = memory.cache(self._local_dispatch_execute, ignore=['self', 'ctx'])
         else:
             dispatch_execute = self._local_dispatch_execute

--- a/requirements-spark2.txt
+++ b/requirements-spark2.txt
@@ -29,9 +29,9 @@ black==21.7b0
     # via papermill
 bleach==4.0.0
     # via nbconvert
-boto3==1.18.15
+boto3==1.18.19
     # via sagemaker-training
-botocore==1.21.15
+botocore==1.21.19
     # via
     #   boto3
     #   s3transfer
@@ -78,7 +78,7 @@ flyteidl==0.19.19
     # via flytekit
 gevent==21.8.0
     # via sagemaker-training
-greenlet==1.1.0
+greenlet==1.1.1
     # via gevent
 grpcio==1.39.0
     # via flytekit
@@ -106,6 +106,8 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
+joblib==1.0.1
+    # via flytekit
 jsonschema==3.2.0
     # via nbformat
 jupyter-client==6.1.12
@@ -245,7 +247,7 @@ requests==2.26.0
     #   flytekit
     #   papermill
     #   responses
-responses==0.13.3
+responses==0.13.4
     # via flytekit
 retry==0.9.2
     # via flytekit
@@ -322,7 +324,7 @@ webencodings==0.5.1
     # via bleach
 werkzeug==2.0.1
     # via sagemaker-training
-wheel==0.36.2
+wheel==0.37.0
     # via flytekit
 wrapt==1.12.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,9 +29,9 @@ black==21.7b0
     # via papermill
 bleach==4.0.0
     # via nbconvert
-boto3==1.18.15
+boto3==1.18.19
     # via sagemaker-training
-botocore==1.21.15
+botocore==1.21.19
     # via
     #   boto3
     #   s3transfer
@@ -78,7 +78,7 @@ flyteidl==0.19.19
     # via flytekit
 gevent==21.8.0
     # via sagemaker-training
-greenlet==1.1.0
+greenlet==1.1.1
     # via gevent
 grpcio==1.39.0
     # via flytekit
@@ -106,6 +106,8 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
+joblib==1.0.1
+    # via flytekit
 jsonschema==3.2.0
     # via nbformat
 jupyter-client==6.1.12
@@ -245,7 +247,7 @@ requests==2.26.0
     #   flytekit
     #   papermill
     #   responses
-responses==0.13.3
+responses==0.13.4
     # via flytekit
 retry==0.9.2
     # via flytekit
@@ -322,7 +324,7 @@ webencodings==0.5.1
     # via bleach
 werkzeug==2.0.1
     # via sagemaker-training
-wheel==0.36.2
+wheel==0.37.0
     # via flytekit
 wrapt==1.12.1
     # via

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
         "docker-image-py>=0.1.10",
         "singledispatchmethod; python_version < '3.8.0'",
         "docstring-parser>=0.9.0",
+        "joblib>=1.0.0",
     ],
     extras_require=extras_require,
     scripts=[

--- a/tests/flytekit/unit/core/test_local_cache.py
+++ b/tests/flytekit/unit/core/test_local_cache.py
@@ -1,0 +1,45 @@
+from flytekit.core.task import task
+from flytekit.core.workflow import workflow
+
+
+def test_single_task_workflow():
+    @task(cache=True, cache_version="v1")
+    def is_even(n: int) -> bool:
+        import time
+        time.sleep(2)
+        return n % 2 == 0
+
+    @task(cache=False)
+    def uncached_task(a: int, b: int) -> int:
+        return a + b
+
+    @workflow
+    def check_evenness(n: int) -> bool:
+        uncached_task(a=n, b=n)
+        return is_even(n=n)
+
+    assert check_evenness(n=1) is False
+    assert check_evenness(n=8) is True
+
+def test_shared_tasks_in_two_separate_workflows():
+    @task(cache=True, cache_version="0.0.1")
+    def is_even(n: int) -> bool:
+        import time
+        time.sleep(2)
+        return n % 2 == 0
+
+    @workflow
+    def check_evenness_wf1(n: int) -> bool:
+        return is_even(n=n)
+
+    @workflow
+    def check_evenness_wf2(n: int) -> bool:
+        return is_even(n=n)
+
+    assert check_evenness_wf1(n=42) is True
+    assert check_evenness_wf1(n=99) is False
+
+    # The next two executions of the *_wf2 workflow are going to
+    # hit the cache for the calls to `is_even`
+    assert check_evenness_wf2(n=42) is True
+    assert check_evenness_wf2(n=99) is False

--- a/tests/flytekit/unit/core/test_local_cache.py
+++ b/tests/flytekit/unit/core/test_local_cache.py
@@ -21,6 +21,7 @@ def test_single_task_workflow():
     assert check_evenness(n=1) is False
     assert check_evenness(n=8) is True
 
+
 def test_shared_tasks_in_two_separate_workflows():
     @task(cache=True, cache_version="0.0.1")
     def is_even(n: int) -> bool:


### PR DESCRIPTION
# TL;DR
Enable the ability to cache the output of tasks in local executions

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
[`joblib.Memory`](https://joblib.readthedocs.io/en/latest/generated/joblib.Memory.html#joblib.Memory) provides a persistent store to cache the result of function invocations. Similarly to how we do in the hosted case, we use the pair `(task inputs, cache version)` to memoize task outputs across different executions.

We're also exposing a configuration knob to let users decide where the cached objects will be written to disk.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/761

## Follow-up issue
_NA_
