### PR TITLE
bugfix flytekit-pandera

### DIFF
--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -524,7 +524,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 try:
                     literals[k] = TypeEngine.to_literal(exec_ctx, v, py_type, literal_type)
                 except Exception as e:
-                    raise AssertionError(f"failed to convert return value for var {k} with error: {e}") from e
+                    raise AssertionError(f"failed to convert return value for var {k} with error {type(e)}: {e}") from e
 
             outputs_literal_map = _literal_models.LiteralMap(literals=literals)
             # After the execute has been successfully completed

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -524,7 +524,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 try:
                     literals[k] = TypeEngine.to_literal(exec_ctx, v, py_type, literal_type)
                 except Exception as e:
-                    raise AssertionError(f"failed to convert return value for var {k}") from e
+                    raise AssertionError(f"failed to convert return value for var {k} with error: {e}") from e
 
             outputs_literal_map = _literal_models.LiteralMap(literals=literals)
             # After the execute has been successfully completed

--- a/plugins/flytekit-pandera/flytekitplugins/pandera/schema.py
+++ b/plugins/flytekit-pandera/flytekitplugins/pandera/schema.py
@@ -78,7 +78,7 @@ class PanderaTransformer(TypeTransformer[pandera.typing.DataFrame]):
         self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[pandera.typing.DataFrame]
     ) -> pandera.typing.DataFrame:
         if not (lv and lv.scalar and lv.scalar.schema):
-            raise AssertionError("Can only covert a literal schema to a pandera schema")
+            raise AssertionError("Can only convert a literal schema to a pandera schema")
 
         def downloader(x, y):
             ctx.file_access.download_directory(x, y)

--- a/plugins/flytekit-pandera/flytekitplugins/pandera/schema.py
+++ b/plugins/flytekit-pandera/flytekitplugins/pandera/schema.py
@@ -6,6 +6,7 @@ import pandera
 
 from flytekit import FlyteContext
 from flytekit.extend import TypeEngine, TypeTransformer
+from flytekit.loggers import logger
 from flytekit.models.literals import Literal, Scalar, Schema
 from flytekit.models.types import LiteralType, SchemaType
 from flytekit.types.schema import FlyteSchema, PandasSchemaWriter, SchemaFormat, SchemaOpenMode
@@ -65,7 +66,7 @@ class PanderaTransformer(TypeTransformer[pandera.typing.DataFrame]):
             w = PandasSchemaWriter(
                 local_dir=local_dir, cols=self._get_col_dtypes(python_type), fmt=SchemaFormat.PARQUET
             )
-            w.write(python_val)
+            w.write(self._pandera_schema(python_type)(python_val))
             remote_path = ctx.file_access.get_random_remote_directory()
             ctx.file_access.put_data(local_dir, remote_path, is_multipart=True)
             return Literal(scalar=Scalar(schema=Schema(remote_path, self._get_schema_type(python_type))))

--- a/plugins/flytekit-pandera/flytekitplugins/pandera/schema.py
+++ b/plugins/flytekit-pandera/flytekitplugins/pandera/schema.py
@@ -6,7 +6,6 @@ import pandera
 
 from flytekit import FlyteContext
 from flytekit.extend import TypeEngine, TypeTransformer
-from flytekit.loggers import logger
 from flytekit.models.literals import Literal, Scalar, Schema
 from flytekit.models.types import LiteralType, SchemaType
 from flytekit.types.schema import FlyteSchema, PandasSchemaWriter, SchemaFormat, SchemaOpenMode

--- a/plugins/tests/pandera/test_plugin.py
+++ b/plugins/tests/pandera/test_plugin.py
@@ -30,22 +30,45 @@ def test_pandera_dataframe_type_hints():
     def transform2(df: pandera.typing.DataFrame[IntermediateSchema]) -> pandera.typing.DataFrame[OutSchema]:
         return df.assign(col4="foo")
 
-    @workflow
-    def my_wf() -> pandera.typing.DataFrame[OutSchema]:
-        df = pandas.DataFrame({"col1": [1, 2, 3], "col2": [10.0, 11.0, 12.0]})
-        return transform2(df=transform1(df=df))
+    valid_df = pandas.DataFrame({"col1": [1, 2, 3], "col2": [10.0, 11.0, 12.0]})
 
     @workflow
-    def invalid_wf() -> pandera.typing.DataFrame[OutSchema]:
-        df = pandas.DataFrame({"col1": [1, 2, 3], "col2": list("abc")})
-        return transform2(df=transform1(df=df))
+    def my_wf() -> pandera.typing.DataFrame[OutSchema]:
+        return transform2(df=transform1(df=valid_df))
 
     result = my_wf()
     assert isinstance(result, pandas.DataFrame)
 
-    # raise error at runtime on invalid types
+    # raise error when defining workflow using invalid data
+    invalid_df = pandas.DataFrame({"col1": [1, 2, 3], "col2": list("abc")})
+
     with pytest.raises(pandera.errors.SchemaError):
-        invalid_wf()
+
+        @workflow
+        def invalid_wf() -> pandera.typing.DataFrame[OutSchema]:
+            return transform2(df=transform1(df=invalid_df))
+
+    # raise error when executing workflow with invalid input
+    @workflow
+    def wf_with_df_input(df: pandera.typing.DataFrame[InSchema]) -> pandera.typing.DataFrame[OutSchema]:
+        return transform2(df=transform1(df=df))
+
+    with pytest.raises(pandera.errors.SchemaError, match="^expected series 'col2' to have type float64, got object"):
+        wf_with_df_input(df=invalid_df)
+
+    # raise error when executing workflow with invalid output
+    @task
+    def transform2_noop(df: pandera.typing.DataFrame[IntermediateSchema]) -> pandera.typing.DataFrame[OutSchema]:
+        return df
+
+    @workflow
+    def wf_invalid_output(df: pandera.typing.DataFrame[InSchema]) -> pandera.typing.DataFrame[OutSchema]:
+        return transform2_noop(df=transform1(df=df))
+
+    with pytest.raises(
+        AssertionError, match="^failed to convert return value for var o0 with error: column 'col4' not in dataframe"
+    ):
+        wf_invalid_output(df=valid_df)
 
 
 @pytest.mark.parametrize(

--- a/plugins/tests/pandera/test_plugin.py
+++ b/plugins/tests/pandera/test_plugin.py
@@ -66,7 +66,7 @@ def test_pandera_dataframe_type_hints():
         return transform2_noop(df=transform1(df=df))
 
     with pytest.raises(
-        AssertionError, match="^failed to convert return value for var o0 with error: column 'col4' not in dataframe"
+        AssertionError, match="^failed to convert return value for var o0 with error .+: column 'col4' not in dataframe"
     ):
         wf_invalid_output(df=valid_df)
 


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

# TL;DR

This PR fixes an issue where the pandera schema was not validating out-going dataframes in the `PanderaTransformer.to_literal` method. This resulted in a no-op when executing a task on a flyte backend

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

The flytekit pandera plugin was not working correctly on a flyte backend because the pandera schema was not being invoked in the `PanderaTransformer.to_literal` method. This PR fixes this by validating a dataframe output before it's written out to disk.

## Tracking Issue
NA

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
