### PR TITLE
[mypy] Fix Incompatible types

### DIFF
--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -202,7 +202,7 @@ class Task(object):
         """
         return type(v)
 
-    def get_input_types(self) -> Dict[str, type]:
+    def get_input_types(self) -> Optional[Dict[str, type]]:
         """
         Returns python native types for inputs. In case this is not a python native task (base class) and hence
         returns a None. we could deduce the type from literal types, but that is not a required exercise

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -24,7 +24,7 @@ import typing
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Dict, Generator, List, Optional
+from typing import Any, Dict, Generator, List, Optional, Union
 
 from docker_image import reference
 
@@ -80,8 +80,8 @@ class ImageConfig(object):
         images (List[Image]): Optional, additional images which can be used in task container definitions.
     """
 
-    default_image: Image = None
-    images: List[Image] = None
+    default_image: Optional[Image] = None
+    images: Optional[List[Image]] = None
 
     def find_image(self, name) -> Optional[Image]:
         """
@@ -133,8 +133,8 @@ class EntrypointSettings(object):
     to execute tasks at runtime.
     """
 
-    path: str = None
-    command: str = None
+    path: Optional[str] = None
+    command: Optional[str] = None
     version: int = 0
 
 
@@ -145,7 +145,7 @@ class FastSerializationSettings(object):
     """
 
     enabled: bool = False
-    destination_dir: str = None
+    destination_dir: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -333,9 +333,9 @@ class ExecutionState(object):
         #: or propeller.
         LOCAL_TASK_EXECUTION = 3
 
-    mode: ExecutionState.Mode
+    mode: Optional[ExecutionState.Mode]
     working_dir: os.PathLike
-    engine_dir: os.PathLike
+    engine_dir: Optional[Union[os.PathLike, str]]
     additional_context: Optional[Dict[Any, Any]]
     branch_eval_mode: Optional[BranchEvalMode]
     user_space_params: Optional[ExecutionParameters]
@@ -344,7 +344,7 @@ class ExecutionState(object):
         self,
         working_dir: os.PathLike,
         mode: Optional[ExecutionState.Mode] = None,
-        engine_dir: Optional[os.PathLike] = None,
+        engine_dir: Optional[Union[os.PathLike, str]] = None,
         additional_context: Optional[Dict[Any, Any]] = None,
         branch_eval_mode: Optional[BranchEvalMode] = None,
         user_space_params: Optional[ExecutionParameters] = None,
@@ -485,7 +485,7 @@ class FlyteContext(object):
         return ExecutionState(working_dir=working_dir, user_space_params=self.user_space_params)
 
     @staticmethod
-    def current_context() -> FlyteContext:
+    def current_context() -> Optional[FlyteContext]:
         """
         This method exists only to maintain backwards compatibility. Please use
         ``FlyteContextManager.current_context()`` instead.
@@ -565,7 +565,7 @@ class FlyteContext(object):
             """
             return CompilationState(prefix=prefix)
 
-        def new_execution_state(self, working_dir: Optional[os.PathLike] = None) -> ExecutionState:
+        def new_execution_state(self, working_dir: Optional[Union[os.PathLike, str]] = None) -> ExecutionState:
             """
             Creates and returns a new default execution state. This should be used at the entrypoint of execution,
             in all other cases it is preferable to use with_execution_state
@@ -606,7 +606,7 @@ class FlyteContextManager(object):
         return ss[0]
 
     @staticmethod
-    def current_context() -> FlyteContext:
+    def current_context() -> Optional[FlyteContext]:
         if FlyteContextManager._OBJS:
             return FlyteContextManager._OBJS[-1]
         return None

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -22,7 +22,7 @@ class Interface(object):
 
     def __init__(
         self,
-        inputs: typing.Optional[typing.Dict[str, Union[Type, Tuple[Type, Any]]]] = None,
+        inputs: typing.Optional[typing.Dict[str, Union[Type, Tuple[Type, Any]], None]] = None,
         outputs: typing.Optional[typing.Dict[str, Type]] = None,
         output_tuple_name: Optional[str] = None,
         docstring: Optional[Docstring] = None,
@@ -230,7 +230,7 @@ def transform_types_to_list_of_type(m: Dict[str, type]) -> Dict[str, type]:
     om = {}
     for k, v in m.items():
         om[k] = typing.List[v]
-    return om
+    return om  # type: ignore
 
 
 def transform_interface_to_list_interface(interface: Interface) -> Interface:

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -75,8 +75,8 @@ def translate_inputs_to_literals(
                 if len(input_val) == 0:
                     raise
                 sub_type = type(input_val[0])
-            literals = [extract_value(ctx, v, sub_type, flyte_literal_type.collection_type) for v in input_val]
-            return _literal_models.Literal(collection=_literal_models.LiteralCollection(literals=literals))
+            literal_list = [extract_value(ctx, v, sub_type, flyte_literal_type.collection_type) for v in input_val]
+            return _literal_models.Literal(collection=_literal_models.LiteralCollection(literals=literal_list))
         elif isinstance(input_val, dict):
             if (
                 flyte_literal_type.map_value_type is None
@@ -87,10 +87,10 @@ def translate_inputs_to_literals(
             if flyte_literal_type.simple == _type_models.SimpleType.STRUCT:
                 return TypeEngine.to_literal(ctx, input_val, type(input_val), flyte_literal_type)
             else:
-                literals = {
+                literal_map = {
                     k: extract_value(ctx, v, sub_type, flyte_literal_type.map_value_type) for k, v in input_val.items()
                 }
-                return _literal_models.Literal(map=_literal_models.LiteralMap(literals=literals))
+                return _literal_models.Literal(map=_literal_models.LiteralMap(literals=literal_map))
         elif isinstance(input_val, Promise):
             # In the example above, this handles the "in2=a" type of argument
             return input_val.val
@@ -532,7 +532,7 @@ def create_task_output(
             # See comment for runs_before
             return self
 
-    return Output(*promises)
+    return Output(*promises)  # type: ignore
 
 
 def binding_data_from_python_std(

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections
 import typing
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from typing_extensions import Protocol
 

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -83,7 +83,7 @@ def translate_inputs_to_literals(
                 and flyte_literal_type.simple != _type_models.SimpleType.STRUCT
             ):
                 raise Exception(f"Not a map type {flyte_literal_type} but got a map {input_val}")
-            k_type, sub_type = DictTransformer.get_dict_types(val_type)
+            k_type, sub_type = DictTransformer.get_dict_types(val_type)  # type: ignore
             if flyte_literal_type.simple == _type_models.SimpleType.STRUCT:
                 return TypeEngine.to_literal(ctx, input_val, type(input_val), flyte_literal_type)
             else:

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections
 import typing
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from typing_extensions import Protocol
 

--- a/flytekit/core/reference_entity.py
+++ b/flytekit/core/reference_entity.py
@@ -141,7 +141,7 @@ class ReferenceEntity(object):
         # After the execute has been successfully completed
         return outputs_literal_map
 
-    def local_execute(self, ctx: FlyteContext, **kwargs) -> Union[Tuple[Promise], Promise, VoidPromise]:
+    def local_execute(self, ctx: FlyteContext, **kwargs) -> Optional[Union[Tuple[Promise], Promise, VoidPromise]]:
         """
         Please see the local_execute comments in the main task.
         """

--- a/flytekit/core/resources.py
+++ b/flytekit/core/resources.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -23,14 +24,14 @@ class Resources(object):
     Also refer to the `K8s conventions. <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes>`__
     """
 
-    cpu: str = None
-    mem: str = None
-    gpu: str = None
-    storage: str = None
-    ephemeral_storage: str = None
+    cpu: Optional[str] = None
+    mem: Optional[str] = None
+    gpu: Optional[str] = None
+    storage: Optional[str] = None
+    ephemeral_storage: Optional[str] = None
 
 
 @dataclass
 class ResourceSpec(object):
-    requests: Resources = None
-    limits: Resources = None
+    requests: Optional[Resources] = None
+    limits: Optional[Resources] = None

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -8,7 +8,7 @@ import json as _json
 import mimetypes
 import typing
 from abc import ABC, abstractmethod
-from typing import Type, cast, Optional
+from typing import Optional, Type, cast
 
 from dataclasses_json import DataClassJsonMixin
 from google.protobuf import json_format as _json_format

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -495,7 +495,7 @@ class ListTransformer(TypeTransformer[T]):
                 return t.__args__[0]  # type: ignore
         raise ValueError("Only generic univariate typing.List[T] type is supported.")
 
-    def get_literal_type(self, t: Type[T]) -> LiteralType:
+    def get_literal_type(self, t: Type[T]) -> typing.Optional[LiteralType]:
         """
         Only univariate Lists are supported in Flyte
         """
@@ -510,14 +510,14 @@ class ListTransformer(TypeTransformer[T]):
         lit_list = [TypeEngine.to_literal(ctx, x, t, expected.collection_type) for x in python_val]  # type: ignore
         return Literal(collection=LiteralCollection(literals=lit_list))
 
-    def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
+    def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> typing.List[T]:
         st = self.get_sub_type(expected_python_type)
         return [TypeEngine.to_python_value(ctx, x, st) for x in lv.collection.literals]
 
-    def guess_python_type(self, literal_type: LiteralType) -> Type[T]:
+    def guess_python_type(self, literal_type: LiteralType) -> typing.List[Type[typing.Any]]:
         if literal_type.collection_type:
             ct = TypeEngine.guess_python_type(literal_type.collection_type)
-            return typing.List[ct]
+            return [ct]
         raise ValueError(f"List transformer cannot reverse {literal_type}")
 
 
@@ -600,7 +600,7 @@ class DictTransformer(TypeTransformer[dict]):
     def guess_python_type(self, literal_type: LiteralType) -> Type[T]:
         if literal_type.map_value_type:
             mt = TypeEngine.guess_python_type(literal_type.map_value_type)
-            return typing.Dict[str, mt]
+            return typing.Dict[str, mt]  # type: ignore
         raise ValueError(f"Dictionary transformer cannot reverse {literal_type}")
 
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -8,7 +8,7 @@ import json as _json
 import mimetypes
 import typing
 from abc import ABC, abstractmethod
-from typing import Type, cast
+from typing import Type, cast, Optional
 
 from dataclasses_json import DataClassJsonMixin
 from google.protobuf import json_format as _json_format
@@ -303,7 +303,7 @@ class TypeEngine(typing.Generic[T]):
     _DATACLASS_TRANSFORMER: TypeTransformer = DataclassTransformer()
 
     @classmethod
-    def register(cls, transformer: TypeTransformer, additional_types: typing.Optional[typing.List[Type]] = None):
+    def register(cls, transformer: TypeTransformer, additional_types: Optional[typing.List[Type]] = None):
         """
         This should be used for all types that respond with the right type annotation when you use type(...) function
         """
@@ -424,7 +424,7 @@ class TypeEngine(typing.Generic[T]):
         cls,
         ctx: FlyteContext,
         d: typing.Dict[str, typing.Any],
-        guessed_python_types: typing.Optional[typing.Dict[str, type]] = None,
+        guessed_python_types: Optional[typing.Dict[str, type]] = None,
     ) -> LiteralMap:
         """
         Given a dictionary mapping string keys to python values and a dictionary containing guessed types for such string keys,
@@ -495,7 +495,7 @@ class ListTransformer(TypeTransformer[T]):
                 return t.__args__[0]  # type: ignore
         raise ValueError("Only generic univariate typing.List[T] type is supported.")
 
-    def get_literal_type(self, t: Type[T]) -> typing.Optional[LiteralType]:
+    def get_literal_type(self, t: Type[T]) -> Optional[LiteralType]:
         """
         Only univariate Lists are supported in Flyte
         """
@@ -514,7 +514,7 @@ class ListTransformer(TypeTransformer[T]):
         st = self.get_sub_type(expected_python_type)
         return [TypeEngine.to_python_value(ctx, x, st) for x in lv.collection.literals]
 
-    def guess_python_type(self, literal_type: LiteralType) -> typing.List[Type[typing.Any]]:
+    def guess_python_type(self, literal_type: LiteralType) -> typing.List[Type[T]]:
         if literal_type.collection_type:
             ct = TypeEngine.guess_python_type(literal_type.collection_type)
             return [ct]
@@ -531,7 +531,7 @@ class DictTransformer(TypeTransformer[dict]):
         super().__init__("Typed Dict", dict)
 
     @staticmethod
-    def get_dict_types(t: Type[dict]) -> typing.Tuple[type, type]:
+    def get_dict_types(t: Optional[Type[dict]]) -> typing.Tuple[Optional[type], Optional[type]]:
         """
         Return the generic Type T of the Dict
         """

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -514,10 +514,10 @@ class ListTransformer(TypeTransformer[T]):
         st = self.get_sub_type(expected_python_type)
         return [TypeEngine.to_python_value(ctx, x, st) for x in lv.collection.literals]
 
-    def guess_python_type(self, literal_type: LiteralType) -> typing.List[Type[T]]:
+    def guess_python_type(self, literal_type: LiteralType) -> Type[list]:
         if literal_type.collection_type:
             ct = TypeEngine.guess_python_type(literal_type.collection_type)
-            return [ct]
+            return typing.List[ct]
         raise ValueError(f"List transformer cannot reverse {literal_type}")
 
 

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -136,9 +136,9 @@ class FlyteDirectory(os.PathLike, typing.Generic[T]):
     def __class_getitem__(cls, item: typing.Type) -> typing.Type[FlyteDirectory]:
         if item is None:
             return cls
-        item = str(item)
-        item = item.strip().lstrip("~").lstrip(".")
-        if item == "":
+        item_string = str(item)
+        item_string = item_string.strip().lstrip("~").lstrip(".")
+        if item_string == "":
             return cls
 
         class _SpecificFormatDirectoryClass(FlyteDirectory):
@@ -147,7 +147,7 @@ class FlyteDirectory(os.PathLike, typing.Generic[T]):
 
             @classmethod
             def extension(cls) -> str:
-                return item
+                return item_string
 
         return _SpecificFormatDirectoryClass
 
@@ -169,7 +169,7 @@ class FlyteDirectory(os.PathLike, typing.Generic[T]):
         If this is an input to a task, and the original path is s3://something, flytekit will download the
         directory for the user. In case the user wants access to the original path, it will be here.
         """
-        return self._remote_source
+        return typing.cast(str, self._remote_source)
 
     def download(self) -> str:
         if self._downloaded:
@@ -285,7 +285,7 @@ class FlyteDirToMultipartBlobTransformer(TypeTransformer[FlyteDirectory]):
 
         return fd
 
-    def guess_python_type(self, literal_type: LiteralType) -> typing.Type[T]:
+    def guess_python_type(self, literal_type: LiteralType) -> typing.Type[FlyteDirectory[typing.Any]]:
         if (
             literal_type.blob is not None
             and literal_type.blob.dimensionality == _core_types.BlobType.BlobDimensionality.MULTIPART

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -141,8 +141,8 @@ class FlyteFile(os.PathLike, typing.Generic[T]):
     def __class_getitem__(cls, item: typing.Type) -> typing.Type[FlyteFile]:
         if item is None:
             return cls
-        item = str(item)
-        item = item.strip().lstrip("~").lstrip(".")
+        item_string = str(item)
+        item_string = item_string.strip().lstrip("~").lstrip(".")
         if item == "":
             return cls
 
@@ -152,7 +152,7 @@ class FlyteFile(os.PathLike, typing.Generic[T]):
 
             @classmethod
             def extension(cls) -> str:
-                return item
+                return item_string
 
         return _SpecificFormatClass
 
@@ -204,7 +204,7 @@ class FlyteFile(os.PathLike, typing.Generic[T]):
         If this is an input to a task, and the original path is ``s3://something``, flytekit will download the
         file for the user. In case the user wants access to the original path, it will be here.
         """
-        return self._remote_source
+        return typing.cast(str, self._remote_source)
 
     def download(self) -> str:
         if self._downloaded:
@@ -345,7 +345,7 @@ class FlyteFilePathTransformer(TypeTransformer[FlyteFile]):
 
         return ff
 
-    def guess_python_type(self, literal_type: LiteralType) -> typing.Type[T]:
+    def guess_python_type(self, literal_type: LiteralType) -> typing.Type[FlyteFile[typing.Any]]:
         if (
             literal_type.blob is not None
             and literal_type.blob.dimensionality == _core_types.BlobType.BlobDimensionality.SINGLE

--- a/flytekit/types/schema/types.py
+++ b/flytekit/types/schema/types.py
@@ -6,7 +6,7 @@ import typing
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Type
+from typing import Type
 
 import numpy as _np
 

--- a/flytekit/types/schema/types.py
+++ b/flytekit/types/schema/types.py
@@ -6,7 +6,7 @@ import typing
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Type
+from typing import Optional, Type
 
 import numpy as _np
 
@@ -35,7 +35,7 @@ class SchemaOpenMode(Enum):
     WRITE = "w"
 
 
-def generate_ordered_files(directory: os.PathLike, n: int) -> typing.Generator[os.PathLike, None, None]:
+def generate_ordered_files(directory: os.PathLike, n: int) -> str:
     for i in range(n):
         yield os.path.join(directory, f"{i:05}")
 
@@ -249,7 +249,7 @@ class FlyteSchema(object):
 
     @property
     def remote_path(self) -> str:
-        return self._remote_path
+        return typing.cast(str, self._remote_path)
 
     @property
     def supported_mode(self) -> SchemaOpenMode:
@@ -377,7 +377,7 @@ class FlyteSchemaTransformer(TypeTransformer[FlyteSchema]):
     def guess_python_type(self, literal_type: LiteralType) -> Type[T]:
         if not literal_type.schema:
             raise ValueError(f"Cannot reverse {literal_type}")
-        columns = {}
+        columns: Optional[Type[T]] = None
         for literal_column in literal_type.schema.columns:
             if literal_column.type == SchemaType.SchemaColumn.SchemaColumnType.INTEGER:
                 columns[literal_column.name] = int

--- a/flytekit/types/schema/types.py
+++ b/flytekit/types/schema/types.py
@@ -377,7 +377,7 @@ class FlyteSchemaTransformer(TypeTransformer[FlyteSchema]):
     def guess_python_type(self, literal_type: LiteralType) -> Type[T]:
         if not literal_type.schema:
             raise ValueError(f"Cannot reverse {literal_type}")
-        columns: Optional[Type[T]] = None
+        columns: dict[Type] = {}
         for literal_column in literal_type.schema.columns:
             if literal_column.type == SchemaType.SchemaColumn.SchemaColumnType.INTEGER:
                 columns[literal_column.name] = int

--- a/plugins/flytekit-data-fsspec/flytekitplugins/fsspec/persist.py
+++ b/plugins/flytekit-data-fsspec/flytekitplugins/fsspec/persist.py
@@ -95,13 +95,13 @@ class FSSpecPersistence(DataPersistence):
         return fs.put(from_path, to_path, recursive=recursive)
 
     def construct_path(self, add_protocol: bool, add_prefix: bool, *paths) -> str:
-        paths = list(paths)  # make type check happy
+        path_list = list(paths)  # make type check happy
         if add_prefix:
-            paths.insert(0, self.default_prefix)  # type: ignore
-        path = "/".join(paths)
+            path_list.insert(0, self.default_prefix)  # type: ignore
+        path = "/".join(path_list)
         if add_protocol:
             return f"{self.default_protocol}://{path}"
-        return path
+        return typing.cast(str, path)
 
 
 def _register():

--- a/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py
+++ b/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import os
+import typing
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
@@ -66,7 +67,7 @@ class GreatExpectationsType(object):
     """
 
     @classmethod
-    def config(cls) -> Tuple[Type[str], GreatExpectationsFlyteConfig]:
+    def config(cls) -> Tuple[Type, GreatExpectationsFlyteConfig]:
         return (
             str,
             GreatExpectationsFlyteConfig(datasource_name="", data_connector_name="", expectation_suite_name=""),
@@ -182,7 +183,7 @@ class GreatExpectationsTypeTransformer(TypeTransformer[GreatExpectationsType]):
         ctx: FlyteContext,
         lv: Literal,
         expected_python_type: Type[GreatExpectationsType],
-    ) -> str:
+    ) -> GreatExpectationsType:
         if not (
             lv
             and lv.scalar
@@ -322,7 +323,7 @@ class GreatExpectationsTypeTransformer(TypeTransformer[GreatExpectationsType]):
 
         logging.info("Validation succeeded!")
 
-        return return_dataset
+        return typing.cast(GreatExpectationsType, return_dataset)
 
 
 TypeEngine.register(GreatExpectationsTypeTransformer())

--- a/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py
+++ b/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py
@@ -51,7 +51,7 @@ class GreatExpectationsFlyteConfig(object):
     """
     local_file_path: Optional[str] = None
     checkpoint_params: Optional[Dict[str, Union[str, List[str]]]] = None
-    batch_request_config: BatchRequestConfig = None
+    batch_request_config: Optional[BatchRequestConfig] = None
     context_root_dir: str = "./great_expectations"
 
 
@@ -66,7 +66,7 @@ class GreatExpectationsType(object):
     """
 
     @classmethod
-    def config(cls) -> Tuple[Type, Type[GreatExpectationsFlyteConfig]]:
+    def config(cls) -> Tuple[Type[str], GreatExpectationsFlyteConfig]:
         return (
             str,
             GreatExpectationsFlyteConfig(datasource_name="", data_connector_name="", expectation_suite_name=""),
@@ -80,7 +80,7 @@ class GreatExpectationsType(object):
             __origin__ = GreatExpectationsType
 
             @classmethod
-            def config(cls) -> Tuple[Type, Type[GreatExpectationsFlyteConfig]]:
+            def config(cls) -> Tuple[Type, GreatExpectationsFlyteConfig]:
                 return config
 
         return _GreatExpectationsTypeClass
@@ -91,7 +91,7 @@ class GreatExpectationsTypeTransformer(TypeTransformer[GreatExpectationsType]):
         super().__init__(name="GreatExpectations Transformer", t=GreatExpectationsType)
 
     @staticmethod
-    def get_config(t: Type[GreatExpectationsType]) -> Tuple[Type, Type[GreatExpectationsFlyteConfig]]:
+    def get_config(t: Type[GreatExpectationsType]) -> Tuple[Type, GreatExpectationsFlyteConfig]:
         return t.config()
 
     def get_literal_type(self, t: Type[GreatExpectationsType]) -> LiteralType:
@@ -182,7 +182,7 @@ class GreatExpectationsTypeTransformer(TypeTransformer[GreatExpectationsType]):
         ctx: FlyteContext,
         lv: Literal,
         expected_python_type: Type[GreatExpectationsType],
-    ) -> GreatExpectationsType:
+    ) -> str:
         if not (
             lv
             and lv.scalar

--- a/plugins/flytekit-hive/flytekitplugins/hive/task.py
+++ b/plugins/flytekit-hive/flytekitplugins/hive/task.py
@@ -77,7 +77,7 @@ class HiveTask(SQLTask[HiveConfig]):
         return self.task_config.cluster_label
 
     @property
-    def output_schema_type(self) -> Type[FlyteSchema]:
+    def output_schema_type(self) -> Optional[Type[FlyteSchema]]:
         return self._output_schema_type
 
     @property

--- a/plugins/flytekit-k8s-pod/flytekitplugins/pod/task.py
+++ b/plugins/flytekit-k8s-pod/flytekitplugins/pod/task.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 from flyteidl.core import tasks_pb2 as _core_task
 from kubernetes.client import ApiClient
@@ -21,8 +21,8 @@ class Pod(object):
         self,
         pod_spec: V1PodSpec,
         primary_container_name: str,
-        labels: Dict[str, str] = None,
-        annotations: Dict[str, str] = None,
+        labels: Optional[Dict[str, str]] = None,
+        annotations: Optional[Dict[str, str]] = None,
     ):
         if not pod_spec:
             raise _user_exceptions.FlyteValidationException("A pod spec cannot be undefined")
@@ -43,11 +43,11 @@ class Pod(object):
         return self._primary_container_name
 
     @property
-    def labels(self) -> Dict[str, str]:
+    def labels(self) -> Optional[Dict[str, str]]:
         return self._labels
 
     @property
-    def annotations(self) -> Dict[str, str]:
+    def annotations(self) -> Optional[Dict[str, str]]:
         return self._annotations
 
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
 
 from google.protobuf.json_format import MessageToDict
+from pyspark.sql import SparkSession
 
 from flytekit import FlyteContextManager, PythonFunctionTask
 from flytekit.common.tasks.sdk_runnable import ExecutionParameters
@@ -87,7 +88,7 @@ class PysparkFunctionTask(PythonFunctionTask[Spark]):
             task_function=task_function,
             **kwargs,
         )
-        self.sess = None
+        self.sess: Optional[SparkSession] = None
 
     def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
         job = _task_model.SparkJob(

--- a/tests/flytekit/unit/core/test_composition.py
+++ b/tests/flytekit/unit/core/test_composition.py
@@ -38,7 +38,9 @@ def test_single_named_output_subwf():
     @task
     def t1(a: int) -> nt:
         a = a + 2
-        return (a,)  # returns a regular tuple
+        return nt(
+            a,
+        )  # returns a named tuple
 
     @task
     def t2(a: int, b: int) -> nt:

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -270,15 +270,15 @@ def test_subworkflow_condition_named_tuple():
 
     @task
     def t() -> nt:
-        return 5, "foo"
+        return nt(5, "foo")
 
     @workflow
     def wf1() -> nt:
-        return 3, "bar"
+        return nt(3, "bar")
 
     @workflow
     def branching(x: int) -> nt:
-        return conditional("test").if_(x == 2).then(t()).else_().then(wf1())
+        return nt(conditional("test").if_(x == 2).then(t()).else_().then(wf1()))
 
     assert branching(x=2) == (5, "foo")
     assert branching(x=3) == (3, "bar")
@@ -289,7 +289,9 @@ def test_subworkflow_condition_single_named_tuple():
 
     @task
     def t() -> nt:
-        return (5,)
+        return nt(
+            5,
+        )
 
     @workflow
     def wf1() -> nt:

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -278,7 +278,7 @@ def test_subworkflow_condition_named_tuple():
 
     @workflow
     def branching(x: int) -> nt:
-        return nt(conditional("test").if_(x == 2).then(t()).else_().then(wf1()))
+        return conditional("test").if_(x == 2).then(t()).else_().then(wf1())
 
     assert branching(x=2) == (5, "foo")
     assert branching(x=3) == (3, "bar")

--- a/tests/flytekit/unit/core/test_imperative.py
+++ b/tests/flytekit/unit/core/test_imperative.py
@@ -73,7 +73,9 @@ def test_imperative():
     def my_workflow(in1: str) -> nt:
         x = t1(a=in1)
         t2()
-        return (x,)
+        return nt(
+            x,
+        )
 
     # docs_equivalent_end
 

--- a/tests/flytekit/unit/core/test_launch_plan.py
+++ b/tests/flytekit/unit/core/test_launch_plan.py
@@ -296,7 +296,7 @@ def test_lp_all_parameters():
     @task
     def t1(a: int) -> nt:
         a = a + 2
-        return a, "world-" + str(a)
+        return nt(a, "world-" + str(a))
 
     @task
     def t2(a: str, b: str, c: str) -> str:

--- a/tests/flytekit/unit/core/test_node_creation.py
+++ b/tests/flytekit/unit/core/test_node_creation.py
@@ -101,7 +101,9 @@ def test_more_normal_task():
     @task
     def t1(a: int) -> nt:
         # This one returns a regular tuple
-        return (f"{a + 2}",)
+        return nt(
+            f"{a + 2}",
+        )
 
     @task
     def t1_nt(a: int) -> nt:
@@ -129,7 +131,9 @@ def test_reserved_keyword():
     @task
     def t1(a: int) -> nt:
         # This one returns a regular tuple
-        return (f"{a + 2}",)
+        return nt(
+            f"{a + 2}",
+        )
 
     # Test that you can't name an output "outputs"
     with pytest.raises(FlyteAssertion):

--- a/tests/flytekit/unit/core/test_references.py
+++ b/tests/flytekit/unit/core/test_references.py
@@ -159,7 +159,7 @@ def test_ref_plain_no_outputs():
     @task
     def t1(a: int) -> nt1:
         a = a + 2
-        return a, "world-" + str(a)
+        return nt1(a, "world-" + str(a))
 
     @workflow
     def wf2(a: int):

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -145,7 +145,9 @@ def test_wf1():
 
     @task
     def t3(a: int) -> nt:
-        return (a + 2,)
+        return nt(
+            a + 2,
+        )
 
     assert t3.python_interface.output_tuple_name == "SingleNT"
     assert t3.interface.outputs["t1_int_output"] is not None
@@ -241,13 +243,13 @@ def test_wf_output_mismatch():
 
         @workflow
         def my_wf2(a: int, b: str) -> int:
-            return a, b
+            return a, b  # type: ignore
 
     with pytest.raises(AssertionError):
 
         @workflow
         def my_wf3(a: int, b: str) -> int:
-            return (a,)
+            return (a,)  # type: ignore
 
     assert context_manager.FlyteContextManager.size() == 1
 

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -94,7 +94,7 @@ def test_sub_wf_single_named_tuple():
     @task
     def t1(a: int) -> nt:
         a = a + 2
-        return (a,)
+        return nt(a)
 
     @workflow
     def subwf(a: int) -> nt:


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Fix mypy errors like "Incompatible types  ..."
```
plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py:54: error: Incompatible types in assignment (expression has type "None", variable has type "BatchRequestConfig")
plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py:70: error: Incompatible return value type (got "Tuple[Type[str], GreatExpectationsFlyteConfig]", expected "Tuple[Type[Any], Type[GreatExpectationsFlyteConfig]]")
plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py:84: error: Incompatible return value type (got "Tuple[Type[Any], GreatExpectationsFlyteConfig]", expected "Tuple[Type[Any], Type[GreatExpectationsFlyteConfig]]")
plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py:325: error: Incompatible return value type (got "str", expected "GreatExpectationsType")
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Pass mypy checks
`make test | grep "Incompatible"`

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1427

## Follow-up issue
_NA_