### PR TITLE
Change docs for HTMLPage type to say HTMLPage instead of PNGImage

### DIFF
--- a/flytekit/types/file/__init__.py
+++ b/flytekit/types/file/__init__.py
@@ -34,7 +34,7 @@ hdf5 = typing.TypeVar("hdf5")
 HDF5EncodedFile = FlyteFile[hdf5]
 
 html = typing.TypeVar("html")
-#: Can be used to receive or return an PNGImage. The underlying type is a FlyteFile type. This is just a
+#: Can be used to receive or return an HTMLPage. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 HTMLPage = FlyteFile[html]
 


### PR DESCRIPTION
# TL;DR
Correct docs for HTMLPage type in flytekit.types.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Fixed by changing docs in `flytekit/types/file/__init__.py` for `HTMLPage` type. Documentation change only.

## Follow-up issue
_NA_
