### PR TITLE
flytekit-spark: remove spark dependency

### DIFF
--- a/plugins/flytekit-spark/setup.py
+++ b/plugins/flytekit-spark/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "spark"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=0.16.0b0,<1.0.0", "pyspark>=3.0.0"]
+plugin_requires = ["flytekit>=0.16.0b0,<1.0.0"]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
# TL;DR

flytekitplugins-spark installs spark. But when following [these instructions](https://docs.flyte.org/projects/cookbook/en/latest/auto/integrations/kubernetes/k8s_spark/index.html) the container is built with spark already installed. 

This PR removes the unneeded dependency on spark, and reduces the container size.


## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
