### PR TITLE
Move lint check out of unit test

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -34,14 +34,6 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         make setup${{ matrix.spark-version-suffix }}
         pip freeze
-    - name: Lint
-      run: |
-        make lint
-    - name: ShellCheck
-      uses: ludeeus/action-shellcheck@master
-      with:
-        ignore:
-          boilerplate
     - name: Test with coverage
       run: |
         coverage run -m pytest tests/flytekit/unit tests/scripts
@@ -87,6 +79,34 @@ jobs:
         cd plugins/${{ matrix.plugin-names }}
         coverage run -m pytest tests
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch the code
+        uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/dev-requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r dev-requirements.txt
+      - name: Lint
+        run: |
+          make lint
+      - name: ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          ignore:
+            boilerplate
+
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -98,7 +118,7 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           pip install -r doc-requirements.txt
       - name: Build the documentation
         run: make -C docs html


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
We run lint check three times per run, but we should only run once per run.
I've Ran the workflow in my fork's Github actions 
https://github.com/pingsutw/flytekit/actions/runs/1285916415

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_