### PR TITLE
[pr into #785] Format cleanup

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -38,7 +38,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip==21.2.4 setuptools wheel
         make setup${{ matrix.spark-version-suffix }}
-        git clone https://github.com/flyteorg/flyteidl.git && cd flyteidl && git checkout new-schema && pip install --no-deps . && cd ..
         pip install fsspec
         pip freeze
     - name: Test with coverage
@@ -103,7 +102,6 @@ jobs:
         cd plugins/${{ matrix.plugin-names }}
         pip install -e .
         pip install --no-deps -U https://github.com/flyteorg/flytekit/archive/${{ github.sha }}.zip#egg=flytekit
-        git clone https://github.com/flyteorg/flyteidl.git && cd flyteidl && git checkout new-schema && pip install --no-deps . && cd ..
         pip install fsspec
         pip freeze
     - name: Test with coverage
@@ -152,6 +150,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip==21.2.4 setuptools wheel
           pip install -r doc-requirements.txt
-          git clone https://github.com/flyteorg/flyteidl.git && cd flyteidl && git checkout new-schema && pip install --no-deps . && cd ..
       - name: Build the documentation
         run: make -C docs html

--- a/dataset_example.py
+++ b/dataset_example.py
@@ -11,7 +11,6 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pyspark.sql.dataframe
-from flytekitplugins.spark.schema import ParquetToSparkDecodingHandler
 from pyspark.sql import SparkSession
 
 from flytekit import FlyteContext, kwtypes, task, workflow

--- a/dataset_example.py
+++ b/dataset_example.py
@@ -12,6 +12,7 @@ from pyspark.sql import SparkSession
 from flytekit import FlyteContext, kwtypes, task, workflow
 from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
+from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
     DF,
     FLYTE_DATASET_TRANSFORMER,
@@ -114,6 +115,7 @@ class NumpyEncodingHandlers(StructuredDatasetEncoder):
         self,
         ctx: FlyteContext,
         structured_dataset: StructuredDataset,
+        structured_dataset_type: StructuredDatasetType,
     ) -> literals.StructuredDataset:
         path = typing.cast(str, structured_dataset.uri) or ctx.file_access.get_random_remote_directory()
         df = typing.cast(np.ndarray, structured_dataset.dataframe)
@@ -123,7 +125,8 @@ class NumpyEncodingHandlers(StructuredDatasetEncoder):
         local_path = os.path.join(local_dir, f"{0:05}")
         pq.write_table(table, local_path, filesystem=get_filesystem(local_path))
         ctx.file_access.upload_directory(local_dir, path)
-        return literals.StructuredDataset(uri=path, metadata=StructuredDatasetMetadata(format=PARQUET))
+        structured_dataset_type.format = PARQUET
+        return literals.StructuredDataset(uri=path, metadata=StructuredDatasetMetadata(structured_dataset_type))
 
 
 class NumpyDecodingHandlers(StructuredDatasetDecoder):

--- a/dataset_example.py
+++ b/dataset_example.py
@@ -1,5 +1,6 @@
 import os
 import typing
+
 try:
     from typing import Annotated
 except ImportError:
@@ -10,6 +11,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pyspark.sql.dataframe
+from flytekitplugins.spark.schema import ParquetToSparkDecodingHandler
 from pyspark.sql import SparkSession
 
 from flytekit import FlyteContext, kwtypes, task, workflow
@@ -25,8 +27,6 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDatasetEncoder,
 )
 from flytekit.types.structured.utils import get_filesystem
-from flytekitplugins.spark.schema import ParquetToSparkDecodingHandler
-
 
 PANDAS_PATH = "/tmp/pandas"
 NUMPY_PATH = "/tmp/numpy"

--- a/dataset_example.py
+++ b/dataset_example.py
@@ -1,6 +1,9 @@
 import os
 import typing
-from typing import Annotated
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 import numpy as np
 import pandas as pd
@@ -22,6 +25,8 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDatasetEncoder,
 )
 from flytekit.types.structured.utils import get_filesystem
+from flytekitplugins.spark.schema import ParquetToSparkDecodingHandler
+
 
 PANDAS_PATH = "/tmp/pandas"
 NUMPY_PATH = "/tmp/numpy"
@@ -44,7 +49,7 @@ def t1(dataframe: pd.DataFrame) -> Annotated[pd.DataFrame, my_cols]:
 @task
 def t1a(dataframe: pd.DataFrame) -> StructuredDataset[my_cols, PARQUET]:
     # S3 (parquet) -> Pandas -> S3 (parquet) default behaviour
-    return StructuredDataset(dataframe=dataframe, file_format=PARQUET)
+    return StructuredDataset(dataframe=dataframe)
 
 
 @task
@@ -92,7 +97,7 @@ def t6(dataset: StructuredDataset[my_cols]) -> pd.DataFrame:
 def t7(df1: pd.DataFrame, df2: pd.DataFrame) -> (StructuredDataset[my_cols], StructuredDataset[my_cols]):
     # df1: pandas -> bq
     # df2: pandas -> s3 (parquet)
-    return StructuredDataset(dataframe=df1, uri=BQ_PATH), StructuredDataset(dataframe=df1, file_format=PARQUET)
+    return StructuredDataset(dataframe=df1, uri=BQ_PATH), StructuredDataset(dataframe=df1)
 
 
 @task
@@ -100,7 +105,7 @@ def t8(dataframe: pa.Table) -> StructuredDataset[my_cols]:
     # Arrow table -> s3 (parquet)
     print("Arrow table")
     print(dataframe.columns)
-    return StructuredDataset(dataframe=dataframe, file_format=PARQUET)
+    return StructuredDataset(dataframe=dataframe)
 
 
 @task
@@ -149,7 +154,7 @@ FLYTE_DATASET_TRANSFORMER.register_handler(NumpyDecodingHandlers(np.ndarray, "/"
 @task
 def t9(dataframe: np.ndarray) -> StructuredDataset[my_cols]:
     # numpy -> Arrow table -> s3 (parquet)
-    return StructuredDataset(dataframe=dataframe, uri=NUMPY_PATH, file_format=PARQUET)
+    return StructuredDataset(dataframe=dataframe, uri=NUMPY_PATH)
 
 
 @task
@@ -161,7 +166,7 @@ def t10(dataset: StructuredDataset[my_cols]) -> np.ndarray:
 
 @task
 def t11(dataframe: pyspark.sql.dataframe.DataFrame) -> StructuredDataset[my_cols]:
-    return StructuredDataset(dataframe, file_format=PARQUET)
+    return StructuredDataset(dataframe)
 
 
 @task
@@ -206,16 +211,16 @@ def wf():
     t1(dataframe=df)
     t1a(dataframe=df)
     t2(dataframe=df)
-    t3(dataset=StructuredDataset(uri=PANDAS_PATH, file_format=PARQUET))
-    t3a(dataset=StructuredDataset(uri=PANDAS_PATH, file_format=PARQUET))
-    t4(dataset=StructuredDataset(uri=PANDAS_PATH, file_format=PARQUET))
+    t3(dataset=StructuredDataset(uri=PANDAS_PATH))
+    t3a(dataset=StructuredDataset(uri=PANDAS_PATH))
+    t4(dataset=StructuredDataset(uri=PANDAS_PATH))
     t5(dataframe=df)
     t6(dataset=StructuredDataset(uri=BQ_PATH))
     t7(df1=df, df2=df)
     t8(dataframe=arrow_df)
     t8a(dataframe=arrow_df)
     t9(dataframe=np_array)
-    t10(dataset=StructuredDataset(uri=NUMPY_PATH, file_format=PARQUET))
+    t10(dataset=StructuredDataset(uri=NUMPY_PATH))
     dataset = t11(dataframe=spark_df)
     t12(dataset=dataset)
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -118,7 +118,7 @@ docstring-parser==0.13
     #   flytekit
 filelock==3.4.0
     # via virtualenv
-flyteidl==0.21.13
+flyteidl==0.21.17
     # via
     #   -c requirements.txt
     #   flytekit

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -95,7 +95,7 @@ entrypoints==0.3
     #   jupyter-client
     #   nbconvert
     #   papermill
-flyteidl==0.21.13
+flyteidl==0.21.17
     # via flytekit
 furo @ git+git://github.com/flyteorg/furo@main
     # via -r doc-requirements.in

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -141,7 +141,7 @@ class DataPersistencePlugins(object):
         Returns a plugin for the given protocol, else raise a TypeError
         """
         for k, p in cls._PLUGINS.items():
-            if path.startswith(k):
+            if path.startswith(k) or path.startswith(k.replace("://", "")):
                 return p
         raise TypeError(f"No plugin found for matching protocol of path {path}")
 

--- a/flytekit/models/literals.py
+++ b/flytekit/models/literals.py
@@ -549,13 +549,8 @@ class Schema(_common.FlyteIdlEntity):
 
 
 class StructuredDatasetMetadata(_common.FlyteIdlEntity):
-    def __init__(self, format: str, structured_dataset_type: StructuredDatasetType = None):
-        self._format = format
+    def __init__(self, structured_dataset_type: StructuredDatasetType = None):
         self._structured_dataset_type = structured_dataset_type
-
-    @property
-    def format(self) -> str:
-        return self._format
 
     @property
     def structured_dataset_type(self) -> StructuredDatasetType:
@@ -563,7 +558,6 @@ class StructuredDatasetMetadata(_common.FlyteIdlEntity):
 
     def to_flyte_idl(self) -> _literals_pb2.StructuredDatasetMetadata:
         return _literals_pb2.StructuredDatasetMetadata(
-            format=self.format,
             structured_dataset_type=self.structured_dataset_type.to_flyte_idl()
             if self._structured_dataset_type
             else None,
@@ -572,7 +566,6 @@ class StructuredDatasetMetadata(_common.FlyteIdlEntity):
     @classmethod
     def from_flyte_idl(cls, pb2_object: _literals_pb2.StructuredDatasetMetadata) -> "StructuredDatasetMetadata":
         return cls(
-            format=pb2_object.format,
             structured_dataset_type=StructuredDatasetType.from_flyte_idl(pb2_object.structured_dataset_type),
         )
 

--- a/flytekit/models/types.py
+++ b/flytekit/models/types.py
@@ -150,6 +150,10 @@ class StructuredDatasetType(_common.FlyteIdlEntity):
     def format(self) -> str:
         return self._format
 
+    @format.setter
+    def format(self, format: str):
+        self._format = format
+
     @property
     def external_schema_type(self) -> str:
         return self._external_schema_type

--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -41,7 +41,7 @@ class PandasToParquetEncodingHandler(StructuredDatasetEncoder):
         local_path = os.path.join(local_dir, f"{0:05}")
         df.to_parquet(local_path, coerce_timestamps="us", allow_truncated_timestamps=False)
         ctx.file_access.upload_directory(local_dir, path)
-        return literals.StructuredDataset(uri=path, metadata=StructuredDatasetMetadata(format=PARQUET))
+        return literals.StructuredDataset(uri=path, metadata=StructuredDatasetMetadata())
 
 
 class ParquetToPandasDecodingHandler(StructuredDatasetDecoder):
@@ -72,7 +72,7 @@ class ArrowToParquetEncodingHandler(StructuredDatasetEncoder):
         path = typing.cast(str, structured_dataset.uri) or ctx.file_access.get_random_remote_path()
         df = structured_dataset.dataframe
         pq.write_table(df, path, filesystem=get_filesystem(path))
-        return literals.StructuredDataset(uri=path, metadata=StructuredDatasetMetadata(format=PARQUET))
+        return literals.StructuredDataset(uri=path, metadata=StructuredDatasetMetadata())
 
 
 class ParquetToArrowDecodingHandler(StructuredDatasetDecoder):

--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -16,6 +16,7 @@ from flytekit.types.structured.structured_dataset import (
     FLYTE_DATASET_TRANSFORMER,
     LOCAL,
     PARQUET,
+    S3,
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
@@ -28,7 +29,8 @@ T = TypeVar("T")
 class PandasToParquetEncodingHandler(StructuredDatasetEncoder):
     def __init__(self, protocol: str):
         super().__init__(pd.DataFrame, protocol, PARQUET)
-        self._persistence = DataPersistencePlugins.find_plugin(protocol)()  # want to use this somehow
+        # todo: Use this somehow instead of relaying ont he ctx file_access
+        self._persistence = DataPersistencePlugins.find_plugin(protocol)()
 
     def encode(
         self,
@@ -95,7 +97,7 @@ class ParquetToArrowDecodingHandler(StructuredDatasetDecoder):
         return pq.read_table(path, filesystem=get_filesystem(path))
 
 
-for protocol in [LOCAL]:  # Think how to add S3 and GCS
+for protocol in [LOCAL, S3]:  # Should we add GCS
     FLYTE_DATASET_TRANSFORMER.register_handler(PandasToParquetEncodingHandler(protocol), default_for_type=True)
     FLYTE_DATASET_TRANSFORMER.register_handler(ParquetToPandasDecodingHandler(protocol), default_for_type=True)
     FLYTE_DATASET_TRANSFORMER.register_handler(ArrowToParquetEncodingHandler(protocol), default_for_type=True)

--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -67,6 +67,9 @@ class ParquetToPandasDecodingHandler(StructuredDatasetDecoder):
 
 
 class ArrowToParquetEncodingHandler(StructuredDatasetEncoder):
+    def __init__(self, protocol: str):
+        super().__init__(pa.Table, protocol, PARQUET)
+
     def encode(
         self,
         ctx: FlyteContext,
@@ -76,11 +79,13 @@ class ArrowToParquetEncodingHandler(StructuredDatasetEncoder):
         path = typing.cast(str, structured_dataset.uri) or ctx.file_access.get_random_remote_path()
         df = structured_dataset.dataframe
         pq.write_table(df, path, filesystem=get_filesystem(path))
-        structured_dataset_type.format = PARQUET
         return literals.StructuredDataset(uri=path, metadata=StructuredDatasetMetadata(structured_dataset_type))
 
 
 class ParquetToArrowDecodingHandler(StructuredDatasetDecoder):
+    def __init__(self, protocol: str):
+        super().__init__(pa.Table, protocol, PARQUET)
+
     def decode(
         self,
         ctx: FlyteContext,
@@ -93,5 +98,5 @@ class ParquetToArrowDecodingHandler(StructuredDatasetDecoder):
 for protocol in [LOCAL]:  # Think how to add S3 and GCS
     FLYTE_DATASET_TRANSFORMER.register_handler(PandasToParquetEncodingHandler(protocol), default_for_type=True)
     FLYTE_DATASET_TRANSFORMER.register_handler(ParquetToPandasDecodingHandler(protocol), default_for_type=True)
-    FLYTE_DATASET_TRANSFORMER.register_handler(ArrowToParquetEncodingHandler(pa.Table, protocol, PARQUET))
-    FLYTE_DATASET_TRANSFORMER.register_handler(ParquetToArrowDecodingHandler(pa.Table, protocol, PARQUET))
+    FLYTE_DATASET_TRANSFORMER.register_handler(ArrowToParquetEncodingHandler(protocol), default_for_type=True)
+    FLYTE_DATASET_TRANSFORMER.register_handler(ParquetToArrowDecodingHandler(protocol), default_for_type=True)

--- a/flytekit/types/structured/bigquery.py
+++ b/flytekit/types/structured/bigquery.py
@@ -51,6 +51,9 @@ def _read_from_bq(flyte_value: literals.StructuredDataset) -> pd.DataFrame:
 
 
 class PandasToBQEncodingHandlers(StructuredDatasetEncoder):
+    def __init__(self):
+        super().__init__(pd.DataFrame, BIGQUERY, supported_format="")
+
     def encode(
         self,
         ctx: FlyteContext,
@@ -58,13 +61,15 @@ class PandasToBQEncodingHandlers(StructuredDatasetEncoder):
         structured_dataset_type: StructuredDatasetType,
     ) -> literals.StructuredDataset:
         _write_to_bq(structured_dataset)
-        structured_dataset_type.format = self.supported_format
         return literals.StructuredDataset(
             uri=typing.cast(str, structured_dataset.uri), metadata=StructuredDatasetMetadata(structured_dataset_type)
         )
 
 
 class BQToPandasDecodingHandler(StructuredDatasetDecoder):
+    def __init__(self):
+        super().__init__(pd.DataFrame, BIGQUERY, supported_format="")
+
     def decode(
         self,
         ctx: FlyteContext,
@@ -74,6 +79,9 @@ class BQToPandasDecodingHandler(StructuredDatasetDecoder):
 
 
 class ArrowToBQEncodingHandlers(StructuredDatasetEncoder):
+    def __init__(self):
+        super().__init__(pa.Table, BIGQUERY, supported_format="")
+
     def encode(
         self,
         ctx: FlyteContext,
@@ -81,13 +89,15 @@ class ArrowToBQEncodingHandlers(StructuredDatasetEncoder):
         structured_dataset_type: StructuredDatasetType,
     ) -> literals.StructuredDataset:
         _write_to_bq(structured_dataset)
-        structured_dataset_type.format = self.supported_format
         return literals.StructuredDataset(
             uri=typing.cast(str, structured_dataset.uri), metadata=StructuredDatasetMetadata(structured_dataset_type)
         )
 
 
 class BQToArrowDecodingHandler(StructuredDatasetDecoder):
+    def __init__(self):
+        super().__init__(pa.Table, BIGQUERY, supported_format="")
+
     def decode(
         self,
         ctx: FlyteContext,
@@ -96,7 +106,7 @@ class BQToArrowDecodingHandler(StructuredDatasetDecoder):
         return pa.Table.from_pandas(_read_from_bq(flyte_value))
 
 
-FLYTE_DATASET_TRANSFORMER.register_handler(PandasToBQEncodingHandlers(pd.DataFrame, protocol=BIGQUERY), False)
-FLYTE_DATASET_TRANSFORMER.register_handler(BQToPandasDecodingHandler(pd.DataFrame, protocol=BIGQUERY), False)
-FLYTE_DATASET_TRANSFORMER.register_handler(ArrowToBQEncodingHandlers(pa.Table, protocol=BIGQUERY), False)
-FLYTE_DATASET_TRANSFORMER.register_handler(BQToArrowDecodingHandler(pa.Table, protocol=BIGQUERY), False)
+FLYTE_DATASET_TRANSFORMER.register_handler(PandasToBQEncodingHandlers(), default_for_type=False)
+FLYTE_DATASET_TRANSFORMER.register_handler(BQToPandasDecodingHandler(), default_for_type=False)
+FLYTE_DATASET_TRANSFORMER.register_handler(ArrowToBQEncodingHandlers(), default_for_type=False)
+FLYTE_DATASET_TRANSFORMER.register_handler(BQToArrowDecodingHandler(), default_for_type=False)

--- a/flytekit/types/structured/bigquery.py
+++ b/flytekit/types/structured/bigquery.py
@@ -8,6 +8,7 @@ from google.cloud.bigquery_storage_v1 import types
 
 from flytekit import FlyteContext
 from flytekit.models import literals
+from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
     BIGQUERY,
     DF,
@@ -15,6 +16,7 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
+    StructuredDatasetMetadata,
 )
 
 
@@ -53,9 +55,13 @@ class PandasToBQEncodingHandlers(StructuredDatasetEncoder):
         self,
         ctx: FlyteContext,
         structured_dataset: StructuredDataset,
+        structured_dataset_type: StructuredDatasetType,
     ) -> literals.StructuredDataset:
         _write_to_bq(structured_dataset)
-        return literals.StructuredDataset(uri=typing.cast(str, structured_dataset.uri))
+        structured_dataset_type.format = self.supported_format
+        return literals.StructuredDataset(
+            uri=typing.cast(str, structured_dataset.uri), metadata=StructuredDatasetMetadata(structured_dataset_type)
+        )
 
 
 class BQToPandasDecodingHandler(StructuredDatasetDecoder):
@@ -72,9 +78,13 @@ class ArrowToBQEncodingHandlers(StructuredDatasetEncoder):
         self,
         ctx: FlyteContext,
         structured_dataset: StructuredDataset,
+        structured_dataset_type: StructuredDatasetType,
     ) -> literals.StructuredDataset:
         _write_to_bq(structured_dataset)
-        return literals.StructuredDataset(uri=typing.cast(str, structured_dataset.uri))
+        structured_dataset_type.format = self.supported_format
+        return literals.StructuredDataset(
+            uri=typing.cast(str, structured_dataset.uri), metadata=StructuredDatasetMetadata(structured_dataset_type)
+        )
 
 
 class BQToArrowDecodingHandler(StructuredDatasetDecoder):
@@ -86,7 +96,7 @@ class BQToArrowDecodingHandler(StructuredDatasetDecoder):
         return pa.Table.from_pandas(_read_from_bq(flyte_value))
 
 
-FLYTE_DATASET_TRANSFORMER.register_handler(PandasToBQEncodingHandlers(pd.DataFrame, BIGQUERY), False)
-FLYTE_DATASET_TRANSFORMER.register_handler(BQToPandasDecodingHandler(pd.DataFrame, BIGQUERY), False)
-FLYTE_DATASET_TRANSFORMER.register_handler(ArrowToBQEncodingHandlers(pa.Table, BIGQUERY), False)
-FLYTE_DATASET_TRANSFORMER.register_handler(BQToArrowDecodingHandler(pa.Table, BIGQUERY), False)
+FLYTE_DATASET_TRANSFORMER.register_handler(PandasToBQEncodingHandlers(pd.DataFrame, protocol=BIGQUERY), False)
+FLYTE_DATASET_TRANSFORMER.register_handler(BQToPandasDecodingHandler(pd.DataFrame, protocol=BIGQUERY), False)
+FLYTE_DATASET_TRANSFORMER.register_handler(ArrowToBQEncodingHandlers(pa.Table, protocol=BIGQUERY), False)
+FLYTE_DATASET_TRANSFORMER.register_handler(BQToArrowDecodingHandler(pa.Table, protocol=BIGQUERY), False)

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -295,7 +295,9 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
         except KeyError:
             try:
                 hh = handler_map[df_type][protocol][""]
-                logger.info(f"Didn't find format specific handler {type(handler_map)} for protocol {protocol} format {format}, using default instead.")
+                logger.info(
+                    f"Didn't find format specific handler {type(handler_map)} for protocol {protocol} format {format}, using default instead."
+                )
                 return hh
             except KeyError:
                 ...

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -364,7 +364,8 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
         expected: LiteralType,
     ) -> Literal:
         # Make a copy in case we need to hand off to encoders, since we can't be sure of mutations.
-        sdt = StructuredDatasetType()
+        # Check first to see if it's even an SD type. For backwards compatibility, we may be getting a
+        sdt = StructuredDatasetType(format=self.DEFAULT_FORMATS.get(python_type, None))
         if expected.structured_dataset_type:
             sdt = StructuredDatasetType(
                 columns=expected.structured_dataset_type.columns,

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -306,9 +306,11 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
         raise ValueError(f"Failed to find a handler for {df_type}, protocol {protocol}, fmt {format}")
 
     def get_encoder(self, df_type: Type, protocol: str, format: str):
+        protocol.replace("://", "")
         return self._finder(self.ENCODERS, df_type, protocol, format)
 
     def get_decoder(self, df_type: Type, protocol: str, format: str):
+        protocol.replace("://", "")
         return self._finder(self.DECODERS, df_type, protocol, format)
 
     def _handler_finder(self, h: Handlers) -> Dict[str, Handlers]:
@@ -362,12 +364,14 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
         expected: LiteralType,
     ) -> Literal:
         # Make a copy in case we need to hand off to encoders, since we can't be sure of mutations.
-        sdt = StructuredDatasetType(
-            columns=expected.structured_dataset_type.columns,
-            format=expected.structured_dataset_type.format,
-            external_schema_type=expected.structured_dataset_type.external_schema_type,
-            external_schema_bytes=expected.structured_dataset_type.external_schema_bytes,
-        )
+        sdt = StructuredDatasetType()
+        if expected.structured_dataset_type:
+            sdt = StructuredDatasetType(
+                columns=expected.structured_dataset_type.columns,
+                format=expected.structured_dataset_type.format,
+                external_schema_type=expected.structured_dataset_type.external_schema_type,
+                external_schema_bytes=expected.structured_dataset_type.external_schema_bytes,
+            )
 
         if get_origin(python_type) is Annotated:
             python_type = get_args(python_type)[0]

--- a/plugins/flytekit-spark/flytekitplugins/spark/schema.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/schema.py
@@ -8,7 +8,7 @@ from flytekit import FlyteContext
 from flytekit.extend import T, TypeEngine, TypeTransformer
 from flytekit.models import literals
 from flytekit.models.literals import Literal, Scalar, Schema, StructuredDatasetMetadata
-from flytekit.models.types import LiteralType, SchemaType
+from flytekit.models.types import LiteralType, SchemaType, StructuredDatasetType
 from flytekit.types.schema import SchemaEngine, SchemaFormat, SchemaHandler, SchemaReader, SchemaWriter
 from flytekit.types.structured.structured_dataset import (
     FLYTE_DATASET_TRANSFORMER,
@@ -17,7 +17,6 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
 )
-from flytekit.models.types import LiteralType, StructuredDatasetType
 
 
 class SparkDataFrameSchemaReader(SchemaReader[pyspark.sql.DataFrame]):

--- a/plugins/flytekit-spark/flytekitplugins/spark/schema.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/schema.py
@@ -17,6 +17,7 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
 )
+from flytekit.models.types import LiteralType, StructuredDatasetType
 
 
 class SparkDataFrameSchemaReader(SchemaReader[pyspark.sql.DataFrame]):
@@ -116,11 +117,12 @@ class SparkToParquetEncodingHandler(StructuredDatasetEncoder):
         self,
         ctx: FlyteContext,
         structured_dataset: StructuredDataset,
+        structured_dataset_type: StructuredDatasetType,
     ) -> literals.StructuredDataset:
         path = typing.cast(str, structured_dataset.uri) or ctx.file_access.get_random_remote_directory()
         df = typing.cast(DataFrame, structured_dataset.dataframe)
-        df.write.mode("overwrite").parquet(self.to_path)
-        return literals.StructuredDataset(uri=path, metadata=StructuredDatasetMetadata(format=PARQUET))
+        df.write.mode("overwrite").parquet(path)
+        return literals.StructuredDataset(uri=path, metadata=StructuredDatasetMetadata(structured_dataset_type))
 
 
 class ParquetToSparkDecodingHandler(StructuredDatasetDecoder):

--- a/requirements-spark2.txt
+++ b/requirements-spark2.txt
@@ -83,7 +83,7 @@ entrypoints==0.3
     #   jupyter-client
     #   nbconvert
     #   papermill
-flyteidl==0.21.13
+flyteidl==0.21.17
     # via flytekit
 gevent==21.12.0
     # via sagemaker-training

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ entrypoints==0.3
     #   jupyter-client
     #   nbconvert
     #   papermill
-flyteidl==0.21.13
+flyteidl==0.21.17
     # via flytekit
 gevent==21.12.0
     # via sagemaker-training

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         ]
     },
     install_requires=[
-        "flyteidl>=0.21.4",
+        "flyteidl>=0.21.17",
         "wheel>=0.30.0,<1.0.0",
         "pandas>=1.0.0,<2.0.0",
         "pyarrow>=4.0.0,<7.0.0",

--- a/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
+++ b/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
@@ -44,7 +44,7 @@ docker-image-py==0.1.12
     # via flytekit
 docstring-parser==0.13
     # via flytekit
-flyteidl==0.21.13
+flyteidl==0.21.17
     # via flytekit
 flytekit==0.25.0
     # via -r tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.in

--- a/tests/flytekit/unit/core/test_structured_dataset.py
+++ b/tests/flytekit/unit/core/test_structured_dataset.py
@@ -63,3 +63,14 @@ def test_types_sd():
     pt = StructuredDataset[my_cols]
     lt = TypeEngine.to_literal_type(pt)
     assert len(lt.structured_dataset_type.columns) == 4
+
+    pt = StructuredDataset[my_cols, "csv"]
+    lt = TypeEngine.to_literal_type(pt)
+    assert len(lt.structured_dataset_type.columns) == 4
+    assert lt.structured_dataset_type.format == "csv"
+
+    pt = StructuredDataset[{}, "csv"]
+    assert pt.FILE_FORMAT == "csv"
+    lt = TypeEngine.to_literal_type(pt)
+    assert len(lt.structured_dataset_type.columns) == 0
+    assert lt.structured_dataset_type.format == "csv"

--- a/tests/flytekit/unit/core/test_structured_dataset_handlers.py
+++ b/tests/flytekit/unit/core/test_structured_dataset_handlers.py
@@ -5,6 +5,7 @@ import pyarrow as pa
 
 from flytekit import kwtypes
 from flytekit.core import context_manager
+from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured import basic_dfs
 from flytekit.types.structured.structured_dataset import StructuredDataset
 
@@ -23,7 +24,7 @@ def test_pandas():
     sd = StructuredDataset(
         dataframe=df,
     )
-    sd_lit = encoder.encode(ctx, sd)
+    sd_lit = encoder.encode(ctx, sd, StructuredDatasetType(format="parquet"))
 
     df2 = decoder.decode(ctx, sd_lit)
     assert df.equals(df2)

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -609,14 +609,14 @@ def test_structured_dataset_type():
     from flytekit.types.structured.structured_dataset import StructuredDataset, StructuredDatasetTransformerEngine
 
     tf = StructuredDatasetTransformerEngine()
-    lt = tf.get_literal_type(StructuredDataset[{name: str, age: int}])
+    lt = tf.get_literal_type(StructuredDataset[{name: str, age: int}, "parquet"])
     assert lt.structured_dataset_type is not None
 
     ctx = FlyteContextManager.current_context()
     lv = tf.to_literal(ctx, df, pd.DataFrame, lt)
     assert "/tmp/flyte" in lv.scalar.structured_dataset.uri
     metadata = lv.scalar.structured_dataset.metadata
-    assert metadata.format == "parquet"
+    assert metadata.structured_dataset_type.format == "parquet"
     v1 = tf.to_python_value(ctx, lv, pd.DataFrame)
     v2 = tf.to_python_value(ctx, lv, pa.Table)
     assert_frame_equal(df, v1)

--- a/tests/flytekit/unit/models/test_literals.py
+++ b/tests/flytekit/unit/models/test_literals.py
@@ -372,7 +372,7 @@ def test_structured_dataset():
     ds = literals.StructuredDataset(
         uri="s3://bucket",
         metadata=literals.StructuredDatasetMetadata(
-            format="parquet", structured_dataset_type=_types.StructuredDatasetType(columns=my_cols, format="parquet")
+            structured_dataset_type=_types.StructuredDatasetType(columns=my_cols, format="parquet")
         ),
     )
     obj = literals.Scalar(structured_dataset=ds)
@@ -383,7 +383,6 @@ def test_structured_dataset():
     assert obj.none_type is None
     assert obj.structured_dataset is not None
     assert obj.value.uri == "s3://bucket"
-    assert obj.value.metadata.format == "parquet"
     assert len(obj.value.metadata.structured_dataset_type.columns) == 4
     obj2 = literals.Scalar.from_flyte_idl(obj.to_flyte_idl())
     assert obj == obj2
@@ -393,7 +392,6 @@ def test_structured_dataset():
     assert obj2.none_type is None
     assert obj2.structured_dataset is not None
     assert obj2.value.uri == "s3://bucket"
-    assert obj2.value.metadata.format == "parquet"
     assert len(obj2.value.metadata.structured_dataset_type.columns) == 4
 
 


### PR DESCRIPTION
* Remove the format field from the literal model object since it's no longer in the IDL literal.  It's now only in the type.
* Remove `file_format` field from the python `StructuredDataset` object.  It will default to "parquet", and will only be settable by the user through `Annotate`. This should be okay because we don't see format to be used too often.
* Add helper functions to decoder/encoder lookup. Default to use `""` in case a matching format cannot be found.
* Update remaining handlers to have static values for at least type and format, in some cases also protocol.
* Change the `Encoder` interface to add `structured_literal_type: StructuredDatasetType` as an input argument. The reason is because we want contributors to be able to fill in/potentially modify the type information that's embedded in the literal.
* Change the default format in the class-get-item of the python `StructuredDataset` to also be parquet, otherwise `StructuredDataset[my_cols]` got a format of "" instead of parquet.
* Make the TransformerEngine fill in missing type information in the literal if not supplied by the encoder.
