### PR TITLE
Improve Python Package Installation Process on M1 Macs

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -204,7 +204,7 @@ py==1.10.0
     #   -c requirements.txt
     #   pytest
     #   retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via
     #   -c requirements.txt
     #   flytekit

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -231,7 +231,7 @@ py==1.10.0
     # via retry
 py4j==0.10.9.2
     # via pyspark
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 pycparser==2.20
     # via cffi

--- a/plugins/flytekit-aws-athena/requirements.txt
+++ b/plugins/flytekit-aws-athena/requirements.txt
@@ -69,7 +69,7 @@ protobuf==3.17.3
     #   flytekit
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 python-dateutil==2.8.1
     # via

--- a/plugins/flytekit-aws-sagemaker/requirements.txt
+++ b/plugins/flytekit-aws-sagemaker/requirements.txt
@@ -101,7 +101,7 @@ psutil==5.8.0
     # via sagemaker-training
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 pycparser==2.20
     # via cffi

--- a/plugins/flytekit-data-fsspec/requirements.txt
+++ b/plugins/flytekit-data-fsspec/requirements.txt
@@ -71,7 +71,7 @@ protobuf==3.17.3
     #   flytekit
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 python-dateutil==2.8.1
     # via

--- a/plugins/flytekit-dolt/requirements.txt
+++ b/plugins/flytekit-dolt/requirements.txt
@@ -77,7 +77,7 @@ protobuf==3.17.3
     #   flytekit
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 python-dateutil==2.8.1
     # via

--- a/plugins/flytekit-greatexpectations/requirements.txt
+++ b/plugins/flytekit-greatexpectations/requirements.txt
@@ -204,7 +204,7 @@ ptyprocess==0.7.0
     #   terminado
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 pycparser==2.20
     # via cffi

--- a/plugins/flytekit-hive/requirements.txt
+++ b/plugins/flytekit-hive/requirements.txt
@@ -69,7 +69,7 @@ protobuf==3.17.3
     #   flytekit
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 python-dateutil==2.8.1
     # via

--- a/plugins/flytekit-k8s-pod/requirements.txt
+++ b/plugins/flytekit-k8s-pod/requirements.txt
@@ -79,7 +79,7 @@ protobuf==3.17.3
     #   flytekit
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 pyasn1==0.4.8
     # via

--- a/plugins/flytekit-kf-pytorch/requirements.txt
+++ b/plugins/flytekit-kf-pytorch/requirements.txt
@@ -69,7 +69,7 @@ protobuf==3.17.3
     #   flytekit
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 python-dateutil==2.8.1
     # via

--- a/plugins/flytekit-kf-tensorflow/requirements.txt
+++ b/plugins/flytekit-kf-tensorflow/requirements.txt
@@ -69,7 +69,7 @@ protobuf==3.17.3
     #   flytekit
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 python-dateutil==2.8.1
     # via

--- a/plugins/flytekit-modin/requirements.txt
+++ b/plugins/flytekit-modin/requirements.txt
@@ -98,7 +98,7 @@ protobuf==3.18.0
     #   ray
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 pycparser==2.20
     # via cffi

--- a/plugins/flytekit-pandera/requirements.txt
+++ b/plugins/flytekit-pandera/requirements.txt
@@ -76,7 +76,7 @@ protobuf==3.17.3
     #   flytekit
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via
     #   flytekit
     #   pandera

--- a/plugins/flytekit-papermill/requirements.txt
+++ b/plugins/flytekit-papermill/requirements.txt
@@ -173,7 +173,7 @@ py==1.10.0
     # via retry
 py4j==0.10.9
     # via pyspark
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 pygments==2.10.0
     # via

--- a/plugins/flytekit-snowflake/requirements.txt
+++ b/plugins/flytekit-snowflake/requirements.txt
@@ -69,7 +69,7 @@ protobuf==3.17.3
     #   flytekit
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 python-dateutil==2.8.1
     # via

--- a/plugins/flytekit-spark/requirements.txt
+++ b/plugins/flytekit-spark/requirements.txt
@@ -71,7 +71,7 @@ py==1.10.0
     # via retry
 py4j==0.10.9
     # via pyspark
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 pyspark==3.1.2
     # via flytekitplugins-spark

--- a/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/requirements.txt
+++ b/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/requirements.txt
@@ -67,7 +67,7 @@ protobuf==3.17.3
     #   flytekit
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 python-dateutil==2.8.1
     # via

--- a/plugins/flytekit-sqlalchemy/requirements.txt
+++ b/plugins/flytekit-sqlalchemy/requirements.txt
@@ -71,7 +71,7 @@ protobuf==3.17.3
     #   flytekit
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 python-dateutil==2.8.1
     # via

--- a/requirements-spark2.txt
+++ b/requirements-spark2.txt
@@ -206,7 +206,7 @@ py==1.10.0
     # via retry
 py4j==0.10.9.2
     # via pyspark
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 pycparser==2.20
     # via cffi

--- a/requirements.txt
+++ b/requirements.txt
@@ -204,7 +204,7 @@ py==1.10.0
     # via retry
 py4j==0.10.9.2
     # via pyspark
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 pycparser==2.20
     # via cffi

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ elif CURRENT_PYTHON < MIN_PYTHON_VERSION:
 spark = ["pyspark>=2.4.0,<3.0.0"]
 spark3 = ["pyspark>=3.0.0"]
 sidecar = ["k8s-proto>=0.0.3,<1.0.0"]
-schema = ["numpy>=1.14.0,<2.0.0", "pandas>=0.22.0,<2.0.0", "pyarrow>2.0.0,<4.0.0"]
+schema = ["numpy>=1.14.0,<2.0.0", "pandas>=0.22.0,<2.0.0", "pyarrow>=6.0.0,<7.0.0"]
 hive_sensor = ["hmsclient>=0.0.1,<1.0.0"]
 notebook = ["papermill>=1.2.0", "nbconvert>=6.0.7", "ipykernel>=5.0.0,<6.0.0"]
 sagemaker = ["sagemaker-training>=3.6.2,<4.0.0"]
@@ -67,7 +67,7 @@ setup(
         "flyteidl>=0.21.4",
         "wheel>=0.30.0,<1.0.0",
         "pandas>=1.0.0,<2.0.0",
-        "pyarrow>=2.0.0,<4.0.0",
+        "pyarrow>=6.0.0,<7.0.0",
         "click>=6.6,<8.0",
         "croniter>=0.3.20,<4.0.0",
         "deprecated>=1.0,<2.0",

--- a/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
+++ b/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
@@ -89,7 +89,7 @@ protobuf==3.19.0
     #   flytekit
 py==1.10.0
     # via retry
-pyarrow==3.0.0
+pyarrow==6.0.0
     # via flytekit
 pycparser==2.20
     # via cffi


### PR DESCRIPTION
# TL;DR
Updates the `pyarrow` dependency to 6.0.0 for easier `flytekit` installation on M1 macs. 

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

Previously, installation on M1 macs required `pyarrow` to be built from source since no prebuilt arm64 wheels were available for the 3.0.0 version. This build, in turn, depended on the 3.0.0 version of the [Apache Arrow](https://github.com/apache/arrow) library (`pyarrow`'s build system had breaking changes between 3.0.0 and 4.0.0). Apache Arrow can be installed via `brew`, but only the 6.0.0 version is currently available. This meant that users had to _also_ build the Apache Arrow library from source (and remember to set the correct `LDFLAGS` and `CFLAGS`, etc.) prior to building `pyarrow`. 

Since `pyarrow` version 6.0.0 includes prebuilt wheels for the arm64 architecture, simply upgrading the `pyarrow` dependency version to 6.0.0 elides the above steps, yielding a much more pleasant `flytekit` installation experience. 


## Tracking Issue
_NA_

## Follow-up issue
_NA_
