### PR TITLE
Restrict SQLAlchemy GH workflow to master branch

### DIFF
--- a/.github/workflows/sqlachemy_publish.yml
+++ b/.github/workflows/sqlachemy_publish.yml
@@ -2,6 +2,8 @@ name: Push SQLAlchemy Docker Image
 
 on:
   push:
+    branches:
+      - master
   create:
     tags:
       - v*


### PR DESCRIPTION
Signed-off-by: Yee Hing Tong <wild-endeavor@users.noreply.github.com>

# TL;DR
I think I missed this when checking https://github.com/flyteorg/flytekit/pull/634/

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

