### PR TITLE
Fix flaky test: test_spark_task

### DIFF
--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -110,6 +110,7 @@ class PysparkFunctionTask(PythonFunctionTask[Spark]):
             # If either of above cases is not true, then we are in local execution of this task
             # Add system spark-conf for local/notebook based execution.
             spark_conf = _pyspark.SparkConf()
+            spark_conf.set("spark.driver.bindAddress", "127.0.0.1")
             for k, v in self.task_config.spark_conf.items():
                 spark_conf.set(k, v)
             # In local execution, propagate PYTHONPATH to executors too. This makes the spark


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Error: https://github.com/flyteorg/flytekit/runs/4859818955?check_suite_focus=true
It might be related to https://stackoverflow.com/questions/52133731/how-to-solve-cant-assign-requested-address-service-sparkdriver-failed-after

Updating spark conf can fix it.
```python
conf_spark = SparkConf().set("spark.driver.host", "127.0.0.1")
```

I ran the tests 100 times, The tests were all passed. 
https://github.com/pingsutw/flytekit/commits/spark-driver?before=8b7cb7d6449db4fea5add36de8014060b7522f9b+35&branch=spark-driver

The test which didn't update the spark config failed 3 times. 
https://github.com/pingsutw/flytekit/commits/bad-spark-driver?before=4cf2a1a41ab470946dcc7485adc573214fb74de7+35&branch=bad-spark-driver

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
