### PR TITLE
Add guess python type to FlyteFile and FlyteDirectory

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -154,7 +154,7 @@ from flytekit.core.task import Secret, reference_task, task
 from flytekit.core.workflow import ImperativeWorkflow as Workflow
 from flytekit.core.workflow import WorkflowFailurePolicy, reference_workflow, workflow
 from flytekit.loggers import logger
-from flytekit.types import schema
+from flytekit.types import directory, file, schema
 
 __version__ = "0.0.0+develop"
 

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -233,5 +233,13 @@ class FlyteDirToMultipartBlobTransformer(TypeTransformer[FlyteDirectory]):
 
         return fd
 
+    def guess_python_type(self, literal_type: LiteralType) -> typing.Type[T]:
+        if (
+            literal_type.blob is not None
+            and literal_type.blob.dimensionality == _core_types.BlobType.BlobDimensionality.MULTIPART
+        ):
+            return FlyteDirectory[literal_type.blob.format]
+        raise ValueError(f"Transformer {self} cannot reverse {literal_type}")
+
 
 TypeEngine.register(FlyteDirToMultipartBlobTransformer())

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -274,5 +274,13 @@ class FlyteFilePathTransformer(TypeTransformer[FlyteFile]):
 
         return ff
 
+    def guess_python_type(self, literal_type: LiteralType) -> typing.Type[T]:
+        if (
+            literal_type.blob is not None
+            and literal_type.blob.dimensionality == _core_types.BlobType.BlobDimensionality.SINGLE
+        ):
+            return FlyteFile[literal_type.blob.format]
+        raise ValueError(f"Transformer {self} cannot reverse {literal_type}")
+
 
 TypeEngine.register(FlyteFilePathTransformer())

--- a/tests/flytekit/unit/core/test_flyte_directory.py
+++ b/tests/flytekit/unit/core/test_flyte_directory.py
@@ -185,3 +185,22 @@ def test_download_caching():
     for _ in range(10):
         os.fspath(f)
     assert mock_downloader.call_count == 1
+
+
+def test_directory_guess():
+    transformer = TypeEngine.get_transformer(FlyteDirectory)
+    lt = transformer.get_literal_type(FlyteDirectory["txt"])
+    assert lt.blob.format == "txt"
+    assert lt.blob.dimensionality == 1
+
+    fft = transformer.guess_python_type(lt)
+    assert issubclass(fft, FlyteDirectory)
+    assert fft.extension() == "txt"
+
+    lt = transformer.get_literal_type(FlyteDirectory)
+    assert lt.blob.format == ""
+    assert lt.blob.dimensionality == 1
+
+    fft = transformer.guess_python_type(lt)
+    assert issubclass(fft, FlyteDirectory)
+    assert fft.extension() == ""

--- a/tests/flytekit/unit/core/test_flyte_file.py
+++ b/tests/flytekit/unit/core/test_flyte_file.py
@@ -274,3 +274,11 @@ def test_file_guess():
     fft = transformer.guess_python_type(lt)
     assert issubclass(fft, FlyteFile)
     assert fft.extension() == "txt"
+
+    lt = transformer.get_literal_type(FlyteFile)
+    assert lt.blob.format == ""
+    assert lt.blob.dimensionality == 0
+
+    fft = transformer.guess_python_type(lt)
+    assert issubclass(fft, FlyteFile)
+    assert fft.extension() == ""

--- a/tests/flytekit/unit/core/test_flyte_file.py
+++ b/tests/flytekit/unit/core/test_flyte_file.py
@@ -263,3 +263,14 @@ def test_download_caching():
     for _ in range(10):
         os.fspath(f)
     assert mock_downloader.call_count == 1
+
+
+def test_file_guess():
+    transformer = TypeEngine.get_transformer(FlyteFile)
+    lt = transformer.get_literal_type(FlyteFile["txt"])
+    assert lt.blob.format == "txt"
+    assert lt.blob.dimensionality == 0
+
+    fft = transformer.guess_python_type(lt)
+    assert issubclass(fft, FlyteFile)
+    assert fft.extension() == "txt"


### PR DESCRIPTION
Signed-off-by: Yee Hing Tong <wild-endeavor@users.noreply.github.com>

# TL;DR
Adding guess for FlyteFile and FlyteDirectory.
Importing in base `__init__` file to trigger transformer loading.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1335
