### PR TITLE
Add option to flyte-cli for specifying root certificate

### DIFF
--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -303,7 +303,7 @@ _HOST_FLAGS = ["-h", "--host"]
 _CONFIG_FLAGS = ["-c", "--config"]
 _PRINCIPAL_FLAGS = ["-r", "--principal"]
 _INSECURE_FLAGS = ["-i", "--insecure"]
-_CERT_FLAGS = ["-e", "--cacert"]
+_CERT_FLAGS = ["--cacert"]
 
 _project_option = _click.option(*_PROJECT_FLAGS, required=True, help="The project namespace to query.")
 _optional_project_option = _click.option(
@@ -673,9 +673,7 @@ def list_task_names(project, domain, host, insecure, token, limit, show_all, sor
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     _click.echo("Task Names Found in {}:{}\n".format(_tt(project), _tt(domain)))
     while True:
@@ -718,9 +716,7 @@ def list_task_versions(project, domain, name, host, insecure, token, limit, show
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     _click.echo("Task Versions Found for {}:{}:{}\n".format(_tt(project), _tt(domain), _tt(name or "*")))
     _click.echo("{:50} {:40}".format("Version", "Urn"))
@@ -761,9 +757,7 @@ def get_task(urn, host, insecure):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     t = client.get_task(_identifier.Identifier.from_python_std(urn))
     _click.echo(_tt(t))
     _click.echo("")
@@ -837,9 +831,7 @@ def list_workflow_names(project, domain, host, insecure, token, limit, show_all,
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     _click.echo("Workflow Names Found in {}:{}\n".format(_tt(project), _tt(domain)))
     while True:
@@ -882,9 +874,7 @@ def list_workflow_versions(project, domain, name, host, insecure, token, limit, 
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     _click.echo("Workflow Versions Found for {}:{}:{}\n".format(_tt(project), _tt(domain), _tt(name or "*")))
     _click.echo("{:50} {:40}".format("Version", "Urn"))
@@ -925,9 +915,7 @@ def get_workflow(urn, host, insecure):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     _click.echo(client.get_workflow(_identifier.Identifier.from_python_std(urn)))
     # TODO: Print workflow pretty
     _click.echo("")
@@ -955,9 +943,7 @@ def list_launch_plan_names(project, domain, host, insecure, token, limit, show_a
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     _click.echo("Launch Plan Names Found in {}:{}\n".format(_tt(project), _tt(domain)))
     while True:
@@ -1002,9 +988,7 @@ def list_active_launch_plans(project, domain, host, insecure, token, limit, show
         _click.echo("{:30} {:50} {:80}".format("Schedule", "Version", "Urn"))
 
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     while True:
         active_lps, next_token = client.list_active_launch_plans_paginated(
@@ -1074,9 +1058,7 @@ def list_launch_plan_versions(
         _click.echo("{:50} {:80} {:30} {:15}".format("Version", "Urn", "Schedule", "Schedule State"))
 
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     while True:
         lp_list, next_token = client.list_launch_plans_paginated(
@@ -1130,9 +1112,7 @@ def get_launch_plan(urn, host, insecure):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     _click.echo(_tt(client.get_launch_plan(_identifier.Identifier.from_python_std(urn))))
     # TODO: Print launch plan pretty
     _click.echo("")
@@ -1150,9 +1130,7 @@ def get_active_launch_plan(project, domain, name, host, insecure):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     lp = client.get_active_launch_plan(_common_models.NamedEntityIdentifier(project, domain, name))
     _click.echo("Active Launch Plan for {}:{}:{}\n".format(_tt(project), _tt(domain), _tt(name)))
@@ -1168,9 +1146,7 @@ def get_active_launch_plan(project, domain, name, host, insecure):
 def update_launch_plan(state, host, insecure, urn=None):
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     if urn is None:
         try:
@@ -1253,9 +1229,7 @@ def watch_execution(host, insecure, urn):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     ex_id = _identifier.WorkflowExecutionIdentifier.from_python_std(urn)
 
     execution = _workflow_execution_common.SdkWorkflowExecution.promote_from_model(client.get_execution(ex_id))
@@ -1301,9 +1275,7 @@ def relaunch_execution(project, domain, name, host, insecure, urn, principal, ve
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     _click.echo("Relaunching execution {}\n".format(_tt(urn)))
     existing_workflow_execution_identifier = _identifier.WorkflowExecutionIdentifier.from_python_std(urn)
@@ -1378,9 +1350,7 @@ def recover_execution(urn, name, host, insecure):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     _click.echo("Recovering execution {}\n".format(_tt(urn)))
 
@@ -1418,9 +1388,7 @@ def terminate_execution(host, insecure, cause, urn=None):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     _click.echo("Killing the following executions:\n")
     _click.echo("{:100} {:40}".format("Urn", "Cause"))
@@ -1473,9 +1441,7 @@ def list_executions(project, domain, host, insecure, token, limit, show_all, fil
         _click.echo("{:100} {:40} {:10}".format("Urn", "Name", "Status"))
 
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     while True:
         exec_ids, next_token = client.list_executions_paginated(
@@ -1730,9 +1696,7 @@ def get_execution(urn, host, insecure, show_io, verbose):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     e = client.get_execution(_identifier.WorkflowExecutionIdentifier.from_python_std(urn))
     node_execs = _get_all_node_executions(client, workflow_execution_identifier=e.id)
     _render_node_executions(client, node_execs, show_io, verbose, host, insecure, wf_execution=e)
@@ -1747,9 +1711,7 @@ def get_execution(urn, host, insecure, show_io, verbose):
 def get_child_executions(urn, host, insecure, show_io, verbose):
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     node_execs = _get_all_node_executions(
         client,
         task_execution_identifier=_identifier.TaskExecutionIdentifier.from_python_std(urn),
@@ -1770,9 +1732,7 @@ def register_project(identifier, name, description, host, insecure):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     client.register_project(_Project(identifier, name, description))
     _click.echo("Registered project [id: {}, name: {}, description: {}]".format(identifier, name, description))
 
@@ -1792,9 +1752,7 @@ def list_projects(host, insecure, token, limit, show_all, filter, sort_by):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     _click.echo("Projects Found\n")
     while True:
@@ -1828,9 +1786,7 @@ def archive_project(identifier, host, insecure):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     client.update_project(_Project.archived_project(identifier))
     _click.echo("Archived project [id: {}]".format(identifier))
@@ -1847,9 +1803,7 @@ def activate_project(identifier, host, insecure):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     client.update_project(_Project.active_project(identifier))
     _click.echo("Activated project [id: {}]".format(identifier))
 
@@ -2035,9 +1989,7 @@ def register_files(
         )
     }
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     _extract_and_register(client, project, domain, version, files, patches)
 
 
@@ -2162,9 +2114,7 @@ def fast_register_files(
         ),
     }
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     _extract_and_register(client, project, domain, version, pb_files, patches)
 
@@ -2183,9 +2133,7 @@ def update_workflow_meta(description, state, host, insecure, project, domain, na
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     if state == "active":
         state = _named_entity.NamedEntityState.ACTIVE
     elif state == "archived":
@@ -2211,9 +2159,7 @@ def update_task_meta(description, host, insecure, project, domain, name):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     client.update_named_entity(
         _core_identifier.ResourceType.TASK,
         _named_entity.NamedEntityIdentifier(project, domain, name),
@@ -2235,9 +2181,7 @@ def update_launch_plan_meta(description, host, insecure, project, domain, name):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     client.update_named_entity(
         _core_identifier.ResourceType.LAUNCH_PLAN,
         _named_entity.NamedEntityIdentifier(project, domain, name),
@@ -2267,9 +2211,7 @@ def update_cluster_resource_attributes(host, insecure, project, domain, name, at
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     cluster_resource_attributes = _ClusterResourceAttributes({attribute[0]: attribute[1] for attribute in attributes})
     matching_attributes = _MatchingAttributes(cluster_resource_attributes=cluster_resource_attributes)
 
@@ -2304,9 +2246,7 @@ def update_execution_queue_attributes(host, insecure, project, domain, name, tag
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     execution_queue_attributes = _ExecutionQueueAttributes(list(tags))
     matching_attributes = _MatchingAttributes(execution_queue_attributes=execution_queue_attributes)
 
@@ -2341,9 +2281,7 @@ def update_execution_cluster_label(host, insecure, project, domain, name, value)
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     execution_cluster_label = _ExecutionClusterLabel(value)
     matching_attributes = _MatchingAttributes(execution_cluster_label=execution_cluster_label)
 
@@ -2382,9 +2320,7 @@ def update_plugin_override(host, insecure, project, domain, name, task_type, plu
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
     plugin_override = _PluginOverride(
         task_type, list(plugin_id), _PluginOverride.string_to_enum(missing_plugin_behavior.upper())
     )
@@ -2429,9 +2365,7 @@ def get_matching_attributes(host, insecure, project, domain, name, resource_type
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     if name is not None:
         attributes = client.get_workflow_attributes(
@@ -2468,9 +2402,7 @@ def list_matching_attributes(host, insecure, resource_type):
     """
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
-    client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
-    )
+    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"])
 
     attributes = client.list_matchable_attributes(_MatchableResource.string_to_enum(resource_type.upper()))
     for configuration in attributes.configurations:

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -305,7 +305,7 @@ _HOST_FLAGS = ["-h", "--host"]
 _CONFIG_FLAGS = ["-c", "--config"]
 _PRINCIPAL_FLAGS = ["-r", "--principal"]
 _INSECURE_FLAGS = ["-i", "--insecure"]
-_CERT_FLAGS = ["-e", "--root_ssl_cert"]
+_CERT_FLAGS = ["-e", "--cacert"]
 
 _project_option = _click.option(*_PROJECT_FLAGS, required=True, help="The project namespace to query.")
 _optional_project_option = _click.option(
@@ -517,7 +517,7 @@ class _FlyteSubCommand(_click.Command):
         if cmd_name == "setup-config":
             ctx = super(_FlyteSubCommand, self).make_context(cmd_name, prefix_args + args, parent=parent)
             ctx.obj = ctx.obj or {}
-            ctx.obj["root_ssl_cert"] = parent.params["root_ssl_cert"] or None
+            ctx.obj["cacert"] = parent.params["cacert"] or None
             return ctx
 
         config = parent.params["config"]
@@ -567,7 +567,7 @@ class _FlyteSubCommand(_click.Command):
             prefix_args.extend([_HOST_FLAGS[0], str(_HOST_URL)])
         ctx = super(_FlyteSubCommand, self).make_context(cmd_name, prefix_args + args, parent=parent)
         ctx.obj = ctx.obj or {}
-        ctx.obj["root_ssl_cert"] = parent.params["root_ssl_cert"] or None
+        ctx.obj["cacert"] = parent.params["cacert"] or None
         return ctx
 
 
@@ -621,7 +621,7 @@ class _FlyteSubCommand(_click.Command):
 @_insecure_option
 @_click.group("flyte-cli", deprecated=True)
 @_click.pass_context
-def _flyte_cli(ctx, host, config, project, domain, name, root_ssl_cert, insecure):
+def _flyte_cli(ctx, host, config, project, domain, name, cacert, insecure):
     """
     Command line tool for interacting with all entities on the Flyte Platform.
     """
@@ -1735,7 +1735,7 @@ def list_projects(host, insecure, token, limit, show_all, filter, sort_by):
     _welcome_message()
     parent_ctx = _click.get_current_context(silent=True)
     client = _friendly_client.SynchronousFlyteClient(
-        host, insecure=insecure, root_cert_file=parent_ctx.obj["root_ssl_cert"]
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
     )
 
     _click.echo("Projects Found\n")

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -274,9 +274,7 @@ def _terminate_one_execution(client, urn, cause, shouldPrint=True):
     client.terminate_execution(_identifier.WorkflowExecutionIdentifier.from_python_std(urn), cause)
 
 
-def _update_one_launch_plan(urn, host, insecure, state):
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
-
+def _update_one_launch_plan(client: _friendly_client.SynchronousFlyteClient, urn, state):
     if state == "active":
         state = _launch_plan.LaunchPlanState.ACTIVE
     else:
@@ -674,7 +672,10 @@ def list_task_names(project, domain, host, insecure, token, limit, show_all, sor
     a specific project and domain.
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     _click.echo("Task Names Found in {}:{}\n".format(_tt(project), _tt(domain)))
     while True:
@@ -716,7 +717,10 @@ def list_task_versions(project, domain, name, host, insecure, token, limit, show
     versions of that particular task (identifiable by {Project, Domain, Name}).
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     _click.echo("Task Versions Found for {}:{}:{}\n".format(_tt(project), _tt(domain), _tt(name or "*")))
     _click.echo("{:50} {:40}".format("Version", "Urn"))
@@ -756,7 +760,10 @@ def get_task(urn, host, insecure):
     The URN of the versioned task is in the form of ``tsk:<project>:<domain>:<task_name>:<version>``.
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     t = client.get_task(_identifier.Identifier.from_python_std(urn))
     _click.echo(_tt(t))
     _click.echo("")
@@ -829,7 +836,10 @@ def list_workflow_names(project, domain, host, insecure, token, limit, show_all,
     List the names of the workflows under a scope specified by ``{project, domain}``.
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     _click.echo("Workflow Names Found in {}:{}\n".format(_tt(project), _tt(domain)))
     while True:
@@ -871,7 +881,10 @@ def list_workflow_versions(project, domain, name, host, insecure, token, limit, 
     versions of that particular workflow (identifiable by ``{project, domain, name}``).
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     _click.echo("Workflow Versions Found for {}:{}:{}\n".format(_tt(project), _tt(domain), _tt(name or "*")))
     _click.echo("{:50} {:40}".format("Version", "Urn"))
@@ -911,7 +924,10 @@ def get_workflow(urn, host, insecure):
     ``wf:<project>:<domain>:<workflow_name>:<version>``
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     _click.echo(client.get_workflow(_identifier.Identifier.from_python_std(urn)))
     # TODO: Print workflow pretty
     _click.echo("")
@@ -938,7 +954,10 @@ def list_launch_plan_names(project, domain, host, insecure, token, limit, show_a
     List the names of the launch plans under the scope specified by {project, domain}.
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     _click.echo("Launch Plan Names Found in {}:{}\n".format(_tt(project), _tt(domain)))
     while True:
@@ -982,7 +1001,10 @@ def list_active_launch_plans(project, domain, host, insecure, token, limit, show
         _click.echo("Active Launch Plan Found in {}:{}\n".format(_tt(project), _tt(domain)))
         _click.echo("{:30} {:50} {:80}".format("Schedule", "Version", "Urn"))
 
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     while True:
         active_lps, next_token = client.list_active_launch_plans_paginated(
@@ -1051,7 +1073,10 @@ def list_launch_plan_versions(
         _click.echo("Launch Plan Versions Found for {}:{}:{}\n".format(_tt(project), _tt(domain), _tt(name)))
         _click.echo("{:50} {:80} {:30} {:15}".format("Version", "Urn", "Schedule", "Schedule State"))
 
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     while True:
         lp_list, next_token = client.list_launch_plans_paginated(
@@ -1104,7 +1129,10 @@ def get_launch_plan(urn, host, insecure):
     The URN of a launch plan is in the form of ``lp:<project>:<domain>:<launch_plan_name>:<version>``
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     _click.echo(_tt(client.get_launch_plan(_identifier.Identifier.from_python_std(urn))))
     # TODO: Print launch plan pretty
     _click.echo("")
@@ -1121,7 +1149,10 @@ def get_active_launch_plan(project, domain, name, host, insecure):
     List the versions of all the launch plans under the scope specified by {project, domain}.
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     lp = client.get_active_launch_plan(_common_models.NamedEntityIdentifier(project, domain, name))
     _click.echo("Active Launch Plan for {}:{}:{}\n".format(_tt(project), _tt(domain), _tt(name)))
@@ -1136,13 +1167,17 @@ def get_active_launch_plan(project, domain, name, host, insecure):
 @_optional_urn_option
 def update_launch_plan(state, host, insecure, urn=None):
     _welcome_message()
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     if urn is None:
         try:
             # Examine whether the input is from the named pipe
             if _stat.S_ISFIFO(_os.fstat(0).st_mode):
                 for line in _sys.stdin.readlines():
-                    _update_one_launch_plan(urn=line.rstrip(), host=host, insecure=insecure, state=state)
+                    _update_one_launch_plan(client, urn=line.rstrip(), state=state)
             else:
                 # If the commandline parameter urn is not supplied, and neither
                 # the input comes from a pipe, it means the user is not using
@@ -1151,7 +1186,7 @@ def update_launch_plan(state, host, insecure, urn=None):
         except KeyboardInterrupt:
             _sys.stdout.flush()
     else:
-        _update_one_launch_plan(urn=urn, host=host, insecure=insecure, state=state)
+        _update_one_launch_plan(client, urn=urn, state=state)
 
 
 @_flyte_cli.command("execute-launch-plan", cls=_FlyteSubCommand)
@@ -1217,8 +1252,10 @@ def watch_execution(host, insecure, urn):
         $ flyte-cli -h localhost:30081 watch-execution -u ex:flyteexamples:development:abc123
     """
     _welcome_message()
-
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     ex_id = _identifier.WorkflowExecutionIdentifier.from_python_std(urn)
 
     execution = _workflow_execution_common.SdkWorkflowExecution.promote_from_model(client.get_execution(ex_id))
@@ -1263,7 +1300,10 @@ def relaunch_execution(project, domain, name, host, insecure, urn, principal, ve
     Users should use the get-execution and get-launch-plan commands to ascertain the names of inputs to use.
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     _click.echo("Relaunching execution {}\n".format(_tt(urn)))
     existing_workflow_execution_identifier = _identifier.WorkflowExecutionIdentifier.from_python_std(urn)
@@ -1337,7 +1377,10 @@ def recover_execution(urn, name, host, insecure):
     Users should use the get-execution and get-launch-plan commands to ascertain the names of inputs to use.
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     _click.echo("Recovering execution {}\n".format(_tt(urn)))
 
@@ -1374,7 +1417,10 @@ def terminate_execution(host, insecure, cause, urn=None):
             -u lp:flyteexamples:development:some-execution:abc123
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     _click.echo("Killing the following executions:\n")
     _click.echo("{:100} {:40}".format("Urn", "Cause"))
@@ -1426,7 +1472,10 @@ def list_executions(project, domain, host, insecure, token, limit, show_all, fil
         _click.echo("Executions Found in {}:{}\n".format(_tt(project), _tt(domain)))
         _click.echo("{:100} {:40} {:10}".format("Urn", "Name", "Status"))
 
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     while True:
         exec_ids, next_token = client.list_executions_paginated(
@@ -1680,7 +1729,10 @@ def get_execution(urn, host, insecure, show_io, verbose):
     The URN of an execution is in the form of ``ex:<project>:<domain>:<execution_name>``
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     e = client.get_execution(_identifier.WorkflowExecutionIdentifier.from_python_std(urn))
     node_execs = _get_all_node_executions(client, workflow_execution_identifier=e.id)
     _render_node_executions(client, node_execs, show_io, verbose, host, insecure, wf_execution=e)
@@ -1694,7 +1746,10 @@ def get_execution(urn, host, insecure, show_io, verbose):
 @_verbose_option
 def get_child_executions(urn, host, insecure, show_io, verbose):
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     node_execs = _get_all_node_executions(
         client,
         task_execution_identifier=_identifier.TaskExecutionIdentifier.from_python_std(urn),
@@ -1714,7 +1769,10 @@ def register_project(identifier, name, description, host, insecure):
 
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     client.register_project(_Project(identifier, name, description))
     _click.echo("Registered project [id: {}, name: {}, description: {}]".format(identifier, name, description))
 
@@ -1769,7 +1827,11 @@ def archive_project(identifier, host, insecure):
 
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
+
     client.update_project(_Project.archived_project(identifier))
     _click.echo("Archived project [id: {}]".format(identifier))
 
@@ -1784,7 +1846,10 @@ def activate_project(identifier, host, insecure):
 
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     client.update_project(_Project.active_project(identifier))
     _click.echo("Activated project [id: {}]".format(identifier))
 
@@ -1891,16 +1956,13 @@ def _get_patch_launch_plan_fn(
 
 
 def _extract_and_register(
-    host: str,
-    insecure: bool,
+    client: _friendly_client.SynchronousFlyteClient,
     project: str,
     domain: str,
     version: str,
     file_paths: List[str],
     patches: Dict[int, Callable[[_GeneratedProtocolMessageType], _GeneratedProtocolMessageType]] = None,
 ):
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
-
     flyte_entities_list = _extract_files(project, domain, version, file_paths, patches)
     for id, flyte_entity in flyte_entities_list:
         _click.secho(f"Registering {id}", fg="yellow")
@@ -1972,8 +2034,11 @@ def register_files(
             assumable_iam_role, kubernetes_service_account, output_location_prefix
         )
     }
-
-    _extract_and_register(host, insecure, project, domain, version, files, patches)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
+    _extract_and_register(client, project, domain, version, files, patches)
 
 
 def _substitute_fast_register_task_args(args: List[str], full_remote_path: str, dest_dir: str) -> List[str]:
@@ -2096,8 +2161,12 @@ def fast_register_files(
             assumable_iam_role, kubernetes_service_account, output_location_prefix
         ),
     }
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
-    _extract_and_register(host, insecure, project, domain, version, pb_files, patches)
+    _extract_and_register(client, project, domain, version, pb_files, patches)
 
 
 @_flyte_cli.command("update-workflow-meta", cls=_FlyteSubCommand)
@@ -2113,7 +2182,10 @@ def update_workflow_meta(description, state, host, insecure, project, domain, na
     Updates a workflow entity under the scope specified by {project, domain, name} across versions.
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     if state == "active":
         state = _named_entity.NamedEntityState.ACTIVE
     elif state == "archived":
@@ -2138,7 +2210,10 @@ def update_task_meta(description, host, insecure, project, domain, name):
     Updates a task entity under the scope specified by {project, domain, name} across versions.
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     client.update_named_entity(
         _core_identifier.ResourceType.TASK,
         _named_entity.NamedEntityIdentifier(project, domain, name),
@@ -2159,7 +2234,10 @@ def update_launch_plan_meta(description, host, insecure, project, domain, name):
     Updates a launch plan entity under the scope specified by {project, domain, name} across versions.
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     client.update_named_entity(
         _core_identifier.ResourceType.LAUNCH_PLAN,
         _named_entity.NamedEntityIdentifier(project, domain, name),
@@ -2188,7 +2266,10 @@ def update_cluster_resource_attributes(host, insecure, project, domain, name, at
             --attributes projectQuotaCpu 1 --attributes projectQuotaMemory 500M
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     cluster_resource_attributes = _ClusterResourceAttributes({attribute[0]: attribute[1] for attribute in attributes})
     matching_attributes = _MatchingAttributes(cluster_resource_attributes=cluster_resource_attributes)
 
@@ -2222,7 +2303,10 @@ def update_execution_queue_attributes(host, insecure, project, domain, name, tag
             --tags critical --tags gpu_intensive
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     execution_queue_attributes = _ExecutionQueueAttributes(list(tags))
     matching_attributes = _MatchingAttributes(execution_queue_attributes=execution_queue_attributes)
 
@@ -2256,7 +2340,10 @@ def update_execution_cluster_label(host, insecure, project, domain, name, value)
         $ flyte-cli -h localhost:30081 -p flyteexamples -d development update-execution-cluster-label --value foo
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     execution_cluster_label = _ExecutionClusterLabel(value)
     matching_attributes = _MatchingAttributes(execution_cluster_label=execution_cluster_label)
 
@@ -2294,7 +2381,10 @@ def update_plugin_override(host, insecure, project, domain, name, task_type, plu
             --plugin-id my_cool_plugin --plugin-id my_fallback_plugin --missing-plugin-behavior FAIL
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
     plugin_override = _PluginOverride(
         task_type, list(plugin_id), _PluginOverride.string_to_enum(missing_plugin_behavior.upper())
     )
@@ -2338,7 +2428,10 @@ def get_matching_attributes(host, insecure, project, domain, name, resource_type
     combination.
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     if name is not None:
         attributes = client.get_workflow_attributes(
@@ -2374,7 +2467,10 @@ def list_matching_attributes(host, insecure, resource_type):
     Fetches all matchable resources of the given resource type.
     """
     _welcome_message()
-    client = _friendly_client.SynchronousFlyteClient(host, insecure=insecure)
+    parent_ctx = _click.get_current_context(silent=True)
+    client = _friendly_client.SynchronousFlyteClient(
+        host, insecure=insecure, root_cert_file=parent_ctx.obj["cacert"]
+    )
 
     attributes = client.list_matchable_attributes(_MatchableResource.string_to_enum(resource_type.upper()))
     for configuration in attributes.configurations:

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -179,4 +179,4 @@ def test_explicit_grpc_channel_credentials(mock_insecure, mock_url, mock_secure_
     _ = FlyteRemote.from_config("project", "domain", grpc_credentials=credentials)
     assert mock_secure_channel.called
     assert mock_secure_channel.call_args[0][1] == credentials
-    assert not mock_ssl_channel_credentials.called
+    assert mock_ssl_channel_credentials.call_count == 1


### PR DESCRIPTION
# TL;DR
Adding a switch (`-e` or `--cacert`) that takes a path to a PEM encoded file.  If specified, will be read and used as the root certificate to use in SSL connection with Admin.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
* Adding click option to main flyte-cli command.
* Setting the path in the click context object if specified, None otherwise
* Value is always passed to client constructor. If present, file will be read and used as `root_certificates` value in `grpc.ssl_channel_credentials`

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1888
