### PR TITLE
update pyarrow version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -60,7 +60,6 @@ cryptography==35.0.0
     # via
     #   -c requirements.txt
     #   paramiko
-    #   secretstorage
 dataclasses-json==0.5.6
     # via
     #   -c requirements.txt
@@ -121,11 +120,6 @@ importlib-metadata==4.8.1
     #   keyring
 iniconfig==1.1.1
     # via pytest
-jeepney==0.7.1
-    # via
-    #   -c requirements.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.0.2
     # via
     #   -c requirements.txt
@@ -173,7 +167,7 @@ natsort==8.0.0
     #   flytekit
 nodeenv==1.6.0
     # via pre-commit
-numpy==1.21.3
+numpy==1.21.4
     # via
     #   -c requirements.txt
     #   pandas
@@ -282,10 +276,6 @@ retry==0.9.2
     # via
     #   -c requirements.txt
     #   flytekit
-secretstorage==3.3.1
-    # via
-    #   -c requirements.txt
-    #   keyring
 six==1.16.0
     # via
     #   -c requirements.txt

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -10,6 +10,10 @@ alabaster==0.7.12
     # via sphinx
 ansiwrap==0.8.4
     # via papermill
+appnope==0.1.2
+    # via
+    #   ipykernel
+    #   ipython
 astroid==2.8.4
     # via sphinx-autoapi
 attrs==21.2.0
@@ -29,9 +33,9 @@ black==21.10b0
     # via papermill
 bleach==4.1.0
     # via nbconvert
-boto3==1.19.11
+boto3==1.19.12
     # via sagemaker-training
-botocore==1.22.11
+botocore==1.22.12
     # via
     #   boto3
     #   s3transfer
@@ -60,7 +64,6 @@ cryptography==35.0.0
     # via
     #   -r doc-requirements.in
     #   paramiko
-    #   secretstorage
 css-html-js-minify==2.5.5
     # via sphinx-material
 dataclasses-json==0.5.6
@@ -120,10 +123,6 @@ ipython-genutils==0.2.0
     #   nbformat
 jedi==0.18.0
     # via ipython
-jeepney==0.7.1
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.0.2
     # via
     #   nbconvert
@@ -133,7 +132,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-jsonschema==4.2.0
+jsonschema==4.2.1
     # via nbformat
 jupyter-client==7.0.6
     # via
@@ -190,7 +189,7 @@ nest-asyncio==1.5.1
     # via
     #   jupyter-client
     #   nbclient
-numpy==1.21.3
+numpy==1.21.4
     # via
     #   flytekit
     #   pandas
@@ -300,8 +299,6 @@ sagemaker-training==3.9.2
     # via flytekit
 scipy==1.7.1
     # via sagemaker-training
-secretstorage==3.3.1
-    # via keyring
 six==1.16.0
     # via
     #   bcrypt

--- a/requirements-spark2.txt
+++ b/requirements-spark2.txt
@@ -10,6 +10,10 @@
     #   -r requirements-spark2.in
 ansiwrap==0.8.4
     # via papermill
+appnope==0.1.2
+    # via
+    #   ipykernel
+    #   ipython
 attrs==20.3.0
     # via
     #   -c requirements.in
@@ -22,9 +26,9 @@ black==21.10b0
     # via papermill
 bleach==4.1.0
     # via nbconvert
-boto3==1.19.11
+boto3==1.19.12
     # via sagemaker-training
-botocore==1.22.11
+botocore==1.22.12
     # via
     #   boto3
     #   s3transfer
@@ -50,9 +54,7 @@ cloudpickle==2.0.0
 croniter==1.0.15
     # via flytekit
 cryptography==35.0.0
-    # via
-    #   paramiko
-    #   secretstorage
+    # via paramiko
 dataclasses-json==0.5.6
     # via flytekit
 decorator==5.1.0
@@ -100,10 +102,6 @@ ipython-genutils==0.2.0
     #   nbformat
 jedi==0.18.0
     # via ipython
-jeepney==0.7.1
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.0.2
     # via nbconvert
 jmespath==0.10.0
@@ -165,7 +163,7 @@ nest-asyncio==1.5.1
     # via
     #   jupyter-client
     #   nbclient
-numpy==1.21.3
+numpy==1.21.4
     # via
     #   flytekit
     #   pandas
@@ -267,8 +265,6 @@ sagemaker-training==3.9.2
     # via flytekit
 scipy==1.7.1
     # via sagemaker-training
-secretstorage==3.3.1
-    # via keyring
 six==1.16.0
     # via
     #   bcrypt

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,10 @@
     # via -r requirements.in
 ansiwrap==0.8.4
     # via papermill
+appnope==0.1.2
+    # via
+    #   ipykernel
+    #   ipython
 attrs==20.3.0
     # via
     #   -r requirements.in
@@ -20,9 +24,9 @@ black==21.10b0
     # via papermill
 bleach==4.1.0
     # via nbconvert
-boto3==1.19.11
+boto3==1.19.12
     # via sagemaker-training
-botocore==1.22.11
+botocore==1.22.12
     # via
     #   boto3
     #   s3transfer
@@ -48,9 +52,7 @@ cloudpickle==2.0.0
 croniter==1.0.15
     # via flytekit
 cryptography==35.0.0
-    # via
-    #   paramiko
-    #   secretstorage
+    # via paramiko
 dataclasses-json==0.5.6
     # via flytekit
 decorator==5.1.0
@@ -98,10 +100,6 @@ ipython-genutils==0.2.0
     #   nbformat
 jedi==0.18.0
     # via ipython
-jeepney==0.7.1
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.0.2
     # via nbconvert
 jmespath==0.10.0
@@ -163,7 +161,7 @@ nest-asyncio==1.5.1
     # via
     #   jupyter-client
     #   nbclient
-numpy==1.21.3
+numpy==1.21.4
     # via
     #   flytekit
     #   pandas
@@ -265,8 +263,6 @@ sagemaker-training==3.9.2
     # via flytekit
 scipy==1.7.1
     # via sagemaker-training
-secretstorage==3.3.1
-    # via keyring
 six==1.16.0
     # via
     #   bcrypt

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ elif CURRENT_PYTHON < MIN_PYTHON_VERSION:
 spark = ["pyspark>=2.4.0,<3.0.0"]
 spark3 = ["pyspark>=3.0.0"]
 sidecar = ["k8s-proto>=0.0.3,<1.0.0"]
-schema = ["numpy>=1.14.0,<2.0.0", "pandas>=0.22.0,<2.0.0", "pyarrow>2.0.0,<4.0.0"]
+schema = ["numpy>=1.14.0,<2.0.0", "pandas>=0.22.0,<2.0.0", "pyarrow>2.0.0,<=6.0.0"]
 hive_sensor = ["hmsclient>=0.0.1,<1.0.0"]
 notebook = ["papermill>=1.2.0", "nbconvert>=6.0.7", "ipykernel>=5.0.0,<6.0.0"]
 sagemaker = ["sagemaker-training>=3.6.2,<4.0.0"]

--- a/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
+++ b/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
@@ -8,16 +8,12 @@ attrs==21.2.0
     # via scantree
 certifi==2021.10.8
     # via requests
-cffi==1.15.0
-    # via cryptography
 charset-normalizer==2.0.7
     # via requests
 click==7.1.2
     # via flytekit
 croniter==1.0.15
     # via flytekit
-cryptography==35.0.0
-    # via secretstorage
 cycler==0.11.0
     # via matplotlib
 dataclasses-json==0.5.6
@@ -44,10 +40,6 @@ idna==3.3
     # via requests
 importlib-metadata==4.8.1
     # via keyring
-jeepney==0.7.1
-    # via
-    #   keyring
-    #   secretstorage
 joblib==1.1.0
     # via -r tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.in
 keyring==23.2.1
@@ -69,7 +61,7 @@ mypy-extensions==0.4.3
     # via typing-inspect
 natsort==8.0.0
     # via flytekit
-numpy==1.21.3
+numpy==1.21.4
     # via
     #   matplotlib
     #   opencv-python
@@ -91,8 +83,6 @@ py==1.11.0
     # via retry
 pyarrow==3.0.0
     # via flytekit
-pycparser==2.20
-    # via cffi
 pyparsing==3.0.4
     # via matplotlib
 python-dateutil==2.8.1
@@ -121,8 +111,6 @@ retry==0.9.2
     # via flytekit
 scantree==0.0.1
     # via dirhash
-secretstorage==3.3.1
-    # via keyring
 six==1.16.0
     # via
     #   flytekit


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

# TL;DR

Need to update the pyarrow version max, as there's a conflict with the feast plugin:
```
Could not find a version that matches pyarrow<4.0.0,>=2.0.0,>=4.0.0 (from flytekit==0.23.1->-r requirements.in (line 1))
Tried: 0.9.0, 0.10.0, 0.11.0, 0.11.1, 0.12.0, 0.12.1, 0.13.0, 0.14.0, 0.15.1, 0.16.0, 0.16.0, 0.17.0, 0.17.0, 0.17.1, 0.17.1, 1.0.0, 1.0.0, 1.0.1, 1.0.1, 2.0.0, 2.0.0, 2.0.0, 3.0.0, 3.0.0, 3.0.0, 4.0.0, 4.0.0, 4.0.0, 4.0.1, 4.0.1, 4.0.1, 5.0.0, 5.0.0, 5.0.0, 6.0.0, 6.0.0, 6.0.0
There are incompatible versions in the resolved dependencies:
  pyarrow>=4.0.0 (from feast[aws]==0.14.1->-r requirements.in (line 4))
  pyarrow<4.0.0,>=2.0.0 (from flytekit==0.23.1->-r requirements.in (line 1))
```

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

There are new versions of pyarrow available but flytekit sets a max for pyarrow<4.0.0

## Tracking Issue
NA

## Follow-up issue
NA