### PR TITLE
Add module name parameter for workflows and tasks

### DIFF
--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -112,6 +112,8 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):
         :param Optional[ExecutionBehavior] execution_mode: Defines how the execution should behave, for example
             executing normally or specially handling a dynamic case.
         :param Optional[TaskResolverMixin] task_type: String task type to be associated with this Task
+        :param module_name: Explicitly pass which module the workflow belongs to, can be used to override default
+            __main__.<workflow name>
         """
         if task_function is None:
             raise ValueError("TaskFunction is a required parameter for PythonFunctionTask")

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -101,6 +101,7 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):
         ignore_input_vars: Optional[List[str]] = None,
         execution_mode: Optional[ExecutionBehavior] = ExecutionBehavior.DEFAULT,
         task_resolver: Optional[TaskResolverMixin] = None,
+        module_name: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -117,10 +118,11 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):
         self._native_interface = transform_signature_to_interface(
             inspect.signature(task_function), Docstring(callable_=task_function)
         )
+        self._module_name = module_name
         mutated_interface = self._native_interface.remove_inputs(ignore_input_vars)
         super().__init__(
             task_type=task_type,
-            name=f"{task_function.__module__}.{task_function.__name__}",
+            name=f"{module_name or task_function.__module__}.{task_function.__name__}",
             interface=mutated_interface,
             task_config=task_config,
             task_resolver=task_resolver,
@@ -149,6 +151,10 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):
     @property
     def execution_mode(self) -> ExecutionBehavior:
         return self._execution_mode
+
+    @property
+    def module_name(self) -> Optional[str]:
+        return self._module_name
 
     @property
     def task_function(self):

--- a/flytekit/core/task.py
+++ b/flytekit/core/task.py
@@ -87,6 +87,7 @@ def task(
     limits: Optional[Resources] = None,
     secret_requests: Optional[List[Secret]] = None,
     execution_mode: Optional[PythonFunctionTask.ExecutionBehavior] = PythonFunctionTask.ExecutionBehavior.DEFAULT,
+    module_name: Optional[str] = None,
 ) -> Union[Callable, PythonFunctionTask]:
     """
     This is the core decorator to use for any task type in flytekit.
@@ -192,6 +193,7 @@ def task(
             limits=limits,
             secret_requests=secret_requests,
             execution_mode=execution_mode,
+            module_name=module_name,
         )
 
         return task_instance

--- a/flytekit/core/task.py
+++ b/flytekit/core/task.py
@@ -171,6 +171,8 @@ def task(
                      Refer to :py:class:`Secret` to understand how to specify the request for a secret. It
                      may change based on the backend provider.
     :param execution_mode: This is mainly for internal use. Please ignore. It is filled in automatically.
+    :param module_name: Explicitly pass which module the workflow belongs to, can be used to override default
+                     __main__.<workflow name>
     """
 
     def wrapper(fn) -> PythonFunctionTask:

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -28,7 +28,10 @@ class InstanceTrackingMeta(type):
 
     def __call__(cls, *args, **kwargs):
         o = super(InstanceTrackingMeta, cls).__call__(*args, **kwargs)
-        o._instantiated_in = InstanceTrackingMeta._find_instance_module()
+        if hasattr(o, "_module_name"):
+            o._instantiated_in = o._module_name
+        else:
+            o._instantiated_in = InstanceTrackingMeta._find_instance_module()
         return o
 
 

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -579,6 +579,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
         docstring: Docstring = None,
         module_name: Optional[str] = None,
     ):
+        # If module name is passed explicitly use that instead of workflow_function.__module__
         name = f"{module_name or workflow_function.__module__}.{workflow_function.__name__}"
         self._workflow_function = workflow_function
         native_interface = transform_signature_to_interface(inspect.signature(workflow_function), docstring=docstring)
@@ -726,6 +727,8 @@ def workflow(
     :param _workflow_function: This argument is implicitly passed and represents the decorated function.
     :param failure_policy: Use the options in flytekit.WorkflowFailurePolicy
     :param interruptible: Whether or not tasks launched from this workflow are by default interruptible
+    :param module_name: Explicitly pass which module the workflow belongs to, can be used to override default
+        __main__.<workflow name>
     """
 
     def wrapper(fn):

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -167,7 +167,7 @@ class WorkflowBase(object):
         workflow_metadata: WorkflowMetadata,
         workflow_metadata_defaults: WorkflowMetadataDefaults,
         python_interface: Interface,
-        module_name: Optional[str],
+        module_name: Optional[str] = None,
         **kwargs,
     ):
         self._name = name
@@ -698,7 +698,7 @@ def workflow(
     _workflow_function=None,
     failure_policy: Optional[WorkflowFailurePolicy] = None,
     interruptible: bool = False,
-    module_name: str = None,
+    module_name: Optional[str] = None,
 ):
     """
     This decorator declares a function to be a Flyte workflow. Workflows are declarative entities that construct a DAG

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -96,3 +96,21 @@ def test_metadata():
     metadata = foo.metadata
     assert metadata.cache is True
     assert metadata.cache_version == "1.0"
+
+
+def test_module_name():
+    # Test if the flyte tasks can be registered with overwritten module names
+    @task(cache=True, cache_version="1.0")
+    def foo(i: str):
+        print(f"{i}")
+
+    @task(cache=True, cache_version="1.0", module_name="flytedemo.workflows.example")
+    def bar(i: str):
+        print(f"{i}")
+
+    assert foo.name != bar.name
+    # Should be the module name the tests are called
+    assert __name__ in foo.name
+    assert __name__ not in bar.name
+    assert foo._module_name is None
+    assert bar._module_name is not None

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -3,6 +3,7 @@ import os
 import pytest
 from mock import MagicMock, patch
 
+from flytekit import task, workflow
 from flytekit.common.exceptions import user as user_exceptions
 from flytekit.configuration import internal
 from flytekit.models import common as common_models
@@ -19,7 +20,7 @@ from flytekit.models.launch_plan import LaunchPlan
 from flytekit.models.node_execution import NodeExecution, NodeExecutionMetaData
 from flytekit.models.task import Task
 from flytekit.models.types import LiteralType, SimpleType
-from flytekit.remote import FlyteWorkflow, workflow
+from flytekit.remote import FlyteWorkflow
 from flytekit.remote.remote import FlyteRemote
 
 CLIENT_METHODS = {
@@ -273,9 +274,6 @@ def test_explicit_grpc_channel_credentials(mock_insecure, mock_url, mock_secure_
 @patch("flytekit.configuration.platform.URL")
 @patch("flytekit.configuration.platform.INSECURE")
 def test_explicit_module_name(mock_insecure, mock_url):
-
-    from flytekit import task, workflow
-
     custom_module_name = "flytedemo.workflows.tester"
 
     version = "v1"
@@ -318,8 +316,6 @@ def test_explicit_module_name(mock_insecure, mock_url):
 @patch("flytekit.configuration.platform.URL")
 @patch("flytekit.configuration.platform.INSECURE")
 def test_missing_explicit_module_name(mock_insecure, mock_url):
-
-    from flytekit import task, workflow
 
     custom_module_name = "flytedemo.workflows.tester"
 


### PR DESCRIPTION
# TL;DR
This PR adds an optional parameter to workflow and task types to make the module name explicitly available.

```python
@task(
    cache_version="1",
    container_image="{{.images.default.fqn}}:{{.images.default.version}}",
    module_name="<app.workflows.workflow_file>",
)
def my_task() -> None:
...

...
@workflow(module_name="<app.workflows.workflow_file>")
def my_workflow() -> None:
```

So that it can be avoided that the workflows and tasks default to `__main__.my_task` and `__main__.my_workflow`, by overriding module name in tasks and workflows

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [X] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Added extra optional parameter `module_name` to workflow and task definitions.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1813

## Follow-up issue
_NA_
