### PR TITLE
Register the task first when executing the workflow

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -459,6 +459,7 @@ class Config(object):
     secrets: SecretsConfig = SecretsConfig()
     stats: StatsConfig = StatsConfig()
     data_config: DataConfig = DataConfig()
+    image_config: ImageConfig = ImageConfig()
     local_sandbox_path: str = tempfile.mkdtemp(prefix="flyte")
 
     def with_params(


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Failed to execute a workflow when we run `remote.execute(chain_tasks.workflows.example.chain_tasks_wf, inputs={}, version=version, wait=False)`  because we try to register a Luanch Plan before registering tasks

- Register the task first when registering the workflow
- Add `image_config` in Options, so we can set up the image when creating a remote client or executing the workflow
- Remove `from_project` and `from_domain` because we already have `project` and `domain` in args

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
