### PR TITLE
remote_source lost on serialization of @dataclass_json with FlyteFile

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -287,8 +287,12 @@ class DataclassTransformer(TypeTransformer[object]):
                 lv = TypeEngine.to_literal(FlyteContext.current_context(), v, field_type, None)
                 # dataclass_json package will extract the "path" from FlyteFile, FlyteDirectory, and write it to a
                 # JSON which will be stored in IDL. The path here should always be a remote path, but sometimes the
-                # path in FlyteFile and FlyteDirectory could be a local path. Therefore, We reset the python value here,
+                # path in FlyteFile and FlyteDirectory could be a local path. Therefore, reset the python value here,
                 # so that dataclass_json can always get a remote path.
+                # In other words, the file transformer has special code that handles the fact that if remote_source is
+                # set, then the real uri in the literal should be the remote source, not the path (which may be an
+                # auto-generated random local path). To be sure we're writing the right path to the json, use the uri
+                # as determined by the transformer.
                 if issubclass(field_type, FlyteFile) or issubclass(field_type, FlyteDirectory):
                     python_val.__setattr__(f.name, field_type(path=lv.scalar.blob.uri))
 

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -369,13 +369,25 @@ def test_flyte_file_in_dataclass():
         fs = FileStruct(a=file, b=InnerFileStruct(a=file, b=PNGImageFile(path)))
         return fs
 
+    @dynamic
+    def dyn(fs: FileStruct):
+        t2(fs=fs)
+
     @task
     def t2(fs: FileStruct) -> os.PathLike:
+        assert fs.a.remote_source == "s3://somewhere"
+        assert fs.b.a.remote_source == "s3://somewhere"
+        assert fs.b.b.remote_source == "s3://somewhere"
+        assert "/tmp/flyte/" in fs.a.path
+        assert "/tmp/flyte/" in fs.b.a.path
+        assert "/tmp/flyte/" in fs.b.b.path
+
         return fs.a.path
 
     @workflow
     def wf(path: str) -> os.PathLike:
         n1 = t1(path=path)
+        dyn(fs=n1)
         return t2(fs=n1)
 
     assert "/tmp/flyte/" in wf(path="s3://somewhere").path


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Failed to run dynamic task which input is dataclass that has FlyteFile inside it.

The crux of the problem is that there was a mistake in the `FlyteFile` design.  The object does not invert cleanly.  That is,
if `X = FlyteFile(path="s3://abc")`, `X != TypeEngine.to_python_value(TypeEngine.to_literal(X))`. What happens rather is:

``` 
X -> to_literal -> Blob(uri="s3://abc") -> to_python_value -> FlyteFile(path="/tmp/xyz", remote_source="s3://abc")
```
where `/tmp/xyz` is the autogenerated folder on disk where the contents of the s3 would be downloaded to, if it were opened.

This means that the `path` in the `FlyteFile` object might not always be the path you want.  The `FlyteFile` transformer has special logic built in to detect this but the json serializer does not. Therefore we have to take the `uri` as determined by the type engine.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Reset the FlyteFile and FlyteDirectory values when doing serialization.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1938

## Follow-up issue
_NA_