### PR TITLE
wip - Add guessed typed information to flyteremote objects

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -407,17 +407,18 @@ class TypeEngine(typing.Generic[T]):
         return {k: TypeEngine.to_python_value(ctx, lm.literals[k], v) for k, v in python_types.items()}
 
     @classmethod
-    def dict_to_literal_map(cls, ctx: FlyteContext, d: typing.Dict[str, typing.Any]) -> LiteralMap:
+    def dict_to_literal_map(cls, ctx: FlyteContext, d: typing.Dict[str, typing.Any], m: typing.Dict[str, type]) -> LiteralMap:
         """
         Given a dictionary mapping string keys to python values, convert to a LiteralMap.
         """
         literal_map = {}
         for k, v in d.items():
+            python_type=m.get(k, type(v))
             literal_map[k] = TypeEngine.to_literal(
                 ctx=ctx,
                 python_val=v,
-                python_type=type(v),
-                expected=TypeEngine.to_literal_type(type(v)),
+                python_type=python_type,
+                expected=TypeEngine.to_literal_type(python_type),
             )
         return LiteralMap(literal_map)
 

--- a/flytekit/remote/tasks/task.py
+++ b/flytekit/remote/tasks/task.py
@@ -1,4 +1,5 @@
 from flytekit.common.mixins import hash as _hash_mixin
+from flytekit.core.interface import Interface
 from flytekit.models import task as _task_model
 from flytekit.models.core import identifier as _identifier_model
 from flytekit.remote import identifier as _identifier
@@ -19,6 +20,7 @@ class FlyteTask(_hash_mixin.HashOnReferenceMixin, _task_model.TaskTemplate):
             task_type_version=task_type_version,
             config=config,
         )
+        # _python_interface = None
 
     @property
     def interface(self) -> _interfaces.TypedInterface:
@@ -31,6 +33,13 @@ class FlyteTask(_hash_mixin.HashOnReferenceMixin, _task_model.TaskTemplate):
     @property
     def entity_type_text(self) -> str:
         return "Task"
+
+    @property
+    def guessed_python_interface(self) -> Interface:
+        """
+        Returns this task's python interface.
+        """
+        return self._python_interface
 
     @classmethod
     def promote_from_model(cls, base_model: _task_model.TaskTemplate) -> "FlyteTask":

--- a/flytekit/remote/workflow.py
+++ b/flytekit/remote/workflow.py
@@ -62,6 +62,13 @@ class FlyteWorkflow(_hash_mixin.HashOnReferenceMixin, _workflow_models.WorkflowT
     def flyte_nodes(self) -> List[_nodes.FlyteNode]:
         return self._flyte_nodes
 
+    # @property
+    # def guessed_python_interface(self) -> Interface:
+    #     """
+    #     Returns this workflow's python interface.
+    #     """
+    #     return self._python_interface
+
     def get_sub_workflows(self) -> List["FlyteWorkflow"]:
         result = []
         for node in self.nodes:


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <curupa@gmail.com>

# TL;DR
Tasks and workflows loaded via remote do not contain enough typing information to allow for the reconstruction of the original types. This PR augments the `flyteremote` types with typing information as defined by the user.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
