### PR TITLE
Pyarrow greater than 4.0.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -183,7 +183,7 @@ marshmallow-jsonschema==0.13.0
     #   flytekit
 mock==4.0.3
     # via -r dev-requirements.in
-mypy==0.920
+mypy==0.930
     # via -r dev-requirements.in
 mypy-extensions==0.4.3
     # via
@@ -288,6 +288,7 @@ pytimeparse==1.1.8
 pytz==2021.3
     # via
     #   -c requirements.txt
+    #   flytekit
     #   pandas
 pyyaml==5.4.1
     # via
@@ -376,7 +377,7 @@ websocket-client==0.59.0
     # via
     #   docker
     #   docker-compose
-wheel==0.37.0
+wheel==0.37.1
     # via
     #   -c requirements.txt
     #   flytekit

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -33,9 +33,9 @@ black==21.12b0
     # via papermill
 bleach==4.1.0
     # via nbconvert
-boto3==1.20.24
+boto3==1.20.26
     # via sagemaker-training
-botocore==1.23.24
+botocore==1.23.26
     # via
     #   boto3
     #   s3transfer
@@ -286,6 +286,7 @@ pytimeparse==1.1.8
 pytz==2021.3
     # via
     #   babel
+    #   flytekit
     #   pandas
 pyyaml==6.0
     # via
@@ -429,7 +430,7 @@ webencodings==0.5.1
     # via bleach
 werkzeug==2.0.2
     # via sagemaker-training
-wheel==0.37.0
+wheel==0.37.1
     # via flytekit
 wrapt==1.13.3
     # via

--- a/requirements-spark2.txt
+++ b/requirements-spark2.txt
@@ -26,9 +26,9 @@ black==21.12b0
     # via papermill
 bleach==4.1.0
     # via nbconvert
-boto3==1.20.24
+boto3==1.20.26
     # via sagemaker-training
-botocore==1.23.24
+botocore==1.23.26
     # via
     #   boto3
     #   s3transfer
@@ -256,7 +256,9 @@ python-slugify==5.0.2
 pytimeparse==1.1.8
     # via flytekit
 pytz==2021.3
-    # via pandas
+    # via
+    #   flytekit
+    #   pandas
 pyyaml==5.4.1
     # via
     #   -r requirements.in
@@ -349,7 +351,7 @@ webencodings==0.5.1
     # via bleach
 werkzeug==2.0.2
     # via sagemaker-training
-wheel==0.37.0
+wheel==0.37.1
     # via flytekit
 wrapt==1.13.3
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,9 +24,9 @@ black==21.12b0
     # via papermill
 bleach==4.1.0
     # via nbconvert
-boto3==1.20.25
+boto3==1.20.26
     # via sagemaker-training
-botocore==1.23.25
+botocore==1.23.26
     # via
     #   boto3
     #   s3transfer
@@ -349,7 +349,7 @@ webencodings==0.5.1
     # via bleach
 werkzeug==2.0.2
     # via sagemaker-training
-wheel==0.37.0
+wheel==0.37.1
     # via flytekit
 wrapt==1.13.3
     # via

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ elif CURRENT_PYTHON < MIN_PYTHON_VERSION:
 spark = ["pyspark>=2.4.0,<3.0.0"]
 spark3 = ["pyspark>=3.0.0"]
 sidecar = ["k8s-proto>=0.0.3,<1.0.0"]
-schema = ["numpy>=1.14.0,<2.0.0", "pandas>=0.22.0,<2.0.0", "pyarrow>=6.0.0"]
+schema = ["numpy>=1.14.0,<2.0.0", "pandas>=0.22.0,<2.0.0", "pyarrow>=4.0.0"]
 hive_sensor = ["hmsclient>=0.0.1,<1.0.0"]
 notebook = ["papermill>=1.2.0", "nbconvert>=6.0.7", "ipykernel>=5.0.0,<6.0.0"]
 sagemaker = ["sagemaker-training>=3.6.2,<4.0.0"]
@@ -67,7 +67,7 @@ setup(
         "flyteidl>=0.21.4",
         "wheel>=0.30.0,<1.0.0",
         "pandas>=1.0.0,<2.0.0",
-        "pyarrow>=6.0.0,<7.0.0",
+        "pyarrow>=4.0.0,<7.0.0",
         "click>=6.6,<8.0",
         "croniter>=0.3.20,<4.0.0",
         "deprecated>=1.0,<2.0",

--- a/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
+++ b/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
@@ -171,7 +171,7 @@ urllib3==1.26.7
     #   flytekit
     #   requests
     #   responses
-wheel==0.37.0
+wheel==0.37.1
     # via
     #   -r tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.in
     #   flytekit


### PR DESCRIPTION
# TL;DR
Relax the pyarrow requirements to allow for a wider installation base

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The pyarrow minimal version is now set to 4.0.0. This will allow for clients that pin `pyarrow` to versions other than latest, while we still pull in latest from pypi in the simple case. 


## Tracking Issue
https://github.com/flyteorg/flyte/issues/1979

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
