### PR TITLE
Refresh client credentials in secure mode

### DIFF
--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -208,7 +208,7 @@ class RawSynchronousFlyteClient(object):
             )
         self._stub = _admin_service.AdminServiceStub(self._channel)
         self._metadata = None
-        if _AUTH.get():
+        if _AUTH.get() or insecure is False:
             self.force_auth_flow()
 
     @property


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
flyte-cli setup-config will not create "auth" config, so we will only refresh credentials after failing to connect flyte admin (check [here](https://github.com/flyteorg/flytekit/blob/4013f1b65fcbe3b09f3ce3f13c7590b463b3e8c3/flytekit/clients/raw.py#L140)).
And we will always get errors the first time we connect to the flyte admin.
Refreshing client credentials in secure mode when initializing `RawSynchronousFlyteClient` can fix it.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
```
(flytekit-3.8) ➜  flytekit git:(refresh_token) ✗ flyte-cli setup-config -h demo.nuclyde.io
Welcome to Flyte CLI! Version: 0.0.0+develop
Config file already exists at /Users/kevin/.flyte/config
(flytekit-3.8) ➜  flytekit git:(refresh_token) ✗ flyte-cli list-projects                  
Using default config file at /Users/kevin/.flyte/config
Welcome to Flyte CLI! Version: 0.0.0+develop
Projects Found

	cluster-deploy
	flytectldemo
	flyteexamples
	flytelab
	flytesnacks
	flytetester
	testorg1
	test-org1
	testorg3
	testorg33
	testorg4
	testorg5

(flytekit-3.8) ➜  flytekit git:(refresh_token) ✗ rm ~/.flyte/config
(flytekit-3.8) ➜  flytekit git:(refresh_token) ✗ flyte-cli setup-config -h localhost:30081 -i

Welcome to Flyte CLI! Version: 0.0.0+develop
Wrote default config file to /Users/kevin/.flyte/config
(flytekit-3.8) ➜  flytekit git:(refresh_token) ✗ flyte-cli list-projects                     
Using default config file at /Users/kevin/.flyte/config
Welcome to Flyte CLI! Version: 0.0.0+develop
Projects Found

	flyteexamples
	flytesnacks
	flytetester
```
## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
