### PR TITLE
Fix lint error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   hooks:
     - id: flake8
 - repo: https://github.com/psf/black
-  rev:  21.7b0
+  rev:  22.3.0
   hooks:
     - id: black
 - repo: https://github.com/PyCQA/isort

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -50,7 +50,7 @@ checksumdir==1.2.0
     # via
     #   -c requirements.txt
     #   flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   -c requirements.txt
     #   cookiecutter

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -31,7 +31,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -55,7 +55,7 @@ def _handle_rpc_error(retry=False):
                             raise
                         else:
                             # Retry: Start with 200ms wait-time and exponentially back-off up to 1 second.
-                            wait_time = min(200 * (2 ** i), max_wait_time)
+                            wait_time = min(200 * (2**i), max_wait_time)
                             cli_logger.error(f"Non-auth RPC error {e}, sleeping {wait_time}ms and retrying")
                             time.sleep(wait_time / 1000)
 

--- a/plugins/flytekit-aws-athena/requirements.txt
+++ b/plugins/flytekit-aws-athena/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-aws-batch/requirements.txt
+++ b/plugins/flytekit-aws-batch/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-aws-sagemaker/requirements.txt
+++ b/plugins/flytekit-aws-sagemaker/requirements.txt
@@ -31,7 +31,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-bigquery/requirements.txt
+++ b/plugins/flytekit-bigquery/requirements.txt
@@ -22,7 +22,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-data-fsspec/requirements.txt
+++ b/plugins/flytekit-data-fsspec/requirements.txt
@@ -22,7 +22,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-dolt/requirements.txt
+++ b/plugins/flytekit-dolt/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-greatexpectations/requirements.txt
+++ b/plugins/flytekit-greatexpectations/requirements.txt
@@ -42,7 +42,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-hive/requirements.txt
+++ b/plugins/flytekit-hive/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-k8s-pod/requirements.txt
+++ b/plugins/flytekit-k8s-pod/requirements.txt
@@ -24,7 +24,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-kf-mpi/requirements.txt
+++ b/plugins/flytekit-kf-mpi/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-kf-pytorch/requirements.txt
+++ b/plugins/flytekit-kf-pytorch/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-kf-tensorflow/requirements.txt
+++ b/plugins/flytekit-kf-tensorflow/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-modin/requirements.txt
+++ b/plugins/flytekit-modin/requirements.txt
@@ -24,7 +24,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-pandera/requirements.txt
+++ b/plugins/flytekit-pandera/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-papermill/requirements.txt
+++ b/plugins/flytekit-papermill/requirements.txt
@@ -32,7 +32,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-snowflake/requirements.txt
+++ b/plugins/flytekit-snowflake/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-spark/requirements.txt
+++ b/plugins/flytekit-spark/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/plugins/flytekit-sqlalchemy/requirements.txt
+++ b/plugins/flytekit-sqlalchemy/requirements.txt
@@ -20,7 +20,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.01
     # via
     #   cookiecutter
     #   flytekit

--- a/requirements-spark2.txt
+++ b/requirements-spark2.txt
@@ -26,7 +26,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
+++ b/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
@@ -18,7 +18,7 @@ charset-normalizer==2.0.12
     # via requests
 checksumdir==1.2.0
     # via flytekit
-click==8.0.4
+click==8.0.1
     # via
     #   cookiecutter
     #   flytekit

--- a/tests/flytekit/unit/cli/test_cli_helpers.py
+++ b/tests/flytekit/unit/cli/test_cli_helpers.py
@@ -11,7 +11,7 @@ from flytekit.clis.helpers import _hydrate_identifier, _hydrate_workflow_templat
 
 
 def test_parse_args_into_dict():
-    sample_args1 = (u"input_b=mystr", u"input_c=18")
+    sample_args1 = ("input_b=mystr", "input_c=18")
     sample_args2 = ("input_a=mystr===d",)
     sample_args3 = ()
     output = helpers.parse_args_into_dict(sample_args1)

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -297,7 +297,7 @@ def test_serialization_types():
     @task(cache=True, cache_version="1.0.0")
     def squared(value: int) -> typing.List[typing.Dict[str, int]]:
         return [
-            {"squared_value": value ** 2},
+            {"squared_value": value**2},
         ]
 
     @workflow

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1328,7 +1328,7 @@ def test_wf_explicitly_returning_empty_task():
 def test_nested_dict():
     @task(cache=True, cache_version="1.0.0")
     def squared(value: int) -> typing.Dict[str, int]:
-        return {"value:": value ** 2}
+        return {"value:": value**2}
 
     @workflow
     def compute_square_wf(input_integer: int) -> typing.Dict[str, int]:
@@ -1342,7 +1342,7 @@ def test_nested_dict2():
     @task(cache=True, cache_version="1.0.0")
     def squared(value: int) -> typing.List[typing.Dict[str, int]]:
         return [
-            {"squared_value": value ** 2},
+            {"squared_value": value**2},
         ]
 
     @workflow


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Error:
```
Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repozuci9iid/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/runner/.cache/pre-commit/repozuci9iid/py_env-python3/lib/python3.8/site-packages/black/__init__.py", line 1129, in patched_main
    patch_click()
  File "/home/runner/.cache/pre-commit/repozuci9iid/py_env-python3/lib/python3.8/site-packages/black/__init__.py", line 1115, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/.cache/pre-commit/repozuci9iid/py_env-python3/lib/python3.8/site-packages/click/__init__.py)
```

It's related to this issue https://github.com/psf/black/issues/2964#issuecomment-1080970453

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
pin click version

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_