### PR TITLE
Stop pinning pip, setuptools, and wheel in github workflow

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -31,7 +31,7 @@ jobs:
         key: ${{ format('{0}-pip-{1}', runner.os, hashFiles('dev-requirements.txt', format('requirements{0}.txt', matrix.spark-version-suffix))) }}
     - name: Install dependencies
       run: |
-        python -m pip install pip==21.2.4 setuptools==57.4.0 wheel==0.37.0
+        python -m pip install --upgrade pip setuptools wheel
         make setup${{ matrix.spark-version-suffix }}
         pip freeze
     - name: Lint


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
This is just some cleanup work. A followup to https://github.com/flyteorg/flytekit/pull/641/

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
