### PR TITLE
Assign input and output to FlyteWorkflowExecution

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -460,7 +460,7 @@ class FlyteRemote(object):
         """
         if name is None:
             raise user_exceptions.FlyteAssertion("the 'name' argument must be specified.")
-        return FlyteWorkflowExecution.promote_from_model(
+        execution = FlyteWorkflowExecution.promote_from_model(
             self.client.get_execution(
                 WorkflowExecutionIdentifier(
                     project or self.default_project,
@@ -469,6 +469,7 @@ class FlyteRemote(object):
                 )
             )
         )
+        return self.sync_workflow_execution(execution)
 
     ######################
     #  Listing Entities  #

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -190,6 +190,10 @@ def test_execute_python_workflow_and_launch_plan(flyteclient, flyte_workflows_re
     assert execution.outputs["o0"] == 16
     assert execution.outputs["o1"] == "foobarworld"
 
+    flyte_workflow_execution = remote.fetch_workflow_execution(name=execution.id.name)
+    assert execution.inputs == flyte_workflow_execution.inputs
+    assert execution.outputs == flyte_workflow_execution.outputs
+
 
 def test_fetch_execute_launch_plan_list_of_floats(flyteclient, flyte_workflows_register):
     remote = FlyteRemote.from_config(PROJECT, "development")


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Assign input and output to FlyteWorkflowExecution after fetching execution.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2108

## Follow-up issue
_NA_
