### PR TITLE
Add GCS protocol in the structured dataset

### DIFF
--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -12,6 +12,7 @@ from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
+    GCS,
     LOCAL,
     PARQUET,
     S3,
@@ -106,7 +107,7 @@ class ParquetToArrowDecodingHandler(StructuredDatasetDecoder):
         return pq.read_table(local_dir)
 
 
-for protocol in [LOCAL, S3]:  # Should we add GCS
+for protocol in [LOCAL, S3, GCS]:
     StructuredDatasetTransformerEngine.register(PandasToParquetEncodingHandler(protocol), default_for_type=True)
     StructuredDatasetTransformerEngine.register(ParquetToPandasDecodingHandler(protocol), default_for_type=True)
     StructuredDatasetTransformerEngine.register(ArrowToParquetEncodingHandler(protocol), default_for_type=True)

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -37,6 +37,7 @@ DF = typing.TypeVar("DF")  # Dataframe type
 # Protocols
 BIGQUERY = "bq"
 S3 = "s3"
+GCS = "gs"
 LOCAL = "/"
 
 # For specifying the storage formats of StructuredDatasets. It's just a string, nothing fancy.

--- a/plugins/flytekit-data-fsspec/flytekitplugins/fsspec/__init__.py
+++ b/plugins/flytekit-data-fsspec/flytekitplugins/fsspec/__init__.py
@@ -1,7 +1,7 @@
 import importlib
 
 from flytekit import USE_STRUCTURED_DATASET, StructuredDatasetTransformerEngine, logger
-from flytekit.types.structured.structured_dataset import S3
+from flytekit.types.structured.structured_dataset import GCS, S3
 
 from .persist import FSSpecPersistence
 
@@ -18,3 +18,6 @@ if USE_STRUCTURED_DATASET.get():
 
     if importlib.util.find_spec("s3fs"):
         _register(S3)
+
+    if importlib.util.find_spec("gcsfs"):
+        _register(GCS)

--- a/plugins/flytekit-data-fsspec/setup.py
+++ b/plugins/flytekit-data-fsspec/setup.py
@@ -23,6 +23,7 @@ setup(
     extras_require={
         # https://github.com/fsspec/filesystem_spec/blob/master/setup.py#L36
         "aws": ["s3fs>=2021.7.0"],
+        "gcp": ["gcsfs>=2021.7.0"],
     },
     license="apache2",
     python_requires=">=3.7",


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Add GCS protocol in the structured dataset. 
Note: we can access google public bucket without adding `{anon: True}` in storage_options
https://gcsfs.readthedocs.io/en/latest/#credentials

sample code: https://gist.github.com/pingsutw/cd3e53905aba6b2073b11ad72c900b14

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
