### PR TITLE
Pin pip to 21.2.4

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -83,7 +83,7 @@ jobs:
         key: ${{ format('{0}-pip-{1}', runner.os, hashFiles('dev-requirements.txt', format('plugins/{0}/requirements.txt', matrix.plugin-names ))) }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip==21.2.4 setuptools wheel
         make setup
         cd plugins/${{ matrix.plugin-names }}
         # install in develop mode so setuptools doesn't override flytekit on current branch


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
pip version 21.3 broke `pip-sync`

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
We're seeing build failures (e.g.  https://github.com/flyteorg/flytekit/pull/660/checks?check_run_id=3863335213) with error message:
```
pip-sync requirements.txt dev-requirements.txt
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.12/x64/bin/pip-sync", line 5, in <module>
    from piptools.scripts.sync import cli
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/piptools/scripts/sync.py", line 12, in <module>
    from pip._internal.utils.misc import get_installed_distributions
ImportError: cannot import name 'get_installed_distributions' from 'pip._internal.utils.misc' (/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/pip/_internal/utils/misc.py)
```

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
