### PR TITLE
[pr into #785] wip - Compatibility testing

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -187,6 +187,7 @@ from flytekit.models.core.types import BlobType
 from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
 from flytekit.types import directory, file, schema
+from flytekit.types.structured.structured_dataset import StructuredDataset, StructuredDatasetType
 
 __version__ = "0.0.0+develop"
 

--- a/flytekit/types/structured/__init__.py
+++ b/flytekit/types/structured/__init__.py
@@ -5,8 +5,6 @@ from .basic_dfs import (
     PandasToParquetEncodingHandler,
     ParquetToArrowDecodingHandler,
     ParquetToPandasDecodingHandler,
-    ParquetToSparkDecodingHandler,
-    SparkToParquetEncodingHandler,
 )
 
 try:

--- a/plugins/flytekit-spark/flytekitplugins/spark/__init__.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/__init__.py
@@ -1,2 +1,2 @@
-from .schema import SparkDataFrameSchemaReader, SparkDataFrameSchemaWriter, SparkDataFrameTransformer
+from .schema import ParquetToSparkDecodingHandler, SparkToParquetEncodingHandler
 from .task import Spark, new_spark_session

--- a/tests/flytekit/unit/core/test_local_cache.py
+++ b/tests/flytekit/unit/core/test_local_cache.py
@@ -250,3 +250,15 @@ def test_dict_wf_with_constants():
     x = my_wf(a=5, b="hello")
     assert x == (7, "hello world")
     assert n_cached_task_calls == 2
+
+
+"""
+Update SD transformer so that it can to_python_value a Schema literal
+  - If a Schema literal is detected, copy the uri and use the new decoder to unwrap the uri  
+Update FS transformer so that it can to_python_value a StructuredDataset literal
+  - If a StructuredDataset literal is detected, use the uri from that instead.  
+
+Update all plugins that can take in a FlyteSchema to also be able to take in a StructuredDataset.
+
+All tests should work with the presence of SD imports.
+"""

--- a/tests/flytekit/unit/core/test_local_cache.py
+++ b/tests/flytekit/unit/core/test_local_cache.py
@@ -254,9 +254,9 @@ def test_dict_wf_with_constants():
 
 """
 Update SD transformer so that it can to_python_value a Schema literal
-  - If a Schema literal is detected, copy the uri and use the new decoder to unwrap the uri  
+  - If a Schema literal is detected, copy the uri and use the new decoder to unwrap the uri
 Update FS transformer so that it can to_python_value a StructuredDataset literal
-  - If a StructuredDataset literal is detected, use the uri from that instead.  
+  - If a StructuredDataset literal is detected, use the uri from that instead.
 
 Update all plugins that can take in a FlyteSchema to also be able to take in a StructuredDataset.
 


### PR DESCRIPTION
* Add new types to top level import to trigger transformer loading and overriding of base dataframe types in all instances.
* Moved Spark encoder and decoder into the spark plugin.
  * Changed encoder to use a randomly generated remote directory instead of a file.
* `flytekit-sqlalchemy`, `flytekit-snowflake`, `flytekit-hive`, `flytekit-aws-athena` need backend changes to handle the new StructuredDataset type in addition to FlyteSchema.  Probably lower priority unless someone asks for it. After backend changes are done, we can update the Python type hints.
* `flytekit-modin` seems to operate on its own type, no interoperability present with the normal `pandas.DataFrame` type, so we don't have to worry about `pandas` -> `modin` compatibility.
* `flytekit-dolt` seems to be the same as `modin`.