### PR TITLE
[wip - do not merge] Testing pyflyte run + fully qualified package names

### DIFF
--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -21,6 +21,7 @@ from google.protobuf.pyext.cpp_message import GeneratedProtocolMessageType as _G
 from flytekit import __version__, configuration
 from flytekit.clients import friendly as _friendly_client
 from flytekit.clis.helpers import hydrate_registration_parameters
+from flytekit.clis.sdk_in_container.utils import produce_fast_register_task_closure
 from flytekit.core import utils
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.exceptions import user as _user_exceptions
@@ -1825,35 +1826,8 @@ def fast_register_files(
     ctx.file_access.put_data(compressed_source, full_remote_path)
     _click.secho(f"Uploaded compressed code archive {compressed_source} to {full_remote_path}", fg="green")
 
-    def fast_register_task(entity: _GeneratedProtocolMessageType) -> _GeneratedProtocolMessageType:
-        """
-        Updates task definitions during fast-registration in order to use the compatible pyflyte fast execute command at
-        task execution.
-        """
-        # entity is of type flyteidl.admin.task_pb2.TaskSpec
-
-        if entity.template.HasField("container") and len(entity.template.container.args) > 0:
-            complete_args = _substitute_fast_register_task_args(
-                entity.template.container.args, full_remote_path, dest_dir
-            )
-            # Because we're dealing with a proto list, we have to delete the existing args before we can extend the list
-            # with the substituted ones.
-            del entity.template.container.args[:]
-            entity.template.container.args.extend(complete_args)
-
-        if entity.template.HasField("k8s_pod"):
-            pod_spec_struct = entity.template.k8s_pod.pod_spec
-            if "containers" in pod_spec_struct:
-                for idx in range(len(pod_spec_struct["containers"])):
-                    if "args" in pod_spec_struct["containers"][idx]:
-                        # We can directly overwrite the args in the pod spec struct definition.
-                        pod_spec_struct["containers"][idx]["args"] = _substitute_fast_register_task_args(
-                            pod_spec_struct["containers"][idx]["args"], full_remote_path, dest_dir
-                        )
-        return entity
-
     patches = {
-        _identifier_pb2.TASK: fast_register_task,
+        _identifier_pb2.TASK: produce_fast_register_task_closure(full_remote_path, dest_dir),
         _identifier_pb2.LAUNCH_PLAN: _get_patch_launch_plan_fn(
             assumable_iam_role, kubernetes_service_account, output_location_prefix
         ),

--- a/flytekit/clis/sdk_in_container/pyflyte.py
+++ b/flytekit/clis/sdk_in_container/pyflyte.py
@@ -5,6 +5,7 @@ from flytekit.clis.sdk_in_container.constants import CTX_CONFIG_FILE, CTX_PACKAG
 from flytekit.clis.sdk_in_container.init import init
 from flytekit.clis.sdk_in_container.local_cache import local_cache
 from flytekit.clis.sdk_in_container.package import package
+from flytekit.clis.sdk_in_container.run import run
 from flytekit.clis.sdk_in_container.serialize import serialize
 from flytekit.configuration.internal import LocalSDK
 
@@ -58,6 +59,7 @@ main.add_command(serialize)
 main.add_command(package)
 main.add_command(local_cache)
 main.add_command(init)
+main.add_command(run)
 
 if __name__ == "__main__":
     main()

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -1,0 +1,170 @@
+import os
+import tarfile
+import tempfile
+from typing import List
+
+import click
+from flyteidl.core import identifier_pb2
+from google.protobuf.pyext.cpp_message import GeneratedProtocolMessageType
+
+from flytekit import configuration
+from flytekit.clients import friendly
+from flytekit.clis.flyte_cli.main import _extract_and_register
+from flytekit.configuration import FastSerializationSettings, ImageConfig, SerializationSettings
+from flytekit.core import context_manager
+from flytekit.exceptions.user import FlyteValidationException
+from flytekit.tools import fast_registration, module_loader, serialize_helpers
+
+
+@click.command("run")
+@click.argument(
+    "workflow_path_and_name",
+)
+@click.option(
+    "image",
+    "-i",
+    "--image",
+    required=False,
+    type=str,
+    # TODO: fix default images push gh workflow
+    # default="ghcr.io/flyteorg/flytekit:py39-latest",
+    default="pyflyte-fast-execute:latest",
+    help="Image used to register and run.",
+)
+@click.option(
+    "help",
+    "-h",
+    "--help",
+    required=False,
+    is_flag=True,
+    help="Shows inputs to workflow and potentially the workflow docstring",
+)
+@click.pass_context
+def run(
+    ctx,
+    workflow_path_and_name,
+    image,
+    help=None,
+):
+    """
+    TODO description (remember to document parameters)
+    """
+    # TODO is it `--help`? Figure out a way to parse the inputs to the workflow
+    #
+
+    split_input = workflow_path_and_name.split(":")
+    if len(split_input) != 2:
+        raise FlyteValidationException(f"Input {workflow_path_and_name} must be in format '<module>:<worfklow>'")
+
+    workflow_path, workflow_name = split_input
+    # TODO: find the project root and use it to build the package name
+    pkgs = ["flyte.workflows"]
+    source = "/home/eduardo/tmp/pyflyte-run/"
+    destination_dir = "/root"
+
+    # Load the code
+    #
+
+    image_config = ImageConfig.validate_single_image(image)
+    serialization_settings = SerializationSettings(
+        image_config=image_config,
+        fast_serialization_settings=FastSerializationSettings(
+            enabled=True,
+            destination_dir=destination_dir,
+        ),
+        # TODO: do I really need to define a python interpreter?
+        # python_interpreter=python_interpreter,
+    )
+    ctx = context_manager.FlyteContextManager.current_context().with_serialization_settings(serialization_settings)
+    # TODO: figure out source
+    with context_manager.FlyteContextManager.with_context(ctx) as ctx:
+        # Scan all modules. the act of loading populates the global singleton that contains all objects
+        # TODO: find root of project
+        with module_loader.add_sys_path(source):
+            click.secho(f"Loading code {workflow_path}", fg="yellow")
+            module_loader.just_load_modules(pkgs=pkgs)
+
+    registrable_entities = serialize_helpers.get_registrable_entities(ctx)
+
+    if registrable_entities:
+        # Open a temp directory and dump the contents of the digest.
+        tmp_dir = tempfile.TemporaryDirectory()
+
+        # Write
+        source_path = os.fspath(source)
+        digest = fast_registration.compute_digest(source_path)
+        archive_fname = os.path.join(tmp_dir.name, f"{digest}.tar.gz")
+        # Write using gzip
+        with tarfile.open(archive_fname, "w:gz") as tar:
+            tar.add(source, arcname="", filter=fast_registration.filter_tar_file_fn)
+
+        serialize_helpers.persist_registrable_entities(registrable_entities, tmp_dir.name)
+
+        # List al pb files
+        pb_files = []
+        for f in os.listdir(tmp_dir.name):
+            if f.endswith(".pb"):
+                pb_files.append(os.path.join(tmp_dir.name, f))
+
+        version = str(os.getpid())  # TODO: find a better source of entropy
+
+        # TODO Get signed url from flyteadmin
+        # TODO: Patch task specs with the signed url before writing them to disk
+        full_remote_path = f"s3://my-s3-bucket/fast-register-test/{digest}.tar.gz"
+        flyte_ctx = context_manager.FlyteContextManager.current_context()
+        flyte_ctx.file_access.put_data(archive_fname, full_remote_path)
+
+        def fast_register_task(entity: GeneratedProtocolMessageType) -> GeneratedProtocolMessageType:
+            """
+            Updates task definitions during fast-registration in order to use the compatible pyflyte fast execute command at
+            task execution.
+            """
+            # entity is of type flyteidl.admin.task_pb2.TaskSpec
+
+            def _substitute_fast_register_task_args(args: List[str], full_remote_path: str, dest_dir: str) -> List[str]:
+                complete_args = []
+                for arg in args:
+                    if arg == "{{ .remote_package_path }}":
+                        arg = full_remote_path
+                    elif arg == "{{ .dest_dir }}":
+                        arg = dest_dir if dest_dir else "."
+                    complete_args.append(arg)
+                return complete_args
+
+            if entity.template.HasField("container") and len(entity.template.container.args) > 0:
+                complete_args = _substitute_fast_register_task_args(
+                    entity.template.container.args, full_remote_path, destination_dir
+                )
+                # Because we're dealing with a proto list, we have to delete the existing args before we can extend the list
+                # with the substituted ones.
+                del entity.template.container.args[:]
+                entity.template.container.args.extend(complete_args)
+
+            if entity.template.HasField("k8s_pod"):
+                pod_spec_struct = entity.template.k8s_pod.pod_spec
+                if "containers" in pod_spec_struct:
+                    for idx in range(len(pod_spec_struct["containers"])):
+                        if "args" in pod_spec_struct["containers"][idx]:
+                            # We can directly overwrite the args in the pod spec struct definition.
+                            pod_spec_struct["containers"][idx]["args"] = _substitute_fast_register_task_args(
+                                pod_spec_struct["containers"][idx]["args"], full_remote_path, destination_dir
+                            )
+            return entity
+
+        patches = {
+            identifier_pb2.TASK: fast_register_task,
+            # _identifier_pb2.LAUNCH_PLAN: _get_patch_launch_plan_fn(
+            #     assumable_iam_role, kubernetes_service_account, output_location_prefix
+            # ),
+        }
+
+        # TODO: get this from the config file
+        config_obj = configuration.PlatformConfig.auto()
+        client = friendly.SynchronousFlyteClient(config_obj)
+        # TODO: fix version in this call
+        _extract_and_register(client, "flytesnacks", "development", version, pb_files, patches)
+    else:
+        click.secho(f"No flyte objects found in packages {pkgs}", fg="yellow")
+
+    # TODO: Schedule execution using flyteremote
+    # TODO: Dump flyteremote snippet to access the run

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -1,15 +1,16 @@
+import importlib
 import os
 import tarfile
 import tempfile
-from typing import List
+from pathlib import Path
 
 import click
 from flyteidl.core import identifier_pb2
-from google.protobuf.pyext.cpp_message import GeneratedProtocolMessageType
 
 from flytekit import configuration
 from flytekit.clients import friendly
 from flytekit.clis.flyte_cli.main import _extract_and_register
+from flytekit.clis.sdk_in_container.utils import produce_fast_register_task_closure
 from flytekit.configuration import FastSerializationSettings, ImageConfig, SerializationSettings
 from flytekit.core import context_manager
 from flytekit.exceptions.user import FlyteValidationException
@@ -18,7 +19,7 @@ from flytekit.tools import fast_registration, module_loader, serialize_helpers
 
 @click.command("run")
 @click.argument(
-    "workflow_path_and_name",
+    "module_and_workflow",
 )
 @click.option(
     "image",
@@ -27,8 +28,8 @@ from flytekit.tools import fast_registration, module_loader, serialize_helpers
     required=False,
     type=str,
     # TODO: fix default images push gh workflow
-    # default="ghcr.io/flyteorg/flytekit:py39-latest",
-    default="pyflyte-fast-execute:latest",
+    default="ghcr.io/flyteorg/flytekit:py39-latest",
+    # default="pyflyte-fast-execute:latest",
     help="Image used to register and run.",
 )
 @click.option(
@@ -41,29 +42,23 @@ from flytekit.tools import fast_registration, module_loader, serialize_helpers
 )
 @click.pass_context
 def run(
-    ctx,
-    workflow_path_and_name,
+    click_ctx,
+    module_and_workflow,
     image,
     help=None,
 ):
     """
-    TODO description (remember to document parameters)
+    TODO description (remember to document workflow inputs)
     """
     # TODO is it `--help`? Figure out a way to parse the inputs to the workflow
-    #
 
-    split_input = workflow_path_and_name.split(":")
+    split_input = module_and_workflow.split(":")
     if len(split_input) != 2:
-        raise FlyteValidationException(f"Input {workflow_path_and_name} must be in format '<module>:<worfklow>'")
+        raise FlyteValidationException(f"Input {module_and_workflow} must be in format '<module>:<worfklow>'")
 
-    workflow_path, workflow_name = split_input
-    # TODO: find the project root and use it to build the package name
-    pkgs = ["flyte.workflows"]
-    source = "/home/eduardo/tmp/pyflyte-run/"
+    module, workflow_name = split_input
+    pkg, source = _find_full_package_name_and_project_root()
     destination_dir = "/root"
-
-    # Load the code
-    #
 
     image_config = ImageConfig.validate_single_image(image)
     serialization_settings = SerializationSettings(
@@ -72,99 +67,71 @@ def run(
             enabled=True,
             destination_dir=destination_dir,
         ),
-        # TODO: do I really need to define a python interpreter?
-        # python_interpreter=python_interpreter,
     )
-    ctx = context_manager.FlyteContextManager.current_context().with_serialization_settings(serialization_settings)
-    # TODO: figure out source
-    with context_manager.FlyteContextManager.with_context(ctx) as ctx:
-        # Scan all modules. the act of loading populates the global singleton that contains all objects
-        # TODO: find root of project
+    flyte_ctx = context_manager.FlyteContextManager.current_context().with_serialization_settings(
+        serialization_settings
+    )
+    with context_manager.FlyteContextManager.with_context(flyte_ctx) as flyte_ctx:
         with module_loader.add_sys_path(source):
-            click.secho(f"Loading code {workflow_path}", fg="yellow")
-            module_loader.just_load_modules(pkgs=pkgs)
+            importlib.import_module(f"{pkg}.{module}")
 
-    registrable_entities = serialize_helpers.get_registrable_entities(ctx)
+    registrable_entities = serialize_helpers.get_registrable_entities(flyte_ctx)
 
-    if registrable_entities:
-        # Open a temp directory and dump the contents of the digest.
-        tmp_dir = tempfile.TemporaryDirectory()
+    if not registrable_entities:
+        click.secho(f"No flyte objects found in package {pkg}", fg="yellow")
+        return
 
-        # Write
-        source_path = os.fspath(source)
-        digest = fast_registration.compute_digest(source_path)
-        archive_fname = os.path.join(tmp_dir.name, f"{digest}.tar.gz")
-        # Write using gzip
-        with tarfile.open(archive_fname, "w:gz") as tar:
-            tar.add(source, arcname="", filter=fast_registration.filter_tar_file_fn)
+    # Open a temp directory and dump the contents of the digest.
+    tmp_dir = tempfile.TemporaryDirectory()
+    source_path = os.fspath(source)
+    digest = fast_registration.compute_digest(source_path)
+    archive_fname = os.path.join(tmp_dir.name, f"{digest}.tar.gz")
+    with tarfile.open(archive_fname, "w:gz") as tar:
+        tar.add(source, arcname="", filter=fast_registration.filter_tar_file_fn)
+    serialize_helpers.persist_registrable_entities(registrable_entities, tmp_dir.name)
 
-        serialize_helpers.persist_registrable_entities(registrable_entities, tmp_dir.name)
+    pb_files = []
+    for f in os.listdir(tmp_dir.name):
+        if f.endswith(".pb"):
+            pb_files.append(os.path.join(tmp_dir.name, f))
 
-        # List al pb files
-        pb_files = []
-        for f in os.listdir(tmp_dir.name):
-            if f.endswith(".pb"):
-                pb_files.append(os.path.join(tmp_dir.name, f))
+    version = str(os.getpid())  # TODO: find a better source of entropy
 
-        version = str(os.getpid())  # TODO: find a better source of entropy
+    # TODO Get signed url from flyteadmin
+    full_remote_path = f"s3://my-s3-bucket/fast-register-test/{digest}.tar.gz"
+    flyte_ctx = context_manager.FlyteContextManager.current_context()
+    flyte_ctx.file_access.put_data(archive_fname, full_remote_path)
 
-        # TODO Get signed url from flyteadmin
-        # TODO: Patch task specs with the signed url before writing them to disk
-        full_remote_path = f"s3://my-s3-bucket/fast-register-test/{digest}.tar.gz"
-        flyte_ctx = context_manager.FlyteContextManager.current_context()
-        flyte_ctx.file_access.put_data(archive_fname, full_remote_path)
+    patches = {
+        identifier_pb2.TASK: produce_fast_register_task_closure(full_remote_path, destination_dir),
+        # TODO: handle launch plans
+        # _identifier_pb2.LAUNCH_PLAN: _get_patch_launch_plan_fn(
+        #     assumable_iam_role, kubernetes_service_account, output_location_prefix
+        # ),
+    }
 
-        def fast_register_task(entity: GeneratedProtocolMessageType) -> GeneratedProtocolMessageType:
-            """
-            Updates task definitions during fast-registration in order to use the compatible pyflyte fast execute command at
-            task execution.
-            """
-            # entity is of type flyteidl.admin.task_pb2.TaskSpec
-
-            def _substitute_fast_register_task_args(args: List[str], full_remote_path: str, dest_dir: str) -> List[str]:
-                complete_args = []
-                for arg in args:
-                    if arg == "{{ .remote_package_path }}":
-                        arg = full_remote_path
-                    elif arg == "{{ .dest_dir }}":
-                        arg = dest_dir if dest_dir else "."
-                    complete_args.append(arg)
-                return complete_args
-
-            if entity.template.HasField("container") and len(entity.template.container.args) > 0:
-                complete_args = _substitute_fast_register_task_args(
-                    entity.template.container.args, full_remote_path, destination_dir
-                )
-                # Because we're dealing with a proto list, we have to delete the existing args before we can extend the list
-                # with the substituted ones.
-                del entity.template.container.args[:]
-                entity.template.container.args.extend(complete_args)
-
-            if entity.template.HasField("k8s_pod"):
-                pod_spec_struct = entity.template.k8s_pod.pod_spec
-                if "containers" in pod_spec_struct:
-                    for idx in range(len(pod_spec_struct["containers"])):
-                        if "args" in pod_spec_struct["containers"][idx]:
-                            # We can directly overwrite the args in the pod spec struct definition.
-                            pod_spec_struct["containers"][idx]["args"] = _substitute_fast_register_task_args(
-                                pod_spec_struct["containers"][idx]["args"], full_remote_path, destination_dir
-                            )
-            return entity
-
-        patches = {
-            identifier_pb2.TASK: fast_register_task,
-            # _identifier_pb2.LAUNCH_PLAN: _get_patch_launch_plan_fn(
-            #     assumable_iam_role, kubernetes_service_account, output_location_prefix
-            # ),
-        }
-
-        # TODO: get this from the config file
-        config_obj = configuration.PlatformConfig.auto()
-        client = friendly.SynchronousFlyteClient(config_obj)
-        # TODO: fix version in this call
-        _extract_and_register(client, "flytesnacks", "development", version, pb_files, patches)
-    else:
-        click.secho(f"No flyte objects found in packages {pkgs}", fg="yellow")
+    # TODO: get this from the config file
+    config_obj = configuration.PlatformConfig.auto()
+    client = friendly.SynchronousFlyteClient(config_obj)
+    _extract_and_register(client, "flytesnacks", "development", version, pb_files, patches)
 
     # TODO: Schedule execution using flyteremote
     # TODO: Dump flyteremote snippet to access the run
+
+
+def _find_full_package_name_and_project_root() -> (str, Path):
+    """
+    Traverse from current working directory until it can no longer find __init__.py files
+    """
+    # N.B.: this path traversal is *extremely* naive. In other words it will not handle cycles
+    # and probably will be
+    dirs = []
+    path = Path(os.getcwd())
+    while os.path.exists(os.path.join(path, "__init__.py")):
+        dirs.insert(0, path.parts[-1])
+        path = path.parent
+
+    full_pkg = ".".join(dirs)
+    source = path
+
+    return full_pkg, source

--- a/flytekit/clis/sdk_in_container/utils.py
+++ b/flytekit/clis/sdk_in_container/utils.py
@@ -1,0 +1,44 @@
+from typing import List
+
+from google.protobuf.pyext.cpp_message import GeneratedProtocolMessageType
+
+
+def produce_fast_register_task_closure(full_remote_path, destination_dir):
+    def fast_register_task(entity: GeneratedProtocolMessageType) -> GeneratedProtocolMessageType:
+        """
+        Updates task definitions during fast-registration in order to use the compatible pyflyte fast execute command at
+        task execution.
+        """
+        # entity is of type flyteidl.admin.task_pb2.TaskSpec
+
+        def _substitute_fast_register_task_args(args: List[str], full_remote_path: str, dest_dir: str) -> List[str]:
+            complete_args = []
+            for arg in args:
+                if arg == "{{ .remote_package_path }}":
+                    arg = full_remote_path
+                elif arg == "{{ .dest_dir }}":
+                    arg = dest_dir if dest_dir else "."
+                complete_args.append(arg)
+            return complete_args
+
+        if entity.template.HasField("container") and len(entity.template.container.args) > 0:
+            complete_args = _substitute_fast_register_task_args(
+                entity.template.container.args, full_remote_path, destination_dir
+            )
+            # Because we're dealing with a proto list, we have to delete the existing args before we can extend the list
+            # with the substituted ones.
+            del entity.template.container.args[:]
+            entity.template.container.args.extend(complete_args)
+
+        if entity.template.HasField("k8s_pod"):
+            pod_spec_struct = entity.template.k8s_pod.pod_spec
+            if "containers" in pod_spec_struct:
+                for idx in range(len(pod_spec_struct["containers"])):
+                    if "args" in pod_spec_struct["containers"][idx]:
+                        # We can directly overwrite the args in the pod spec struct definition.
+                        pod_spec_struct["containers"][idx]["args"] = _substitute_fast_register_task_args(
+                            pod_spec_struct["containers"][idx]["args"], full_remote_path, destination_dir
+                        )
+        return entity
+
+    return fast_register_task

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -181,6 +181,27 @@ class ImageConfig(object):
         return None
 
     @staticmethod
+    def validate_single_image(value: str) -> ImageConfig:
+        """
+        TODO
+        """
+        default_image = None
+        images = []
+
+        if "=" in value:
+            splits = value.split("=", maxsplit=1)
+            img = Image.look_up_image_info(name=splits[0], tag=splits[1], optional_tag=False)
+        else:
+            img = Image.look_up_image_info(DEFAULT_IMAGE_NAME, value, False)
+
+        if img.name == DEFAULT_IMAGE_NAME:
+            default_image = img
+        else:
+            images.append(img)
+
+        return ImageConfig(default_image, images)
+
+    @staticmethod
     def validate_image(_: typing.Any, param: str, values: tuple) -> ImageConfig:
         """
         Validates the image to match the standard format. Also validates that only one default image


### PR DESCRIPTION
This is a PR on top of https://github.com/flyteorg/flytekit/pull/902/ just for the purpose of testing out the module sanitizer.

In order to run `pyflyte run` run:
```
FLYTE_AWS_ENDPOINT='http://localhost:30084/' FLYTE_AWS_ACCESS_KEY_ID=minio FLYTE_AWS_SECRET_ACCESS_KEY=miniostorage pyflyte run <module.example>:wf --image "baseimage:latest"
```
where `<module.example>` refers to a specific module and `wf` is a workflow found in the `example` module. Note the use of `--image`. 

These env vars are used to write the tar file to an specific localtion in s3 via minio. In the real command we're going to get the s3 from the data proxy call.
