### PR TITLE
Fix auth comparison

### DIFF
--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -252,11 +252,11 @@ class RawSynchronousFlyteClient(object):
         pass
 
     def refresh_credentials(self):
-        if self._cfg.auth_mode == AuthType.STANDARD:
+        if self._cfg.auth_mode == AuthType.STANDARD.value:
             return self._refresh_credentials_standard()
-        elif self._cfg.auth_mode == AuthType.BASIC or self._cfg.auth_mode == AuthType.CLIENT_CREDENTIALS:
+        elif self._cfg.auth_mode == AuthType.BASIC.value or self._cfg.auth_mode == AuthType.CLIENT_CREDENTIALS.value:
             return self._refresh_credentials_basic()
-        elif self._cfg.auth_mode == AuthType.EXTERNAL_PROCESS:
+        elif self._cfg.auth_mode == AuthType.EXTERNAL_PROCESS.value:
             return self._refresh_credentials_from_command()
         else:
             raise ValueError(

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -252,15 +252,23 @@ class RawSynchronousFlyteClient(object):
         pass
 
     def refresh_credentials(self):
-        if self._cfg.auth_mode == AuthType.STANDARD.value:
+        cfg_auth = self._cfg.auth_mode
+        if type(cfg_auth) is str:
+            try:
+                cfg_auth = AuthType[cfg_auth.upper()]
+            except KeyError:
+                cli_logger.warning(f"Authentication type {cfg_auth} does not exist, defaulting to standard")
+                cfg_auth = AuthType.STANDARD
+
+        if cfg_auth == AuthType.STANDARD:
             return self._refresh_credentials_standard()
-        elif self._cfg.auth_mode == AuthType.BASIC.value or self._cfg.auth_mode == AuthType.CLIENT_CREDENTIALS.value:
+        elif cfg_auth == AuthType.BASIC or cfg_auth == AuthType.CLIENT_CREDENTIALS:
             return self._refresh_credentials_basic()
-        elif self._cfg.auth_mode == AuthType.EXTERNAL_PROCESS.value:
+        elif cfg_auth == AuthType.EXTERNAL_PROCESS:
             return self._refresh_credentials_from_command()
         else:
             raise ValueError(
-                f"Invalid auth mode [{self._cfg.auth_mode}] specified."
+                f"Invalid auth mode [{cfg_auth}] specified."
                 f"Please update the creds config to use a valid value"
             )
 

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -268,8 +268,7 @@ class RawSynchronousFlyteClient(object):
             return self._refresh_credentials_from_command()
         else:
             raise ValueError(
-                f"Invalid auth mode [{cfg_auth}] specified."
-                f"Please update the creds config to use a valid value"
+                f"Invalid auth mode [{cfg_auth}] specified." f"Please update the creds config to use a valid value"
             )
 
     def set_access_token(self, access_token: str, authorization_header_key: Optional[str] = "authorization"):

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -81,7 +81,6 @@ import enum
 import gzip
 import os
 import re
-import sys
 import tempfile
 import typing
 from dataclasses import dataclass, field

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -591,7 +591,7 @@ class FlyteRemote(object):
                     entity.id,
                     ExecutionMetadata(
                         ExecutionMetadata.ExecutionMode.MANUAL,
-                        "placeholder",  # Admin should replace this from oidc token if auth is enabled.
+                        "placeholder",  # Admin replaces this from oidc token if auth is enabled.
                         0,
                     ),
                     notifications=notifications,

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -591,7 +591,7 @@ class FlyteRemote(object):
                     entity.id,
                     ExecutionMetadata(
                         ExecutionMetadata.ExecutionMode.MANUAL,
-                        "placeholder",  # TODO: get principle
+                        "placeholder",  # Admin should replace this from oidc token if auth is enabled.
                         0,
                     ),
                     notifications=notifications,

--- a/tests/flytekit/unit/clients/test_raw.py
+++ b/tests/flytekit/unit/clients/test_raw.py
@@ -175,7 +175,18 @@ def test_refresh_basic(mocked_method):
 
     cc = RawSynchronousFlyteClient(PlatformConfig(auth_mode=AuthType.CLIENT_CREDENTIALS))
     cc.refresh_credentials()
+    assert mocked_method.call_count == 2
+
+
+@patch.object(RawSynchronousFlyteClient, "_refresh_credentials_basic")
+def test_basic_strings(mocked_method):
+    cc = RawSynchronousFlyteClient(PlatformConfig(auth_mode="basic"))
+    cc.refresh_credentials()
     assert mocked_method.called
+
+    cc = RawSynchronousFlyteClient(PlatformConfig(auth_mode="client_credentials"))
+    cc.refresh_credentials()
+    assert mocked_method.call_count == 2
 
 
 @patch.object(RawSynchronousFlyteClient, "_refresh_credentials_from_command")


### PR DESCRIPTION
Signed-off-by: Yee Hing Tong <wild-endeavor@users.noreply.github.com>

# TL;DR
Users might not do
```python
from flytekit.configuration import AuthType
PlatformConfig(auth_type=AuthType.BASIC)
```

they might just write `PlatformConfig(auth_mode="basic")` in which case the comparison breaks.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin
