### PR TITLE
Add reference entities to FlyteTask and FlyteLaunchPlan

### DIFF
--- a/flytekit/remote/launch_plan.py
+++ b/flytekit/remote/launch_plan.py
@@ -23,10 +23,6 @@ class FlyteLaunchPlan(_launch_plan_models.LaunchPlanSpec):
         self._python_interface = None
         self._reference_entity = None
 
-    @property
-    def interface(self) -> Optional[_interface_models.TypedInterface]:
-        return self._interface
-
     def __call__(self, *args, **kwargs):
         if self.reference_entity is None:
             logger.warning(
@@ -98,7 +94,7 @@ class FlyteLaunchPlan(_launch_plan_models.LaunchPlanSpec):
         return self._workflow_id
 
     @property
-    def interface(self) -> _interface.TypedInterface:
+    def interface(self) -> Optional[_interface.TypedInterface]:
         """
         The interface is not technically part of the admin.LaunchPlanSpec in the IDL, however the workflow ID is, and
         from the workflow ID, fetch will fill in the interface. This is nice because then you can __call__ the=

--- a/flytekit/remote/launch_plan.py
+++ b/flytekit/remote/launch_plan.py
@@ -1,7 +1,9 @@
 from typing import Optional
 
 from flytekit.core.interface import Interface
+from flytekit.core.launch_plan import ReferenceLaunchPlan
 from flytekit.core.type_engine import TypeEngine
+from flytekit.loggers import remote_logger as logger
 from flytekit.models import interface as _interface_models
 from flytekit.models import launch_plan as _launch_plan_models
 from flytekit.models.core import identifier as id_models
@@ -18,8 +20,45 @@ class FlyteLaunchPlan(_launch_plan_models.LaunchPlanSpec):
 
         # The interface is not set explicitly unless fetched in an engine context
         self._interface = None
-
         self._python_interface = None
+        self._reference_entity = None
+
+    @property
+    def interface(self) -> Optional[_interface_models.TypedInterface]:
+        return self._interface
+
+    def __call__(self, *args, **kwargs):
+        if self.reference_entity is None:
+            logger.warning(
+                f"FlyteLaunchPlan {self} is not callable, most likely because flytekit could not "
+                f"guess the python interface. The workflow calling this launch plan may not behave correctly."
+            )
+            return
+        return self.reference_entity(*args, **kwargs)
+
+    # TODO: Refactor behind mixin
+    @property
+    def reference_entity(self) -> Optional[ReferenceLaunchPlan]:
+        if self._reference_entity is None:
+            if self.guessed_python_interface is None:
+                try:
+                    self.guessed_python_interface = Interface(
+                        TypeEngine.guess_python_types(self.interface.inputs),
+                        TypeEngine.guess_python_types(self.interface.outputs),
+                    )
+                except Exception as e:
+                    logger.warning(f"Error backing out interface {e}, Flyte interface {self.interface}")
+                    return None
+
+            self._reference_entity = ReferenceLaunchPlan(
+                self.id.project,
+                self.id.domain,
+                self.id.name,
+                self.id.version,
+                inputs=self.guessed_python_interface.inputs,
+                outputs=self.guessed_python_interface.outputs,
+            )
+        return self._reference_entity
 
     @classmethod
     def promote_from_model(
@@ -36,12 +75,6 @@ class FlyteLaunchPlan(_launch_plan_models.LaunchPlanSpec):
             auth_role=model.auth_role,
             raw_output_data_config=model.raw_output_data_config,
         )
-
-        if lp.interface is not None:
-            lp.guessed_python_interface = Interface(
-                inputs=TypeEngine.guess_python_types(lp.interface.inputs),
-                outputs=TypeEngine.guess_python_types(lp.interface.outputs),
-            )
 
         return lp
 

--- a/flytekit/remote/workflow.py
+++ b/flytekit/remote/workflow.py
@@ -57,7 +57,6 @@ class FlyteWorkflow(_hash_mixin.HashOnReferenceMixin, _workflow_models.WorkflowT
         self._tasks = tasks
         self._launch_plans = launch_plans
         self._compiled_closure = compiled_closure
-
         self._node_map = None
 
     @property

--- a/plugins/flytekit-greatexpectations/setup.py
+++ b/plugins/flytekit-greatexpectations/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "great_expectations"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=0.21.0,<1.0.0", "great-expectations>=0.13.30", "sqlalchemy>=1.4.23"]
+plugin_requires = ["flytekit>=0.21.0,<1.0.0", "great-expectations>=0.13.30,<0.14.6", "sqlalchemy>=1.4.23"]
 
 __version__ = "0.0.0+develop"
 

--- a/tests/flytekit/unit/remote/test_calling.py
+++ b/tests/flytekit/unit/remote/test_calling.py
@@ -10,6 +10,7 @@ from flytekit.core.reference_entity import ReferenceSpec
 from flytekit.core.task import task
 from flytekit.core.workflow import workflow
 from flytekit.remote import FlyteLaunchPlan, FlyteTask
+from flytekit.remote.interface import TypedInterface
 from flytekit.tools.translator import gather_dependent_entities, get_serializable
 
 default_img = Image(name="default", fqn="test", tag="tag")
@@ -72,7 +73,7 @@ def test_calling_lp():
     remote_lp = FlyteLaunchPlan.promote_from_model(lp_model.id, lp_model.spec)
     # To pretend that we've fetched this launch plan from Admin, also fill in the Flyte interface, which isn't
     # part of the IDL object but is something FlyteRemote does
-    remote_lp._interface = spec.template.interface
+    remote_lp._interface = TypedInterface.promote_from_model(spec.template.interface)
     serialized = OrderedDict()
 
     @workflow

--- a/tests/flytekit/unit/remote/test_calling.py
+++ b/tests/flytekit/unit/remote/test_calling.py
@@ -1,0 +1,86 @@
+import typing
+from collections import OrderedDict
+
+import pytest
+
+from flytekit.core import context_manager
+from flytekit.core.context_manager import Image, ImageConfig
+from flytekit.core.launch_plan import LaunchPlan
+from flytekit.core.reference_entity import ReferenceSpec
+from flytekit.core.task import task
+from flytekit.core.workflow import workflow
+from flytekit.remote import FlyteTask, FlyteLaunchPlan
+from flytekit.tools.translator import gather_dependent_entities, get_serializable
+
+default_img = Image(name="default", fqn="test", tag="tag")
+serialization_settings = context_manager.SerializationSettings(
+    project="project",
+    domain="domain",
+    version="version",
+    env=None,
+    image_config=ImageConfig(default_image=default_img, images=[default_img]),
+)
+
+
+@task
+def t1(a: int) -> int:
+    return a + 2
+
+
+@task
+def t2(a: int, b: str) -> str:
+    return b + str(a)
+
+
+@workflow
+def sub_wf(a: int, b: str) -> (int, str):
+    x = t1(a=a)
+    d = t2(a=x, b=b)
+    return x, d
+
+
+serialized = OrderedDict()
+t1_spec = get_serializable(serialized, serialization_settings, t1)
+ft = FlyteTask.promote_from_model(t1_spec.template)
+
+
+
+
+def test_fetched_task():
+    @workflow
+    def wf(a: int) -> int:
+        return ft(a=a)
+
+    # Should not work unless mocked out.
+    with pytest.raises(Exception, match="cannot be run locally"):
+        wf(a=3)
+
+    # Should have one reference entity
+    serialized = OrderedDict()
+    get_serializable(serialized, serialization_settings, wf)
+    vals = [v for v in serialized.values()]
+    refs = [f for f in filter(lambda x: isinstance(x, ReferenceSpec), vals)]
+    assert len(refs) == 1
+
+
+def test_calling_lp():
+    sub_wf_lp = LaunchPlan.get_or_create(sub_wf)
+    serialized = OrderedDict()
+    lp_model = get_serializable(serialized, serialization_settings, sub_wf_lp)
+    task_templates, wf_specs, lp_specs = gather_dependent_entities(serialized)
+    for wf_id, spec in wf_specs.items():
+        break
+
+    remote_lp = FlyteLaunchPlan.promote_from_model(lp_model.id, lp_model.spec)
+    # To pretend that we've fetched this launch plan from Admin, also fill in the Flyte interface, which isn't
+    # part of the IDL object but is something FlyteRemote does
+    remote_lp._interface = spec.template.interface
+    serialized = OrderedDict()
+
+    @workflow
+    def wf2(a: int) -> typing.Tuple[int, str]:
+        return remote_lp(a=a, b="hello")
+
+    wf_spec = get_serializable(serialized, serialization_settings, wf2)
+    print(wf_spec.template.nodes[0].workflow_node.launchplan_ref)
+    assert wf_spec.template.nodes[0].workflow_node.launchplan_ref == lp_model.id

--- a/tests/flytekit/unit/remote/test_calling.py
+++ b/tests/flytekit/unit/remote/test_calling.py
@@ -9,7 +9,7 @@ from flytekit.core.launch_plan import LaunchPlan
 from flytekit.core.reference_entity import ReferenceSpec
 from flytekit.core.task import task
 from flytekit.core.workflow import workflow
-from flytekit.remote import FlyteTask, FlyteLaunchPlan
+from flytekit.remote import FlyteLaunchPlan, FlyteTask
 from flytekit.tools.translator import gather_dependent_entities, get_serializable
 
 default_img = Image(name="default", fqn="test", tag="tag")
@@ -42,8 +42,6 @@ def sub_wf(a: int, b: str) -> (int, str):
 serialized = OrderedDict()
 t1_spec = get_serializable(serialized, serialization_settings, t1)
 ft = FlyteTask.promote_from_model(t1_spec.template)
-
-
 
 
 def test_fetched_task():


### PR DESCRIPTION
Signed-off-by: Yee Hing Tong <wild-endeavor@users.noreply.github.com>

# TL;DR
Attempting to partially address the fact that remote entities can't be used inside workflows.  See [slack](https://flyte-org.slack.com/archives/CREL4QVAQ/p1640009288109500) for more information.

Also upper bounding the great expectations library in the plugin as the latest version is causing some test errors.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Ignoring workflows for now because workflows are harder.  Since Admin doesn't do the fetching internally, we have to maintain the full set of subworkflows for each workflow.

Also still uses guessing.  Will remove in future iterations.  See issue for details.

Tested with the following script in local ipython with a sandbox running:

```python
import typing
from flytekit.remote.remote import FlyteRemote
from flytekit import workflow, LaunchPlan
from flytekit.extend import Image, ImageConfig

default_img = Image(name="default", fqn="ghcr.io/flyteorg/flytecookbook", tag="core-6f527f59dc9dafe9dad00c6e3edb73e261077628")
image_config = ImageConfig(default_image=default_img, images=[default_img])

rr = FlyteRemote.from_config("flytesnacks", "development", config_file_path="/Users/ytong/.flyte/local_sandbox")
rr._image_config = image_config
remote_basic_lp = rr.fetch_launch_plan(name="core.flyte_basics.lp.my_wf")
remote_basic_task = rr.fetch_task(name="core.flyte_basics.basic_workflow.t1")

@workflow
def fetched_wf_demo(parent_input: int) -> typing.Tuple[int, str]:
    lp_output = remote_basic_lp(val=parent_input)
    return remote_basic_task(a=lp_output)

# Need to overwrite name to remove __main__
fetched_wf_demo._name = "fetched_wf_demo"
rr.register(fetched_wf_demo, name="fetched_wf_demo", version="remote_demo_v2")

launch_plan = LaunchPlan.get_or_create(workflow=fetched_wf_demo, name=fetched_wf_demo.name)
rr.register(launch_plan)
```

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2157
