### PR TITLE
Add back support for reading from parent command, config file, or subcommand in flyte-cli

### DIFF
--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -5,7 +5,6 @@ import os as _os
 import stat as _stat
 import sys as _sys
 from typing import Callable, Dict, List, Tuple, Union
-
 import click as _click
 import requests as _requests
 from flyteidl.admin import launch_plan_pb2 as _launch_plan_pb2
@@ -272,9 +271,13 @@ def _render_schedule_expr(lp):
 
 def _get_client(host: str, insecure: bool) -> _friendly_client.SynchronousFlyteClient:
     parent_ctx = _click.get_current_context(silent=True)
+    kwargs = {}
+    if parent_ctx.obj["cacert"]:
+        kwargs["root_certificates"] = parent_ctx.obj["cacert"]
     cfg = parent_ctx.obj["config"]
     cfg = cfg.with_parameters(endpoint=host, insecure=insecure)
-    return _friendly_client.SynchronousFlyteClient(cfg, root_certificates=parent_ctx.obj["cacert"])
+
+    return _friendly_client.SynchronousFlyteClient(cfg, **kwargs)
 
 
 _PROJECT_FLAGS = ["-p", "--project"]
@@ -477,6 +480,7 @@ class _FlyteSubCommand(_click.Command):
     }
 
     def make_context(self, cmd_name, args, parent=None):
+        # This list represents the set of args/flags that can be, and are, set on both the parent and subcommand.
         prefix_args = []
         for param in self.params:
             if (
@@ -499,14 +503,38 @@ class _FlyteSubCommand(_click.Command):
         if cmd_name == "setup-config":
             return ctx
 
-        config = parent.params["config"]
-        if config is None:
+        config_file = parent.params["config"]
+        if config_file is None:
             # Run this as the module is loading to pick up settings that click can
             # then use when constructing the commands
-            config = _detect_default_config_file()
+            config_file = _detect_default_config_file()
 
-        print("Config loading")
-        ctx.obj["config"] = configuration.PlatformConfig.auto(config_file=config)
+        config_obj = configuration.PlatformConfig.auto(config_file=config_file)
+
+        # These two flags are special in that they are specifiable in both the user's default ~/.flyte/config file,
+        # and in the flyte-cli command itself, both in the parent-command position (flyte-cli) , and in the
+        # child-command position (e.g. list-task-names).
+        # For both host and insecure, command line values will override the setting in a config file.
+        #
+        # The host url option is a required setting, so if missing it will fail, but it may be set in the click command,
+        # so we don't have to check now. It will be checked later.
+
+        # If the host was not specified in the parent command, and also not in the subcommand, but is in the file,
+        # then add in the switch and value before creating the context
+        if _HOST_FLAGS[0] not in prefix_args and _HOST_FLAGS[0] not in args and config_obj.endpoint:
+            prefix_args.extend([_HOST_FLAGS[0], config_obj.endpoint])
+
+        # If insecure was not in the parent command and not in the subcommand, but is true in the config object (the
+        # default is False), then add the flag to the args before creating the context.
+        if _INSECURE_FLAGS[0] not in prefix_args and _INSECURE_FLAGS[0] not in args and config_obj.insecure:
+            prefix_args.append(_INSECURE_FLAGS[0])
+
+        # Create context object and fill in with additional objects
+        ctx = super(_FlyteSubCommand, self).make_context(cmd_name, prefix_args + args, parent=parent)
+        ctx.obj = ctx.obj or {}
+        ctx.obj["cacert"] = parent.params["cacert"] or None
+        ctx.obj["config"] = config_obj
+
         return ctx
 
 

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -5,6 +5,7 @@ import os as _os
 import stat as _stat
 import sys as _sys
 from typing import Callable, Dict, List, Tuple, Union
+
 import click as _click
 import requests as _requests
 from flyteidl.admin import launch_plan_pb2 as _launch_plan_pb2

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -278,6 +278,7 @@ class PlatformConfig(object):
     ) -> PlatformConfig:
         return PlatformConfig(
             endpoint=endpoint,
+            insecure=insecure,
             command=command,
             client_id=client_id,
             client_credentials_secret=client_credentials_secret,


### PR DESCRIPTION
# TL;DR
If not set on the command line, flyte-cli was not reading the host/insecure flags from the config file.  Behavior on master is:

```bash
(flytekit) ytong@argus:~/go/src/github.com/flyteorg/flytekit [flyte-sandbox] (master) $ cat ~/.flyte/local_sandbox
[platform]
url=localhost:30081
insecure=True

(flytekit) ytong@argus:~/go/src/github.com/flyteorg/flytekit [flyte-sandbox] (master) $ flyte-cli -c ~/.flyte/local_sandbox get-workflow -u wf:flytesnacks:development:core.control_flow.subworkflows.parent_wf:v0.3.56
DeprecationWarning: The command 'flyte-cli' is deprecated.
Config loading

################################################################################################################################
# flyte-cli is being deprecated in favor of flytectl. More details about flytectl in https://docs.flyte.org/projects/flytectl/ #
################################################################################################################################

Welcome to Flyte CLI! Version: 0.0.0+develop

Traceback (most recent call last):
  File "/Users/ytong/envs/flytekit/bin/flyte-cli", line 33, in <module>
    sys.exit(load_entry_point('flytekit', 'console_scripts', 'flyte-cli')())
  File "/Users/ytong/envs/flytekit/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/ytong/envs/flytekit/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/ytong/envs/flytekit/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/ytong/envs/flytekit/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/ytong/envs/flytekit/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/ytong/go/src/github.com/flyteorg/flytekit/flytekit/clis/flyte_cli/main.py", line 809, in get_workflow
    client = _get_client(host, insecure)
  File "/Users/ytong/go/src/github.com/flyteorg/flytekit/flytekit/clis/flyte_cli/main.py", line 277, in _get_client
    return _friendly_client.SynchronousFlyteClient(cfg, root_certificates=parent_ctx.obj["cacert"])
  File "/Users/ytong/go/src/github.com/flyteorg/flytekit/flytekit/clients/raw.py", line 116, in __init__
    self._channel = grpc.secure_channel(
  File "/Users/ytong/envs/flytekit/lib/python3.8/site-packages/grpc/__init__.py", line 2004, in secure_channel
    return _channel.Channel(target, () if options is None else options,
  File "/Users/ytong/envs/flytekit/lib/python3.8/site-packages/grpc/_channel.py", line 1479, in __init__
    _common.encode(target), _augment_options(core_options, compression),
  File "/Users/ytong/envs/flytekit/lib/python3.8/site-packages/grpc/_common.py", line 72, in encode
    return s.encode('utf8')
AttributeError: 'NoneType' object has no attribute 'encode'

```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
* Add back creation of a separate context (separate from the `setup-config` command).
* If values for host/insecure are in the config object but not in the parent or sub command, then fill them in.
* Missing insecure in `with_parameters` in `PlatformConfig`.
* Don't pass root certs if creating an insecure client.

See the `make_context` code before the change [here](https://github.com/flyteorg/flytekit/blob/457f323c0052df822c962186f44a6989a418d23d/flytekit/clis/flyte_cli/main.py#L474).

