### PR TITLE
Support enum in dataclass

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -17,7 +17,6 @@ from google.protobuf import struct_pb2 as _struct
 from google.protobuf.json_format import MessageToDict as _MessageToDict
 from google.protobuf.json_format import ParseDict as _ParseDict
 from google.protobuf.struct_pb2 import Struct
-from marshmallow import fields
 from marshmallow_enum import EnumField, LoadDumpOptions
 from marshmallow_jsonschema import JSONSchema
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -17,6 +17,7 @@ from google.protobuf import struct_pb2 as _struct
 from google.protobuf.json_format import MessageToDict as _MessageToDict
 from google.protobuf.json_format import ParseDict as _ParseDict
 from google.protobuf.struct_pb2 import Struct
+from marshmallow_enum import LoadDumpOptions
 from marshmallow_jsonschema import JSONSchema
 
 from flytekit.common.exceptions import user as user_exceptions
@@ -226,7 +227,9 @@ class DataclassTransformer(TypeTransformer[object]):
             )
         schema = None
         try:
-            schema = JSONSchema().dump(cast(DataClassJsonMixin, t).schema())
+            s = cast(DataClassJsonMixin, t).schema()
+            s.fields["y"].load_by = LoadDumpOptions.name
+            schema = JSONSchema().dump(s)
         except Exception as e:
             logger.warn("failed to extract schema for object %s, (will run schemaless) error: %s", str(t), e)
 
@@ -777,6 +780,7 @@ def convert_json_schema_to_python_class(schema: dict, schema_name) -> Type[datac
     :param schema: dict representing valid JSON schema
     :param schema_name: dataclass name of return type
     """
+    print(schema)
     attribute_list = []
     for property_key, property_val in schema[schema_name]["properties"].items():
         # Handle list

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -556,9 +556,6 @@ def test_enum_in_dataclass():
         x: int
         y: Color
 
-        def __str__(self):
-            return self.value
-
     lt = TypeEngine.to_literal_type(Datum)
     schema = Datum.schema()
     schema.fields["y"].load_by = LoadDumpOptions.name

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import typing
-from ctypes import cast
 from dataclasses import asdict, dataclass
 from datetime import timedelta
 from enum import Enum

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import typing
+from ctypes import cast
 from dataclasses import asdict, dataclass
 from datetime import timedelta
 from enum import Enum
@@ -10,6 +11,7 @@ from dataclasses_json import DataClassJsonMixin, dataclass_json
 from flyteidl.core import errors_pb2
 from google.protobuf import json_format as _json_format
 from google.protobuf import struct_pb2 as _struct
+from marshmallow_enum import LoadDumpOptions
 from marshmallow_jsonschema import JSONSchema
 
 from flytekit.common.exceptions import user as user_exceptions
@@ -545,6 +547,31 @@ def test_enum_type():
 
     with pytest.raises(AssertionError):
         TypeEngine.to_literal_type(UnsupportedEnumValues)
+
+
+def test_enum_in_dataclass():
+    @dataclass_json
+    @dataclass
+    class Datum(object):
+        x: int
+        y: Color
+
+        def __str__(self):
+            return self.value
+
+    lt = TypeEngine.to_literal_type(Datum)
+    schema = Datum.schema()
+    schema.fields["y"].load_by = LoadDumpOptions.name
+    assert lt.metadata == JSONSchema().dump(schema)
+
+    transformer = DataclassTransformer()
+    ctx = FlyteContext.current_context()
+    datum = Datum(5, Color.RED)
+    lv = transformer.to_literal(ctx, datum, Datum, lt)
+    gt = transformer.guess_python_type(lt)
+    pv = transformer.to_python_value(ctx, lv, expected_python_type=gt)
+    assert datum.x == pv.x
+    assert datum.y.value == pv.y
 
 
 @pytest.mark.parametrize(

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -6,6 +6,7 @@ import random
 import typing
 from collections import OrderedDict
 from dataclasses import dataclass
+from enum import Enum
 
 import pandas
 import pytest
@@ -1061,6 +1062,29 @@ def test_dataclass_more():
         return add(x=stringify(x=x), y=stringify(x=y))
 
     wf(x=10, y=20)
+
+
+def test_enum_in_dataclass():
+    class Color(Enum):
+        RED = "red"
+        GREEN = "green"
+        BLUE = "blue"
+
+    @dataclass_json
+    @dataclass
+    class Datum(object):
+        x: int
+        y: Color
+
+    @task
+    def t1(x: int) -> Datum:
+        return Datum(x=x, y=Color.RED)
+
+    @workflow
+    def wf(x: int) -> Datum:
+        return t1(x=x)
+
+    assert wf(x=10) == Datum(10, Color.RED)
 
 
 def test_environment():


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
change the `load_by` value in the enum field so that we can dump JSON Schema from dataclass which has enum inside it.
otherwise, we will get the following errors from `marshmallow_jsonschema`
```
    value = field_obj.serialize(attr_name, obj, accessor=self.get_attribute)
  File "/Users/kevin/opt/anaconda3/envs/flytekit-3.8/lib/python3.8/site-packages/marshmallow/fields.py", line 338, in serialize
    return self._serialize(value, attr, obj, **kwargs)
  File "/Users/kevin/opt/anaconda3/envs/flytekit-3.8/lib/python3.8/site-packages/marshmallow/fields.py", line 1864, in _serialize
    return self._serialize_method(obj)
  File "/Users/kevin/opt/anaconda3/envs/flytekit-3.8/lib/python3.8/site-packages/marshmallow_jsonschema/base.py", line 163, in get_properties
    schema = self._get_schema_for_field(obj, field)
  File "/Users/kevin/opt/anaconda3/envs/flytekit-3.8/lib/python3.8/site-packages/marshmallow_jsonschema/base.py", line 267, in _get_schema_for_field
    schema = self._from_python_type(obj, field, pytype)
  File "/Users/kevin/opt/anaconda3/envs/flytekit-3.8/lib/python3.8/site-packages/marshmallow_jsonschema/base.py", line 194, in _from_python_type
    json_schema["enum"] = self._get_enum_values(field)
  File "/Users/kevin/opt/anaconda3/envs/flytekit-3.8/lib/python3.8/site-packages/marshmallow_jsonschema/base.py", line 226, in _get_enum_values
    raise NotImplementedError(
NotImplementedError: Currently do not support JSON schema for enums loaded by value
```
## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1514

## Follow-up issue
_NA_