### PR TITLE
Duplicate error messages when running the workflow

### DIFF
--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -262,15 +262,13 @@ class WorkflowBase(object):
             if len(self.python_interface.outputs) != 0:
                 raise FlyteValueException(
                     function_outputs,
-                    f"{function_outputs} received but interface has {len(self.python_interface.outputs)} outputs.",
+                    f"Interface has {len(self.python_interface.outputs)} outputs.",
                 )
             return VoidPromise(self.name)
 
         # Because we should've already returned in the above check, we just raise an error here.
         if len(self.python_interface.outputs) == 0:
-            raise FlyteValueException(
-                function_outputs, f"{function_outputs} received but should've been VoidPromise or None."
-            )
+            raise FlyteValueException(function_outputs, "Interface output should've been VoidPromise or None.")
 
         expected_output_names = list(self.python_interface.outputs.keys())
         if len(expected_output_names) == 1:
@@ -418,7 +416,7 @@ class ImperativeWorkflow(WorkflowBase):
 
             # Because we should've already returned in the above check, we just raise an Exception here.
             if len(entity.python_interface.outputs) == 0:
-                raise FlyteValueException(results, f"{results} received but should've been VoidPromise or None.")
+                raise FlyteValueException(results, "Interface output should've been VoidPromise or None.")
 
             # if there's only one output,
             if len(expected_output_names) == 1:


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Nit: remove duplicate error messages

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Update error message in `flytekit/core/workflow.py`

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_

### Before
```bash=
Traceback (most recent call last):
  File "test/workflows/example.py", line 17, in <module>
    print(welcome(name="Kevin"))
  File "/Users/kevin/opt/anaconda3/envs/flyte/lib/python3.8/site-packages/flytekit/core/workflow.py", line 236, in __call__
    return flyte_entity_call_handler(self, *args, **input_kwargs)
  File "/Users/kevin/opt/anaconda3/envs/flyte/lib/python3.8/site-packages/flytekit/core/promise.py", line 857, in flyte_entity_call_handler
    result = cast(LocallyExecutable, entity).local_execute(child_ctx, **kwargs)
  File "/Users/kevin/opt/anaconda3/envs/flyte/lib/python3.8/site-packages/flytekit/core/workflow.py", line 271, in local_execute
    raise FlyteValueException(
flytekit.common.exceptions.user.FlyteValueException: Value error!  Received: Resolved(o0=scalar {
  primitive {
    string_value: "Welcome, Kevin! How are you?"
  }
}
). Resolved(o0=scalar {
  primitive {
    string_value: "Welcome, Kevin! How are you?"
  }
}
) received but should've been VoidPromise or None.
```
### After
```bash=
Traceback (most recent call last):
  File "test/workflows/example.py", line 17, in <module>
    print(welcome(name="Kevin"))
  File "/Users/kevin/opt/anaconda3/envs/flyte/lib/python3.8/site-packages/flytekit/core/workflow.py", line 236, in __call__
    return flyte_entity_call_handler(self, *args, **input_kwargs)
  File "/Users/kevin/opt/anaconda3/envs/flyte/lib/python3.8/site-packages/flytekit/core/promise.py", line 857, in flyte_entity_call_handler
    result = cast(LocallyExecutable, entity).local_execute(child_ctx, **kwargs)
  File "/Users/kevin/opt/anaconda3/envs/flyte/lib/python3.8/site-packages/flytekit/core/workflow.py", line 271, in local_execute
    raise FlyteValueException(
flytekit.common.exceptions.user.FlyteValueException: Value error!  Received: Resolved(o0=scalar {
  primitive {
    string_value: "Welcome, Kevin! How are you?"
  }
}
). Interface output should've been VoidPromise or None.
```