### PR TITLE
Add secretsmanager back

### DIFF
--- a/flytekit/testing/__init__.py
+++ b/flytekit/testing/__init__.py
@@ -16,4 +16,5 @@ testing workflows that contain tasks that cannot run locally (a Hive task for in
 
 """
 
+from flytekit.core.context_manager import SecretsManager
 from flytekit.core.testing import patch, task_mock


### PR DESCRIPTION
Signed-off-by: Yee Hing Tong <wild-endeavor@users.noreply.github.com>

# TL;DR
Add `SecretsManager` back to the old location - it doesn't belong but easier to leave it here than break people.