### PR TITLE
Add debug log to surface original error 

### DIFF
--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -135,6 +135,7 @@ def _handle_rpc_error(retry=False):
                             if i == (max_retries - 1):
                                 # Exit the loop and wrap the authentication error.
                                 raise _user_exceptions.FlyteAuthenticationException(_six.text_type(e))
+                            cli_logger.error(f"Unauthenticated RPC error {e}, refreshing credentials and retrying\n")
                             refresh_handler_fn = _get_refresh_handler(_creds_config.AUTH_MODE.get())
                             refresh_handler_fn(args[0])
                         else:


### PR DESCRIPTION
Add debug log to surface original error in case refresh credentials throws exception.

When our proxy service which implements all endpoints of admin return unauthenticated exit code, the retry handler refreshes credentials using the default AUTH_MODE=standard. Since we don't support this auth method, it throws an exception and the original error is not shown. 

Not sure if there is a better way of handling this, maybe have the [AUTH_MODE](https://github.com/flyteorg/flytekit/blob/f6ee06f3f822c86201b482da69593672a70c825a/flytekit/configuration/creds.py#L70) be no op by default, would that be ok? This would make the error message more evident for our users, or maybe only refresh credentials when [AUTH](https://github.com/flyteorg/flytekit/blob/master/flytekit/configuration/platform.py#L21) is true

This will add a debug log to show the user error 

```
{"asctime": "2021-10-20 16:52:47,442", "name": "flytekit.cli", "levelname": "ERROR", "message": "Unauthenticated RPC error <_InactiveRpcError of RPC that terminated with:\n\tstatus = StatusCode.UNAUTHENTICATED\n\tdetails = \"No authorization header provided\"\n\tdebug_error_string = \"{\"created\":\"@1634741567.442136000\",\"description\":\"Error received from peer ipv6:[::1]:5990\",\"file\":\"src/core/lib/surface/call.cc\",\"file_line\":1070,\"grpc_message\":\"No authorization header provided\",\"grpc_status\":16}\"\n>, refreshing credentials and retrying\n"}
```

on top of the stacktrace:

```
Traceback (most recent call last):
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 706, in urlopen
    chunked=chunked,
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 445, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 440, in _make_request
    httplib_response = conn.getresponse()
  File "/Users/sonjae/.pyenv/versions/3.7.5/lib/python3.7/http/client.py", line 1344, in getresponse
    response.begin()
  File "/Users/sonjae/.pyenv/versions/3.7.5/lib/python3.7/http/client.py", line 306, in begin
    version, status, reason = self._read_status()
  File "/Users/sonjae/.pyenv/versions/3.7.5/lib/python3.7/http/client.py", line 288, in _read_status
    raise BadStatusLine(line)
http.client.BadStatusLine: ÿÿÿQUnexpected HTTP/1.x request: GET /.well-known/oauth-authorization-server

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/requests/adapters.py", line 449, in send
    timeout=timeout
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 756, in urlopen
    method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/util/retry.py", line 532, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/packages/six.py", line 769, in reraise
    raise value.with_traceback(tb)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 706, in urlopen
    chunked=chunked,
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 445, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 440, in _make_request
    httplib_response = conn.getresponse()
  File "/Users/sonjae/.pyenv/versions/3.7.5/lib/python3.7/http/client.py", line 1344, in getresponse
    response.begin()
  File "/Users/sonjae/.pyenv/versions/3.7.5/lib/python3.7/http/client.py", line 306, in begin
    version, status, reason = self._read_status()
  File "/Users/sonjae/.pyenv/versions/3.7.5/lib/python3.7/http/client.py", line 288, in _read_status
    raise BadStatusLine(line)
urllib3.exceptions.ProtocolError: ('Connection aborted.', BadStatusLine('\x00\x00\x12\x04\x00\x00\x00\x00\x00\x00\x03\x7fÿÿÿ\x00\x04\x00\x10\x00\x00\x00\x06\x00\x00 \x00\x00\x00\x04\x08\x00\x00\x00\x00\x00\x00\x0f\x00\x01\x00\x00Q\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01Unexpected HTTP/1.x request: GET /.well-known/oauth-authorization-server '))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/sonjae/flytekit/venv/bin/flyte-cli", line 33, in <module>
    sys.exit(load_entry_point('flytekit', 'console_scripts', 'flyte-cli')())
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/sonjae/flytekit/flytekit/clis/flyte_cli/main.py", line 1721, in list_projects
    sort_by=_admin_common.Sort.from_python_std(sort_by) if sort_by else None,
  File "/Users/sonjae/flytekit/flytekit/clients/friendly.py", line 880, in list_projects_paginated
    sort_by=None if sort_by is None else sort_by.to_flyte_idl(),
  File "/Users/sonjae/flytekit/flytekit/clients/raw.py", line 140, in handler
    refresh_handler_fn(args[0])
  File "/Users/sonjae/flytekit/flytekit/clients/raw.py", line 34, in _refresh_credentials_standard
    client = _credentials_access.get_client(flyte_client.url)
  File "/Users/sonjae/flytekit/flytekit/clis/auth/credentials.py", line 45, in get_client
    authorization_endpoints = get_authorization_endpoints(flyte_client_url)
  File "/Users/sonjae/flytekit/flytekit/clis/auth/credentials.py", line 67, in get_authorization_endpoints
    return discovery_client.get_authorization_endpoints()
  File "/Users/sonjae/flytekit/flytekit/clis/auth/discovery.py", line 50, in get_authorization_endpoints
    url=self._discovery_url,
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/requests/api.py", line 75, in get
    return request('get', url, params=params, **kwargs)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/requests/sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/requests/sessions.py", line 655, in send
    r = adapter.send(request, **kwargs)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/requests/adapters.py", line 498, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', BadStatusLine('\x00\x00\x12\x04\x00\x00\x00\x00\x00\x00\x03\x7fÿÿÿ\x00\x04\x00\x10\x00\x00\x00\x06\x00\x00 \x00\x00\x00\x04\x08\x00\x00\x00\x00\x00\x00\x0f\x00\x01\x00\x00Q\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01Unexpected HTTP/1.x request: GET /.well-known/oauth-authorization-server '))
```

# TL;DR
_Please replace this text with a description of what this PR accomplishes._

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
