### PR TITLE
update remote.sync behavior, remove FlyteWorkflowExecution.sync

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -986,15 +986,13 @@ class FlyteRemote(object):
                 f"Resource type {execution.spec.launch_plan.resource_type} not recognized. Must be a TASK or WORKFLOW."
             )
 
-        synced_execution = deepcopy(execution)
         # sync closure, node executions, and inputs/outputs
-        synced_execution._closure = self.client.get_execution(execution.id).closure
-
-        synced_execution._node_executions = {
+        execution = self.client.get_execution(execution.id).closure
+        execution._node_executions = {
             node.id.node_id: self.sync(FlyteNodeExecution.promote_from_model(node), flyte_entity)
             for node in iterate_node_executions(self.client, execution.id)
         }
-        return self._assign_inputs_and_outputs(synced_execution, execution_data, flyte_entity.interface)
+        return self._assign_inputs_and_outputs(execution, execution_data, flyte_entity.interface)
 
     @sync.register
     def _(
@@ -1008,29 +1006,27 @@ class FlyteRemote(object):
         ):
             return execution
 
-        synced_execution = deepcopy(execution)
-
         # sync closure, child nodes, interface, and inputs/outputs
-        synced_execution._closure = self.client.get_node_execution(execution.id).closure
-        if synced_execution.metadata.is_parent_node:
-            synced_execution._subworkflow_node_executions = [
+        execution._closure = self.client.get_node_execution(execution.id).closure
+        if execution.metadata.is_parent_node:
+            execution._subworkflow_node_executions = [
                 self.sync(FlyteNodeExecution.promote_from_model(node), entity_definition)
                 for node in iterate_node_executions(
                     self.client,
-                    workflow_execution_identifier=synced_execution.id.execution_id,
-                    unique_parent_id=synced_execution.id.node_id,
+                    workflow_execution_identifier=execution.id.execution_id,
+                    unique_parent_id=execution.id.node_id,
                 )
             ]
         else:
-            synced_execution._task_executions = [
+            execution._task_executions = [
                 self.sync(FlyteTaskExecution.promote_from_model(t))
-                for t in iterate_task_executions(self.client, synced_execution.id)
+                for t in iterate_task_executions(self.client, execution.id)
             ]
-        synced_execution._interface = self._get_node_execution_interface(synced_execution, entity_definition)
+        execution._interface = self._get_node_execution_interface(execution, entity_definition)
         return self._assign_inputs_and_outputs(
-            synced_execution,
+            execution,
             self.client.get_node_execution_data(execution.id),
-            synced_execution.interface,
+            execution.interface,
         )
 
     @sync.register
@@ -1040,14 +1036,13 @@ class FlyteRemote(object):
         """Sync a FlyteTaskExecution object with its corresponding remote state."""
         if entity_definition is not None:
             raise ValueError("Entity definition arguments aren't supported when syncing task executions")
-        synced_execution = deepcopy(execution)
 
         # sync closure and inputs/outputs
-        synced_execution._closure = self.client.get_task_execution(synced_execution.id).closure
-        execution_data = self.client.get_task_execution_data(synced_execution.id)
+        execution._closure = self.client.get_task_execution(execution.id).closure
+        execution_data = self.client.get_task_execution_data(execution.id)
         task_id = execution.id.task_id
         task = self.fetch_task(task_id.project, task_id.domain, task_id.name, task_id.version)
-        return self._assign_inputs_and_outputs(synced_execution, execution_data, task.interface)
+        return self._assign_inputs_and_outputs(execution, execution_data, task.interface)
 
     #############################
     # Terminate Execution State #

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -987,7 +987,7 @@ class FlyteRemote(object):
             )
 
         # sync closure, node executions, and inputs/outputs
-        execution = self.client.get_execution(execution.id).closure
+        execution._closure = self.client.get_execution(execution.id).closure
         execution._node_executions = {
             node.id.node_id: self.sync(FlyteNodeExecution.promote_from_model(node), flyte_entity)
             for node in iterate_node_executions(self.client, execution.id)

--- a/flytekit/remote/workflow_execution.py
+++ b/flytekit/remote/workflow_execution.py
@@ -7,7 +7,7 @@ from flytekit.remote import identifier as _core_identifier
 from flytekit.remote import nodes as _nodes
 
 
-class FlyteWorkflowExecution(_execution_models.Execution):
+class FlyteWorkflowExecution(_execution_models.Execution, _artifact.ExecutionArtifact):
     """A class encapsulating a workflow execution being run on a Flyte remote backend."""
 
     def __init__(self, *args, **kwargs):
@@ -15,6 +15,7 @@ class FlyteWorkflowExecution(_execution_models.Execution):
         self._node_executions = None
         self._inputs = None
         self._outputs = None
+        self._closure = None
 
     @property
     def node_executions(self) -> Dict[str, _nodes.FlyteNodeExecution]:

--- a/flytekit/remote/workflow_execution.py
+++ b/flytekit/remote/workflow_execution.py
@@ -7,7 +7,7 @@ from flytekit.remote import identifier as _core_identifier
 from flytekit.remote import nodes as _nodes
 
 
-class FlyteWorkflowExecution(_execution_models.Execution, _artifact.ExecutionArtifact):
+class FlyteWorkflowExecution(_execution_models.Execution):
     """A class encapsulating a workflow execution being run on a Flyte remote backend."""
 
     def __init__(self, *args, **kwargs):

--- a/flytekit/remote/workflow_execution.py
+++ b/flytekit/remote/workflow_execution.py
@@ -1,17 +1,13 @@
-from typing import Any, Dict, List
+from typing import Any, Dict
 
-from flytekit.clients.helpers import iterate_node_executions as _iterate_node_executions
 from flytekit.common.exceptions import user as _user_exceptions
-from flytekit.common.mixins import artifact as _artifact
-from flytekit.engines.flyte import engine as _flyte_engine
 from flytekit.models import execution as _execution_models
-from flytekit.models import filters as _filter_models
 from flytekit.models.core import execution as _core_execution_models
 from flytekit.remote import identifier as _core_identifier
 from flytekit.remote import nodes as _nodes
 
 
-class FlyteWorkflowExecution(_execution_models.Execution, _artifact.ExecutionArtifact):
+class FlyteWorkflowExecution(_execution_models.Execution):
     """A class encapsulating a workflow execution being run on a Flyte remote backend."""
 
     def __init__(self, *args, **kwargs):
@@ -78,29 +74,3 @@ class FlyteWorkflowExecution(_execution_models.Execution, _artifact.ExecutionArt
             id=_core_identifier.WorkflowExecutionIdentifier.promote_from_model(base_model.id),
             spec=base_model.spec,
         )
-
-    def sync(self):
-        """
-        Syncs the state of the underlying execution artifact with the state observed by the platform.
-        """
-        if not self.is_complete or self._node_executions is None:
-            self._sync_closure()
-            self._node_executions = self.get_node_executions()
-
-        for node_execution in self._node_executions.values():
-            node_execution.sync()
-
-    def _sync_closure(self):
-        if not self.is_complete:
-            client = _flyte_engine.get_client()
-            self._closure = client.get_execution(self.id).closure
-
-    def get_node_executions(self, filters: List[_filter_models.Filter] = None) -> Dict[str, _nodes.FlyteNodeExecution]:
-        client = _flyte_engine.get_client()
-        return {
-            node.id.node_id: _nodes.FlyteNodeExecution.promote_from_model(node)
-            for node in _iterate_node_executions(client, self.id, filters=filters)
-        }
-
-    def terminate(self, cause: str):
-        _flyte_engine.get_client().terminate_execution(self.id, cause)


### PR DESCRIPTION
- remote.sync updates the execution object in place

Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

# TL;DR

`FlyteRemote.sync` no longer makes a copy of the input workflow execution, remove `FlyteWorkflowExecution.sync`

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

To make the UX around `FlyteRemote` more intuitive, we remove the `sync` method from the workflow execution object and make is so the `remote.sync` syncs the inputs and outputs of the underlying execution instead of making a copy

See more details in https://docs.google.com/document/d/1v1EFdqnHrsB7XSNzQLrpSSZtXtoBGQGoRFcztFGxRfM/edit

## Tracking Issue
NA

## Follow-up issue
NA