### PR TITLE
Support typing.Tuple for multiple returns

### DIFF
--- a/flytekit/core/condition.py
+++ b/flytekit/core/condition.py
@@ -361,7 +361,7 @@ def transform_to_operand(v: Union[Promise, Literal]) -> Tuple[_core_cond.Operand
     return _core_cond.Operand(primitive=v.scalar.primitive), None
 
 
-def transform_to_comp_expr(expr: ComparisonExpression) -> (_core_cond.ComparisonExpression, typing.List[Promise]):
+def transform_to_comp_expr(expr: ComparisonExpression) -> Tuple[_core_cond.ComparisonExpression, typing.List[Promise]]:
     o_lhs, b_lhs = transform_to_operand(expr.lhs)
     o_rhs, b_rhs = transform_to_operand(expr.rhs)
     return (
@@ -372,7 +372,7 @@ def transform_to_comp_expr(expr: ComparisonExpression) -> (_core_cond.Comparison
 
 def transform_to_boolexpr(
     expr: Union[ComparisonExpression, ConjunctionExpression]
-) -> (_core_cond.BooleanExpression, typing.List[Promise]):
+) -> Tuple[_core_cond.BooleanExpression, typing.List[Promise]]:
     if isinstance(expr, ConjunctionExpression):
         cexpr, promises = transform_to_conj_expr(expr)
         return _core_cond.BooleanExpression(conjunction=cexpr), promises
@@ -380,13 +380,13 @@ def transform_to_boolexpr(
     return _core_cond.BooleanExpression(comparison=cexpr), promises
 
 
-def to_case_block(c: Case) -> (Union[_core_wf.IfBlock], typing.List[Promise]):
+def to_case_block(c: Case) -> Tuple[Union[_core_wf.IfBlock], typing.List[Promise]]:
     expr, promises = transform_to_boolexpr(c.expr)
     n = c.output_promise.ref.node
     return _core_wf.IfBlock(condition=expr, then_node=n), promises
 
 
-def to_ifelse_block(node_id: str, cs: ConditionalSection) -> (_core_wf.IfElseBlock, typing.List[Binding]):
+def to_ifelse_block(node_id: str, cs: ConditionalSection) -> Tuple[_core_wf.IfElseBlock, typing.List[Binding]]:
     if len(cs.cases) == 0:
         raise AssertionError("Illegal Condition block, with no if-else cases")
     if len(cs.cases) < 2:
@@ -414,7 +414,7 @@ def to_ifelse_block(node_id: str, cs: ConditionalSection) -> (_core_wf.IfElseBlo
     )
 
 
-def to_branch_node(name: str, cs: ConditionalSection) -> (BranchNode, typing.List[Promise]):
+def to_branch_node(name: str, cs: ConditionalSection) -> Tuple[BranchNode, typing.List[Promise]]:
     blocks, promises = to_ifelse_block(name, cs)
     return BranchNode(name=name, ifelse_block=blocks), promises
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -529,7 +529,7 @@ class DictTransformer(TypeTransformer[dict]):
         super().__init__("Typed Dict", dict)
 
     @staticmethod
-    def get_dict_types(t: Type[dict]) -> (type, type):
+    def get_dict_types(t: Type[dict]) -> typing.Tuple[type, type]:
         """
         Return the generic Type T of the Dict
         """

--- a/plugins/tests/greatexpectations/test_schema.py
+++ b/plugins/tests/greatexpectations/test_schema.py
@@ -1,5 +1,6 @@
 import os
 import sqlite3
+import typing
 
 import pandas as pd
 import pytest

--- a/plugins/tests/greatexpectations/test_schema.py
+++ b/plugins/tests/greatexpectations/test_schema.py
@@ -75,7 +75,7 @@ def test_ge_schema_multiple_args():
     @task
     def get_file_name(
         dataset_one: GreatExpectationsType[str, ge_config_one], dataset_two: GreatExpectationsType[str, ge_config_two]
-    ) -> (int, int):
+    ) -> typing.Tuple[int, int]:
         df_one = pd.read_csv(os.path.join("data", dataset_one))
         df_two = pd.read_csv(os.path.join("data", dataset_two))
         return len(df_one), len(df_two)
@@ -83,7 +83,7 @@ def test_ge_schema_multiple_args():
     @workflow
     def wf(
         dataset_one: str = "yellow_tripdata_sample_2019-01.csv", dataset_two: str = "yellow_tripdata_sample_2019-02.csv"
-    ) -> (int, int):
+    ) -> typing.Tuple[int, int]:
         return get_file_name(dataset_one=dataset_one, dataset_two=dataset_two)
 
     assert wf() == (10000, 10000)

--- a/plugins/tests/greatexpectations/test_task.py
+++ b/plugins/tests/greatexpectations/test_task.py
@@ -1,5 +1,6 @@
 import os
 import sqlite3
+import typing
 
 import pandas as pd
 import pytest
@@ -268,7 +269,7 @@ def test_ge_flytefile_multiple_args():
     )
 
     @task
-    def get_file_name(dataset_one: FlyteFile, dataset_two: FlyteFile) -> (int, int):
+    def get_file_name(dataset_one: FlyteFile, dataset_two: FlyteFile) -> typing.Tuple[int, int]:
         df_one = pd.read_csv(os.path.join("data", dataset_one))
         df_two = pd.read_csv(os.path.join("data", dataset_two))
         return len(df_one), len(df_two)
@@ -277,7 +278,7 @@ def test_ge_flytefile_multiple_args():
     def wf(
         dataset_one: FlyteFile = "https://raw.githubusercontent.com/superconductive/ge_tutorials/main/data/yellow_tripdata_sample_2019-01.csv",
         dataset_two: FlyteFile = "https://raw.githubusercontent.com/superconductive/ge_tutorials/main/data/yellow_tripdata_sample_2019-02.csv",
-    ) -> (int, int):
+    ) -> typing.Tuple[int, int]:
         task_object_one(dataset=dataset_one)
         task_object_two(dataset=dataset_two)
         return get_file_name(dataset_one=dataset_one, dataset_two=dataset_two)

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -81,11 +81,11 @@ def test_condition_sub_workflows():
         return a + b, a - b
 
     @workflow
-    def sub_wf(a: int, b: int) -> (int, int):
+    def sub_wf(a: int, b: int) -> typing.Tuple[int, int]:
         return sum_sub(a=a, b=b)
 
     @workflow
-    def math_ops(a: int, b: int) -> (int, int):
+    def math_ops(a: int, b: int) -> typing.Tuple[int, int]:
         # Flyte will only make `sum` and `sub` available as outputs because they are common between all branches
         sum, sub = (
             conditional("noDivByZero")
@@ -108,7 +108,7 @@ def test_condition_tuple_branches():
         return a + b, a - b
 
     @workflow
-    def math_ops(a: int, b: int) -> (int, int):
+    def math_ops(a: int, b: int) -> typing.Tuple[int, int]:
         add, sub = (
             conditional("noDivByZero")
             .if_(a > b)

--- a/tests/flytekit/unit/core/test_launch_plan.py
+++ b/tests/flytekit/unit/core/test_launch_plan.py
@@ -372,7 +372,7 @@ def test_lp_nodes():
     lp = launch_plan.LaunchPlan.get_or_create(my_sub_wf, "my_sub_wf_lp1")
 
     @workflow
-    def my_wf(a: int) -> (int, int):
+    def my_wf(a: int) -> typing.Tuple[int, int]:
         t = t1(a=a)
         w = lp(a=a)
         return t, w

--- a/tests/flytekit/unit/core/test_local_cache.py
+++ b/tests/flytekit/unit/core/test_local_cache.py
@@ -47,7 +47,7 @@ def test_to_confirm_that_cache_keys_include_function_name():
         return n + 1
 
     @workflow
-    def wf(n: int) -> (int, int):
+    def wf(n: int) -> typing.Tuple[int, int]:
         n_f1 = f1(n=n)
         n_f2 = f2(n=n)
         return n_f1, n_f2

--- a/tests/flytekit/unit/core/test_references.py
+++ b/tests/flytekit/unit/core/test_references.py
@@ -96,7 +96,7 @@ def test_ref_task_more():
 
 
 @reference_workflow(project="proj", domain="development", name="wf_name", version="abc")
-def ref_wf1(a: int) -> (str, str):
+def ref_wf1(a: int) -> typing.Tuple[str, str]:
     ...
 
 

--- a/tests/flytekit/unit/core/test_resolver.py
+++ b/tests/flytekit/unit/core/test_resolver.py
@@ -1,3 +1,4 @@
+import typing
 from collections import OrderedDict
 
 import pytest
@@ -23,9 +24,9 @@ serialization_settings = context_manager.SerializationSettings(
 
 def test_wf_resolving():
     @workflow
-    def my_wf(a: int, b: str) -> (int, str):
+    def my_wf(a: int, b: str) -> typing.Tuple[int, str]:
         @task
-        def t1(a: int) -> (int, str):
+        def t1(a: int) -> typing.Tuple[int, str]:
             return a + 2, "world"
 
         @task

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -341,7 +341,7 @@ def test_serialization_nested_subwf():
         return a + 2
 
     @workflow
-    def leaf_subwf(a: int = 42) -> ().Tuple[int, int]:
+    def leaf_subwf(a: int = 42) -> typing.Tuple[int, int]:
         x = t1(a=a)
         u = t1(a=x)
         return x, u

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -341,18 +341,18 @@ def test_serialization_nested_subwf():
         return a + 2
 
     @workflow
-    def leaf_subwf(a: int = 42) -> (int, int):
+    def leaf_subwf(a: int = 42) -> ().Tuple[int, int]:
         x = t1(a=a)
         u = t1(a=x)
         return x, u
 
     @workflow
-    def middle_subwf() -> (int, int):
+    def middle_subwf() -> typing.Tuple[int, int]:
         s1, s2 = leaf_subwf(a=50)
         return s2, s2
 
     @workflow
-    def parent_wf() -> (int, int, int, int):
+    def parent_wf() -> typing.Tuple[int, int, int, int]:
         m1, m2 = middle_subwf()
         l1, l2 = leaf_subwf()
         return m1, m2, l1, l2

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1252,7 +1252,7 @@ def test_conditional_asymmetric_return():
         return False
 
     @task
-    def sum_diff(a: int, b: int) -> (int, int):
+    def sum_diff(a: int, b: int) -> typing.Tuple[int, int]:
         """
         sum_diff returns the sum and difference between a and b.
         """

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -172,7 +172,7 @@ def test_wf_nested_comp():
         return a
 
     @workflow
-    def outer() -> (int, int):
+    def outer() -> typing.Tuple[int, int]:
         # You should not do this. This is just here for testing.
         @workflow
         def wf2() -> int:
@@ -207,7 +207,7 @@ def simple_wf() -> int:
 
 
 @workflow
-def my_wf_example(a: int) -> (int, int):
+def my_wf_example(a: int) -> typing.Tuple[int, int]:
     """example
 
     Workflows can have inputs and return outputs of simple or complex types.


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
**Describe the bug**
Currently, if a task returns two or more outputs, users are expected to declare those return signatures as

```
def t1() -> (int, int):
  ...
```

This is fine but is not idiomatic and doesn't pass mypy.  The correct thing to support is:
```
def t1() -> typing.Tuple[int, int]:
  ...
```


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
We could check it by running `make lint | grep "Use Tuple"`.
If there are somewhere don't use Tuple, will get the below error.
```
tests/flytekit/unit/core/test_resolver.py:28: note: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
tests/flytekit/unit/core/test_references.py:99: note: Suggestion: Use Tuple[T1, ..., Tn] instead of (T1, ..., Tn)
``` 

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1029

## Follow-up issue
_NA_