### PR TITLE
Add support FlyteSchema in dataclass

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -262,7 +262,7 @@ class DataclassTransformer(TypeTransformer[object]):
 
         for f in dataclasses.fields(python_type):
             v = python_val.__getattribute__(f.name)
-            if issubclass(f.type, FlyteSchema):
+            if inspect.isclass(f.type) and issubclass(f.type, FlyteSchema):
                 FlyteSchemaTransformer().to_literal(FlyteContext.current_context(), v, f.type, None)
             elif dataclasses.is_dataclass(f.type):
                 self._serialize_flyte_type(v, f.type)
@@ -272,7 +272,7 @@ class DataclassTransformer(TypeTransformer[object]):
 
         for f in dataclasses.fields(expected_python_type):
             v = python_val.__getattribute__(f.name)
-            if issubclass(f.type, FlyteSchema):
+            if inspect.isclass(f.type) and issubclass(f.type, FlyteSchema):
                 t = FlyteSchemaTransformer()
                 t.to_python_value(
                     FlyteContext.current_context(),

--- a/flytekit/types/schema/types.py
+++ b/flytekit/types/schema/types.py
@@ -4,11 +4,13 @@ import datetime as _datetime
 import os
 import typing
 from abc import abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Type
 
 import numpy as _np
+from dataclasses_json import dataclass_json, config
+from marshmallow import fields
 
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.type_engine import T, TypeEngine, TypeTransformer
@@ -167,7 +169,12 @@ class SchemaEngine(object):
         return cls._SCHEMA_HANDLERS[t]
 
 
+@dataclass_json
+@dataclass
 class FlyteSchema(object):
+    supported_mode: typing.Optional[str] = field(default=SchemaOpenMode.WRITE, metadata=config(mm_field=fields.String()))
+    local_path: typing.Optional[str] = field(default=None, metadata=config(mm_field=fields.String()))
+    remote_path: typing.Optional[str] = field(default=None, metadata=config(mm_field=fields.String()))
     """
     This is the main schema class that users should use.
     """
@@ -247,13 +254,28 @@ class FlyteSchema(object):
     def local_path(self) -> os.PathLike:
         return self._local_path
 
+    @local_path.setter
+    def local_path(self, local_path):
+        self._local_path = local_path
+
     @property
     def remote_path(self) -> str:
-        return typing.cast(str, self._remote_path)
+        return self._remote_path
+
+    @remote_path.setter
+    def remote_path(self, remote_path):
+        self._remote_path = remote_path
 
     @property
     def supported_mode(self) -> SchemaOpenMode:
         return self._supported_mode
+
+    @supported_mode.setter
+    def supported_mode(self, supported_mode):
+        self._supported_mode = supported_mode
+
+    def __hash__(self):
+        return hash(3)
 
     def open(
         self, dataframe_fmt: type = pandas.DataFrame, override_mode: SchemaOpenMode = None

--- a/flytekit/types/schema/types.py
+++ b/flytekit/types/schema/types.py
@@ -243,39 +243,12 @@ class FlyteSchema(object):
 
         if local_path is None:
             local_path = FlyteContextManager.current_context().file_access.get_random_local_directory()
-        self._local_path = local_path
-        self._remote_path = remote_path
-        self._supported_mode = supported_mode
+        self.local_path = local_path
+        self.remote_path = remote_path
+        self.supported_mode = supported_mode
         # This is a special attribute that indicates if the data was either downloaded or uploaded
         self._downloaded = False
         self._downloader = downloader
-
-    @property
-    def local_path(self) -> os.PathLike:
-        return self._local_path
-
-    @local_path.setter
-    def local_path(self, local_path):
-        self._local_path = local_path
-
-    @property
-    def remote_path(self) -> str:
-        return self._remote_path
-
-    @remote_path.setter
-    def remote_path(self, remote_path):
-        self._remote_path = remote_path
-
-    @property
-    def supported_mode(self) -> SchemaOpenMode:
-        return self._supported_mode
-
-    @supported_mode.setter
-    def supported_mode(self, supported_mode):
-        self._supported_mode = supported_mode
-
-    def __hash__(self):
-        return hash(3)
 
     def open(
         self, dataframe_fmt: type = pandas.DataFrame, override_mode: SchemaOpenMode = None
@@ -291,14 +264,14 @@ class FlyteSchema(object):
                So if you have written to a schema and want to re-open it for reading, you can use this
                mode. A ReadOnly Schema object cannot be opened in write mode.
         """
-        if override_mode and self._supported_mode == SchemaOpenMode.READ and override_mode == SchemaOpenMode.WRITE:
+        if override_mode and self.supported_mode == SchemaOpenMode.READ and override_mode == SchemaOpenMode.WRITE:
             raise AssertionError("Readonly schema cannot be opened in write mode!")
 
-        mode = override_mode if override_mode else self._supported_mode
+        mode = override_mode if override_mode else self.supported_mode
         h = SchemaEngine.get_handler(dataframe_fmt)
         if not h.handles_remote_io:
             # The Schema Handler does not manage its own IO, and this it will expect the files are on local file-system
-            if self._supported_mode == SchemaOpenMode.READ and not self._downloaded:
+            if self.supported_mode == SchemaOpenMode.READ and not self._downloaded:
                 # Only for readable objects if they are not downloaded already, we should download them
                 # Write objects should already have everything written to
                 self._downloader(self.remote_path, self.local_path)
@@ -313,7 +286,7 @@ class FlyteSchema(object):
         return h.reader(self.remote_path, self.columns(), self.format())
 
     def as_readonly(self) -> FlyteSchema:
-        if self._supported_mode == SchemaOpenMode.READ:
+        if self.supported_mode == SchemaOpenMode.READ:
             return self
         s = FlyteSchema.__class_getitem__(self.columns(), self.format())(
             local_path=self.local_path,

--- a/flytekit/types/schema/types.py
+++ b/flytekit/types/schema/types.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import Type
 
 import numpy as _np
-from dataclasses_json import dataclass_json, config
+from dataclasses_json import config, dataclass_json
 from marshmallow import fields
 
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
@@ -172,7 +172,9 @@ class SchemaEngine(object):
 @dataclass_json
 @dataclass
 class FlyteSchema(object):
-    supported_mode: typing.Optional[str] = field(default=SchemaOpenMode.WRITE, metadata=config(mm_field=fields.String()))
+    supported_mode: typing.Optional[str] = field(
+        default=SchemaOpenMode.WRITE, metadata=config(mm_field=fields.String())
+    )
     local_path: typing.Optional[str] = field(default=None, metadata=config(mm_field=fields.String()))
     remote_path: typing.Optional[str] = field(default=None, metadata=config(mm_field=fields.String()))
     """

--- a/flytekit/types/schema/types.py
+++ b/flytekit/types/schema/types.py
@@ -172,11 +172,9 @@ class SchemaEngine(object):
 @dataclass_json
 @dataclass
 class FlyteSchema(object):
-    supported_mode: typing.Optional[str] = field(
-        default=SchemaOpenMode.WRITE, metadata=config(mm_field=fields.String())
-    )
-    local_path: typing.Optional[str] = field(default=None, metadata=config(mm_field=fields.String()))
-    remote_path: typing.Optional[str] = field(default=None, metadata=config(mm_field=fields.String()))
+    supported_mode: str = field(default=SchemaOpenMode.WRITE, metadata=config(mm_field=fields.String()))
+    local_path: typing.Optional[os.PathLike] = field(default=None, metadata=config(mm_field=fields.String()))
+    remote_path: typing.Optional[os.PathLike] = field(default=None, metadata=config(mm_field=fields.String()))
     """
     This is the main schema class that users should use.
     """
@@ -229,7 +227,7 @@ class FlyteSchema(object):
     def __init__(
         self,
         local_path: os.PathLike = None,
-        remote_path: str = None,
+        remote_path: os.PathLike = None,
         supported_mode: SchemaOpenMode = SchemaOpenMode.WRITE,
         downloader: typing.Callable[[str, os.PathLike], None] = None,
     ):

--- a/flytekit/types/schema/types.py
+++ b/flytekit/types/schema/types.py
@@ -271,14 +271,14 @@ class FlyteSchema(object):
                So if you have written to a schema and want to re-open it for reading, you can use this
                mode. A ReadOnly Schema object cannot be opened in write mode.
         """
-        if override_mode and self.supported_mode == SchemaOpenMode.READ and override_mode == SchemaOpenMode.WRITE:
+        if override_mode and self._supported_mode == SchemaOpenMode.READ and override_mode == SchemaOpenMode.WRITE:
             raise AssertionError("Readonly schema cannot be opened in write mode!")
 
-        mode = override_mode if override_mode else self.supported_mode
+        mode = override_mode if override_mode else self._supported_mode
         h = SchemaEngine.get_handler(dataframe_fmt)
         if not h.handles_remote_io:
             # The Schema Handler does not manage its own IO, and this it will expect the files are on local file-system
-            if self.supported_mode == SchemaOpenMode.READ and not self._downloaded:
+            if self._supported_mode == SchemaOpenMode.READ and not self._downloaded:
                 # Only for readable objects if they are not downloaded already, we should download them
                 # Write objects should already have everything written to
                 self._downloader(self.remote_path, self.local_path)
@@ -293,7 +293,7 @@ class FlyteSchema(object):
         return h.reader(self.remote_path, self.columns(), self.format())
 
     def as_readonly(self) -> FlyteSchema:
-        if self.supported_mode == SchemaOpenMode.READ:
+        if self._supported_mode == SchemaOpenMode.READ:
             return self
         s = FlyteSchema.__class_getitem__(self.columns(), self.format())(
             local_path=self.local_path,

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -672,20 +672,6 @@ class Result:
     schema: TestSchema
 
 
-@task
-def t1() -> Result:
-    schema = TestSchema()
-    df = pd.DataFrame(data={"some_str": ["a", "b", "c"]})
-    schema.open().write(df)
-
-    return Result(number=1, schema=schema)
-
-
-@workflow
-def wf() -> Result:
-    return t1()
-
-
 def test_schema_in_dataclass():
     schema = TestSchema()
     df = pd.DataFrame(data={"some_str": ["a", "b", "c"]})

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -14,7 +14,7 @@ from google.protobuf import struct_pb2 as _struct
 from marshmallow_enum import LoadDumpOptions
 from marshmallow_jsonschema import JSONSchema
 
-from flytekit import workflow, task, kwtypes
+from flytekit import kwtypes, task, workflow
 from flytekit.common.exceptions import user as user_exceptions
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.type_engine import (

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -14,7 +14,7 @@ from google.protobuf import struct_pb2 as _struct
 from marshmallow_enum import LoadDumpOptions
 from marshmallow_jsonschema import JSONSchema
 
-from flytekit import kwtypes, task, workflow
+from flytekit import kwtypes
 from flytekit.common.exceptions import user as user_exceptions
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.type_engine import (

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1086,6 +1086,34 @@ def test_enum_in_dataclass():
 
     assert wf(x=10) == Datum(10, Color.RED)
 
+def test_flyte_schema_dataclass():
+    TestSchema = FlyteSchema[kwtypes(some_str=str)]
+
+    @dataclass_json
+    @dataclass
+    class InnerResult:
+        number: int
+        schema: TestSchema
+
+    @dataclass_json
+    @dataclass
+    class Result:
+        result: InnerResult
+        schema: TestSchema
+
+    schema = TestSchema()
+
+    @task
+    def t1(x: int) -> Result:
+
+        return Result(result=InnerResult(number=x, schema=schema), schema=schema)
+
+    @workflow
+    def wf(x: int) -> Result:
+        return t1(x=x)
+
+    assert wf(x=10) == Result(result=InnerResult(number=10, schema=schema), schema=schema)
+
 
 def test_environment():
     @task(environment={"FOO": "foofoo", "BAZ": "baz"})

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1086,6 +1086,7 @@ def test_enum_in_dataclass():
 
     assert wf(x=10) == Datum(10, Color.RED)
 
+
 def test_flyte_schema_dataclass():
     TestSchema = FlyteSchema[kwtypes(some_str=str)]
 


### PR DESCRIPTION
# TL;DR
- Support FlyteSchema in dataclass
- Update cookbook https://github.com/flyteorg/flytesnacks/pull/491

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Make FlyteSchema as dataclass
![image](https://user-images.githubusercontent.com/37936015/143309878-a4ddf30d-1167-4d97-800a-d982f701a355.png)
My sample code
```python
@dataclass_json
@dataclass
class SomeResult:
    some_int: int
    some_schema: SomeSchema


@task
def some_task() -> SomeResult:
    some_schema = SomeSchema()
    print("some_schema", some_schema.local_path)
    some_df = pd.DataFrame(data={"some_str": ["a", "b", "c"]})
    some_schema.open().write(some_df)

    return SomeResult(some_int=1, some_schema=some_schema)


@workflow
def some_workflow() -> SomeResult:
    return some_task()

```

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1521

## Follow-up issue
_NA_