### PR TITLE
`ctx` Context can be used within shell tasks - to access context vars and secrets

### DIFF
--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -325,23 +325,6 @@ class ExecutionParameters(object):
         return self.__getattr__(attr_name=key)
 
 
-class _GroupSecrets(object):
-    """
-    This is a dummy class whose sole purpose is to support "attribute" style lookup for secrets
-    """
-
-    def __init__(self, group: str, sm: typing.Any):
-        self._group = group
-        self._sm = sm
-
-    def __getattr__(self, item: str) -> str:
-        """
-        Returns the secret that matches "group"."key"
-        the key, here is the item
-        """
-        return self._sm.get(self._group, item)
-
-
 class SecretsManager(object):
     """
     This provides a secrets resolution logic at runtime.
@@ -354,6 +337,22 @@ class SecretsManager(object):
     All configuration values can always be overridden by injecting an environment variable
     """
 
+    class _GroupSecrets(object):
+        """
+        This is a dummy class whose sole purpose is to support "attribute" style lookup for secrets
+        """
+
+        def __init__(self, group: str, sm: typing.Any):
+            self._group = group
+            self._sm = sm
+
+        def __getattr__(self, item: str) -> str:
+            """
+            Returns the secret that matches "group"."key"
+            the key, here is the item
+            """
+            return self._sm.get(self._group, item)
+
     def __init__(self):
         self._base_dir = str(secrets.SECRETS_DEFAULT_DIR.get()).strip()
         self._file_prefix = str(secrets.SECRETS_FILE_PREFIX.get()).strip()
@@ -363,7 +362,7 @@ class SecretsManager(object):
         """
         returns a new _GroupSecrets objects, that allows all keys within this group to be looked up like attributes
         """
-        return _GroupSecrets(item, self)
+        return self._GroupSecrets(item, self)
 
     def get(self, group: str, key: str) -> str:
         """

--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -7,6 +7,7 @@ import subprocess
 import typing
 from dataclasses import dataclass
 
+import flytekit
 from flytekit.core.context_manager import ExecutionParameters
 from flytekit.core.interface import Interface
 from flytekit.core.python_function_task import PythonInstanceTask
@@ -76,7 +77,7 @@ class _PythonFStringInterpolizer:
         reused_vars = inputs.keys() & outputs.keys()
         if reused_vars:
             raise ValueError(f"Variables {reused_vars} in Query cannot be shared between inputs and outputs.")
-        consolidated_args = collections.ChainMap(inputs, outputs)
+        consolidated_args = collections.ChainMap(inputs, outputs, {"ctx": flytekit.current_context()})
         try:
             return self._Formatter().format(tmpl, **consolidated_args)
         except KeyError as e:

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -1,4 +1,16 @@
-from flytekit.core.context_manager import ExecutionState, FlyteContext, FlyteContextManager, look_up_image_info
+import os
+
+import py
+import pytest
+
+from flytekit.configuration import secrets
+from flytekit.core.context_manager import (
+    ExecutionState,
+    FlyteContext,
+    FlyteContextManager,
+    SecretsManager,
+    look_up_image_info,
+)
 
 
 class SampleTestClass(object):
@@ -65,3 +77,76 @@ def test_additional_context():
             )
         ) as exec_ctx_inner:
             assert exec_ctx_inner.execution_state.additional_context == {1: "inner", 2: "foo", 3: "baz"}
+
+
+def test_secrets_manager_default():
+    with pytest.raises(ValueError):
+        sec = SecretsManager()
+        sec.get("group", "key")
+
+    with pytest.raises(ValueError):
+        _ = sec.group.key
+
+
+def test_secrets_manager_get_envvar():
+    sec = SecretsManager()
+    with pytest.raises(ValueError):
+        sec.get_secrets_env_var("test", "")
+    with pytest.raises(ValueError):
+        sec.get_secrets_env_var("", "x")
+    assert sec.get_secrets_env_var("group", "test") == f"{secrets.SECRETS_ENV_PREFIX.get()}GROUP_TEST"
+
+
+def test_secrets_manager_get_file():
+    sec = SecretsManager()
+    with pytest.raises(ValueError):
+        sec.get_secrets_file("test", "")
+    with pytest.raises(ValueError):
+        sec.get_secrets_file("", "x")
+    assert sec.get_secrets_file("group", "test") == os.path.join(
+        secrets.SECRETS_DEFAULT_DIR.get(),
+        "group",
+        f"{secrets.SECRETS_FILE_PREFIX.get()}test",
+    )
+
+
+def test_secrets_manager_file(tmpdir: py.path.local):
+    tmp = tmpdir.mkdir("file_test").dirname
+    os.environ["FLYTE_SECRETS_DEFAULT_DIR"] = tmp
+    sec = SecretsManager()
+    f = os.path.join(tmp, "test")
+    with open(f, "w+") as w:
+        w.write("my-password")
+
+    with pytest.raises(ValueError):
+        sec.get("test", "")
+    with pytest.raises(ValueError):
+        sec.get("", "x")
+    # Group dir not exists
+    with pytest.raises(ValueError):
+        sec.get("group", "test")
+
+    g = os.path.join(tmp, "group")
+    os.makedirs(g)
+    f = os.path.join(g, "test")
+    with open(f, "w+") as w:
+        w.write("my-password")
+    assert sec.get("group", "test") == "my-password"
+    assert sec.group.test == "my-password"
+    del os.environ["FLYTE_SECRETS_DEFAULT_DIR"]
+
+
+def test_secrets_manager_bad_env():
+    with pytest.raises(ValueError):
+        os.environ["TEST"] = "value"
+        sec = SecretsManager()
+        sec.get("group", "test")
+
+
+def test_secrets_manager_env():
+    sec = SecretsManager()
+    os.environ[sec.get_secrets_env_var("group", "test")] = "value"
+    assert sec.get("group", "test") == "value"
+
+    os.environ[sec.get_secrets_env_var(group="group", key="key")] = "value"
+    assert sec.get(group="group", key="key") == "value"

--- a/tests/flytekit/unit/extras/tasks/test_shell.py
+++ b/tests/flytekit/unit/extras/tasks/test_shell.py
@@ -7,6 +7,7 @@ from subprocess import CalledProcessError
 import pytest
 from dataclasses_json import dataclass_json
 
+import flytekit
 from flytekit import kwtypes
 from flytekit.extras.tasks.shell import OutputLocation, ShellTask
 from flytekit.types.directory import FlyteDirectory
@@ -46,8 +47,8 @@ def test_input_substitution_primitive():
         name="test",
         script="""
             set -ex
-            cat {f}
-            echo "Hello World {y} on  {j}"
+            cat {inputs.f}
+            echo "Hello World {inputs.y} on  {inputs.j}"
             """,
         inputs=kwtypes(f=str, y=int, j=datetime.datetime),
     )
@@ -62,8 +63,8 @@ def test_input_substitution_files():
     t = ShellTask(
         name="test",
         script="""
-            cat {f}
-            echo "Hello World {y} on  {j}"
+            cat {inputs.f}
+            echo "Hello World {inputs.y} on  {inputs.j}"
             """,
         inputs=kwtypes(f=CSVFile, y=FlyteDirectory, j=datetime.datetime),
     )
@@ -72,28 +73,36 @@ def test_input_substitution_files():
 
 
 def test_input_substitution_files_ctx():
+    sec = flytekit.current_context().secrets
+    envvar = sec.get_secrets_env_var("group", "key")
+    os.environ[envvar] = "value"
+    assert sec.get("group", "key") == "value"
+
     t = ShellTask(
         name="test",
         script="""
-            export X={ctx.execution_id}
-            cat {f}
-            echo "Hello World {y} on  {j}"
+            export EXEC={ctx.execution_id}
+            export SECRET={ctx.secrets.group.key}
+            cat {inputs.f}
+            echo "Hello World {inputs.y} on  {inputs.j}"
             """,
         inputs=kwtypes(f=CSVFile, y=FlyteDirectory, j=datetime.datetime),
+        debug=True,
     )
 
     assert t(f=test_csv, y=testdata, j=datetime.datetime(2021, 11, 10, 12, 15, 0)) is None
+    del os.environ[envvar]
 
 
 def test_input_output_substitution_files():
-    script = "cat {f} > {y}"
+    script = "cat {inputs.f} > {outputs.y}"
     t = ShellTask(
         name="test",
         debug=True,
         script=script,
         inputs=kwtypes(f=CSVFile),
         output_locs=[
-            OutputLocation(var="y", var_type=FlyteFile, location="{f}.mod"),
+            OutputLocation(var="y", var_type=FlyteFile, location="{inputs.f}.mod"),
         ],
     )
 
@@ -115,15 +124,15 @@ def test_input_output_substitution_files():
 
 def test_input_single_output_substitution_files():
     script = """
-            cat {f} >> {z}
-            echo "Hello World {y} on  {j}"
+            cat {inputs.f} >> {outputs.z}
+            echo "Hello World {inputs.y} on  {inputs.j}"
             """
     t = ShellTask(
         name="test",
         debug=True,
         script=script,
         inputs=kwtypes(f=CSVFile, y=FlyteDirectory, j=datetime.datetime),
-        output_locs=[OutputLocation(var="z", var_type=FlyteFile, location="{f}.pyc")],
+        output_locs=[OutputLocation(var="z", var_type=FlyteFile, location="{inputs.f}.pyc")],
     )
 
     assert t.script == script
@@ -136,14 +145,14 @@ def test_input_single_output_substitution_files():
     [
         (
             """
-            cat {missing} >> {z}
-            echo "Hello World {y} on  {j} - output {x}"
+            cat {missing} >> {outputs.z}
+            echo "Hello World {inputs.y} on  {inputs.j} - output {outputs.x}"
             """
         ),
         (
             """
-            cat {f} {missing} >> {z}
-            echo "Hello World {y} on  {j} - output {x}"
+            cat {inputs.f} {missing} >> {outputs.z}
+            echo "Hello World {inputs.y} on  {inputs.j} - output {outputs.x}"
             """
         ),
     ],
@@ -155,8 +164,8 @@ def test_input_output_extra_and_missing_variables(script):
         script=script,
         inputs=kwtypes(f=CSVFile, y=FlyteDirectory, j=datetime.datetime),
         output_locs=[
-            OutputLocation(var="x", var_type=FlyteDirectory, location="{y}"),
-            OutputLocation(var="z", var_type=FlyteFile, location="{f}.pyc"),
+            OutputLocation(var="x", var_type=FlyteDirectory, location="{inputs.y}"),
+            OutputLocation(var="z", var_type=FlyteFile, location="{inputs.f}.pyc"),
         ],
     )
 
@@ -164,22 +173,21 @@ def test_input_output_extra_and_missing_variables(script):
         t(f=test_csv, y=testdata, j=datetime.datetime(2021, 11, 10, 12, 15, 0))
 
 
-def test_cannot_reuse_variables_for_both_inputs_and_outputs():
+def test_reuse_variables_for_both_inputs_and_outputs():
     t = ShellTask(
         name="test",
         debug=True,
         script="""
-        cat {f} >> {y}
-        echo "Hello World {y} on  {j}"
+        cat {inputs.f} >> {outputs.y}
+        echo "Hello World {inputs.y} on  {inputs.j}"
         """,
         inputs=kwtypes(f=CSVFile, y=FlyteDirectory, j=datetime.datetime),
         output_locs=[
-            OutputLocation(var="y", var_type=FlyteFile, location="{f}.pyc"),
+            OutputLocation(var="y", var_type=FlyteFile, location="{inputs.f}.pyc"),
         ],
     )
 
-    with pytest.raises(ValueError, match="Variables {'y'} in Query"):
-        t(f=test_csv, y=testdata, j=datetime.datetime(2021, 11, 10, 12, 15, 0))
+    t(f=test_csv, y=testdata, j=datetime.datetime(2021, 11, 10, 12, 15, 0))
 
 
 def test_can_use_complex_types_for_inputs_to_f_string_template():
@@ -191,10 +199,10 @@ def test_can_use_complex_types_for_inputs_to_f_string_template():
     t = ShellTask(
         name="test",
         debug=True,
-        script="""cat {input_args.in_file} >> {input_args.in_file}.tmp""",
+        script="""cat {inputs.input_args.in_file} >> {inputs.input_args.in_file}.tmp""",
         inputs=kwtypes(input_args=InputArgs),
         output_locs=[
-            OutputLocation(var="x", var_type=FlyteFile, location="{input_args.in_file}.tmp"),
+            OutputLocation(var="x", var_type=FlyteFile, location="{inputs.input_args.in_file}.tmp"),
         ],
     )
 
@@ -210,8 +218,8 @@ def test_shell_script():
         script_file=script_sh,
         inputs=kwtypes(f=CSVFile, y=FlyteDirectory, j=datetime.datetime),
         output_locs=[
-            OutputLocation(var="x", var_type=FlyteDirectory, location="{y}"),
-            OutputLocation(var="z", var_type=FlyteFile, location="{f}.pyc"),
+            OutputLocation(var="x", var_type=FlyteDirectory, location="{inputs.y}"),
+            OutputLocation(var="z", var_type=FlyteFile, location="{inputs.f}.pyc"),
         ],
     )
 

--- a/tests/flytekit/unit/extras/tasks/test_shell.py
+++ b/tests/flytekit/unit/extras/tasks/test_shell.py
@@ -71,6 +71,20 @@ def test_input_substitution_files():
     assert t(f=test_csv, y=testdata, j=datetime.datetime(2021, 11, 10, 12, 15, 0)) is None
 
 
+def test_input_substitution_files_ctx():
+    t = ShellTask(
+        name="test",
+        script="""
+            export X={ctx.execution_id}
+            cat {f}
+            echo "Hello World {y} on  {j}"
+            """,
+        inputs=kwtypes(f=CSVFile, y=FlyteDirectory, j=datetime.datetime),
+    )
+
+    assert t(f=test_csv, y=testdata, j=datetime.datetime(2021, 11, 10, 12, 15, 0)) is None
+
+
 def test_input_output_substitution_files():
     script = "cat {f} > {y}"
     t = ShellTask(

--- a/tests/flytekit/unit/extras/tasks/testdata/script.sh
+++ b/tests/flytekit/unit/extras/tasks/testdata/script.sh
@@ -2,5 +2,5 @@
 
 set -ex
 
-cat "{f}" >> "{z}"
-echo "Hello World {y} on  {j} - output {x}"
+cat "{inputs.f}" >> "{outputs.z}"
+echo "Hello World {inputs.y} on  {inputs.j} - output {outputs.x}"


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
- Allows users to use `ctx.*` in shell tasks
- For secrets, it is necessary to use the attribute accessor api - `ctx.secrets.group.key`. The group and key are the actual group and key values to look for
- Also all inputs and outputs are now namesapced. So to access inputs it is necessary to use `inputs.x`

Example:
```python
    t = ShellTask(
        name="test",
        script="""
            export EXEC_ID={ctx.execution_id}
            export SEC={ctx.secrets.group.key}
            cat {inputs.f}
            echo "Hello World {inputs.y} on  {inputs.j}"
            """,
        inputs=kwtypes(f=CSVFile, y=FlyteDirectory, j=datetime.datetime),
    )
```

all variables supported by flytekit.current_context are replaceable.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue


## Tracking Issue
https://github.com/flyteorg/flyte/issues/2110

## Follow-up issue
_NA_

