### PR TITLE
Remove singleton from structured dataset transformer engine

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -39,9 +39,11 @@ jobs:
         python -m pip install --upgrade pip==21.2.4 setuptools wheel
         make setup${{ matrix.spark-version-suffix }}
         pip freeze
+    - name: Test FlyteSchema compatibility
+      run: |
+        FLYTE_SDK_USE_STRUCTURED_DATASET=FALSE python -m pytest tests/flytekit_compatibility
     - name: Test with coverage
       run: |
-        coverage run -m pytest tests/flytekit_compatibility
         FLYTE_SDK_USE_STRUCTURED_DATASET=TRUE coverage run -m pytest tests/flytekit/unit
     - name: Integration Tests with coverage
       # https://github.com/actions/runner/issues/241#issuecomment-577360161

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -193,8 +193,8 @@ if USE_STRUCTURED_DATASET.get():
     from flytekit.types.structured.structured_dataset import (
         StructuredDataset,
         StructuredDatasetFormat,
-        StructuredDatasetType,
         StructuredDatasetTransformerEngine,
+        StructuredDatasetType,
     )
 
 __version__ = "0.0.0+develop"

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -194,6 +194,7 @@ if USE_STRUCTURED_DATASET.get():
         StructuredDataset,
         StructuredDatasetFormat,
         StructuredDatasetType,
+        StructuredDatasetTransformerEngine,
     )
 
 __version__ = "0.0.0+develop"

--- a/flytekit/extend/__init__.py
+++ b/flytekit/extend/__init__.py
@@ -46,7 +46,3 @@ from flytekit.core.shim_task import ExecutableTemplateShimTask, ShimTaskExecutor
 from flytekit.core.task import TaskPlugins
 from flytekit.core.type_engine import DictTransformer, T, TypeEngine, TypeTransformer
 from flytekit.tools.translator import get_serializable
-
-from flytekit.configuration.sdk import USE_STRUCTURED_DATASET
-if USE_STRUCTURED_DATASET.get():
-    from flytekit.types.structured.structured_dataset import FLYTE_DATASET_TRANSFORMER

--- a/flytekit/extend/__init__.py
+++ b/flytekit/extend/__init__.py
@@ -46,3 +46,7 @@ from flytekit.core.shim_task import ExecutableTemplateShimTask, ShimTaskExecutor
 from flytekit.core.task import TaskPlugins
 from flytekit.core.type_engine import DictTransformer, T, TypeEngine, TypeTransformer
 from flytekit.tools.translator import get_serializable
+
+from flytekit.configuration.sdk import USE_STRUCTURED_DATASET
+if USE_STRUCTURED_DATASET.get():
+    from flytekit.types.structured.structured_dataset import FLYTE_DATASET_TRANSFORMER

--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -19,6 +19,7 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
+    StructuredDatasetTransformerEngine,
 )
 
 T = TypeVar("T")
@@ -107,7 +108,7 @@ class ParquetToArrowDecodingHandler(StructuredDatasetDecoder):
 
 
 for protocol in [LOCAL, S3]:  # Should we add GCS
-    FLYTE_DATASET_TRANSFORMER.register_handler(PandasToParquetEncodingHandler(protocol), default_for_type=True)
-    FLYTE_DATASET_TRANSFORMER.register_handler(ParquetToPandasDecodingHandler(protocol), default_for_type=True)
-    FLYTE_DATASET_TRANSFORMER.register_handler(ArrowToParquetEncodingHandler(protocol), default_for_type=True)
-    FLYTE_DATASET_TRANSFORMER.register_handler(ParquetToArrowDecodingHandler(protocol), default_for_type=True)
+    StructuredDatasetTransformerEngine.register_handler(PandasToParquetEncodingHandler(protocol), default_for_type=True)
+    StructuredDatasetTransformerEngine.register_handler(ParquetToPandasDecodingHandler(protocol), default_for_type=True)
+    StructuredDatasetTransformerEngine.register_handler(ArrowToParquetEncodingHandler(protocol), default_for_type=True)
+    StructuredDatasetTransformerEngine.register_handler(ParquetToArrowDecodingHandler(protocol), default_for_type=True)

--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -107,7 +107,7 @@ class ParquetToArrowDecodingHandler(StructuredDatasetDecoder):
 
 
 for protocol in [LOCAL, S3]:  # Should we add GCS
-    StructuredDatasetTransformerEngine.register_handler(PandasToParquetEncodingHandler(protocol), default_for_type=True)
-    StructuredDatasetTransformerEngine.register_handler(ParquetToPandasDecodingHandler(protocol), default_for_type=True)
-    StructuredDatasetTransformerEngine.register_handler(ArrowToParquetEncodingHandler(protocol), default_for_type=True)
-    StructuredDatasetTransformerEngine.register_handler(ParquetToArrowDecodingHandler(protocol), default_for_type=True)
+    StructuredDatasetTransformerEngine.register(PandasToParquetEncodingHandler(protocol), default_for_type=True)
+    StructuredDatasetTransformerEngine.register(ParquetToPandasDecodingHandler(protocol), default_for_type=True)
+    StructuredDatasetTransformerEngine.register(ArrowToParquetEncodingHandler(protocol), default_for_type=True)
+    StructuredDatasetTransformerEngine.register(ParquetToArrowDecodingHandler(protocol), default_for_type=True)

--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -12,7 +12,6 @@ from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
-    FLYTE_DATASET_TRANSFORMER,
     LOCAL,
     PARQUET,
     S3,

--- a/flytekit/types/structured/bigquery.py
+++ b/flytekit/types/structured/bigquery.py
@@ -110,7 +110,7 @@ class BQToArrowDecodingHandler(StructuredDatasetDecoder):
         return pa.Table.from_pandas(_read_from_bq(flyte_value))
 
 
-StructuredDatasetTransformerEngine.register_handler(PandasToBQEncodingHandlers(), default_for_type=False)
-StructuredDatasetTransformerEngine.register_handler(BQToPandasDecodingHandler(), default_for_type=False)
-StructuredDatasetTransformerEngine.register_handler(ArrowToBQEncodingHandlers(), default_for_type=False)
-StructuredDatasetTransformerEngine.register_handler(BQToArrowDecodingHandler(), default_for_type=False)
+StructuredDatasetTransformerEngine.register(PandasToBQEncodingHandlers(), default_for_type=False)
+StructuredDatasetTransformerEngine.register(BQToPandasDecodingHandler(), default_for_type=False)
+StructuredDatasetTransformerEngine.register(ArrowToBQEncodingHandlers(), default_for_type=False)
+StructuredDatasetTransformerEngine.register(BQToArrowDecodingHandler(), default_for_type=False)

--- a/flytekit/types/structured/bigquery.py
+++ b/flytekit/types/structured/bigquery.py
@@ -17,6 +17,7 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
     StructuredDatasetMetadata,
+    StructuredDatasetTransformerEngine,
 )
 
 
@@ -110,7 +111,7 @@ class BQToArrowDecodingHandler(StructuredDatasetDecoder):
         return pa.Table.from_pandas(_read_from_bq(flyte_value))
 
 
-FLYTE_DATASET_TRANSFORMER.register_handler(PandasToBQEncodingHandlers(), default_for_type=False)
-FLYTE_DATASET_TRANSFORMER.register_handler(BQToPandasDecodingHandler(), default_for_type=False)
-FLYTE_DATASET_TRANSFORMER.register_handler(ArrowToBQEncodingHandlers(), default_for_type=False)
-FLYTE_DATASET_TRANSFORMER.register_handler(BQToArrowDecodingHandler(), default_for_type=False)
+StructuredDatasetTransformerEngine.register_handler(PandasToBQEncodingHandlers(), default_for_type=False)
+StructuredDatasetTransformerEngine.register_handler(BQToPandasDecodingHandler(), default_for_type=False)
+StructuredDatasetTransformerEngine.register_handler(ArrowToBQEncodingHandlers(), default_for_type=False)
+StructuredDatasetTransformerEngine.register_handler(BQToArrowDecodingHandler(), default_for_type=False)

--- a/flytekit/types/structured/bigquery.py
+++ b/flytekit/types/structured/bigquery.py
@@ -12,7 +12,6 @@ from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
     BIGQUERY,
     DF,
-    FLYTE_DATASET_TRANSFORMER,
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -380,7 +380,7 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
         self._type_assertions_enabled = False
 
     @classmethod
-    def register_handler(cls, h: Handlers, default_for_type: Optional[bool] = True, override: Optional[bool] = False):
+    def register(cls, h: Handlers, default_for_type: Optional[bool] = True, override: Optional[bool] = False):
         """
         Call this with any handler to register it with this dataframe meta-transformer
 

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -728,8 +728,8 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
 
 
 if USE_STRUCTURED_DATASET.get():
-    logger.warning("Structured dataset module load... using structured datasets!")
+    logger.debug("Structured dataset module load... using structured datasets!")
     flyte_dataset_transformer = StructuredDatasetTransformerEngine()
     TypeEngine.register(flyte_dataset_transformer)
 else:
-    logger.warning("Structured dataset module load... not using structured datasets")
+    logger.debug("Structured dataset module load... not using structured datasets")

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -723,8 +723,8 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
 
 
 if USE_STRUCTURED_DATASET.get():
-    logger.debug("Structured dataset module load... using structured datasets!")
+    logger.warning("Structured dataset module load... using structured datasets!")
     FLYTE_DATASET_TRANSFORMER = StructuredDatasetTransformerEngine()
     TypeEngine.register(FLYTE_DATASET_TRANSFORMER)
 else:
-    logger.debug("Structured dataset module load... not using structured datasets")
+    logger.warning("Structured dataset module load... not using structured datasets")

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -24,8 +24,7 @@ import pyarrow as pa
 
 from flytekit.configuration.sdk import USE_STRUCTURED_DATASET
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
-from flytekit.core.type_engine import TypeTransformer
-from flytekit.extend import TypeEngine
+from flytekit.core.type_engine import TypeTransformer, TypeEngine
 from flytekit.loggers import logger
 from flytekit.models import literals
 from flytekit.models import types as type_models

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -24,7 +24,7 @@ import pyarrow as pa
 
 from flytekit.configuration.sdk import USE_STRUCTURED_DATASET
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
-from flytekit.core.type_engine import TypeTransformer, TypeEngine
+from flytekit.core.type_engine import TypeEngine, TypeTransformer
 from flytekit.loggers import logger
 from flytekit.models import literals
 from flytekit.models import types as type_models

--- a/plugins/flytekit-papermill/dev-requirements.in
+++ b/plugins/flytekit-papermill/dev-requirements.in
@@ -1,1 +1,1 @@
-flytekitplugins-spark>=0.30.0b4
+git+https://github.com/flyteorg/flytekit@add-sd-make-class-methods

--- a/plugins/flytekit-papermill/dev-requirements.in
+++ b/plugins/flytekit-papermill/dev-requirements.in
@@ -1,3 +1,2 @@
 git+https://github.com/flyteorg/flytekit@add-sd-make-class-methods#egg=flytekitplugins-spark&subdirectory=plugins/flytekit-spark
 # vcs+protocol://repo_url/#egg=pkg&subdirectory=flyte
-

--- a/plugins/flytekit-papermill/dev-requirements.in
+++ b/plugins/flytekit-papermill/dev-requirements.in
@@ -1,1 +1,3 @@
-git+https://github.com/flyteorg/flytekit@add-sd-make-class-methods
+git+https://github.com/flyteorg/flytekit@add-sd-make-class-methods#egg=flytekitplugins-spark&subdirectory=plugins/flytekit-spark
+# vcs+protocol://repo_url/#egg=pkg&subdirectory=flyte
+

--- a/plugins/flytekit-papermill/dev-requirements.txt
+++ b/plugins/flytekit-papermill/dev-requirements.txt
@@ -40,7 +40,9 @@ docstring-parser==0.13
     # via flytekit
 flyteidl==0.21.23
     # via flytekit
-flytekit @ git+https://github.com/flyteorg/flytekit@add-sd-make-class-methods
+flytekit==0.30.0
+    # via flytekitplugins-spark
+flytekitplugins-spark @ git+https://github.com/flyteorg/flytekit@add-sd-make-class-methods#subdirectory=plugins/flytekit-spark
     # via -r dev-requirements.in
 grpcio==1.43.0
     # via flytekit
@@ -85,8 +87,12 @@ protobuf==3.19.3
     #   flytekit
 py==1.11.0
     # via retry
+py4j==0.10.9.3
+    # via pyspark
 pyarrow==6.0.1
     # via flytekit
+pyspark==3.2.1
+    # via flytekitplugins-spark
 python-dateutil==2.8.1
     # via
     #   arrow

--- a/plugins/flytekit-papermill/dev-requirements.txt
+++ b/plugins/flytekit-papermill/dev-requirements.txt
@@ -40,9 +40,7 @@ docstring-parser==0.13
     # via flytekit
 flyteidl==0.21.23
     # via flytekit
-flytekit==0.26.0
-    # via flytekitplugins-spark
-flytekitplugins-spark==0.30.0b4
+flytekit @ git+https://github.com/flyteorg/flytekit@add-sd-make-class-methods
     # via -r dev-requirements.in
 grpcio==1.43.0
     # via flytekit
@@ -87,12 +85,8 @@ protobuf==3.19.3
     #   flytekit
 py==1.11.0
     # via retry
-py4j==0.10.9.2
-    # via pyspark
 pyarrow==6.0.1
     # via flytekit
-pyspark==3.2.0
-    # via flytekitplugins-spark
 python-dateutil==2.8.1
     # via
     #   arrow
@@ -123,7 +117,6 @@ retry==0.9.2
 six==1.16.0
     # via
     #   cookiecutter
-    #   flytekit
     #   grpcio
     #   python-dateutil
     #   responses
@@ -134,7 +127,9 @@ statsd==3.3.0
 text-unidecode==1.3
     # via python-slugify
 typing-extensions==4.0.1
-    # via typing-inspect
+    # via
+    #   flytekit
+    #   typing-inspect
 typing-inspect==0.7.1
     # via dataclasses-json
 urllib3==1.26.8

--- a/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
@@ -45,5 +45,5 @@ class ParquetToSparkDecodingHandler(StructuredDatasetDecoder):
 
 
 for protocol in ["/", "s3"]:
-    StructuredDatasetTransformerEngine.register_handler(SparkToParquetEncodingHandler(protocol), default_for_type=True)
-    StructuredDatasetTransformerEngine.register_handler(ParquetToSparkDecodingHandler(protocol), default_for_type=True)
+    StructuredDatasetTransformerEngine.register(SparkToParquetEncodingHandler(protocol), default_for_type=True)
+    StructuredDatasetTransformerEngine.register(ParquetToSparkDecodingHandler(protocol), default_for_type=True)

--- a/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
@@ -7,7 +7,6 @@ from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
-    FLYTE_DATASET_TRANSFORMER,
     PARQUET,
     StructuredDataset,
     StructuredDatasetDecoder,

--- a/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
@@ -12,6 +12,7 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
+    StructuredDatasetTransformerEngine,
 )
 
 
@@ -45,5 +46,5 @@ class ParquetToSparkDecodingHandler(StructuredDatasetDecoder):
 
 
 for protocol in ["/", "s3"]:
-    FLYTE_DATASET_TRANSFORMER.register_handler(SparkToParquetEncodingHandler(protocol), default_for_type=True)
-    FLYTE_DATASET_TRANSFORMER.register_handler(ParquetToSparkDecodingHandler(protocol), default_for_type=True)
+    StructuredDatasetTransformerEngine.register_handler(SparkToParquetEncodingHandler(protocol), default_for_type=True)
+    StructuredDatasetTransformerEngine.register_handler(ParquetToSparkDecodingHandler(protocol), default_for_type=True)

--- a/tests/flytekit/unit/core/test_structured_dataset.py
+++ b/tests/flytekit/unit/core/test_structured_dataset.py
@@ -129,15 +129,15 @@ def test_retrieving():
         def encode(self):
             ...
 
-    StructuredDatasetTransformerEngine.register_handler(TempEncoder("gs"), default_for_type=False)
+    StructuredDatasetTransformerEngine.register(TempEncoder("gs"), default_for_type=False)
     with pytest.raises(ValueError):
-        StructuredDatasetTransformerEngine.register_handler(TempEncoder("gs://"), default_for_type=False)
+        StructuredDatasetTransformerEngine.register(TempEncoder("gs://"), default_for_type=False)
 
     class TempEncoder:
         pass
 
     with pytest.raises(TypeError, match="We don't support this type of handler"):
-        StructuredDatasetTransformerEngine.register_handler(TempEncoder, default_for_type=False)
+        StructuredDatasetTransformerEngine.register(TempEncoder, default_for_type=False)
 
 
 def test_to_literal():
@@ -186,7 +186,7 @@ def test_fill_in_literal_type():
         ) -> literals.StructuredDataset:
             return literals.StructuredDataset(uri="")
 
-    StructuredDatasetTransformerEngine.register_handler(TempEncoder("myavro"), default_for_type=True)
+    StructuredDatasetTransformerEngine.register(TempEncoder("myavro"), default_for_type=True)
     lt = TypeEngine.to_literal_type(MyDF)
     assert lt.structured_dataset_type.format == "myavro"
 
@@ -199,7 +199,7 @@ def test_fill_in_literal_type():
 
     # Test that looking up encoders/decoders falls back to the "" encoder/decoder
     empty_format_temp_encoder = TempEncoder("")
-    StructuredDatasetTransformerEngine.register_handler(empty_format_temp_encoder, default_for_type=False)
+    StructuredDatasetTransformerEngine.register(empty_format_temp_encoder, default_for_type=False)
 
     res = StructuredDatasetTransformerEngine.get_encoder(MyDF, "tmpfs", "rando")
     assert res is empty_format_temp_encoder
@@ -224,7 +224,7 @@ def test_sd():
         ) -> typing.Union[typing.Generator[pd.DataFrame, None, None]]:
             yield pd.DataFrame({"Name": ["Tom", "Joseph"], "Age": [20, 22]})
 
-    StructuredDatasetTransformerEngine.register_handler(
+    StructuredDatasetTransformerEngine.register(
         MockPandasDecodingHandlers(pd.DataFrame, "tmpfs"), default_for_type=False
     )
     sd = StructuredDataset()
@@ -244,7 +244,7 @@ def test_sd():
         ) -> pd.DataFrame:
             pd.DataFrame({"Name": ["Tom", "Joseph"], "Age": [20, 22]})
 
-    StructuredDatasetTransformerEngine.register_handler(
+    StructuredDatasetTransformerEngine.register(
         MockPandasDecodingHandlers(pd.DataFrame, "tmpfs"), default_for_type=False, override=True
     )
     sd = StructuredDataset()

--- a/tests/flytekit/unit/types/structured_dataset/test_structured_dataset_workflow.py
+++ b/tests/flytekit/unit/types/structured_dataset/test_structured_dataset_workflow.py
@@ -18,13 +18,13 @@ from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
     BIGQUERY,
     DF,
-    StructuredDatasetTransformerEngine,
     LOCAL,
     PARQUET,
     S3,
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
+    StructuredDatasetTransformerEngine,
 )
 
 PANDAS_PATH = FlyteContextManager.current_context().file_access.get_random_local_directory()

--- a/tests/flytekit/unit/types/structured_dataset/test_structured_dataset_workflow.py
+++ b/tests/flytekit/unit/types/structured_dataset/test_structured_dataset_workflow.py
@@ -19,6 +19,7 @@ from flytekit.types.structured.structured_dataset import (
     BIGQUERY,
     DF,
     FLYTE_DATASET_TRANSFORMER,
+    StructuredDatasetTransformerEngine,
     LOCAL,
     PARQUET,
     S3,
@@ -58,8 +59,8 @@ class MockBQDecodingHandlers(StructuredDatasetDecoder):
         return pd_df
 
 
-FLYTE_DATASET_TRANSFORMER.register_handler(MockBQEncodingHandlers(pd.DataFrame, BIGQUERY), False, True)
-FLYTE_DATASET_TRANSFORMER.register_handler(MockBQDecodingHandlers(pd.DataFrame, BIGQUERY), False, True)
+StructuredDatasetTransformerEngine.register_handler(MockBQEncodingHandlers(pd.DataFrame, BIGQUERY), False, True)
+StructuredDatasetTransformerEngine.register_handler(MockBQDecodingHandlers(pd.DataFrame, BIGQUERY), False, True)
 
 
 class NumpyEncodingHandlers(StructuredDatasetEncoder):
@@ -95,8 +96,8 @@ class NumpyDecodingHandlers(StructuredDatasetDecoder):
 
 
 for protocol in [LOCAL, S3]:
-    FLYTE_DATASET_TRANSFORMER.register_handler(NumpyEncodingHandlers(np.ndarray, protocol, PARQUET))
-    FLYTE_DATASET_TRANSFORMER.register_handler(NumpyDecodingHandlers(np.ndarray, protocol, PARQUET))
+    StructuredDatasetTransformerEngine.register_handler(NumpyEncodingHandlers(np.ndarray, protocol, PARQUET))
+    StructuredDatasetTransformerEngine.register_handler(NumpyDecodingHandlers(np.ndarray, protocol, PARQUET))
 
 
 @task

--- a/tests/flytekit/unit/types/structured_dataset/test_structured_dataset_workflow.py
+++ b/tests/flytekit/unit/types/structured_dataset/test_structured_dataset_workflow.py
@@ -18,7 +18,6 @@ from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
     BIGQUERY,
     DF,
-    FLYTE_DATASET_TRANSFORMER,
     StructuredDatasetTransformerEngine,
     LOCAL,
     PARQUET,

--- a/tests/flytekit/unit/types/structured_dataset/test_structured_dataset_workflow.py
+++ b/tests/flytekit/unit/types/structured_dataset/test_structured_dataset_workflow.py
@@ -58,8 +58,8 @@ class MockBQDecodingHandlers(StructuredDatasetDecoder):
         return pd_df
 
 
-StructuredDatasetTransformerEngine.register_handler(MockBQEncodingHandlers(pd.DataFrame, BIGQUERY), False, True)
-StructuredDatasetTransformerEngine.register_handler(MockBQDecodingHandlers(pd.DataFrame, BIGQUERY), False, True)
+StructuredDatasetTransformerEngine.register(MockBQEncodingHandlers(pd.DataFrame, BIGQUERY), False, True)
+StructuredDatasetTransformerEngine.register(MockBQDecodingHandlers(pd.DataFrame, BIGQUERY), False, True)
 
 
 class NumpyEncodingHandlers(StructuredDatasetEncoder):
@@ -95,8 +95,8 @@ class NumpyDecodingHandlers(StructuredDatasetDecoder):
 
 
 for protocol in [LOCAL, S3]:
-    StructuredDatasetTransformerEngine.register_handler(NumpyEncodingHandlers(np.ndarray, protocol, PARQUET))
-    StructuredDatasetTransformerEngine.register_handler(NumpyDecodingHandlers(np.ndarray, protocol, PARQUET))
+    StructuredDatasetTransformerEngine.register(NumpyEncodingHandlers(np.ndarray, protocol, PARQUET))
+    StructuredDatasetTransformerEngine.register(NumpyDecodingHandlers(np.ndarray, protocol, PARQUET))
 
 
 @task


### PR DESCRIPTION
# TL;DR
Make the `register_handler` a class method so that we can get rid of the singleton.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin
 - [x] Refactor

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Get rid of the singleton by making a few functions class methods.  This relies on our being able to isolate out the logic for stateful stuff (keeping track of registered handlers/default formats and protocols) with the non-stateful stuff (to literal and to python value and get literal type).


