### PR TITLE
Remote entrypoint serialize

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -37,13 +37,20 @@ except ImportError:
 
 from flytekit.clients.helpers import iterate_node_executions, iterate_task_executions
 from flytekit.clis.flyte_cli.main import _detect_default_config_file
+from flytekit.clis.sdk_in_container import serialize
 from flytekit.common import constants
 from flytekit.common.exceptions import user as user_exceptions
 from flytekit.common.translator import FlyteControlPlaneEntity, FlyteLocalEntity, get_serializable
 from flytekit.configuration import auth as auth_config
 from flytekit.configuration.internal import DOMAIN, PROJECT
 from flytekit.core.base_task import PythonTask
-from flytekit.core.context_manager import FlyteContextManager, ImageConfig, SerializationSettings, get_image_config
+from flytekit.core.context_manager import (
+    EntrypointSettings,
+    FlyteContextManager,
+    ImageConfig,
+    SerializationSettings,
+    get_image_config,
+)
 from flytekit.core.data_persistence import FileAccessProvider
 from flytekit.core.launch_plan import LaunchPlan
 from flytekit.core.type_engine import TypeEngine
@@ -527,6 +534,11 @@ class FlyteRemote(object):
                 self.image_config,
                 # https://github.com/flyteorg/flyte/issues/1359
                 env={internal.IMAGE.env_var: self.image_config.default_image.full},
+                entrypoint_settings=EntrypointSettings(
+                    path=os.path.join(
+                        serialize._DEFAULT_FLYTEKIT_VIRTUALENV_ROOT, serialize._DEFAULT_FLYTEKIT_RELATIVE_ENTRYPOINT_LOC
+                    )
+                ),
             ),
             entity=entity,
         )

--- a/plugins/flytekit-spark/tests/test_remote_register.py
+++ b/plugins/flytekit-spark/tests/test_remote_register.py
@@ -1,0 +1,30 @@
+from flytekitplugins.spark import Spark
+from mock import MagicMock, patch
+
+from flytekit import task
+from flytekit.remote.remote import FlyteRemote
+
+
+@patch("flytekit.configuration.platform.URL")
+@patch("flytekit.configuration.platform.INSECURE")
+def test_spark_template_with_remote(mock_insecure, mock_url):
+    @task(task_config=Spark(spark_conf={"spark": "1"}))
+    def my_spark(a: str) -> int:
+        return 10
+
+    mock_url.get.return_value = "localhost"
+
+    mock_insecure.get.return_value = True
+    mock_client = MagicMock()
+
+    remote = FlyteRemote.from_config("p1", "d1")
+
+    remote._image_config = MagicMock()
+    remote._client = mock_client
+
+    remote.register(my_spark)
+    serialized_spec = mock_client.create_task.call_args.kwargs["task_spec"]
+
+    # Check if the serialized task has mainApplicaitonFile field set.
+    assert serialized_spec.template.custom["mainApplicationFile"]
+    assert serialized_spec.template.custom["sparkConf"]


### PR DESCRIPTION
# TL;DR
Added default EntrypointSettings to flyte remote to eliminate the RuntimeError with spark tasks. The settings are similar to what pyflyte package does:https://github.com/flyteorg/flytekit/blob/751425d573d7ef7d2faa20de772b82b147083c5b/flytekit/clis/sdk_in_container/package.py#L137-L139

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/1755

## Follow-up issue
_NA_

