### PR TITLE
[WIP] Failed to convert dataclass literal to python value

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -737,6 +737,9 @@ class EnumTransformer(TypeTransformer[enum.Enum]):
 
 
 def dataclass_from_dict(cls: type, src: typing.Dict[str, typing.Any]) -> typing.Any:
+    """
+    Utility function to construct a dataclass object from dict
+    """
     field_types_lookup = {field.name: field.type for field in dataclasses.fields(cls)}
 
     constructor_inputs = {}

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import dataclasses
 import datetime as _datetime
 import enum

--- a/flytekit/models/types.py
+++ b/flytekit/models/types.py
@@ -1,3 +1,4 @@
+import json
 import json as _json
 
 from flyteidl.core import types_pb2 as _types_pb2
@@ -165,12 +166,20 @@ class LiteralType(_common.FlyteIdlEntity):
         """
         return self._metadata
 
+    class AdvancedJSONEncoder(json.JSONEncoder):
+        def default(self, obj):
+            try:
+                _json.dumps(obj)
+                return obj
+            except TypeError:
+                return str(obj)
+
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.core.types_pb2.LiteralType
         """
         if self.metadata is not None:
-            metadata = _json_format.Parse(_json.dumps(self.metadata), _struct.Struct())
+            metadata = _json_format.Parse(_json.dumps(self.metadata, cls=self.AdvancedJSONEncoder), _struct.Struct())
         else:
             metadata = None
         t = _types_pb2.LiteralType(

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1,4 +1,3 @@
-import dataclasses
 import datetime
 import os
 import typing


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Failed to convert dataclass literal to python value if `expected_python_type` is guessed from literal
https://github.com/flyteorg/flytekit/blob/523c79861c7b0287c17e6f0bda0fe329212c1e0c/flytekit/core/type_engine.py#L284

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
1. Add value of `dataclass.__annotations__` to `literal_type.metadata[ATTRIBUTE]`
2. Add `_construct_dataclass` to guess dataclass python type from `literal_type.metadata[ATTRIBUTE]`

## Tracking Issue
Related to https://github.com/flyteorg/flytesnacks/pull/424

## Follow-up issue
_NA_