### PR TITLE
When using the `task` and `workflow` decorator, correctly wrap the fu…

### DIFF
--- a/flytekit/core/task.py
+++ b/flytekit/core/task.py
@@ -1,4 +1,5 @@
 import datetime as _datetime
+from functools import update_wrapper
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from flytekit.core.base_task import TaskMetadata, TaskResolverMixin
@@ -195,7 +196,7 @@ def task(
             execution_mode=execution_mode,
             task_resolver=task_resolver,
         )
-
+        update_wrapper(task_instance, fn)
         return task_instance
 
     if _task_function:

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from functools import update_wrapper
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 from flytekit.common import constants as _common_constants
@@ -730,6 +731,7 @@ def workflow(
             docstring=Docstring(callable_=fn),
         )
         workflow_instance.compile()
+        update_wrapper(workflow_instance, fn)
         return workflow_instance
 
     if _workflow_function:

--- a/plugins/flytekit-greatexpectations/tests/test_task.py
+++ b/plugins/flytekit-greatexpectations/tests/test_task.py
@@ -149,7 +149,6 @@ def test_ge_with_task():
         task_object(dataset=dataset)
         return my_task(csv_file=dataset)
 
-    @pytest.mark.xfail(strict=True)
     @workflow
     def invalid_wf(dataset: str = "yellow_tripdata_sample_2019-02.csv") -> int:
         task_object(dataset=dataset)
@@ -158,7 +157,8 @@ def test_ge_with_task():
     valid_result = valid_wf()
     assert valid_result == 10000
 
-    invalid_wf()
+    with pytest.raises(ValidationError, match=r".*passenger_count -> expect_column_min_to_be_between.*"):
+        invalid_wf()
 
 
 def test_ge_workflow():

--- a/tests/flytekit/unit/core/test_wrapping.py
+++ b/tests/flytekit/unit/core/test_wrapping.py
@@ -1,4 +1,3 @@
-# Copyright (C) 2015-2021 Blackshark.ai GmbH. All Rights reserved. www.blackshark.ai
 from flytekit import task, workflow
 
 

--- a/tests/flytekit/unit/core/test_wrapping.py
+++ b/tests/flytekit/unit/core/test_wrapping.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2015-2021 Blackshark.ai GmbH. All Rights reserved. www.blackshark.ai
+from flytekit import task, workflow
+
+
+def test_task_correctly_wrapped():
+    @task
+    def my_task(a: int) -> int:
+        return a
+
+    assert my_task.__wrapped__ == my_task._task_function
+
+
+def test_wf_correctly_wrapped():
+    @workflow
+    def my_workflow(a: int) -> int:
+        return a
+
+    assert my_workflow.__wrapped__ == my_workflow._workflow_function

--- a/tests/flytekit/unit/core/test_wrapping.py
+++ b/tests/flytekit/unit/core/test_wrapping.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from flytekit import task, workflow
 
 
@@ -7,6 +9,45 @@ def test_task_correctly_wrapped():
         return a
 
     assert my_task.__wrapped__ == my_task._task_function
+
+
+def test_stacked_decorators():
+    def task_decorator_1(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            print("running task_decorator_1")
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    def task_decorator_2(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            print("running task_decorator_2")
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    def task_decorator_3(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            print("running task_decorator_3")
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    @task
+    @task_decorator_1
+    @task_decorator_2
+    @task_decorator_3
+    def my_task(x: int) -> int:
+        """Some function doc"""
+        print("running my_task")
+        return x + 1
+
+    assert my_task.__wrapped__.__doc__ == "Some function doc"
+    assert my_task.__wrapped__ == my_task._task_function
+    assert my_task(x=10) == 11
 
 
 def test_wf_correctly_wrapped():


### PR DESCRIPTION
# TL;DR
This enables tooling such as docstring search tools to unwrap the object and show the correct docstring. The method sets the `__wrapped__` attribute of the created instance.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
We're using [mkdocs](https://www.mkdocs.org/) together with [mkdocstrings](https://mkdocstrings.github.io/usage/) to render our Python documentation. We noticed, that documentation for Flyte tasks didn't show up, and upon further investigation found that `mkdocstrings` unwraps all decorated elements to show the correct documentation. See also: https://mkdocstrings.github.io/troubleshooting/#my-wrapped-function-shows-documentationcode-for-its-wrapper-instead-of-its-own

For this unwrapping to work, wrapper elements need to have `__wrapped__` set to a reference of the wrapped (decorated) function. With functions one could use [`functools.wraps()`](https://docs.python.org/3/library/functools.html#functools.wraps), but as Flyte is returning instances of Flyte objects, [`functools.update_wrapper()`](https://docs.python.org/3/library/functools.html#functools.update_wrapper) is what works.

