### PR TITLE
Dataclass should patch int values for nested cases

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -239,26 +239,16 @@ class DataclassTransformer(TypeTransformer[object]):
             return int(val)
 
         if isinstance(val, list):
-            try:
-                if ListTransformer.get_sub_type(t) == int:
-                    return [int(i) for i in val]
-            except ValueError:
-                return val
+            # Handle nested List. e.g. [[1, 2], [3, 4]]
+            return list(map(lambda x: self._fix_val_int(ListTransformer.get_sub_type(t), x), val))
 
         if isinstance(val, dict):
             ktype, vtype = DictTransformer.get_dict_types(t)
-            if (ktype is not None and ktype == int) or (vtype is not None and vtype == int):
-                d = {}
-                for k, v in val.items():
-                    if ktype is not None and ktype == int:
-                        k = int(k)
-                    if vtype is not None and vtype == int:
-                        v = int(v)
-                    d[k] = v
-                return d
+            # Handle nested Dict. e.g. {1: {2: 3}, 4: {5: 6}})
+            return {self._fix_val_int(ktype, k): self._fix_val_int(vtype, v) for k, v in val.items()}
 
         if dataclasses.is_dataclass(t):
-            return self._fix_dataclass_int(t, val)
+            return self._fix_dataclass_int(t, val)  # type: ignore
 
         return val
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -240,9 +240,9 @@ class DataclassTransformer(TypeTransformer[object]):
 
         if isinstance(val, list):
             try:
-                if ListTransformer.get_sub_type(f.type) == int:
+                if ListTransformer.get_sub_type(t) == int:
                     return [int(i) for i in val]
-            except:
+            except ValueError:
                 return val
 
         if isinstance(val, dict):

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -399,76 +399,31 @@ def test_dataclass_transformer():
     assert t.metadata is None
 
 
-def check_element_type_is_int(val):
-    if type(val) == list:
-        for v in val:
-            check_element_type_is_int(v)
-    elif type(val) == dict:
-        for k, v in val.items():
-            check_element_type_is_int(k)
-            check_element_type_is_int(v)
-    else:
-        if type(val) is not str:
-            assert type(val) == int
-
-
 def test_dataclass_int_preserving():
     ctx = FlyteContext.current_context()
 
-    i = InnerStruct(a=5, b=None, c=[1, 2, 3])
+    o = InnerStruct(a=5, b=None, c=[1, 2, 3])
     tf = DataclassTransformer()
-    lv = tf.to_literal(ctx, i, InnerStruct, tf.get_literal_type(InnerStruct))
+    lv = tf.to_literal(ctx, o, InnerStruct, tf.get_literal_type(InnerStruct))
     ot = tf.to_python_value(ctx, lv=lv, expected_python_type=InnerStruct)
-    assert ot.a == 5
-    check_element_type_is_int(ot.a)
-    assert ot.c == [1, 2, 3]
-    check_element_type_is_int(ot.c)
-
-    o = TestStruct(s=InnerStruct(a=5, b=None, c=[1, 2, 3]), m={"a": "b"})
-    lv = tf.to_literal(ctx, o, TestStruct, tf.get_literal_type(TestStruct))
-    ot = tf.to_python_value(ctx, lv=lv, expected_python_type=TestStruct)
-    assert ot.s.a == 5
-    check_element_type_is_int(ot.s.a)
-    assert ot.s.c == [1, 2, 3]
-    check_element_type_is_int(ot.s.c)
-    assert ot.m == {"a": "b"}
-    check_element_type_is_int(ot.m)
+    assert ot == o
 
     o = TestStructB(
         s=InnerStruct(a=5, b=None, c=[1, 2, 3]), m={5: "b"}, n=[[1, 2, 3], [4, 5, 6]], o={1: {2: 3}, 4: {5: 6}}
     )
     lv = tf.to_literal(ctx, o, TestStructB, tf.get_literal_type(TestStructB))
     ot = tf.to_python_value(ctx, lv=lv, expected_python_type=TestStructB)
-    assert ot.s.a == 5
-    check_element_type_is_int(ot.s.a)
-    assert ot.s.c == [1, 2, 3]
-    check_element_type_is_int(ot.s.c)
-    assert ot.m == {5: "b"}
-    check_element_type_is_int(ot.m)
-    assert ot.n == [[1, 2, 3], [4, 5, 6]]
-    check_element_type_is_int(ot.n)
-    assert ot.o == {1: {2: 3}, 4: {5: 6}}
-    check_element_type_is_int(ot.o)
+    assert ot == o
 
     o = TestStructC(s=InnerStruct(a=5, b=None, c=[1, 2, 3]), m={"a": 5})
     lv = tf.to_literal(ctx, o, TestStructC, tf.get_literal_type(TestStructC))
     ot = tf.to_python_value(ctx, lv=lv, expected_python_type=TestStructC)
-    assert ot.s.a == 5
-    check_element_type_is_int(ot.s.a)
-    assert ot.s.c == [1, 2, 3]
-    check_element_type_is_int(ot.s.c)
-    assert ot.m == {"a": 5}
-    check_element_type_is_int(ot.m)
+    assert ot == o
 
     o = TestStructD(s=InnerStruct(a=5, b=None, c=[1, 2, 3]), m={"a": [5]})
     lv = tf.to_literal(ctx, o, TestStructD, tf.get_literal_type(TestStructD))
     ot = tf.to_python_value(ctx, lv=lv, expected_python_type=TestStructD)
-    assert ot.s.a == 5
-    check_element_type_is_int(ot.s.a)
-    assert ot.s.c == [1, 2, 3]
-    check_element_type_is_int(ot.s.c)
-    assert ot.m == {"a": [5]}
-    check_element_type_is_int(ot.m)
+    assert ot == o
 
 
 # Enums should have string values

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -304,6 +304,8 @@ class InnerStruct(object):
     a: int
     b: typing.Optional[str]
     c: typing.List[int]
+    d: typing.List[typing.List[int]] = None
+    e: typing.Dict[int, typing.Dict[int, int]] = None
 
 
 @dataclass_json
@@ -396,43 +398,74 @@ def test_dataclass_transformer():
     assert t.metadata is None
 
 
+def check_element_type_is_int(val):
+    if type(val) == list:
+        for v in val:
+            check_element_type_is_int(v)
+    elif type(val) == dict:
+        for k, v in val.items():
+            check_element_type_is_int(k)
+            check_element_type_is_int(v)
+    else:
+        if type(val) is not str:
+            assert type(val) == int
+
+
 def test_dataclass_int_preserving():
     ctx = FlyteContext.current_context()
 
-    i = InnerStruct(a=5, b=None, c=[1, 2, 3])
+    i = InnerStruct(a=5, b=None, c=[1, 2, 3], d=[[1, 2, 3], [4, 5, 6]], e={1: {2: 3}, 4: {5: 6}})
     tf = DataclassTransformer()
-    l = tf.to_literal(ctx, i, InnerStruct, tf.get_literal_type(InnerStruct))
-    t = tf.to_python_value(ctx, lv=l, expected_python_type=InnerStruct)
-    assert t.a == 5
-    assert t.c == [1, 2, 3]
+    lv = tf.to_literal(ctx, i, InnerStruct, tf.get_literal_type(InnerStruct))
+    ot = tf.to_python_value(ctx, lv=lv, expected_python_type=InnerStruct)
+    assert ot.a == 5
+    check_element_type_is_int(ot.a)
+    assert ot.c == [1, 2, 3]
+    check_element_type_is_int(ot.c)
+    assert ot.d == [[1, 2, 3], [4, 5, 6]]
+    check_element_type_is_int(ot.d)
+    assert ot.e == {1: {2: 3}, 4: {5: 6}}
+    check_element_type_is_int(ot.e)
 
     o = TestStruct(s=InnerStruct(a=5, b=None, c=[1, 2, 3]), m={"a": "b"})
     lv = tf.to_literal(ctx, o, TestStruct, tf.get_literal_type(TestStruct))
     ot = tf.to_python_value(ctx, lv=lv, expected_python_type=TestStruct)
     assert ot.s.a == 5
+    check_element_type_is_int(ot.s.a)
     assert ot.s.c == [1, 2, 3]
+    check_element_type_is_int(ot.s.c)
     assert ot.m == {"a": "b"}
+    check_element_type_is_int(ot.m)
 
     o = TestStructB(s=InnerStruct(a=5, b=None, c=[1, 2, 3]), m={5: "b"})
     lv = tf.to_literal(ctx, o, TestStructB, tf.get_literal_type(TestStructB))
     ot = tf.to_python_value(ctx, lv=lv, expected_python_type=TestStructB)
     assert ot.s.a == 5
+    check_element_type_is_int(ot.s.a)
     assert ot.s.c == [1, 2, 3]
+    check_element_type_is_int(ot.s.c)
     assert ot.m == {5: "b"}
+    check_element_type_is_int(ot.m)
 
     o = TestStructC(s=InnerStruct(a=5, b=None, c=[1, 2, 3]), m={"a": 5})
     lv = tf.to_literal(ctx, o, TestStructC, tf.get_literal_type(TestStructC))
     ot = tf.to_python_value(ctx, lv=lv, expected_python_type=TestStructC)
     assert ot.s.a == 5
+    check_element_type_is_int(ot.s.a)
     assert ot.s.c == [1, 2, 3]
+    check_element_type_is_int(ot.s.c)
     assert ot.m == {"a": 5}
+    check_element_type_is_int(ot.m)
 
     o = TestStructD(s=InnerStruct(a=5, b=None, c=[1, 2, 3]), m={"a": [5]})
     lv = tf.to_literal(ctx, o, TestStructD, tf.get_literal_type(TestStructD))
     ot = tf.to_python_value(ctx, lv=lv, expected_python_type=TestStructD)
     assert ot.s.a == 5
+    check_element_type_is_int(ot.s.a)
     assert ot.s.c == [1, 2, 3]
+    check_element_type_is_int(ot.s.c)
     assert ot.m == {"a": [5]}
+    check_element_type_is_int(ot.m)
 
 
 # Enums should have string values

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -383,7 +383,7 @@ def test_dataclass_transformer():
     assert t.simple is not None
     assert t.simple == SimpleType.STRUCT
     assert t.metadata is not None
-    # assert t.metadata == schema
+    assert t.metadata == schema
 
     t = TypeEngine.to_literal_type(TestStruct)
     assert t is not None


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
Cases in which a Dataclass consists of Generic types of nested types that contain an int, the integer ends up being a Float value. This is because protobuf struct does not have ints only a number.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Tracking Issue
fixes https://github.com/lyft/flyte/issues/1510


