### PR TITLE
Failed to transform path string to Literal

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -476,16 +476,15 @@ class TypeEngine(typing.Generic[T]):
             # to account for the type erasure that happens in the case of built-in collection containers, such as
             # `list` and `dict`.
             python_type = guessed_python_types.get(k, type(v))
-            if (hasattr(python_type, "__origin__") and not isinstance(v, python_type.__origin__)) or (
-                not hasattr(python_type, "__origin__") and not isinstance(v, python_type)
-            ):
+            try:
+                literal_map[k] = TypeEngine.to_literal(
+                    ctx=ctx,
+                    python_val=v,
+                    python_type=python_type,
+                    expected=TypeEngine.to_literal_type(python_type),
+                )
+            except TypeError:
                 raise user_exceptions.FlyteTypeException(type(v), python_type, received_value=v)
-            literal_map[k] = TypeEngine.to_literal(
-                ctx=ctx,
-                python_val=v,
-                python_type=python_type,
-                expected=TypeEngine.to_literal_type(python_type),
-            )
         return LiteralMap(literal_map)
 
     @classmethod

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -28,6 +28,7 @@ from flytekit.models.core.types import BlobType
 from flytekit.models.literals import Blob, BlobMetadata, Literal, LiteralCollection, LiteralMap, Primitive, Scalar
 from flytekit.models.types import LiteralType, SimpleType
 from flytekit.types.directory.types import FlyteDirectory
+from flytekit.types.file import JPEGImageFile
 from flytekit.types.file.file import FlyteFile, FlyteFilePathTransformer
 
 
@@ -594,6 +595,24 @@ def test_enum_type():
                                     TestStructD(s=InnerStruct(a=5, b=None, c=[1, 2, 3]), m={"a": [5]}),
                                 ).to_json(),
                                 _struct.Struct(),
+                            )
+                        )
+                    )
+                }
+            ),
+        ),
+        (
+            {"p1": "s3://tmp/file.jpeg"},
+            {"p1": JPEGImageFile},
+            LiteralMap(
+                literals={
+                    "p1": Literal(
+                        scalar=Scalar(
+                            blob=Blob(
+                                metadata=BlobMetadata(
+                                    type=BlobType(format="jpeg", dimensionality=BlobType.BlobDimensionality.SINGLE)
+                                ),
+                                uri="s3://tmp/file.jpeg",
                             )
                         )
                     )


### PR DESCRIPTION
# TL;DR
Failed to transform path string to Literal

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Return `FlyteTypeException` when getting `TypeError` from `TypeEngine.to_literal`

## Tracking Issue
https://flyte-org.slack.com/archives/CREL4QVAQ/p1633567961295600

## Follow-up issue
_NA_