### PR TITLE
Pass launch plan settings to remote execute

### DIFF
--- a/flytekit/models/launch_plan.py
+++ b/flytekit/models/launch_plan.py
@@ -199,7 +199,7 @@ class LaunchPlanSpec(_common.FlyteIdlEntity):
     def auth_role(self):
         """
         The authorization method with which to execute the workflow.
-        :rtype: flytekit.models.common.Auth
+        :rtype: flytekit.models.common.AuthRole
         """
         return self._auth_role
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -580,6 +580,9 @@ class FlyteRemote(object):
         domain: str,
         execution_name: typing.Optional[str] = None,
         wait: bool = False,
+        labels: typing.Optional[common_models.Labels] = None,
+        annotations: typing.Optional[common_models.Annotations] = None,
+        auth_role: typing.Optional[common_models.AuthRole] = None,
     ) -> FlyteWorkflowExecution:
         """Common method for execution across all entities.
 
@@ -620,9 +623,9 @@ class FlyteRemote(object):
                     ),
                     notifications=notifications,
                     disable_all=disable_all,
-                    labels=self.labels,
-                    annotations=self.annotations,
-                    auth_role=self.auth_role,
+                    labels=labels or self.labels,
+                    annotations=annotations or self.annotations,
+                    auth_role=auth_role or self.auth_role,
                 ),
                 literal_inputs,
             )
@@ -703,6 +706,9 @@ class FlyteRemote(object):
             domain=resolved_identifiers.domain,
             execution_name=execution_name,
             wait=wait,
+            labels=entity.labels if isinstance(entity, FlyteLaunchPlan) else None,
+            annotations=entity.annotations if isinstance(entity, FlyteLaunchPlan) else None,
+            auth_role=entity.auth_role if isinstance(entity, FlyteLaunchPlan) else None,
         )
 
     @execute.register

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -706,9 +706,14 @@ class FlyteRemote(object):
             domain=resolved_identifiers.domain,
             execution_name=execution_name,
             wait=wait,
-            labels=entity.labels if isinstance(entity, FlyteLaunchPlan) else None,
-            annotations=entity.annotations if isinstance(entity, FlyteLaunchPlan) else None,
-            auth_role=entity.auth_role if isinstance(entity, FlyteLaunchPlan) else None,
+            labels=entity.labels if isinstance(entity, FlyteLaunchPlan) and entity.labels.values else None,
+            annotations=entity.annotations
+            if isinstance(entity, FlyteLaunchPlan) and entity.annotations.values
+            else None,
+            auth_role=entity.auth_role
+            if isinstance(entity, FlyteLaunchPlan)
+            and (entity.auth_role.assumable_iam_role or entity.auth_role.kubernetes_service_account)
+            else None,
         )
 
     @execute.register

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -1,6 +1,7 @@
 import pytest
 from mock import MagicMock, patch
 
+from flytekit.models import common as common_models
 from flytekit.models.admin.workflow import Workflow
 from flytekit.models.core.identifier import (
     Identifier,
@@ -131,3 +132,36 @@ def test_get_node_execution_interface(mock_insecure, mock_url):
         NodeExecution(node_exec_id, None, None, NodeExecutionMetaData(None, True, None)), flyte_workflow
     )
     assert actual_interface == expected_interface
+
+
+@patch("flytekit.remote.workflow_execution.FlyteWorkflowExecution.promote_from_model")
+@patch("flytekit.configuration.platform.URL")
+@patch("flytekit.configuration.platform.INSECURE")
+def test_underscore_execute_uses_launch_plan_attributes(mock_insecure, mock_url, mock_wf_exec):
+    mock_url.get.return_value = "localhost"
+    mock_insecure.get.return_value = True
+    mock_wf_exec.return_value = True
+    mock_client = MagicMock()
+
+    remote = FlyteRemote.from_config("p1", "d1")
+    remote._client = mock_client
+
+    def x(*args, **kwargs):
+        execution_spec = args[3]
+        assert execution_spec.auth_role.kubernetes_service_account == "svc"
+        assert execution_spec.labels == common_models.Labels({"a": "my_label_value"})
+        assert execution_spec.annotations == common_models.Annotations({"b": "my_annotation_value"})
+
+    mock_client.create_execution.side_effect = x
+
+    mock_flyte_id = Identifier(1, "proj", "dom", "name", "123")
+
+    remote._execute(
+        mock_flyte_id,
+        inputs={},
+        project="proj",
+        domain="dev",
+        labels=common_models.Labels({"a": "my_label_value"}),
+        annotations=common_models.Annotations({"b": "my_annotation_value"}),
+        auth_role=common_models.AuthRole(kubernetes_service_account="svc"),
+    )


### PR DESCRIPTION
Signed-off-by: Yee Hing Tong <wild-endeavor@users.noreply.github.com>

# TL;DR
When `FlyteRemote` executes a `FlyteLaunchPlan`, it's currently using labels, annotations, and auth information from the remote itself rather than the launch plan.  This defaults to that first.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue


## Tracking Issue
https://github.com/flyteorg/flyte/issues/1365
