### PR TITLE
Remove hashing from local cache keys

### DIFF
--- a/flytekit/core/local_cache.py
+++ b/flytekit/core/local_cache.py
@@ -10,7 +10,7 @@ CACHE_LOCATION = "~/.flyte/local-cache"
 
 
 def _calculate_cache_key(task_name: str, cache_version: str, input_literal_map: LiteralMap) -> str:
-    return f"{task_name}-{cache_version}-{hash(input_literal_map)}"
+    return f"{task_name}-{cache_version}-{input_literal_map}"
 
 
 class LocalTaskCache(object):


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Do not use hashing as part of the cache key calculation in local executions 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Hashing, by default, is not deterministic ([for good reasons!](https://mail.python.org/pipermail/python-announce-list/2012-March/009394.html)). We should not use the hash of the inputs as part of the cache key, instead, let's take the string representation of the input literal map (which is deterministic).

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
