### PR TITLE
feat: better error message when the Any type is used 

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import datetime as _datetime
 import enum
+import inspect
 import json as _json
 import mimetypes
 import os
@@ -345,7 +346,7 @@ class TypeEngine(typing.Generic[T]):
         for base_type in cls._REGISTRY.keys():
             if base_type is None:
                 continue  # None is actually one of the keys, but isinstance/issubclass doesn't work on it
-            if isinstance(python_type, base_type) or issubclass(python_type, base_type):
+            if isinstance(python_type, base_type) or (inspect.isclass(python_type) and issubclass(python_type, base_type)):
                 return cls._REGISTRY[base_type]
         raise ValueError(f"Type {python_type} not supported currently in Flytekit. Please register a new transformer")
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -346,7 +346,9 @@ class TypeEngine(typing.Generic[T]):
         for base_type in cls._REGISTRY.keys():
             if base_type is None:
                 continue  # None is actually one of the keys, but isinstance/issubclass doesn't work on it
-            if isinstance(python_type, base_type) or (inspect.isclass(python_type) and issubclass(python_type, base_type)):
+            if isinstance(python_type, base_type) or (
+                inspect.isclass(python_type) and issubclass(python_type, base_type)
+            ):
                 return cls._REGISTRY[base_type]
         raise ValueError(f"Type {python_type} not supported currently in Flytekit. Please register a new transformer")
 

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -58,6 +58,7 @@ def test_type_resolution():
     with pytest.raises(ValueError):
         TypeEngine.get_transformer(typing.Any)
 
+
 def test_file_formats_getting_literal_type():
     transformer = TypeEngine.get_transformer(FlyteFile)
 

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -55,6 +55,8 @@ def test_type_resolution():
 
     assert type(TypeEngine.get_transformer(os.PathLike)) == PathLikeTransformer
 
+    with pytest.raises(ValueError):
+        TypeEngine.get_transformer(typing.Any)
 
 def test_file_formats_getting_literal_type():
     transformer = TypeEngine.get_transformer(FlyteFile)


### PR DESCRIPTION
Signed-off-by: Oliver Mannion <125105+tekumara@users.noreply.github.com>

# TL;DR

Better error messages when Any is used as a type, eg: in a task signature.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

The following:
```
from typing import Any
from flytekit import task

@task
def could_be_anything() -> Any:
    return "surprise!"
```

Will now error with 
```
ValueError: Type typing.Any not supported currently in Flytekit. Please register a new transformer
```

rather than the less informative message
```
TypeError: issubclass() arg 1 must be a class
```


## Tracking Issue
None

## Follow-up issue
NA