### PR TITLE
[WIP] Broader config file support

### DIFF
--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -356,7 +356,7 @@ _host_option = _click.option(
     required=not bool(_HOST_URL),
     default=_HOST_URL,
     help="The URL for the Flyte Admin Service. If you intend for this to be consistent, set the FLYTE_PLATFORM_URL "
-    "environment variable to the desired URL and this will not need to be set.",
+         "environment variable to the desired URL and this will not need to be set.",
 )
 _token_option = _click.option(
     "-t",
@@ -418,7 +418,7 @@ _show_io_option = _click.option(
     is_flag=True,
     default=False,
     help="Set this flag to view inputs and outputs.  Pair with the --verbose flag to get the full textual description"
-    " inputs and outputs.",
+         " inputs and outputs.",
 )
 _verbose_option = _click.option(
     "--verbose",
@@ -487,7 +487,14 @@ _kubernetes_service_acct_option = _click.option(
 _output_location_prefix_option = _click.option(
     "-o", "--output-location-prefix", help="Custom output location prefix for offloaded types (files/schemas)"
 )
-_output_config_format = _click.option("-o", "--format", type=str, default="ini", help="Output config format (ini/yaml)")
+_output_config_format = _click.option(
+    "-o",
+    "--format",
+    type=_click.Choice(["INI", "YAML"],
+                       case_sensitive=False),
+    default="INI",
+    help="Output config format " "(ini/yaml)",
+)
 _files_argument = _click.argument(
     "files",
     type=_click.Path(exists=True),
@@ -511,9 +518,9 @@ class _FlyteSubCommand(_click.Command):
         prefix_args = []
         for param in self.params:
             if (
-                param.name in type(self)._PASSABLE_ARGS
-                and param.name in parent.params
-                and parent.params[param.name] is not None
+                    param.name in type(self)._PASSABLE_ARGS
+                    and param.name in parent.params
+                    and parent.params[param.name] is not None
             ):
                 prefix_args.extend([type(self)._PASSABLE_ARGS[param.name], _six.text_type(parent.params[param.name])])
 
@@ -538,7 +545,7 @@ class _FlyteSubCommand(_click.Command):
     type=str,
     default=None,
     help="[Optional] The host to pass to the sub-command (if applicable).  If set again in the sub-command, "
-    "the sub-command's parameter takes precedence.",
+         "the sub-command's parameter takes precedence.",
 )
 @_click.option(
     *_PROJECT_FLAGS,
@@ -546,7 +553,7 @@ class _FlyteSubCommand(_click.Command):
     type=str,
     default=None,
     help="[Optional] The project to pass to the sub-command (if applicable)  If set again in the sub-command, "
-    "the sub-command's parameter takes precedence.",
+         "the sub-command's parameter takes precedence.",
 )
 @_click.option(
     *_DOMAIN_FLAGS,
@@ -554,7 +561,7 @@ class _FlyteSubCommand(_click.Command):
     type=str,
     default=None,
     help="[Optional] The domain to pass to the sub-command (if applicable)  If set again in the sub-command, "
-    "the sub-command's parameter takes precedence.",
+         "the sub-command's parameter takes precedence.",
 )
 @_click.option(
     *_NAME_FLAGS,
@@ -562,7 +569,7 @@ class _FlyteSubCommand(_click.Command):
     type=str,
     default=None,
     help="[Optional] The name to pass to the sub-command (if applicable)  If set again in the sub-command, "
-    "the sub-command's parameter takes precedence.",
+         "the sub-command's parameter takes precedence.",
 )
 @_insecure_option
 @_click.group("flyte-cli")
@@ -978,17 +985,17 @@ def list_active_launch_plans(project, domain, host, insecure, token, limit, show
 @_sort_by_option
 @_optional_urns_only_option
 def list_launch_plan_versions(
-    project,
-    domain,
-    name,
-    host,
-    insecure,
-    token,
-    limit,
-    show_all,
-    filter,
-    sort_by,
-    urns_only,
+        project,
+        domain,
+        name,
+        host,
+        insecure,
+        token,
+        limit,
+        show_all,
+        filter,
+        sort_by,
+        urns_only,
 ):
     """
     List the versions of all the launch plans under the scope specified by {project, domain}.
@@ -1020,7 +1027,7 @@ def list_launch_plan_versions(
                     nl=False,
                 )
                 if l.spec.entity_metadata.schedule is not None and (
-                    l.spec.entity_metadata.schedule.cron_expression or l.spec.entity_metadata.schedule.rate
+                        l.spec.entity_metadata.schedule.cron_expression or l.spec.entity_metadata.schedule.rate
                 ):
                     _click.echo("{:30} ".format(_render_schedule_expr(l)), nl=False)
                     _click.secho(
@@ -1405,9 +1412,9 @@ def _get_io(node_executions, wf_execution, show_io, verbose):
         uris = [ne.input_uri for ne in node_executions]
         uris.extend([ne.closure.output_uri for ne in node_executions if ne.closure.output_uri is not None])
         if (
-            wf_execution is not None
-            and wf_execution.closure.outputs is not None
-            and wf_execution.closure.outputs.uri is not None
+                wf_execution is not None
+                and wf_execution.closure.outputs is not None
+                and wf_execution.closure.outputs.uri is not None
         ):
             uris.append(wf_execution.closure.outputs.uri)
 
@@ -1741,12 +1748,12 @@ _resource_map = {
 
 
 def _extract_pair(
-    object_file: str,
-    resource_type: int,
-    project: str,
-    domain: str,
-    version: str,
-    patches: Dict[int, Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]],
+        object_file: str,
+        resource_type: int,
+        project: str,
+        domain: str,
+        version: str,
+        patches: Dict[int, Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]],
 ) -> Tuple[
     _identifier_pb2.Identifier,
     Union[_core_tasks_pb2.TaskTemplate, _core_workflow_pb2.WorkflowTemplate, _launch_plan_pb2.LaunchPlanSpec],
@@ -1772,11 +1779,11 @@ def _extract_pair(
 
 
 def _extract_files(
-    project: str,
-    domain: str,
-    version: str,
-    file_paths: List[str],
-    patches: Dict[int, Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]] = None,
+        project: str,
+        domain: str,
+        version: str,
+        file_paths: List[str],
+        patches: Dict[int, Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]] = None,
 ):
     """
     :param file_paths:
@@ -1798,7 +1805,7 @@ def _extract_files(
 
 
 def _get_patch_launch_plan_fn(
-    assumable_iam_role: str = None, kubernetes_service_account: str = None, output_location_prefix: str = None
+        assumable_iam_role: str = None, kubernetes_service_account: str = None, output_location_prefix: str = None
 ) -> Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]:
     def patch_launch_plan(entity: _GeneratedProtocolMessageType) -> _GeneratedProtocolMessageType:
         """
@@ -1835,13 +1842,13 @@ def _get_patch_launch_plan_fn(
 
 
 def _extract_and_register(
-    host: str,
-    insecure: bool,
-    project: str,
-    domain: str,
-    version: str,
-    file_paths: List[str],
-    patches: Dict[int, Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]] = None,
+        host: str,
+        insecure: bool,
+        project: str,
+        domain: str,
+        version: str,
+        file_paths: List[str],
+        patches: Dict[int, Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]] = None,
 ):
     client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
 
@@ -1877,15 +1884,15 @@ def _extract_and_register(
 @_output_location_prefix_option
 @_files_argument
 def register_files(
-    project,
-    domain,
-    version,
-    host,
-    insecure,
-    assumable_iam_role,
-    kubernetes_service_account,
-    output_location_prefix,
-    files,
+        project,
+        domain,
+        version,
+        host,
+        insecure,
+        assumable_iam_role,
+        kubernetes_service_account,
+        output_location_prefix,
+        files,
 ):
     """
     Given a list of files, this will (after sorting the input list), attempt to register them against Flyte Admin.
@@ -1927,7 +1934,7 @@ def register_files(
     *_VERSION_FLAGS,
     required=False,
     help="Version to register entities with. This is normally computed deterministically from your code, but you can "
-    "override that here",
+         "override that here",
 )
 @_host_option
 @_insecure_option
@@ -1936,24 +1943,24 @@ def register_files(
     "--dest-dir",
     type=str,
     help="[Optional] The output directory for code which is downloaded during fast registration, "
-    "if the current working directory at the time of installation is not desired",
+         "if the current working directory at the time of installation is not desired",
 )
 @_assumable_iam_role_option
 @_kubernetes_service_acct_option
 @_output_location_prefix_option
 @_files_argument
 def fast_register_files(
-    project,
-    domain,
-    version,
-    host,
-    insecure,
-    additional_distribution_dir,
-    dest_dir,
-    assumable_iam_role,
-    kubernetes_service_account,
-    output_location_prefix,
-    files,
+        project,
+        domain,
+        version,
+        host,
+        insecure,
+        additional_distribution_dir,
+        dest_dir,
+        assumable_iam_role,
+        kubernetes_service_account,
+        output_location_prefix,
+        files,
 ):
     """
     Given a list of files, this will (after sorting the input list), attempt to register them against Flyte Admin.
@@ -2327,11 +2334,12 @@ def setup_config(host, insecure, format):
 
     """
     _welcome_message()
-    if format != "yaml" and format != "ini":
+    format = format.upper()
+    if format != "YAML" and format != "INI":
         _click.secho("Unsupported generate this file format: {} ", format, fg="blue")
         return
     config_file = _get_config_file_path()
-    if format == "yaml":
+    if format == "YAML":
         config_file += ".yaml"
     if _get_user_filepath_home() and _os.path.exists(config_file):
         _click.secho("Config file already exists at {}".format(_tt(config_file)), fg="blue")
@@ -2360,7 +2368,7 @@ def setup_config(host, insecure, format):
         "auth_mode": "standard",
     }
 
-    if format == "ini":
+    if format == "INI":
         with open(config_file, "w+") as f:
             parser = _configparser.ConfigParser()
             parser.add_section("platform")
@@ -2370,7 +2378,7 @@ def setup_config(host, insecure, format):
             for key in credentials_config.keys():
                 parser.set("credentials", key, credentials_config[key])
             parser.write(f)
-    elif format == "yaml":
+    elif format == "YAML":
         with open(config_file, "w+") as f:
             data = {"platform": platform_config, "credentials": credentials_config}
             yaml.dump(data, f, default_flow_style=False)

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -492,7 +492,7 @@ _output_config_format = _click.option(
     "--format",
     type=_click.Choice(["INI", "YAML"], case_sensitive=False),
     default="INI",
-    help="Output config format " "(ini/yaml)",
+    help="Output config format (INI/YAML)",
 )
 _files_argument = _click.argument(
     "files",

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -356,7 +356,7 @@ _host_option = _click.option(
     required=not bool(_HOST_URL),
     default=_HOST_URL,
     help="The URL for the Flyte Admin Service. If you intend for this to be consistent, set the FLYTE_PLATFORM_URL "
-         "environment variable to the desired URL and this will not need to be set.",
+    "environment variable to the desired URL and this will not need to be set.",
 )
 _token_option = _click.option(
     "-t",
@@ -418,7 +418,7 @@ _show_io_option = _click.option(
     is_flag=True,
     default=False,
     help="Set this flag to view inputs and outputs.  Pair with the --verbose flag to get the full textual description"
-         " inputs and outputs.",
+    " inputs and outputs.",
 )
 _verbose_option = _click.option(
     "--verbose",
@@ -490,8 +490,7 @@ _output_location_prefix_option = _click.option(
 _output_config_format = _click.option(
     "-o",
     "--format",
-    type=_click.Choice(["INI", "YAML"],
-                       case_sensitive=False),
+    type=_click.Choice(["INI", "YAML"], case_sensitive=False),
     default="INI",
     help="Output config format " "(ini/yaml)",
 )
@@ -518,9 +517,9 @@ class _FlyteSubCommand(_click.Command):
         prefix_args = []
         for param in self.params:
             if (
-                    param.name in type(self)._PASSABLE_ARGS
-                    and param.name in parent.params
-                    and parent.params[param.name] is not None
+                param.name in type(self)._PASSABLE_ARGS
+                and param.name in parent.params
+                and parent.params[param.name] is not None
             ):
                 prefix_args.extend([type(self)._PASSABLE_ARGS[param.name], _six.text_type(parent.params[param.name])])
 
@@ -545,7 +544,7 @@ class _FlyteSubCommand(_click.Command):
     type=str,
     default=None,
     help="[Optional] The host to pass to the sub-command (if applicable).  If set again in the sub-command, "
-         "the sub-command's parameter takes precedence.",
+    "the sub-command's parameter takes precedence.",
 )
 @_click.option(
     *_PROJECT_FLAGS,
@@ -553,7 +552,7 @@ class _FlyteSubCommand(_click.Command):
     type=str,
     default=None,
     help="[Optional] The project to pass to the sub-command (if applicable)  If set again in the sub-command, "
-         "the sub-command's parameter takes precedence.",
+    "the sub-command's parameter takes precedence.",
 )
 @_click.option(
     *_DOMAIN_FLAGS,
@@ -561,7 +560,7 @@ class _FlyteSubCommand(_click.Command):
     type=str,
     default=None,
     help="[Optional] The domain to pass to the sub-command (if applicable)  If set again in the sub-command, "
-         "the sub-command's parameter takes precedence.",
+    "the sub-command's parameter takes precedence.",
 )
 @_click.option(
     *_NAME_FLAGS,
@@ -569,7 +568,7 @@ class _FlyteSubCommand(_click.Command):
     type=str,
     default=None,
     help="[Optional] The name to pass to the sub-command (if applicable)  If set again in the sub-command, "
-         "the sub-command's parameter takes precedence.",
+    "the sub-command's parameter takes precedence.",
 )
 @_insecure_option
 @_click.group("flyte-cli")
@@ -985,17 +984,17 @@ def list_active_launch_plans(project, domain, host, insecure, token, limit, show
 @_sort_by_option
 @_optional_urns_only_option
 def list_launch_plan_versions(
-        project,
-        domain,
-        name,
-        host,
-        insecure,
-        token,
-        limit,
-        show_all,
-        filter,
-        sort_by,
-        urns_only,
+    project,
+    domain,
+    name,
+    host,
+    insecure,
+    token,
+    limit,
+    show_all,
+    filter,
+    sort_by,
+    urns_only,
 ):
     """
     List the versions of all the launch plans under the scope specified by {project, domain}.
@@ -1027,7 +1026,7 @@ def list_launch_plan_versions(
                     nl=False,
                 )
                 if l.spec.entity_metadata.schedule is not None and (
-                        l.spec.entity_metadata.schedule.cron_expression or l.spec.entity_metadata.schedule.rate
+                    l.spec.entity_metadata.schedule.cron_expression or l.spec.entity_metadata.schedule.rate
                 ):
                     _click.echo("{:30} ".format(_render_schedule_expr(l)), nl=False)
                     _click.secho(
@@ -1412,9 +1411,9 @@ def _get_io(node_executions, wf_execution, show_io, verbose):
         uris = [ne.input_uri for ne in node_executions]
         uris.extend([ne.closure.output_uri for ne in node_executions if ne.closure.output_uri is not None])
         if (
-                wf_execution is not None
-                and wf_execution.closure.outputs is not None
-                and wf_execution.closure.outputs.uri is not None
+            wf_execution is not None
+            and wf_execution.closure.outputs is not None
+            and wf_execution.closure.outputs.uri is not None
         ):
             uris.append(wf_execution.closure.outputs.uri)
 
@@ -1748,12 +1747,12 @@ _resource_map = {
 
 
 def _extract_pair(
-        object_file: str,
-        resource_type: int,
-        project: str,
-        domain: str,
-        version: str,
-        patches: Dict[int, Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]],
+    object_file: str,
+    resource_type: int,
+    project: str,
+    domain: str,
+    version: str,
+    patches: Dict[int, Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]],
 ) -> Tuple[
     _identifier_pb2.Identifier,
     Union[_core_tasks_pb2.TaskTemplate, _core_workflow_pb2.WorkflowTemplate, _launch_plan_pb2.LaunchPlanSpec],
@@ -1779,11 +1778,11 @@ def _extract_pair(
 
 
 def _extract_files(
-        project: str,
-        domain: str,
-        version: str,
-        file_paths: List[str],
-        patches: Dict[int, Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]] = None,
+    project: str,
+    domain: str,
+    version: str,
+    file_paths: List[str],
+    patches: Dict[int, Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]] = None,
 ):
     """
     :param file_paths:
@@ -1805,7 +1804,7 @@ def _extract_files(
 
 
 def _get_patch_launch_plan_fn(
-        assumable_iam_role: str = None, kubernetes_service_account: str = None, output_location_prefix: str = None
+    assumable_iam_role: str = None, kubernetes_service_account: str = None, output_location_prefix: str = None
 ) -> Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]:
     def patch_launch_plan(entity: _GeneratedProtocolMessageType) -> _GeneratedProtocolMessageType:
         """
@@ -1842,13 +1841,13 @@ def _get_patch_launch_plan_fn(
 
 
 def _extract_and_register(
-        host: str,
-        insecure: bool,
-        project: str,
-        domain: str,
-        version: str,
-        file_paths: List[str],
-        patches: Dict[int, Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]] = None,
+    host: str,
+    insecure: bool,
+    project: str,
+    domain: str,
+    version: str,
+    file_paths: List[str],
+    patches: Dict[int, Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]] = None,
 ):
     client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
 
@@ -1884,15 +1883,15 @@ def _extract_and_register(
 @_output_location_prefix_option
 @_files_argument
 def register_files(
-        project,
-        domain,
-        version,
-        host,
-        insecure,
-        assumable_iam_role,
-        kubernetes_service_account,
-        output_location_prefix,
-        files,
+    project,
+    domain,
+    version,
+    host,
+    insecure,
+    assumable_iam_role,
+    kubernetes_service_account,
+    output_location_prefix,
+    files,
 ):
     """
     Given a list of files, this will (after sorting the input list), attempt to register them against Flyte Admin.
@@ -1934,7 +1933,7 @@ def register_files(
     *_VERSION_FLAGS,
     required=False,
     help="Version to register entities with. This is normally computed deterministically from your code, but you can "
-         "override that here",
+    "override that here",
 )
 @_host_option
 @_insecure_option
@@ -1943,24 +1942,24 @@ def register_files(
     "--dest-dir",
     type=str,
     help="[Optional] The output directory for code which is downloaded during fast registration, "
-         "if the current working directory at the time of installation is not desired",
+    "if the current working directory at the time of installation is not desired",
 )
 @_assumable_iam_role_option
 @_kubernetes_service_acct_option
 @_output_location_prefix_option
 @_files_argument
 def fast_register_files(
-        project,
-        domain,
-        version,
-        host,
-        insecure,
-        additional_distribution_dir,
-        dest_dir,
-        assumable_iam_role,
-        kubernetes_service_account,
-        output_location_prefix,
-        files,
+    project,
+    domain,
+    version,
+    host,
+    insecure,
+    additional_distribution_dir,
+    dest_dir,
+    assumable_iam_role,
+    kubernetes_service_account,
+    output_location_prefix,
+    files,
 ):
     """
     Given a list of files, this will (after sorting the input list), attempt to register them against Flyte Admin.

--- a/flytekit/configuration/common.py
+++ b/flytekit/configuration/common.py
@@ -2,6 +2,8 @@ import abc as _abc
 import configparser as _configparser
 import os as _os
 
+import yaml
+
 from flytekit.common.exceptions import user as _user_exceptions
 
 
@@ -29,7 +31,13 @@ class FlyteConfigurationFile(object):
     def _load_config(self):
         if self._config is None and self._location:
             config = _configparser.ConfigParser()
-            config.read(self._location)
+            file_extension = self._location.split(".")[-1]
+            if file_extension == "yaml" or file_extension == "yml":
+                with open(self._location) as f:
+                    config_dict = yaml.safe_load(f)
+                    config.read_dict(config_dict)
+            else:
+                config.read(self._location)
             if config.has_section("internal"):
                 raise _user_exceptions.FlyteAssertion(
                     "The config file '{}' cannot contain a section for internal "

--- a/tests/flytekit/unit/cli/test_flyte_cli.py
+++ b/tests/flytekit/unit/cli/test_flyte_cli.py
@@ -1,5 +1,6 @@
 import mock as _mock
 import pytest
+import responses as _responses
 from click.testing import CliRunner as _CliRunner
 
 from flytekit.clis.flyte_cli import main as _main
@@ -105,3 +106,18 @@ def test_activate_project(mock_client):
     result = runner.invoke(_main._flyte_cli, ["activate-project", "-p", "foo", "-h", "a.b.com", "-i"])
     assert result.exit_code == 0
     mock_client().update_project.assert_called_with(_Project.active_project("foo"))
+
+
+@_responses.activate
+def test_setup_config():
+    runner = _CliRunner()
+    data = {
+        "client_id": "123abc123",
+        "redirect_uri": "http://localhost:53593/callback",
+        "scopes": "my_scopes",
+        "authorization_metadata_key": "fake_key",
+    }
+    _responses.add(_responses.GET, "http://flyte.company.com/config/v1/flyte_client", json=data, status=200)
+
+    result = runner.invoke(_main._flyte_cli, ["setup-config", "-h", "flyte.company.com", "-i", "-o", "yaml"])
+    assert result.exit_code == 0

--- a/tests/flytekit/unit/cli/test_flyte_cli.py
+++ b/tests/flytekit/unit/cli/test_flyte_cli.py
@@ -35,18 +35,18 @@ def get_sample_task():
 def test__extract_files(load_mock):
     t = get_sample_task()
     with TemporaryConfiguration(
-            "",
-            internal_overrides={"image": "myflyteimage:v123", "project": "myflyteproject", "domain": "development"},
+        "",
+        internal_overrides={"image": "myflyteimage:v123", "project": "myflyteproject", "domain": "development"},
     ):
         task_spec = t.serialize()
 
     load_mock.side_effect = [task_spec]
     new_id, entity = _main._extract_pair("a", 1, "myproject", "development", "v", {})
     assert (
-            new_id
-            == _core_identifier.Identifier(
-        _core_identifier.ResourceType.TASK, "myproject", "development", "test_flyte_cli.my_task", "v"
-    ).to_flyte_idl()
+        new_id
+        == _core_identifier.Identifier(
+            _core_identifier.ResourceType.TASK, "myproject", "development", "test_flyte_cli.my_task", "v"
+        ).to_flyte_idl()
     )
     assert task_spec == entity
 

--- a/tests/flytekit/unit/cli/test_flyte_cli.py
+++ b/tests/flytekit/unit/cli/test_flyte_cli.py
@@ -35,18 +35,18 @@ def get_sample_task():
 def test__extract_files(load_mock):
     t = get_sample_task()
     with TemporaryConfiguration(
-        "",
-        internal_overrides={"image": "myflyteimage:v123", "project": "myflyteproject", "domain": "development"},
+            "",
+            internal_overrides={"image": "myflyteimage:v123", "project": "myflyteproject", "domain": "development"},
     ):
         task_spec = t.serialize()
 
     load_mock.side_effect = [task_spec]
     new_id, entity = _main._extract_pair("a", 1, "myproject", "development", "v", {})
     assert (
-        new_id
-        == _core_identifier.Identifier(
-            _core_identifier.ResourceType.TASK, "myproject", "development", "test_flyte_cli.my_task", "v"
-        ).to_flyte_idl()
+            new_id
+            == _core_identifier.Identifier(
+        _core_identifier.ResourceType.TASK, "myproject", "development", "test_flyte_cli.my_task", "v"
+    ).to_flyte_idl()
     )
     assert task_spec == entity
 
@@ -121,3 +121,9 @@ def test_setup_config():
 
     result = runner.invoke(_main._flyte_cli, ["setup-config", "-h", "flyte.company.com", "-i", "-o", "yaml"])
     assert result.exit_code == 0
+
+
+def test_setup_config_with_undefined_format():
+    runner = _CliRunner()
+    result = runner.invoke(_main._flyte_cli, ["setup-config", "-h", "flyte.company.com", "-i", "-o", "json"])
+    assert result.exit_code == 2

--- a/tests/flytekit/unit/configuration/configs/good.yaml
+++ b/tests/flytekit/unit/configuration/configs/good.yaml
@@ -1,0 +1,18 @@
+sdk:
+  workflow_packages: "this.module,that.module"
+auth:
+  assumable_iam_role: "some_role"
+platform:
+  url: "fakeflyte.com"
+madeup:
+  int_value: "3"
+  string_value: "abc"
+resources:
+  default_cpu_request: "500m"
+  default_cpu_limit: "501m"
+  default_memory_request: "500Gi"
+  default_memory_limit: "501Gi"
+  default_storage_request: "500Gi"
+  default_storage_limit: "501Gi"
+  default_gpu_request: "1"
+  default_gpu_limit: "2"

--- a/tests/flytekit/unit/configuration/test_common.py
+++ b/tests/flytekit/unit/configuration/test_common.py
@@ -11,8 +11,14 @@ def test_file_loader_bad():
         common.CONFIGURATION_SINGLETON.get_string("a", "b")
 
 
-def test_file_loader_good():
+def test_ini_file_loader_good():
     set_flyte_config_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/good.config"))
+    assert common.CONFIGURATION_SINGLETON.get_string("sdk", "workflow_packages") == "this.module,that.module"
+    assert common.CONFIGURATION_SINGLETON.get_string("auth", "assumable_iam_role") == "some_role"
+
+
+def test_yaml_file_loader_good():
+    set_flyte_config_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/good.yaml"))
     assert common.CONFIGURATION_SINGLETON.get_string("sdk", "workflow_packages") == "this.module,that.module"
     assert common.CONFIGURATION_SINGLETON.get_string("auth", "assumable_iam_role") == "some_role"
 


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
`Setup-config` command in flytekit to use the YAML format so that you can run setup-config with flytekit and then run flytectl.
`flyte-cli` load config in YAML format.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Add an option that lets the user choose the output format.
To support backward compatibility, we could output both `ini` and `yaml` format. 


## Tracking Issue
https://github.com/flyteorg/flyte/issues/1035

## Follow-up issue
_NA_
