### PR TITLE
Add deprecation warning and notice to flyte-cli

### DIFF
--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -75,9 +75,18 @@ _default_config_file_name = "config"
 
 
 def _welcome_message():
-    _click.secho("\n################################################################################################################################", bold=True)
-    _click.secho("# flyte-cli is being deprecated in favor of flytectl. More details about flytectl in https://docs.flyte.org/projects/flytectl/ #", bold=True)
-    _click.secho("################################################################################################################################\n", bold=True)
+    _click.secho(
+        "\n################################################################################################################################",
+        bold=True,
+    )
+    _click.secho(
+        "# flyte-cli is being deprecated in favor of flytectl. More details about flytectl in https://docs.flyte.org/projects/flytectl/ #",
+        bold=True,
+    )
+    _click.secho(
+        "################################################################################################################################\n",
+        bold=True,
+    )
     _click.secho("Welcome to Flyte CLI! Version: {}\n".format(_tt(__version__)), bold=True)
 
 

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -75,7 +75,10 @@ _default_config_file_name = "config"
 
 
 def _welcome_message():
-    _click.secho("Welcome to Flyte CLI! Version: {}".format(_tt(__version__)), bold=True)
+    _click.secho("\n################################################################################################################################", bold=True)
+    _click.secho("# flyte-cli is being deprecated in favor of flytectl. More details about flytectl in https://docs.flyte.org/projects/flytectl/ #", bold=True)
+    _click.secho("################################################################################################################################\n", bold=True)
+    _click.secho("Welcome to Flyte CLI! Version: {}\n".format(_tt(__version__)), bold=True)
 
 
 def _get_user_filepath_home():
@@ -595,7 +598,7 @@ class _FlyteSubCommand(_click.Command):
     "the sub-command's parameter takes precedence.",
 )
 @_insecure_option
-@_click.group("flyte-cli")
+@_click.group("flyte-cli", deprecated=True)
 @_click.pass_context
 def _flyte_cli(ctx, host, config, project, domain, name, insecure):
     """


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Add deprecation notice to `flyte-cli`

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 This is how executions of `flyte-cli` look like now:
```
❯ flyte-cli setup-config --host="localhost:30081" --insecure
...
DeprecationWarning: The command flyte-cli is deprecated.

################################################################################################################################
# flyte-cli is being deprecated in favor of flytectl. More details about flytectl in https://docs.flyte.org/projects/flytectl/ #
################################################################################################################################

Welcome to Flyte CLI! Version: 0.0.0+develop
```

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
