### PR TITLE
make default auth mode noop

### DIFF
--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -102,7 +102,9 @@ def _refresh_credentials_noop(flyte_client):
 
 
 def _get_refresh_handler(auth_mode):
-    if auth_mode == "standard":
+    if auth_mode == "noop":
+        return lambda _: None
+    elif auth_mode == "standard":
         return _refresh_credentials_standard
     elif auth_mode == "basic":
         return _refresh_credentials_basic

--- a/flytekit/configuration/creds.py
+++ b/flytekit/configuration/creds.py
@@ -67,7 +67,7 @@ with at least one element. The first element will be used. If list has more than
 Config files with both this option, and the OAUTH_SCOPES, will use this one.
 """
 
-AUTH_MODE = _config_common.FlyteStringConfigurationEntry("credentials", "auth_mode", default="standard")
+AUTH_MODE = _config_common.FlyteStringConfigurationEntry("credentials", "auth_mode", default="noop")
 """
 The auth mode defines the behavior used to request and refresh credentials. The currently supported modes include:
 - 'standard' This uses the pkce-enhanced authorization code flow by opening a browser window to initiate credentials


### PR DESCRIPTION
# TL;DR

Make default auth mode noop since we don't support standard auth mode and the refresh throws an exception.

Not sure this PR makes sense, but this improves our error messages to:

```
{"asctime": "2021-10-21 11:00:23,790", "name": "flytekit.cli", "levelname": "ERROR", "message": "Unauthenticated RPC error <_InactiveRpcError of RPC that terminated with:\n\tstatus = StatusCode.UNAUTHENTICATED\n\tdetails = \"No authorization header provided\"\n\tdebug_error_string = \"{\"created\":\"@1634806823.790783000\",\"description\":\"Error received from peer ipv6:[::1]:5990\",\"file\":\"src/core/lib/surface/call.cc\",\"file_line\":1070,\"grpc_message\":\"No authorization header provided\",\"grpc_status\":16}\"\n>, refreshing credentials and retrying\n"}
{"asctime": "2021-10-21 11:00:23,793", "name": "flytekit.cli", "levelname": "ERROR", "message": "Unauthenticated RPC error <_InactiveRpcError of RPC that terminated with:\n\tstatus = StatusCode.UNAUTHENTICATED\n\tdetails = \"No authorization header provided\"\n\tdebug_error_string = \"{\"created\":\"@1634806823.793535000\",\"description\":\"Error received from peer ipv6:[::1]:5990\",\"file\":\"src/core/lib/surface/call.cc\",\"file_line\":1070,\"grpc_message\":\"No authorization header provided\",\"grpc_status\":16}\"\n>, refreshing credentials and retrying\n"}
Traceback (most recent call last):
  File "/Users/sonjae/flytekit/flytekit/clients/raw.py", line 133, in handler
    return fn(*args, **kwargs)
  File "/Users/sonjae/flytekit/flytekit/clients/raw.py", line 669, in list_projects
    return self._stub.ListProjects(project_list_request, metadata=self._metadata)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/grpc/_channel.py", line 946, in __call__
    return _end_unary_response_blocking(state, call, False, None)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/grpc/_channel.py", line 849, in _end_unary_response_blocking
    raise _InactiveRpcError(state)
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.UNAUTHENTICATED
	details = "No authorization header provided"
	debug_error_string = "{"created":"@1634806823.794944000","description":"Error received from peer ipv6:[::1]:5990","file":"src/core/lib/surface/call.cc","file_line":1070,"grpc_message":"No authorization header provided","grpc_status":16}"
>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/sonjae/flytekit/venv/bin/flyte-cli", line 33, in <module>
    sys.exit(load_entry_point('flytekit', 'console_scripts', 'flyte-cli')())
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/sonjae/flytekit/flytekit/clis/flyte_cli/main.py", line 1721, in list_projects
    sort_by=_admin_common.Sort.from_python_std(sort_by) if sort_by else None,
  File "/Users/sonjae/flytekit/flytekit/clients/friendly.py", line 880, in list_projects_paginated
    sort_by=None if sort_by is None else sort_by.to_flyte_idl(),
  File "/Users/sonjae/flytekit/flytekit/clients/raw.py", line 139, in handler
    raise _user_exceptions.FlyteAuthenticationException(_six.text_type(e))
flytekit.common.exceptions.user.FlyteAuthenticationException: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.UNAUTHENTICATED
	details = "No authorization header provided"
	debug_error_string = "{"created":"@1634806823.794944000","description":"Error received from peer ipv6:[::1]:5990","file":"src/core/lib/surface/call.cc","file_line":1070,"grpc_message":"No authorization header provided","grpc_status":16}"
>
```



from



```
{"asctime": "2021-10-21 10:59:12,993", "name": "flytekit.cli", "levelname": "ERROR", "message": "Unauthenticated RPC error <_InactiveRpcError of RPC that terminated with:\n\tstatus = StatusCode.UNAUTHENTICATED\n\tdetails = \"No authorization header provided\"\n\tdebug_error_string = \"{\"created\":\"@1634806752.992963000\",\"description\":\"Error received from peer ipv6:[::1]:5990\",\"file\":\"src/core/lib/surface/call.cc\",\"file_line\":1070,\"grpc_message\":\"No authorization header provided\",\"grpc_status\":16}\"\n>, refreshing credentials and retrying\n"}
Traceback (most recent call last):
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 706, in urlopen
    chunked=chunked,
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 445, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 440, in _make_request
    httplib_response = conn.getresponse()
  File "/Users/sonjae/.pyenv/versions/3.7.5/lib/python3.7/http/client.py", line 1344, in getresponse
    response.begin()
  File "/Users/sonjae/.pyenv/versions/3.7.5/lib/python3.7/http/client.py", line 306, in begin
    version, status, reason = self._read_status()
  File "/Users/sonjae/.pyenv/versions/3.7.5/lib/python3.7/http/client.py", line 288, in _read_status
    raise BadStatusLine(line)
http.client.BadStatusLine: ÿÿÿQUnexpected HTTP/1.x request: GET /.well-known/oauth-authorization-server

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/requests/adapters.py", line 449, in send
    timeout=timeout
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 756, in urlopen
    method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/util/retry.py", line 532, in increment
    raise six.reraise(type(error), error, _stacktrace)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/packages/six.py", line 769, in reraise
    raise value.with_traceback(tb)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 706, in urlopen
    chunked=chunked,
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 445, in _make_request
    six.raise_from(e, None)
  File "<string>", line 3, in raise_from
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 440, in _make_request
    httplib_response = conn.getresponse()
  File "/Users/sonjae/.pyenv/versions/3.7.5/lib/python3.7/http/client.py", line 1344, in getresponse
    response.begin()
  File "/Users/sonjae/.pyenv/versions/3.7.5/lib/python3.7/http/client.py", line 306, in begin
    version, status, reason = self._read_status()
  File "/Users/sonjae/.pyenv/versions/3.7.5/lib/python3.7/http/client.py", line 288, in _read_status
    raise BadStatusLine(line)
urllib3.exceptions.ProtocolError: ('Connection aborted.', BadStatusLine('\x00\x00\x12\x04\x00\x00\x00\x00\x00\x00\x03\x7fÿÿÿ\x00\x04\x00\x10\x00\x00\x00\x06\x00\x00 \x00\x00\x00\x04\x08\x00\x00\x00\x00\x00\x00\x0f\x00\x01\x00\x00Q\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01Unexpected HTTP/1.x request: GET /.well-known/oauth-authorization-server '))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/sonjae/flytekit/venv/bin/flyte-cli", line 33, in <module>
    sys.exit(load_entry_point('flytekit', 'console_scripts', 'flyte-cli')())
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/sonjae/flytekit/flytekit/clis/flyte_cli/main.py", line 1721, in list_projects
    sort_by=_admin_common.Sort.from_python_std(sort_by) if sort_by else None,
  File "/Users/sonjae/flytekit/flytekit/clients/friendly.py", line 880, in list_projects_paginated
    sort_by=None if sort_by is None else sort_by.to_flyte_idl(),
  File "/Users/sonjae/flytekit/flytekit/clients/raw.py", line 140, in handler
    refresh_handler_fn(args[0])
  File "/Users/sonjae/flytekit/flytekit/clients/raw.py", line 34, in _refresh_credentials_standard
    client = _credentials_access.get_client(flyte_client.url)
  File "/Users/sonjae/flytekit/flytekit/clis/auth/credentials.py", line 45, in get_client
    authorization_endpoints = get_authorization_endpoints(flyte_client_url)
  File "/Users/sonjae/flytekit/flytekit/clis/auth/credentials.py", line 67, in get_authorization_endpoints
    return discovery_client.get_authorization_endpoints()
  File "/Users/sonjae/flytekit/flytekit/clis/auth/discovery.py", line 50, in get_authorization_endpoints
    url=self._discovery_url,
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/requests/api.py", line 75, in get
    return request('get', url, params=params, **kwargs)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/requests/sessions.py", line 542, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/requests/sessions.py", line 655, in send
    r = adapter.send(request, **kwargs)
  File "/Users/sonjae/flytekit/venv/lib/python3.7/site-packages/requests/adapters.py", line 498, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', BadStatusLine('\x00\x00\x12\x04\x00\x00\x00\x00\x00\x00\x03\x7fÿÿÿ\x00\x04\x00\x10\x00\x00\x00\x06\x00\x00 \x00\x00\x00\x04\x08\x00\x00\x00\x00\x00\x00\x0f\x00\x01\x00\x00Q\x07\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01Unexpected HTTP/1.x request: GET /.well-known/oauth-authorization-server '))
```


## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
