### PR TITLE
Rich Docstring Metadata

### DIFF
--- a/flytekit/core/annotation.py
+++ b/flytekit/core/annotation.py
@@ -1,0 +1,27 @@
+from typing import Any, Dict
+
+
+class FlyteAnnotation:
+    """A core object to add arbitrary annotations to flyte types.
+
+    This metadata is ingested as a python dictionary and will be serialized
+    into fields on the flyteidl type literals. This data is not accessible at
+    runtime but rather can be retrieved from flyteadmin for custom presentation
+    of typed parameters.
+
+    For a task definition:
+
+    .. code-block:: python
+
+        @task
+        def x(a: typing.Annotated[int, FlyteAnnotation({"foo": {"bar": 1}})]):
+            return
+
+    """
+
+    def __init__(self, data: Dict[str, Any]):
+        self._data = data
+
+    @property
+    def data(self):
+        return self._data

--- a/flytekit/core/docstring.py
+++ b/flytekit/core/docstring.py
@@ -1,27 +1,125 @@
-from typing import Callable, Dict, Optional
+import re
+from typing import Any, Dict, Union
 
-from docstring_parser import parse
+import yaml
+from docstring_parser import parse as _parse
+from docstring_parser.common import Docstring
 
 
-class Docstring(object):
-    def __init__(self, docstring: str = None, callable_: Callable = None):
-        if docstring is not None:
-            self._parsed_docstring = parse(docstring)
-        else:
-            self._parsed_docstring = parse(callable_.__doc__)
+def parse_docstring(x: Union[str, Any]) -> Docstring:
+    """ """
 
-    @property
-    def input_descriptions(self) -> Dict[str, str]:
-        return {p.arg_name: p.description for p in self._parsed_docstring.params}
+    if isinstance(x, str):
+        return _parse(x)
 
-    @property
-    def output_descriptions(self) -> Dict[str, str]:
-        return {p.return_name: p.description for p in self._parsed_docstring.many_returns}
+    if not hasattr(x, "__doc__"):
+        raise ValueError(f"No docstring found: '{x}'")
 
-    @property
-    def short_description(self) -> Optional[str]:
-        return self._parsed_docstring.short_description
+    return _parse(x.__doc__)
 
-    @property
-    def long_description(self) -> Optional[str]:
-        return self._parsed_docstring.long_description
+
+_yaml_metadata_regex = re.compile(r"(.*)__metadata__:(.*)", re.MULTILINE | re.DOTALL)
+
+
+def param_metadata_from_docstring(doc: Docstring) -> Dict[str, Dict[str, Any]]:
+    """Extracts structured metadata from docstrings.
+
+    The following pieces of information are extracted from the body:
+
+        * short descrption text
+        * long description text
+        * YAML serialized long description metadata
+
+    The following pieces of information are extracted from each parameter
+    described in the docstring
+
+        * name
+        * description
+        * index/order
+        * default value
+        * YAML serialized parameter description metadata
+
+    An example:
+
+    .. code-block:: python
+
+        @task
+        def foo():
+            ""<short description>
+
+            <long description>
+
+            __metadata__:
+                <YAML serialized long description metadata>
+
+            Args:
+                <param name>:
+                    <param description>
+
+                    __metadata__:
+                        <YAML serialized param description metadata>
+            ""
+    """
+
+    res = {}
+    for idx, x in enumerate(doc.params):
+        meta = _yaml_metadata_regex.match(x.description)
+
+        if meta is not None:
+            try:
+                res[x.arg_name] = {
+                    "idx": idx,
+                    "name": x.arg_name,
+                    "default": x.default,
+                    "description": meta.group(1),
+                    "meta": yaml.safe_load(meta.group(2)),
+                }
+            except:
+                pass
+
+        if x.arg_name not in res:
+            res[x.arg_name] = {"idx": idx, "name": x.arg_name, "default": x.default, "description": x.description}
+
+        if idx == 0:
+            if doc.long_description is not None:
+                meta = _yaml_metadata_regex.match(doc.long_description)
+                if meta is not None:
+                    try:
+                        res[x.arg_name]["__workflow_meta__"] = {
+                            "short_description": doc.short_description,
+                            "long_description": meta.group(1),
+                            "meta": yaml.safe_load(meta.group(2)),
+                        }
+                    except:
+                        pass
+
+            if "__workflow_meta__" not in res[x.arg_name]:
+                res[x.arg_name]["__workflow_meta__"] = {
+                    "short_description": doc.short_description,
+                    "long_description": doc.long_description,
+                }
+
+    return res
+
+
+def returns_metadata_from_docstring(doc: Docstring) -> Dict[str, Dict[str, Any]]:
+    res = {}
+    for idx, x in enumerate(doc.many_returns):
+        meta = _yaml_metadata_regex.match(x.description)
+        if meta is not None:
+            try:
+                tmp = {
+                    "idx": idx,
+                    "name": x.return_name,
+                    "description": meta.group(1),
+                    "meta": yaml.safe_load(meta.group(2)),
+                }
+                res[x.return_name] = tmp
+                continue
+            except Exception as e:
+                print(e)
+                pass
+
+        res[x.return_name] = {"idx": idx, "name": x.return_name, "description": x.description}
+
+    return res

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -209,11 +209,11 @@ def transform_interface_to_typed_interface(
         input_descriptions = param_metadata_from_docstring(interface.docstring)
         output_descriptions = returns_metadata_from_docstring(interface.docstring)
 
-    # Single unnamed return value docstring is shared by all return values.
+    # Single return value docstring is shared by all return values.
     if len(output_descriptions) == 1:
         name, desc = next(iter(output_descriptions.items()))
-        if name is None:
-            output_descriptions = {k: output_descriptions.get(k, desc) for k in interface.outputs}
+        stripped_desc = {"idx": 0, "description": desc["description"]}
+        output_descriptions = {k: stripped_desc for k in interface.outputs}
 
     inputs_map = transform_variable_map(interface.inputs, input_descriptions)
     outputs_map = transform_variable_map(interface.outputs, output_descriptions)

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -23,7 +23,7 @@ from typing import Any, Callable, List, Optional, TypeVar, Union
 from flytekit.common.exceptions import scopes as exception_scopes
 from flytekit.core.base_task import Task, TaskResolverMixin
 from flytekit.core.context_manager import ExecutionState, FastSerializationSettings, FlyteContext, FlyteContextManager
-from flytekit.core.docstring import Docstring
+from flytekit.core.docstring import parse_docstring
 from flytekit.core.interface import transform_signature_to_interface
 from flytekit.core.python_auto_container import PythonAutoContainerTask, default_task_resolver
 from flytekit.core.tracker import is_functools_wrapped_module_level, isnested, istestfunction
@@ -115,7 +115,7 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):
         if task_function is None:
             raise ValueError("TaskFunction is a required parameter for PythonFunctionTask")
         self._native_interface = transform_signature_to_interface(
-            inspect.signature(task_function), Docstring(callable_=task_function)
+            inspect.signature(task_function), parse_docstring(task_function)
         )
         mutated_interface = self._native_interface.remove_inputs(ignore_input_vars)
         super().__init__(

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -413,8 +413,8 @@ class TypeEngine(typing.Generic[T]):
 
             # Handling of annotated generics, eg:
             # typing.Annotated[typing.List[int], 'foo']
-            if isinstance(python_type, typing._AnnotatedAlias):
-                return cls.get_transformer(python_type.__origin__)
+            if typing.get_origin(python_type) is typing.Annotated:
+                return cls.get_transformer(typing.get_args(python_type)[0])
 
             if python_type.__origin__ in cls._REGISTRY:
                 return cls._REGISTRY[python_type.__origin__]
@@ -449,8 +449,8 @@ class TypeEngine(typing.Generic[T]):
         transformer = cls.get_transformer(python_type)
         res = transformer.get_literal_type(python_type)
         data = None
-        if hasattr(python_type, "__metadata__"):
-            for x in python_type.__metadata__:
+        if typing.get_origin(python_type) is typing.Annotated:
+            for x in typing.get_args(python_type)[1:]:
                 if not isinstance(x, FlyteAnnotation):
                     continue
                 if x.data.get("__consumed", False):

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -21,11 +21,13 @@ from marshmallow_jsonschema import JSONSchema
 
 from flytekit.common.exceptions import user as user_exceptions
 from flytekit.common.types import primitives as _primitives
+from flytekit.core.annotation import FlyteAnnotation
 from flytekit.core.context_manager import FlyteContext
 from flytekit.core.type_helpers import load_type_from_tag
 from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
 from flytekit.models import types as _type_models
+from flytekit.models.annotation import TypeAnnotation as _annotation_model
 from flytekit.models.core import types as _core_types
 from flytekit.models.literals import Literal, LiteralCollection, LiteralMap, Primitive, Scalar
 from flytekit.models.types import LiteralType, SimpleType
@@ -401,14 +403,22 @@ class TypeEngine(typing.Generic[T]):
             TODO lets make this deterministic by using an ordered dict
 
         """
+
         # Step 1
         if python_type in cls._REGISTRY:
             return cls._REGISTRY[python_type]
 
         # Step 2
         if hasattr(python_type, "__origin__"):
+
+            # Handling of annotated generics, eg:
+            # typing.Annotated[typing.List[int], 'foo']
+            if isinstance(python_type, typing._AnnotatedAlias):
+                return cls.get_transformer(python_type.__origin__)
+
             if python_type.__origin__ in cls._REGISTRY:
                 return cls._REGISTRY[python_type.__origin__]
+
             raise ValueError(f"Generic Type {python_type.__origin__} not supported currently in Flytekit.")
 
         # Step 3
@@ -437,7 +447,29 @@ class TypeEngine(typing.Generic[T]):
         Converts a python type into a flyte specific ``LiteralType``
         """
         transformer = cls.get_transformer(python_type)
-        return transformer.get_literal_type(python_type)
+        res = transformer.get_literal_type(python_type)
+        data = None
+        if hasattr(python_type, "__metadata__"):
+            for x in python_type.__metadata__:
+                if not isinstance(x, FlyteAnnotation):
+                    continue
+                if x.data.get("__consumed", False):
+                    continue
+                data = x.data
+                x.data["__consumed"] = True
+        if data is not None:
+            idl_type_annotation = _annotation_model(annotations=data)
+            return LiteralType(
+                simple=res.simple,
+                schema=res.schema,
+                collection_type=res.collection_type,
+                map_value_type=res.map_value_type,
+                blob=res.blob,
+                enum_type=res.enum_type,
+                metadata=res.metadata,
+                annotation=idl_type_annotation,
+            )
+        return res
 
     @classmethod
     def to_literal(cls, ctx: FlyteContext, python_val: typing.Any, python_type: Type, expected: LiteralType) -> Literal:
@@ -565,9 +597,17 @@ class ListTransformer(TypeTransformer[T]):
         """
         Return the generic Type T of the List
         """
-        if hasattr(t, "__origin__") and t.__origin__ is list:  # type: ignore
-            if hasattr(t, "__args__"):
-                return t.__args__[0]  # type: ignore
+
+        if hasattr(t, "__origin__"):
+
+            # Handle annotation on list generic, eg:
+            # typing.Annotated[typing.List[int, 'foo']]
+            if isinstance(t, typing._AnnotatedAlias) and hasattr(t.__origin__, "__origin__"):
+                return ListTransformer.get_sub_type(t.__origin__)
+
+            if t.__origin__ is list and hasattr(t, "__args__"):
+                return t.__args__[0]
+
         raise ValueError("Only generic univariate typing.List[T] type is supported.")
 
     def get_literal_type(self, t: Type[T]) -> Optional[LiteralType]:

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
+from docstring_parser.common import Docstring
+
 from flytekit.common import constants as _common_constants
 from flytekit.common.exceptions import scopes as exception_scopes
 from flytekit.common.exceptions.user import FlyteValidationException, FlyteValueException
@@ -12,7 +14,7 @@ from flytekit.core.base_task import PythonTask
 from flytekit.core.class_based_resolver import ClassStorageTaskResolver
 from flytekit.core.condition import ConditionalSection
 from flytekit.core.context_manager import CompilationState, FlyteContext, FlyteContextManager, FlyteEntities
-from flytekit.core.docstring import Docstring
+from flytekit.core.docstring import parse_docstring
 from flytekit.core.interface import (
     Interface,
     transform_inputs_to_parameters,
@@ -728,7 +730,7 @@ def workflow(
             fn,
             metadata=workflow_metadata,
             default_metadata=workflow_metadata_defaults,
-            docstring=Docstring(callable_=fn),
+            docstring=parse_docstring(fn),
         )
         workflow_instance.compile()
         return workflow_instance

--- a/flytekit/models/annotation.py
+++ b/flytekit/models/annotation.py
@@ -1,0 +1,45 @@
+import json as _json
+from typing import Any, Dict
+
+from flyteidl.core import types_pb2 as _types_pb2
+from google.protobuf import json_format as _json_format
+from google.protobuf import struct_pb2 as _struct
+
+
+class TypeAnnotation:
+    """Python class representation of the flyteidl TypeAnnotation message."""
+
+    def __init__(self, annotations: Dict[str, Any]):
+        self._annotations = annotations
+
+    @property
+    def annotations(self) -> Dict[str, Any]:
+        """
+        :rtype: dict[str, Any]
+        """
+        return self._annotations
+
+    def to_flyte_idl(self) -> _types_pb2.TypeAnnotation:
+        """
+        :rtype: flyteidl.core.types_pb2.TypeAnnotation
+        """
+
+        if self._annotations is not None:
+            annotations = _json_format.Parse(_json.dumps(self.annotations), _struct.Struct())
+        else:
+            annotations = None
+
+        t = _types_pb2.TypeAnnotation(
+            annotations=annotations,
+        )
+
+        return t
+
+    @classmethod
+    def from_flyte_idl(cls, proto):
+        """
+        :param flyteidl.core.types_pb2.TypeAnnotation proto:
+        :rtype: TypeAnnotation
+        """
+
+        return cls(annotations=proto.annotations)

--- a/flytekit/models/types.py
+++ b/flytekit/models/types.py
@@ -5,6 +5,7 @@ from google.protobuf import json_format as _json_format
 from google.protobuf import struct_pb2 as _struct
 
 from flytekit.models import common as _common
+from flytekit.models.annotation import TypeAnnotation as _annotation_model
 from flytekit.models.core import types as _core_types
 
 
@@ -108,6 +109,7 @@ class LiteralType(_common.FlyteIdlEntity):
         blob=None,
         enum_type=None,
         metadata=None,
+        annotation=None,
     ):
         """
         This is a oneof message, only one of the kwargs may be set, representing one of the Flyte types.
@@ -120,6 +122,8 @@ class LiteralType(_common.FlyteIdlEntity):
         :param flytekit.models.core.types.BlobType blob: For blob objects, this describes the type.
         :param flytekit.models.core.types.EnumType enum_type: For enum objects, describes an enum
         :param dict[Text, T] metadata: Additional data describing the type
+        :param flytekit.models.annotation.FlyteAnnotation annotation: Additional data
+            describing the type _intended to be saturated by the client_
         """
         self._simple = simple
         self._schema = schema
@@ -128,6 +132,7 @@ class LiteralType(_common.FlyteIdlEntity):
         self._blob = blob
         self._enum_type = enum_type
         self._metadata = metadata
+        self._annotation = annotation
 
     @property
     def simple(self) -> SimpleType:
@@ -166,18 +171,31 @@ class LiteralType(_common.FlyteIdlEntity):
         """
         return self._metadata
 
+    @property
+    def annotation(self) -> _annotation_model:
+        """
+        :rtype: flytekit.models.annotation.FlyteAnnotation
+        """
+        return self._annotation
+
     @metadata.setter
     def metadata(self, value):
         self._metadata = value
+
+    @annotation.setter
+    def annotation(self, value):
+        self.annotation = value
 
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.core.types_pb2.LiteralType
         """
+
         if self.metadata is not None:
             metadata = _json_format.Parse(_json.dumps(self.metadata), _struct.Struct())
         else:
             metadata = None
+
         t = _types_pb2.LiteralType(
             simple=self.simple if self.simple is not None else None,
             schema=self.schema.to_flyte_idl() if self.schema is not None else None,
@@ -186,6 +204,7 @@ class LiteralType(_common.FlyteIdlEntity):
             blob=self.blob.to_flyte_idl() if self.blob is not None else None,
             enum_type=self.enum_type.to_flyte_idl() if self.enum_type else None,
             metadata=metadata,
+            annotation=self.annotation.to_flyte_idl() if self.annotation else None,
         )
         return t
 
@@ -209,6 +228,7 @@ class LiteralType(_common.FlyteIdlEntity):
             blob=_core_types.BlobType.from_flyte_idl(proto.blob) if proto.HasField("blob") else None,
             enum_type=_core_types.EnumType.from_flyte_idl(proto.enum_type) if proto.HasField("enum_type") else None,
             metadata=_json_format.MessageToDict(proto.metadata) or None,
+            annotation=_annotation_model.from_flyte_idl(proto.annotation) if proto.HasField("annotation") else None,
         )
 
 

--- a/tests/flytekit/unit/core/test_typing_annotation.py
+++ b/tests/flytekit/unit/core/test_typing_annotation.py
@@ -1,0 +1,61 @@
+import typing
+from collections import OrderedDict
+
+from flytekit.common.translator import get_serializable
+from flytekit.core import context_manager
+from flytekit.core.annotation import FlyteAnnotation
+from flytekit.core.context_manager import Image, ImageConfig
+from flytekit.core.task import task
+from flytekit.models.annotation import TypeAnnotation
+
+default_img = Image(name="default", fqn="test", tag="tag")
+serialization_settings = context_manager.SerializationSettings(
+    project="project",
+    domain="domain",
+    version="version",
+    env=None,
+    image_config=ImageConfig(default_image=default_img, images=[default_img]),
+)
+entity_mapping = OrderedDict()
+
+
+@task
+def x(a: typing.Annotated[int, FlyteAnnotation({"foo": {"bar": 1}})], b: str):
+    ...
+
+
+@task
+def y0(a: typing.List[typing.Annotated[int, FlyteAnnotation({"foo": {"bar": 1}})]]):
+    ...
+
+
+@task
+def y1(a: typing.Annotated[typing.List[int], FlyteAnnotation({"foo": {"bar": 1}})]):
+    ...
+
+
+def test_get_variable_descriptions():
+
+    x_tsk = get_serializable(entity_mapping, serialization_settings, x)
+    x_input_vars = x_tsk.template.interface.inputs
+
+    a_ann = x_input_vars["a"].type.annotation
+    assert isinstance(a_ann, TypeAnnotation)
+    assert a_ann.annotations["foo"] == {"bar": 1}
+
+    b_ann = x_input_vars["b"].type.annotation
+    assert b_ann is None
+
+    # Annotated simple type within list generic
+    y0_tsk = get_serializable(entity_mapping, serialization_settings, y0)
+    y0_input_vars = y0_tsk.template.interface.inputs
+    y0_a_ann = y0_input_vars["a"].type.collection_type.annotation
+    assert isinstance(y0_a_ann, TypeAnnotation)
+    assert y0_a_ann.annotations["foo"] == {"bar": 1}
+
+    # Annotated list generic
+    y1_tsk = get_serializable(entity_mapping, serialization_settings, y1)
+    y1_input_vars = y1_tsk.template.interface.inputs
+    y1_a_ann = y1_input_vars["a"].type.annotation
+    assert isinstance(y1_a_ann, TypeAnnotation)
+    assert y1_a_ann.annotations["foo"] == {"bar": 1}


### PR DESCRIPTION
# Rich Docstring Metadata

Expanded support for docstring metadata

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ x ] Code completed
 - [ ] Smoke tested
 - [ x ] Unit tests added (only updated interface tests so team can see some examples)
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

The following pieces of information are extracted from the body:

    * short descrption text
    * long description text
    * YAML serialized long description metadata

The following pieces of information are extracted from each parameter
described in the docstring

    * name
    * description
    * index/order
    * default value
    * YAML serialized parameter description metadata

An example:

```
    @task
    def foo():
        ""<short description>

        <long description>

        __metadata__:
            <YAML serialized long description metadata>

        Args:
            <param name>:
                <param description>

                __metadata__:
                    <YAML serialized param description metadata>
        """
```

## Tracking Issue

https://github.com/flyteorg/flyte/pull/1856