### PR TITLE
Fix sagemaker plugin

### DIFF
--- a/plugins/flytekit-aws-sagemaker/setup.py
+++ b/plugins/flytekit-aws-sagemaker/setup.py
@@ -16,7 +16,7 @@ setup(
     author_email="admin@flyte.org",
     description="AWS Plugins for flytekit",
     namespace_packages=["flytekitplugins"],
-    packages=[f"flytekitplugins.{PLUGIN_NAME}"],
+    packages=[f"flytekitplugins.{PLUGIN_NAME}", f"flytekitplugins.{PLUGIN_NAME}.models"],
     install_requires=plugin_requires,
     license="apache2",
     python_requires=">=3.7",


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Sagemaker plugin python package didn't contain the `models` submodule starting on the [0.24.0 release](https://github.com/flyteorg/flytekit/releases/tag/v0.24.0).

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The sagemaker plugin does not contain all the expected files:
```
❯ ls -la flytekitplugins-awssagemaker-0.26.0/flytekitplugins/awssagemaker
.rw-r--r--  903 eduardo  5 Jan 14:04 __init__.py
.rw-r--r-- 3.0k eduardo  5 Jan 14:04 distributed_training.py
.rw-r--r-- 7.1k eduardo  5 Jan 14:04 hpo.py
.rw-r--r-- 8.3k eduardo  5 Jan 14:04 training.py
``` 

Note how the [`models`](https://github.com/flyteorg/flytekit/tree/master/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/models) subdirectory is not present. 

We create source distributions (for both flytekit and the several flytekit plugins packages) using setuptools `sdist` command. In order to find the modules that will be published in a package `sdist` relies on the list of packages listed in the `packages` argument in `setup.py`.  

As part of https://github.com/flyteorg/flytekit/pull/736 we ended up pulling the aws sagemaker models files from a submodule in the plugin as opposed from flytekit and since we [weren't listing this new module in the call to `packages`](https://github.com/flyteorg/flytekit/blob/master/plugins/flytekit-aws-sagemaker/setup.py#L19) in the definition of the plugin, those files were not part of the plugin package. 

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
