### PR TITLE
Fix item has no attribute error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ lint: ## Run linters
 	mypy flytekit/core || true
 	mypy flytekit/types || true
 	mypy tests/flytekit/unit/core || true
-	mypy plugins || true
+	# Exclude setup.py to fix erorr: Duplicate module named "setup"
+	mypy plugins --exclude setup.py || true
 	pre-commit run --all-files
 
 .PHONY: spellcheck

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -226,7 +226,7 @@ class Task(object):
         kwargs = translate_inputs_to_literals(
             ctx,
             incoming_values=kwargs,
-            flyte_interface_types=self.interface.inputs,
+            flyte_interface_types=self.interface.inputs,  # type: ignore
             native_types=self.get_input_types(),
         )
         input_literal_map = _literal_models.LiteralMap(literals=kwargs)
@@ -256,7 +256,7 @@ class Task(object):
         # TODO maybe this is the part that should be done for local execution, we pass the outputs to some special
         #    location, otherwise we dont really need to right? The higher level execute could just handle literalMap
         # After running, we again have to wrap the outputs, if any, back into Promise objects
-        output_names = list(self.interface.outputs.keys())
+        output_names = list(self.interface.outputs.keys())  # type: ignore
         if len(output_names) != len(outputs_literals):
             # Length check, clean up exception
             raise AssertionError(f"Length difference {len(output_names)} {len(outputs_literals)}")
@@ -423,7 +423,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
 
     @property
     def _outputs_interface(self) -> Dict[Any, Variable]:
-        return self.interface.outputs
+        return self.interface.outputs  # type: ignore
 
     def dispatch_execute(
         self, ctx: FlyteContext, input_literal_map: _literal_models.LiteralMap
@@ -443,7 +443,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
 
         # Create another execution context with the new user params, but let's keep the same working dir
         with FlyteContextManager.with_context(
-            ctx.with_execution_state(ctx.execution_state.with_params(user_space_params=new_user_params))
+            ctx.with_execution_state(ctx.execution_state.with_params(user_space_params=new_user_params))  # type: ignore
         ) as exec_ctx:
             # TODO We could support default values here too - but not part of the plan right now
             # Translate the input literals to Python native

--- a/flytekit/core/condition.py
+++ b/flytekit/core/condition.py
@@ -101,13 +101,13 @@ class ConditionalSection:
                     upstream_nodes.add(p.ref.node)
 
             n = Node(
-                id=f"{ctx.compilation_state.prefix}n{len(ctx.compilation_state.nodes)}",
+                id=f"{ctx.compilation_state.prefix}n{len(ctx.compilation_state.nodes)}",  # type: ignore
                 metadata=_core_wf.NodeMetadata(self._name, timeout=datetime.timedelta(), retries=RetryStrategy(0)),
                 bindings=sorted(bindings, key=lambda b: b.var),
                 upstream_nodes=list(upstream_nodes),  # type: ignore
                 flyte_entity=node,
             )
-            FlyteContextManager.current_context().compilation_state.add_node(n)
+            FlyteContextManager.current_context().compilation_state.add_node(n)  # type: ignore
             return self._compute_outputs(n)
         return self._condition
 
@@ -161,7 +161,7 @@ class LocalExecutedConditionalSection(ConditionalSection):
         # We already have a candidate case selected
         if self._selected_case is None:
             if c.expr is None or c.expr.eval() or last_case:
-                ctx.execution_state.take_branch()
+                ctx.execution_state.take_branch()  # type: ignore
                 self._selected_case = added_case
         return added_case
 
@@ -176,8 +176,8 @@ class LocalExecutedConditionalSection(ConditionalSection):
         """
         ctx = FlyteContextManager.current_context()
         # Let us mark the execution state as complete
-        ctx.execution_state.branch_complete()
-        if self._last_case:
+        ctx.execution_state.branch_complete()  # type: ignore
+        if self._last_case and self._selected_case:
             # We have completed the conditional section, lets pop off the branch context
             FlyteContextManager.pop_context()
             if self._selected_case.output_promise is None and self._selected_case.err is None:
@@ -382,7 +382,7 @@ def transform_to_boolexpr(
 
 def to_case_block(c: Case) -> Tuple[Union[_core_wf.IfBlock], typing.List[Promise]]:
     expr, promises = transform_to_boolexpr(c.expr)
-    n = c.output_promise.ref.node
+    n = c.output_promise.ref.node  # type: ignore
     return _core_wf.IfBlock(condition=expr, then_node=n), promises
 
 
@@ -405,7 +405,7 @@ def to_ifelse_block(node_id: str, cs: ConditionalSection) -> Tuple[_core_wf.IfEl
     node = None
     err = None
     if last_case.output_promise is not None:
-        node = last_case.output_promise.ref.node
+        node = last_case.output_promise.ref.node  # type: ignore
     else:
         err = Error(failed_node_id=node_id, message=last_case.err if last_case.err else "Condition failed")
     return (

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -414,7 +414,7 @@ class FlyteContext(object):
     Please do not confuse this object with the :py:class:`flytekit.ExecutionParameters` object.
     """
 
-    file_access: Optional[FileAccessProvider]
+    file_access: FileAccessProvider
     level: int = 0
     flyte_client: Optional[friendly_client.SynchronousFlyteClient] = None
     compilation_state: Optional[CompilationState] = None

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -258,7 +258,7 @@ class FileAccessProvider(object):
         """
         Deprecated. Lets find a replacement
         """
-        return not (path.startswith("/") or path.startswith("file://"))
+        return not (path.startswith("/") or path.startswith("file://"))  # type: ignore
 
     @property
     def local_sandbox_dir(self) -> os.PathLike:

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -342,20 +342,20 @@ def extract_return_annotation(return_annotation: Union[Type, Tuple]) -> Dict[str
     if isinstance(return_annotation, Type) or isinstance(return_annotation, TypeVar):
         # isinstance / issubclass does not work for Namedtuple.
         # Options 1 and 2
-        bases = return_annotation.__bases__
+        bases = return_annotation.__bases__  # type: ignore
         if len(bases) == 1 and bases[0] == tuple and hasattr(return_annotation, "_fields"):
             logger.debug(f"Task returns named tuple {return_annotation}")
             return return_annotation.__annotations__
 
-    if hasattr(return_annotation, "__origin__") and return_annotation.__origin__ is tuple:
+    if hasattr(return_annotation, "__origin__") and return_annotation.__origin__ is tuple:  # type: ignore
         # Handle option 3
         logger.debug(f"Task returns unnamed typing.Tuple {return_annotation}")
-        if len(return_annotation.__args__) == 1:
+        if len(return_annotation.__args__) == 1:  # type: ignore
             raise FlyteValidationException(
                 "Tuples should be used to indicate multiple return values, found only one return variable."
             )
         return OrderedDict(
-            zip(list(output_name_generator(len(return_annotation.__args__))), return_annotation.__args__)
+            zip(list(output_name_generator(len(return_annotation.__args__))), return_annotation.__args__)  # type: ignore
         )
     elif isinstance(return_annotation, tuple):
         if len(return_annotation) == 1:

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections
 import typing
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from typing_extensions import Protocol
 
@@ -804,7 +804,7 @@ class LocallyExecutable(Protocol):
         ...
 
 
-def flyte_entity_call_handler(entity: Union[SupportsNodeCreation, LocallyExecutable], *args, **kwargs):
+def flyte_entity_call_handler(entity: Union[SupportsNodeCreation], *args, **kwargs):
     """
     This function is the call handler for tasks, workflows, and launch plans (which redirects to the underlying
     workflow). The logic is the same for all three, but we did not want to create base class, hence this separate
@@ -828,7 +828,7 @@ def flyte_entity_call_handler(entity: Union[SupportsNodeCreation, LocallyExecuta
         )
     # Make sure arguments are part of interface
     for k, v in kwargs.items():
-        if k not in entity.python_interface.inputs:
+        if k not in cast(SupportsNodeCreation, entity).python_interface.inputs:
             raise ValueError(f"Received unexpected keyword argument {k}")
 
     ctx = FlyteContextManager.current_context()
@@ -837,24 +837,27 @@ def flyte_entity_call_handler(entity: Union[SupportsNodeCreation, LocallyExecuta
         return create_and_link_node(ctx, entity=entity, **kwargs)
     elif ctx.execution_state is not None and ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION:
         if ctx.execution_state.branch_eval_mode == BranchEvalMode.BRANCH_SKIPPED:
-            if len(entity.python_interface.inputs) > 0 or len(entity.python_interface.outputs) > 0:
-                output_names = list(entity.python_interface.outputs.keys())
+            if (
+                len(cast(SupportsNodeCreation, entity).python_interface.inputs) > 0
+                or len(cast(SupportsNodeCreation, entity).python_interface.outputs) > 0
+            ):
+                output_names = list(cast(SupportsNodeCreation, entity).python_interface.outputs.keys())
                 if len(output_names) == 0:
                     return VoidPromise(entity.name)
                 vals = [Promise(var, None) for var in output_names]
-                return create_task_output(vals, entity.python_interface)
+                return create_task_output(vals, cast(SupportsNodeCreation, entity).python_interface)
             else:
                 return None
-        return entity.local_execute(ctx, **kwargs)
+        return cast(LocallyExecutable, entity).local_execute(ctx, **kwargs)
     else:
         with FlyteContextManager.with_context(
             ctx.with_execution_state(
                 ctx.new_execution_state().with_params(mode=ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION)
             )
         ) as child_ctx:
-            result = entity.local_execute(child_ctx, **kwargs)
+            result = cast(LocallyExecutable.entity).local_execute(child_ctx, **kwargs)
 
-        expected_outputs = len(entity.python_interface.outputs)
+        expected_outputs = len(cast(SupportsNodeCreation, entity).python_interface.outputs)
         if expected_outputs == 0:
             if result is None or isinstance(result, VoidPromise):
                 return None
@@ -862,9 +865,9 @@ def flyte_entity_call_handler(entity: Union[SupportsNodeCreation, LocallyExecuta
                 raise Exception(f"Workflow local execution expected 0 outputs but something received {result}")
 
         if (1 < expected_outputs == len(result)) or (result is not None and expected_outputs == 1):
-            return create_native_named_tuple(ctx, result, entity.python_interface)
+            return create_native_named_tuple(ctx, result, cast(SupportsNodeCreation, entity).python_interface)
 
         raise ValueError(
             f"Expected outputs and actual outputs do not match. Result {result}. "
-            f"Python interface: {entity.python_interface}"
+            f"Python interface: {cast(SupportsNodeCreation, entity).python_interface}"
         )

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -855,7 +855,7 @@ def flyte_entity_call_handler(entity: Union[SupportsNodeCreation], *args, **kwar
                 ctx.new_execution_state().with_params(mode=ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION)
             )
         ) as child_ctx:
-            result = cast(LocallyExecutable.entity).local_execute(child_ctx, **kwargs)
+            result = cast(LocallyExecutable, entity).local_execute(child_ctx, **kwargs)
 
         expected_outputs = len(cast(SupportsNodeCreation, entity).python_interface.outputs)
         if expected_outputs == 0:

--- a/flytekit/core/python_customized_container_task.py
+++ b/flytekit/core/python_customized_container_task.py
@@ -230,7 +230,7 @@ class TaskTemplateResolver(TrackedInstance, TaskResolverMixin):
     def load_task(self, loader_args: List[str]) -> ExecutableTemplateShimTask:
         logger.info(f"Task template loader args: {loader_args}")
         ctx = FlyteContext.current_context()
-        task_template_local_path = os.path.join(ctx.execution_state.working_dir, "task_template.pb")
+        task_template_local_path = os.path.join(ctx.execution_state.working_dir, "task_template.pb")  # type: ignore
         ctx.file_access.get_data(loader_args[0], task_template_local_path)
         task_template_proto = common_utils.load_proto_from_file(_tasks_pb2.TaskTemplate, task_template_local_path)
         task_template_model = _task_model.TaskTemplate.from_flyte_idl(task_template_proto)

--- a/flytekit/core/reference_entity.py
+++ b/flytekit/core/reference_entity.py
@@ -83,11 +83,11 @@ class ReferenceEntity(object):
         raise Exception("Remote reference entities cannot be run locally. You must mock this out.")
 
     @property
-    def python_interface(self) -> Optional[Interface]:
+    def python_interface(self) -> Interface:
         return self._native_interface
 
     @property
-    def interface(self) -> Optional[_interface_models.TypedInterface]:
+    def interface(self) -> _interface_models.TypedInterface:
         return self._interface
 
     @property
@@ -104,7 +104,7 @@ class ReferenceEntity(object):
 
     def unwrap_literal_map_and_execute(
         self, ctx: FlyteContext, input_literal_map: _literal_models.LiteralMap
-    ) -> Union[VoidPromise, _literal_models.LiteralMap, _dynamic_job.DynamicJobSpec]:
+    ) -> _literal_models.LiteralMap:
         """
         Please see the implementation of the dispatch_execute function in the real task.
         """

--- a/flytekit/core/reference_entity.py
+++ b/flytekit/core/reference_entity.py
@@ -14,7 +14,6 @@ from flytekit.core.promise import (
 )
 from flytekit.core.type_engine import TypeEngine
 from flytekit.loggers import logger
-from flytekit.models import dynamic_job as _dynamic_job
 from flytekit.models import interface as _interface_models
 from flytekit.models import literals as _literal_models
 from flytekit.models.core import identifier as _identifier_model

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -8,7 +8,7 @@ import json as _json
 import mimetypes
 import typing
 from abc import ABC, abstractmethod
-from typing import Type
+from typing import Type, cast
 
 from dataclasses_json import DataClassJsonMixin
 from google.protobuf import json_format as _json_format
@@ -213,7 +213,7 @@ class DataclassTransformer(TypeTransformer[object]):
             )
         schema = None
         try:
-            schema = JSONSchema().dump(t.schema())
+            schema = JSONSchema().dump(cast(DataClassJsonMixin, t).schema())
         except Exception as e:
             logger.warn("failed to extract schema for object %s, (will run schemaless) error: %s", str(t), e)
 
@@ -229,7 +229,9 @@ class DataclassTransformer(TypeTransformer[object]):
             raise AssertionError(
                 f"Dataclass {python_type} should be decorated with @dataclass_json to be " f"serialized correctly"
             )
-        return Literal(scalar=Scalar(generic=_json_format.Parse(python_val.to_json(), _struct.Struct())))
+        return Literal(
+            scalar=Scalar(generic=_json_format.Parse(cast(DataClassJsonMixin, python_val).to_json(), _struct.Struct()))
+        )
 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
         if not dataclasses.is_dataclass(expected_python_type):
@@ -242,7 +244,7 @@ class DataclassTransformer(TypeTransformer[object]):
                 f"Dataclass {expected_python_type} should be decorated with @dataclass_json to be "
                 f"serialized correctly"
             )
-        dc = expected_python_type.from_json(_json_format.MessageToJson(lv.scalar.generic))
+        dc = cast(DataClassJsonMixin, expected_python_type).from_json(_json_format.MessageToJson(lv.scalar.generic))
         # NOTE: Protobuf Struct does not support explicit int types, int types are upconverted to a double value
         # https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Value
         # Thus we will have to walk the given dataclass and typecast values to int, where expected.
@@ -488,9 +490,9 @@ class ListTransformer(TypeTransformer[T]):
         """
         Return the generic Type T of the List
         """
-        if hasattr(t, "__origin__") and t.__origin__ is list:
+        if hasattr(t, "__origin__") and t.__origin__ is list:  # type: ignore
             if hasattr(t, "__args__"):
-                return t.__args__[0]
+                return t.__args__[0]  # type: ignore
         raise ValueError("Only generic univariate typing.List[T] type is supported.")
 
     def get_literal_type(self, t: Type[T]) -> LiteralType:
@@ -505,7 +507,7 @@ class ListTransformer(TypeTransformer[T]):
 
     def to_literal(self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:
         t = self.get_sub_type(python_type)
-        lit_list = [TypeEngine.to_literal(ctx, x, t, expected.collection_type) for x in python_val]
+        lit_list = [TypeEngine.to_literal(ctx, x, t, expected.collection_type) for x in python_val]  # type: ignore
         return Literal(collection=LiteralCollection(literals=lit_list))
 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
@@ -533,9 +535,9 @@ class DictTransformer(TypeTransformer[dict]):
         """
         Return the generic Type T of the Dict
         """
-        if hasattr(t, "__origin__") and t.__origin__ is dict:
+        if hasattr(t, "__origin__") and t.__origin__ is dict:  # type: ignore
             if hasattr(t, "__args__"):
-                return t.__args__
+                return t.__args__  # type: ignore
         return None, None
 
     @staticmethod
@@ -678,13 +680,13 @@ class EnumTransformer(TypeTransformer[enum.Enum]):
         super().__init__(name="DefaultEnumTransformer", t=enum.Enum)
 
     def get_literal_type(self, t: Type[T]) -> LiteralType:
-        values = [v.value for v in t]
+        values = [v.value for v in t]  # type: ignore
         if not isinstance(values[0], str):
             raise AssertionError("Only EnumTypes with value of string are supported")
         return LiteralType(enum_type=_core_types.EnumType(values=values))
 
     def to_literal(self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:
-        return Literal(scalar=Scalar(primitive=Primitive(string_value=python_val.value)))
+        return Literal(scalar=Scalar(primitive=Primitive(string_value=python_val.value)))  # type: ignore
 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
         return expected_python_type(lv.scalar.primitive.string_value)

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -228,7 +228,7 @@ class FlyteFilePathTransformer(TypeTransformer[FlyteFile]):
         super().__init__(name="FlyteFilePath", t=FlyteFile)
 
     @staticmethod
-    def get_format(t: typing.Union[typing.Type[FlyteFile], os.PathLike]) -> str:
+    def get_format(t: typing.Union[typing.Type[FlyteFile]]) -> str:
         if t is os.PathLike:
             return ""
         return t.extension()

--- a/flytekit/types/schema/types.py
+++ b/flytekit/types/schema/types.py
@@ -313,7 +313,7 @@ class FlyteSchemaTransformer(TypeTransformer[FlyteSchema]):
         _np.float32: SchemaType.SchemaColumn.SchemaColumnType.FLOAT,
         _np.float64: SchemaType.SchemaColumn.SchemaColumnType.FLOAT,
         float: SchemaType.SchemaColumn.SchemaColumnType.FLOAT,
-        _np.bool: SchemaType.SchemaColumn.SchemaColumnType.BOOLEAN,
+        _np.bool: SchemaType.SchemaColumn.SchemaColumnType.BOOLEAN,  # type: ignore
         bool: SchemaType.SchemaColumn.SchemaColumnType.BOOLEAN,
         _np.datetime64: SchemaType.SchemaColumn.SchemaColumnType.DATETIME,
         _datetime.datetime: SchemaType.SchemaColumn.SchemaColumnType.DATETIME,

--- a/plugins/flytekit-data-fsspec/flytekitplugins/fsspec/persist.py
+++ b/plugins/flytekit-data-fsspec/flytekitplugins/fsspec/persist.py
@@ -56,7 +56,7 @@ class FSSpecPersistence(DataPersistence):
             kwargs = {"auto_mkdir": True}
         if protocol == "s3":
             kwargs = s3_setup_args()
-        return fsspec.filesystem(protocol, **kwargs)
+        return fsspec.filesystem(protocol, **kwargs)  # type: ignore
 
     @staticmethod
     def recursive_paths(f: str, t: str) -> typing.Tuple[str, str]:
@@ -97,7 +97,7 @@ class FSSpecPersistence(DataPersistence):
     def construct_path(self, add_protocol: bool, add_prefix: bool, *paths) -> str:
         paths = list(paths)  # make type check happy
         if add_prefix:
-            paths.insert(0, self.default_prefix)
+            paths.insert(0, self.default_prefix)  # type: ignore
         path = "/".join(paths)
         if add_protocol:
             return f"{self.default_protocol}://{path}"

--- a/plugins/flytekit-dolt/flytekitplugins/dolt/schema.py
+++ b/plugins/flytekit-dolt/flytekitplugins/dolt/schema.py
@@ -75,7 +75,7 @@ class DoltTableNameTransformer(TypeTransformer[DoltTable]):
                 )
 
         s = Struct()
-        s.update(python_val.to_dict())
+        s.update(python_val.to_dict())  # type: ignore
         return Literal(Scalar(generic=s))
 
     def to_python_value(

--- a/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py
+++ b/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py
@@ -191,12 +191,12 @@ class GreatExpectationsTypeTransformer(TypeTransformer[GreatExpectationsType]):
             raise AssertionError("Can only validate a literal string/FlyteFile/FlyteSchema value")
 
         # fetch the configuration
-        conf_dict = GreatExpectationsTypeTransformer.get_config(expected_python_type)[1].to_dict()
+        conf_dict = GreatExpectationsTypeTransformer.get_config(expected_python_type)[1].to_dict()  # type: ignore
 
         ge_conf = GreatExpectationsFlyteConfig(**conf_dict)
 
         # fetch the data context
-        context = ge.data_context.DataContext(ge_conf.context_root_dir)
+        context = ge.data_context.DataContext(ge_conf.context_root_dir)  # type: ignore
 
         # determine the type of data connector
         selected_datasource = list(filter(lambda x: x["name"] == ge_conf.datasource_name, context.list_datasources()))

--- a/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/task.py
+++ b/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/task.py
@@ -156,7 +156,7 @@ class GreatExpectationsTask(PythonInstanceTask[BatchRequestConfig]):
         return dataset
 
     def execute(self, **kwargs) -> Any:
-        context = ge.data_context.DataContext(self._context_root_dir)
+        context = ge.data_context.DataContext(self._context_root_dir)  # type: ignore
 
         if len(self.python_interface.inputs.keys()) != 1:
             raise TypeError("Expected one input argument to validate the dataset")

--- a/plugins/flytekit-pandera/flytekitplugins/pandera/schema.py
+++ b/plugins/flytekit-pandera/flytekitplugins/pandera/schema.py
@@ -18,7 +18,7 @@ class PanderaTransformer(TypeTransformer[pandera.typing.DataFrame]):
     ] = FlyteSchemaTransformer._SUPPORTED_TYPES
 
     def __init__(self):
-        super().__init__("Pandera Transformer", pandera.typing.DataFrame)
+        super().__init__("Pandera Transformer", pandera.typing.DataFrame)  # type: ignore
 
     def _pandera_schema(self, t: Type[pandera.typing.DataFrame]):
         try:
@@ -31,7 +31,7 @@ class PanderaTransformer(TypeTransformer[pandera.typing.DataFrame]):
             schema_model, *_ = type_args
             schema = schema_model.to_schema()
         else:
-            schema = pandera.DataFrameSchema()
+            schema = pandera.DataFrameSchema()  # type: ignore
         return schema
 
     @staticmethod

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -119,12 +119,13 @@ class NotebookTask(PythonInstanceTask[T]):
         if not os.path.exists(self._notebook_path):
             raise ValueError(f"Illegal notebook path passed in {self._notebook_path}")
 
-        outputs.update(
-            {
-                self._IMPLICIT_OP_NOTEBOOK: self._IMPLICIT_OP_NOTEBOOK_TYPE,
-                self._IMPLICIT_RENDERED_NOTEBOOK: self._IMPLICIT_RENDERED_NOTEBOOK_TYPE,
-            }
-        )
+        if outputs:
+            outputs.update(
+                {
+                    self._IMPLICIT_OP_NOTEBOOK: self._IMPLICIT_OP_NOTEBOOK_TYPE,
+                    self._IMPLICIT_RENDERED_NOTEBOOK: self._IMPLICIT_RENDERED_NOTEBOOK_TYPE,
+                }
+            )
         super().__init__(
             name, task_config, task_type=task_type, interface=Interface(inputs=inputs, outputs=outputs), **kwargs
         )
@@ -185,7 +186,7 @@ class NotebookTask(PythonInstanceTask[T]):
         """
         logging.info(f"Hijacking the call for task-type {self.task_type}, to call notebook.")
         # Execute Notebook via Papermill.
-        pm.execute_notebook(self._notebook_path, self.output_notebook_path, parameters=kwargs)
+        pm.execute_notebook(self._notebook_path, self.output_notebook_path, parameters=kwargs)  # type: ignore
 
         outputs = self.extract_outputs(self.output_notebook_path)
         self.render_nb_html(self.output_notebook_path, self.rendered_output_path)

--- a/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
+++ b/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
@@ -2,7 +2,7 @@ import typing
 from dataclasses import dataclass
 
 import pandas as pd
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine  # type: ignore
 
 from flytekit import current_context, kwtypes
 from flytekit.core.base_sql_task import SQLTask

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -65,7 +65,7 @@ def test_default_values():
 
     @workflow
     def wf(a: bool = True) -> bool:
-        return conditional("bool").if_(a.is_true()).then(t()).else_().then(f())
+        return conditional("bool").if_(a.is_true()).then(t()).else_().then(f())  # type: ignore
 
     assert wf() is True
     assert wf(a=False) is False


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Add `type: ignore` to Ignore the below errors:
- Item "None" of "Optional[CompilationState]" has no attribute "prefix"
- "Type[T]" has no attribute "from_json"
- Module has no attribute (It seems like a bug in mypy) https://stackoverflow.com/questions/60734086/mypy-gives-an-error-while-importing-submodule-module-has-no-attribute. sqlalchemy has a attribute `create_engine`, but mypy will raise an error `Module "sqlalchemy" has no attribute "create_engine"`

Fix mypy errors like `Item "None" of "Optional[Interface]" has no attribute "inputs"`
```
flytekit/core/reference_entity.py:114: error: Item "None" of "Optional[Interface]" has no attribute "inputs"
flytekit/core/reference_entity.py:124: error: Item "None" of "Optional[Interface]" has no attribute "outputs"
flytekit/core/reference_entity.py:136: error: Item "None" of "Optional[Any]" has no attribute "outputs"
flytekit/core/reference_entity.py:137: error: Item "None" of "Optional[Interface]" has no attribute "outputs"
flytekit/core/reference_entity.py:158: error: Item "None" of "Optional[Any]" has no attribute "inputs"
flytekit/core/reference_entity.py:159: error: Item "None" of "Optional[Interface]" has no attribute "inputs"
flytekit/core/reference_entity.py:166: error: Item "VoidPromise" of "Union[VoidPromise, Any, Any]" has no attribute "literals"
flytekit/core/reference_entity.py:167: error: Item "None" of "Optional[Interface]" has no attribute "outputs"
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Pass mypy checks
`make test | grep "attribute"`

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1447

## Follow-up issue
_NA_