### PR TITLE
Remove flytekit lower bounds from all plugins.

### DIFF
--- a/plugins/flytekit-aws-athena/setup.py
+++ b/plugins/flytekit-aws-athena/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "athena"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=0.19.0,<1.0.0"]
+plugin_requires = ["flytekit<1.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-aws-sagemaker/setup.py
+++ b/plugins/flytekit-aws-sagemaker/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "awssagemaker"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=0.16.0b0,<1.0.0", "sagemaker-training>=3.6.2,<4.0.0"]
+plugin_requires = ["flytekit<1.0.0", "sagemaker-training>=3.6.2,<4.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-data-fsspec/setup.py
+++ b/plugins/flytekit-data-fsspec/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "fsspec"
 
 microlib_name = f"flytekitplugins-data-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=0.21.3,<1.0.0", "fsspec>=2021.7.0"]
+plugin_requires = ["flytekit<1.0.0", "fsspec>=2021.7.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-dolt/setup.py
+++ b/plugins/flytekit-dolt/setup.py
@@ -6,7 +6,7 @@ PLUGIN_NAME = "dolt"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=0.16.0b0,<1.0.0", "dolt_integrations>=0.1.5"]
+plugin_requires = ["flytekit<1.0.0", "dolt_integrations>=0.1.5"]
 dev_requires = ["pytest-mock>=3.6.1"]
 
 __version__ = "0.0.0+develop"

--- a/plugins/flytekit-greatexpectations/setup.py
+++ b/plugins/flytekit-greatexpectations/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "great_expectations"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=0.21.0,<1.0.0", "great-expectations>=0.13.30", "sqlalchemy>=1.4.23"]
+plugin_requires = ["flytekit<1.0.0", "great-expectations>=0.13.30", "sqlalchemy>=1.4.23"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-hive/setup.py
+++ b/plugins/flytekit-hive/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "hive"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=0.16.0b0,<1.0.0"]
+plugin_requires = ["flytekit<1.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-k8s-pod/setup.py
+++ b/plugins/flytekit-k8s-pod/setup.py
@@ -5,7 +5,7 @@ PLUGIN_NAME = "pod"
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 plugin_requires = [
-    "flytekit>=0.16.0b0,<1.0.0",
+    "flytekit<1.0.0",
     "kubernetes>=12.0.1",
 ]
 

--- a/plugins/flytekit-kf-pytorch/setup.py
+++ b/plugins/flytekit-kf-pytorch/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "kfpytorch"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=0.16.0b0,<1.0.0"]
+plugin_requires = ["flytekit<1.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-kf-tensorflow/setup.py
+++ b/plugins/flytekit-kf-tensorflow/setup.py
@@ -5,7 +5,7 @@ PLUGIN_NAME = "kftensorflow"
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 # TODO: Requirements are missing, add them back in later.
-plugin_requires = ["flytekit>=0.16.0b0,<1.0.0"]
+plugin_requires = ["flytekit<1.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-modin/setup.py
+++ b/plugins/flytekit-modin/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "modin"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=0.22.0,<1.0.0", "modin", "ray", "fsspec"]
+plugin_requires = ["flytekit<1.0.0", "modin", "ray", "fsspec"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-pandera/setup.py
+++ b/plugins/flytekit-pandera/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "pandera"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=0.16.0b6,<1.0.0", "pandera>=0.7.1"]
+plugin_requires = ["flytekit<1.0.0", "pandera>=0.7.1"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-papermill/setup.py
+++ b/plugins/flytekit-papermill/setup.py
@@ -5,7 +5,7 @@ PLUGIN_NAME = "papermill"
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 plugin_requires = [
-    "flytekit>=0.16.0b0,<1.0.0",
+    "flytekit<1.0.0",
     "flytekitplugins-spark>=0.16.0b0,<1.0.0",
     "papermill>=1.2.0",
     "nbconvert>=6.0.7",

--- a/plugins/flytekit-snowflake/setup.py
+++ b/plugins/flytekit-snowflake/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "snowflake"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=v0.23.0b0,<1.0.0"]
+plugin_requires = ["flytekit<1.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-spark/setup.py
+++ b/plugins/flytekit-spark/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "spark"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=0.16.0b0,<1.0.0", "pyspark>=3.0.0"]
+plugin_requires = ["flytekit<1.0.0", "pyspark>=3.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-sqlalchemy/setup.py
+++ b/plugins/flytekit-sqlalchemy/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "sqlalchemy"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=0.17.0,<1.0.0", "sqlalchemy>=1.4.7"]
+plugin_requires = ["flytekit<1.0.0", "sqlalchemy>=1.4.7"]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
Signed-off-by: Yee Hing Tong <wild-endeavor@users.noreply.github.com>

# TL;DR
We still can't get the behavior that we want with plugin tests. We want plugin tests to run with the flytekit sha that's being tested, not a released version.

https://github.com/flyteorg/flytekit/runs/3946212444?check_suite_focus=true for instance shows the develop version getting overwritten.

This is a temporary fix that can be reverted once we figure out how to force install of the git sha.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
