### PR TITLE
Single-task execution FlyteRemote sync

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1117,6 +1117,12 @@ class FlyteRemote(object):
         """
         # For single task execution - the metadata spec node id is missing. In these cases, revert to regular node id
         node_id = execution.metadata.spec_node_id
+        if node_id and node_id not in node_mapping:
+            node_id = execution.id.node_id
+            remote_logger.debug(
+                f"Using node execution ID {node_id} instead of spec node id "
+                f"{execution.metadata.spec_node_id}, single-task execution likely."
+            )
         if not node_id:
             node_id = execution.id.node_id
             remote_logger.debug(f"No metadata spec_node_id found, using {node_id}")

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1117,12 +1117,14 @@ class FlyteRemote(object):
         """
         # For single task execution - the metadata spec node id is missing. In these cases, revert to regular node id
         node_id = execution.metadata.spec_node_id
-        if node_id and node_id not in node_mapping:
+        # This case supports single-task execution compiled workflows.
+        if node_id and node_id not in node_mapping and execution.id.node_id in node_mapping:
             node_id = execution.id.node_id
             remote_logger.debug(
                 f"Using node execution ID {node_id} instead of spec node id "
                 f"{execution.metadata.spec_node_id}, single-task execution likely."
             )
+        # This case supports single-task execution compiled workflows with older versions of admin/propeller
         if not node_id:
             node_id = execution.id.node_id
             remote_logger.debug(f"No metadata spec_node_id found, using {node_id}")

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -310,12 +310,3 @@ def test_fetch_not_exist_launch_plan(flyteclient):
     remote = FlyteRemote.from_config(PROJECT, "development")
     with pytest.raises(FlyteEntityNotExistException):
         remote.fetch_launch_plan(name="workflows.basic.list_float_wf.fake_wf", version=f"v{VERSION}")
-
-
-def test_jfdkl():
-    from flytekit.remote.remote import FlyteRemote
-
-    rr = FlyteRemote.from_config("flytesnacks", "development", config_file_path="/Users/ytong/.flyte/local_sandbox")
-    version = "ab2c1fee5fc06c7ea329e1e719f4d1abd06c9175"
-    ft = rr.fetch_task(name="core.control_flow.map_task.a_mappable_task", version=version)
-    ex = rr.execute(ft, inputs={"a": 5}, wait=True)

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -310,3 +310,12 @@ def test_fetch_not_exist_launch_plan(flyteclient):
     remote = FlyteRemote.from_config(PROJECT, "development")
     with pytest.raises(FlyteEntityNotExistException):
         remote.fetch_launch_plan(name="workflows.basic.list_float_wf.fake_wf", version=f"v{VERSION}")
+
+
+def test_jfdkl():
+    from flytekit.remote.remote import FlyteRemote
+
+    rr = FlyteRemote.from_config("flytesnacks", "development", config_file_path="/Users/ytong/.flyte/local_sandbox")
+    version = "ab2c1fee5fc06c7ea329e1e719f4d1abd06c9175"
+    ft = rr.fetch_task(name="core.control_flow.map_task.a_mappable_task", version=version)
+    ex = rr.execute(ft, inputs={"a": 5}, wait=True)


### PR DESCRIPTION
# TL;DR
The semantics for how single-task execution compiled workflows seem to have changed at some point. Previously we relied on the node execution's `metadata.spec_node_id` to be empty, which now appears to not be the case.  Not sure what changed.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Add case for it
