### PR TITLE
Fix to support sphinx doctest with task decorator

### DIFF
--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -21,7 +21,7 @@ class InstanceTrackingMeta(type):
     def _find_instance_module():
         frame = _inspect.currentframe()
         while frame:
-            if frame.f_code.co_name == "<module>":
+            if frame.f_code.co_name == "<module>" and "__name__" in frame.f_globals:
                 return frame.f_globals["__name__"]
             frame = frame.f_back
         return None


### PR DESCRIPTION
# TL;DR
Add fix to allow usage of [sphinx doctest](https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html) with Flyte `@task` decorators

I would like to use Sphinx doctest to document some Flyte concepts for our users and include associated tests with Sphinx doctest. Here is a simple example of something that could be written in a doctest:
```python
  ```{testcode}
  from flytekit import task, workflow
  
  @task
  def simple_squared_task(x: int) -> int:
      return x ** 2
  
  @workflow
  def simple_squared_workflow(x: int) -> int:
      return simple_squared_task(x=x)
  
  print(simple_squared_workflow(x=2))```
```
```
```{testoutput}
4```
```
At present, this raises an exception, because the doctest module does not have `__name__` in globals when running `make doctest`.
```
Exception raised:
    Traceback (most recent call last):
      File "/fn/lib/python3.9/doctest.py", line 1334, in __run
        exec(compile(example.source, filename, "single",
      File "<doctest default[0]>", line 4, in <module>
        def simple_squared_task(x: int) -> int:
      File "/fn/lib/python3.9/site-packages/flytekit/core/task.py", line 209, in task
        return wrapper(_task_function)
      File "/fn/lib/python3.9/site-packages/flytekit/core/task.py", line 193, in wrapper
        task_instance = TaskPlugins.find_pythontask_plugin(type(task_config))(
      File "/fn/lib/python3.9/site-packages/flytekit/core/tracker.py", line 31, in __call__
        o._instantiated_in = InstanceTrackingMeta._find_instance_module()
      File "/fn/lib/python3.9/site-packages/flytekit/core/tracker.py", line 25, in _find_instance_module
        return frame.f_globals["__name__"]
    KeyError: '__name__'
```
The fix in the PR results in doctest properly running the test:
```
1 items passed all tests:
1 tests in default
1 tests in 1 items.
1 passed and 0 failed.
Test passed.
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
I noticed that doctest was coming up in _inspect.currentframe() but it does not have the `__name__` attribute in its globals. Adding a check to confirm that `__name__` is in globals seemed like a small enough change, but let me know if you'd prefer to handle this in a different way!

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
