### PR TITLE
Support a flag to find config file

### DIFF
--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -100,10 +100,6 @@ def _detect_default_config_file():
         )
 
 
-# Run this as the module is loading to pick up settings that click can then use when constructing the commands
-_detect_default_config_file()
-
-
 def _get_io_string(literal_map, verbose=False):
     """
     :param flytekit.models.literals.LiteralMap literal_map:
@@ -311,6 +307,7 @@ _DOMAIN_FLAGS = ["-d", "--domain"]
 _NAME_FLAGS = ["-n", "--name"]
 _VERSION_FLAGS = ["-v", "--version"]
 _HOST_FLAGS = ["-h", "--host"]
+_CONFIG_FLAGS = ["-c", "--config"]
 _PRINCIPAL_FLAGS = ["-r", "--principal"]
 _INSECURE_FLAGS = ["-i", "--insecure"]
 
@@ -498,6 +495,7 @@ class _FlyteSubCommand(_click.Command):
         "domain": _DOMAIN_FLAGS[0],
         "name": _NAME_FLAGS[0],
         "host": _HOST_FLAGS[0],
+        "config": _CONFIG_FLAGS[0],
     }
 
     _PASSABLE_FLAGS = {
@@ -529,6 +527,14 @@ class _FlyteSubCommand(_click.Command):
         return ctx
 
 
+@_click.option(
+    *_CONFIG_FLAGS,
+    required=False,
+    type=str,
+    default=None,
+    help="[Optional] The config to pass to the sub-command (if applicable).  If set again in the sub-command, "
+    "the sub-command's parameter takes precedence.",
+)
 @_click.option(
     *_HOST_FLAGS,
     required=False,
@@ -564,11 +570,22 @@ class _FlyteSubCommand(_click.Command):
 @_insecure_option
 @_click.group("flyte-cli")
 @_click.pass_context
-def _flyte_cli(ctx, host, project, domain, name, insecure):
+def _flyte_cli(ctx, host, config, project, domain, name, insecure):
     """
     Command line tool for interacting with all entities on the Flyte Platform.
     """
-    pass
+    if config is None:
+        # Run this as the module is loading to pick up settings that click can then use when constructing the commands
+        _detect_default_config_file()
+        return
+    if _os.path.exists(config):
+        _click.secho("Using config file at {}".format(_tt(config)), fg="blue")
+        set_flyte_config_file(config_file_path=config)
+    else:
+        _click.secho(
+            "Config file not found at {}".format(_tt(config)),
+            fg="blue",
+        )
 
 
 ########################################################################################################################

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -532,8 +532,8 @@ class _FlyteSubCommand(_click.Command):
     required=False,
     type=str,
     default=None,
-    help="[Optional] The config to pass to the sub-command (if applicable).  If set again in the sub-command, "
-    "the sub-command's parameter takes precedence.",
+    help="[Optional] The filepath to the config file to pass to the sub-command (if applicable)."
+    "  If set again in the sub-command, the sub-command's parameter takes precedence.",
 )
 @_click.option(
     *_HOST_FLAGS,

--- a/tests/flytekit/unit/cli/test_flyte_cli.py
+++ b/tests/flytekit/unit/cli/test_flyte_cli.py
@@ -109,11 +109,11 @@ def test_activate_project(mock_client):
 
 def test_flyte_cli():
     runner = _CliRunner()
-    result = runner.invoke(_main._flyte_cli, ["activate-project", "-p", "foo", "-i"])
-    assert "Using default config file at" in result.output
     result = runner.invoke(_main._flyte_cli, ["-c", "~/.flyte/config", "activate-project", "-i"])
     assert "Config file not found at ~/.flyte/config" in result.output
     with _mock.patch("os.path.exists") as mock_exists:
+        result = runner.invoke(_main._flyte_cli, ["activate-project", "-p", "foo", "-i"])
+        assert "Using default config file at" in result.output
         mock_exists.return_value = True
         result = runner.invoke(_main._flyte_cli, ["-c", "~/.flyte/config", "activate-project", "-i"])
         assert "Using config file at ~/.flyte/config" in result.output

--- a/tests/flytekit/unit/cli/test_flyte_cli.py
+++ b/tests/flytekit/unit/cli/test_flyte_cli.py
@@ -105,3 +105,15 @@ def test_activate_project(mock_client):
     result = runner.invoke(_main._flyte_cli, ["activate-project", "-p", "foo", "-h", "a.b.com", "-i"])
     assert result.exit_code == 0
     mock_client().update_project.assert_called_with(_Project.active_project("foo"))
+
+
+def test_flyte_cli():
+    runner = _CliRunner()
+    result = runner.invoke(_main._flyte_cli, ["activate-project", "-p", "foo", "-i"])
+    assert "Using default config file at" in result.output
+    result = runner.invoke(_main._flyte_cli, ["-c", "~/.flyte/config", "activate-project", "-i"])
+    assert "Config file not found at ~/.flyte/config" in result.output
+    with _mock.patch("os.path.exists") as mock_exists:
+        mock_exists.return_value = True
+        result = runner.invoke(_main._flyte_cli, ["-c", "~/.flyte/config", "activate-project", "-i"])
+        assert "Using config file at ~/.flyte/config" in result.output


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
**flyte-cli** looks to `~/.flyte/config` as the default place to find a configuration file. This is good, but we should also support a flag to allow the user to specify a different one. This is helpful for developers of Flyte, who might have several configuration files pointing to different Admins, and advanced users who might be running a local Flyte cluster as well as a live production (and staging) cluster.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
If users don't specific conf, flyte will use default config.
```
(flyte) ➜  flytekit git:(sub-flag) ✗ flyte-cli --config ~/.flyte/config get-task
Using config file at /home/kevin/.flyte/config
Usage: flyte-cli get-task [OPTIONS]
Try 'flyte-cli get-task --help' for help.

Error: Missing option '-u' / '--urn'.
(flyte) ➜  flytekit git:(sub-flag) ✗ flyte-cli --config ~/.flyte/xxxx get-task  
Config file not found at /home/kevin/.flyte/xxxx
Usage: flyte-cli get-task [OPTIONS]
Try 'flyte-cli get-task --help' for help.

Error: Missing option '-u' / '--urn'.
(flyte) ➜  flytekit git:(sub-flag) ✗ flyte-cli get-task                         
Using default config file at /home/kevin/.flyte/config
Usage: flyte-cli get-task [OPTIONS]
Try 'flyte-cli get-task --help' for help.
```
```
Usage: flyte-cli [OPTIONS] COMMAND [ARGS]...

  Command line tool for interacting with all entities on the Flyte Platform.

Options:
  -i, --insecure      Do not use SSL  [required]
  -n, --name TEXT     [Optional] The name to pass to the sub-command (if
                      applicable)  If set again in the sub-command, the sub-
                      command's parameter takes precedence.

  -d, --domain TEXT   [Optional] The domain to pass to the sub-command (if
                      applicable)  If set again in the sub-command, the sub-
                      command's parameter takes precedence.

  -p, --project TEXT  [Optional] The project to pass to the sub-command (if
                      applicable)  If set again in the sub-command, the sub-
                      command's parameter takes precedence.

  -h, --host TEXT     [Optional] The host to pass to the sub-command (if
                      applicable).  If set again in the sub-command, the sub-
                      command's parameter takes precedence.

  -c, --config TEXT   [Optional] The config to pass to the sub-command (if
                      applicable).  If set again in the sub-command, the sub-
                      command's parameter takes precedence.

  --help              Show this message and exit.
```

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1036

## Follow-up issue
_NA_