### PR TITLE
FlyteRemote.register works 

### DIFF
--- a/flytekit/configuration/feature_flags.py
+++ b/flytekit/configuration/feature_flags.py
@@ -9,5 +9,8 @@ def _get(key: str, default_val: str) -> str:
 class FeatureFlags:
     FLYTE_PYTHON_PACKAGE_ROOT = _get("FLYTE_PYTHON_PACKAGE_ROOT", "auto")
     """
-    Valid values, "auto", "." or an actual path
+    Valid values,
+    "auto" -> Automatically locate the fully qualified module name. This assumes that every python package directory is valid and has an _init__.py file
+     "." -> Assuming current directory as the root
+     or an actual path -> path to the root, this will be used to locate the root.
     """

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -31,6 +31,7 @@ from flytekit.core.promise import (
 )
 from flytekit.core.python_auto_container import PythonAutoContainerTask
 from flytekit.core.reference_entity import ReferenceEntity, WorkflowReference
+from flytekit.core.tracker import extract_task_module
 from flytekit.core.type_engine import TypeEngine
 from flytekit.exceptions import scopes as exception_scopes
 from flytekit.exceptions.user import FlyteValidationException, FlyteValueException
@@ -572,7 +573,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
         default_metadata: Optional[WorkflowMetadataDefaults],
         docstring: Docstring = None,
     ):
-        name = f"{workflow_function.__module__}.{workflow_function.__name__}"
+        name, _, _ = extract_task_module(workflow_function)
         self._workflow_function = workflow_function
         native_interface = transform_function_to_interface(workflow_function, docstring=docstring)
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -61,11 +61,7 @@ from flytekit.remote.launch_plan import FlyteLaunchPlan
 from flytekit.remote.nodes import FlyteNode
 from flytekit.remote.task import FlyteTask
 from flytekit.remote.workflow import FlyteWorkflow
-from flytekit.tools.translator import (
-    FlyteLocalEntity,
-    get_serializable,
-    get_serializable_launch_plan,
-)
+from flytekit.tools.translator import FlyteLocalEntity, get_serializable, get_serializable_launch_plan
 
 ExecutionDataResponse = typing.Union[WorkflowExecutionGetDataResponse, NodeExecutionGetDataResponse]
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -36,7 +36,7 @@ except ImportError:
     from singledispatchmethod import singledispatchmethod
 
 from flytekit.clients.helpers import iterate_node_executions, iterate_task_executions
-from flytekit.configuration import Config, SerializationSettings
+from flytekit.configuration import Config, ImageConfig, SerializationSettings
 from flytekit.core.base_task import PythonTask
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.data_persistence import FileAccessProvider
@@ -65,8 +65,6 @@ from flytekit.tools.translator import (
     FlyteLocalEntity,
     get_serializable,
     get_serializable_launch_plan,
-    get_serializable_task,
-    get_serializable_workflow,
 )
 
 ExecutionDataResponse = typing.Union[WorkflowExecutionGetDataResponse, NodeExecutionGetDataResponse]
@@ -447,7 +445,7 @@ class FlyteRemote(object):
                         workflow_model.TaskNode,
                     ),
                 ):
-                    remote_logger.debug(f"Ignoring node registrations")
+                    remote_logger.debug("Ignoring nodes for registration.")
                 else:
                     raise AssertionError(f"Unknown entity of type {type(cp_entity)}")
             except FlyteEntityAlreadyExistsException:
@@ -468,7 +466,7 @@ class FlyteRemote(object):
         :param version: version that will be used to register. If not specified will default to using the serialization settings default
         :return:
         """
-        ident = self._serialize_and_register(self, entity=entity, settings=serialization_settings, version=version)
+        ident = self._serialize_and_register(entity=entity, settings=serialization_settings, version=version)
         return self.fetch_task(
             ident.project,
             ident.domain,
@@ -543,7 +541,7 @@ class FlyteRemote(object):
             annotations=options.annotations,
         )
 
-        ss = SerializationSettings(image_config=None, project=project, domain=domain, version=version)
+        ss = SerializationSettings(image_config=ImageConfig(), project=project, domain=domain, version=version)
 
         ident = self._resolve_identifier(ResourceType.LAUNCH_PLAN, entity.name, version, ss)
         m = OrderedDict()
@@ -551,7 +549,7 @@ class FlyteRemote(object):
         try:
             self.client.create_launch_plan(ident, idl_lp.spec)
         except FlyteEntityAlreadyExistsException:
-            remote_logger.debug(f"Launchplan already exists, ignoring")
+            remote_logger.debug("Launchplan already exists, ignoring")
         return self.fetch_launch_plan(ident.project, ident.domain, ident.name, ident.version)
 
     ####################

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -19,11 +19,16 @@ from flytekit.clients.friendly import SynchronousFlyteClient
 from flytekit.core import constants, context_manager, utils
 from flytekit.core.interface import Interface
 from flytekit.core.python_auto_container import PythonAutoContainerTask
+from flytekit.core.task import ReferenceTask
 from flytekit.exceptions import user as user_exceptions
 from flytekit.exceptions.user import FlyteEntityAlreadyExistsException, FlyteEntityNotExistException
 from flytekit.loggers import remote_logger
 from flytekit.models import filters as filter_models
+from flytekit.models import launch_plan as launch_plan_models
+from flytekit.models import task as task_models
 from flytekit.models.admin import common as admin_common_models
+from flytekit.models.admin import workflow as admin_workflow_models
+from flytekit.models.core import workflow as workflow_model
 
 try:
     from functools import singledispatchmethod
@@ -35,9 +40,9 @@ from flytekit.configuration import Config, SerializationSettings
 from flytekit.core.base_task import PythonTask
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.data_persistence import FileAccessProvider
-from flytekit.core.launch_plan import LaunchPlan
+from flytekit.core.launch_plan import LaunchPlan, ReferenceLaunchPlan
 from flytekit.core.type_engine import LiteralsResolver, TypeEngine
-from flytekit.core.workflow import WorkflowBase
+from flytekit.core.workflow import ReferenceWorkflow, WorkflowBase
 from flytekit.models import common as common_models
 from flytekit.models import literals as literal_models
 from flytekit.models import security
@@ -56,7 +61,13 @@ from flytekit.remote.launch_plan import FlyteLaunchPlan
 from flytekit.remote.nodes import FlyteNode
 from flytekit.remote.task import FlyteTask
 from flytekit.remote.workflow import FlyteWorkflow
-from flytekit.tools.translator import get_serializable_launch_plan, get_serializable_task, get_serializable_workflow
+from flytekit.tools.translator import (
+    FlyteLocalEntity,
+    get_serializable,
+    get_serializable_launch_plan,
+    get_serializable_task,
+    get_serializable_workflow,
+)
 
 ExecutionDataResponse = typing.Union[WorkflowExecutionGetDataResponse, NodeExecutionGetDataResponse]
 
@@ -395,6 +406,56 @@ class FlyteRemote(object):
             )
         return ident
 
+    def _serialize_and_register(
+        self, entity: FlyteLocalEntity, settings: SerializationSettings, version: str
+    ) -> Identifier:
+        """
+        This method serializes and register the given Flyte entity
+        :return: Identifier of the registered entity
+        """
+        m = OrderedDict()
+        _ = get_serializable(m, settings=settings, entity=entity)
+        ident = None
+        for entity, cp_entity in m.items():
+            try:
+                if isinstance(cp_entity, task_models.TaskSpec):
+                    if isinstance(entity, (FlyteTask, ReferenceTask)):
+                        remote_logger.debug(f"Skipping registration of Task (remote task), name: {entity.name}")
+                        continue
+                    ident = self._resolve_identifier(ResourceType.TASK, entity.name, version, settings)
+                    self.client.create_task(task_identifer=ident, task_spec=cp_entity)
+                elif isinstance(cp_entity, admin_workflow_models.WorkflowSpec):
+                    if isinstance(entity, (FlyteWorkflow, ReferenceWorkflow)):
+                        remote_logger.debug(f"Skipping registration of Workflow (remote workflow), name: {entity.name}")
+                        continue
+                    ident = self._resolve_identifier(ResourceType.WORKFLOW, entity.name, version, settings)
+                    self.client.create_workflow(workflow_identifier=ident, workflow_spec=cp_entity)
+                elif isinstance(cp_entity, launch_plan_models.LaunchPlanSpec):
+                    if isinstance(entity, (FlyteLaunchPlan, ReferenceLaunchPlan)):
+                        remote_logger.debug(
+                            f"Skipping registration of LaunchPlan (remote launchplan), name: {entity.name}"
+                        )
+                        continue
+                    ident = self._resolve_identifier(ResourceType.LAUNCH_PLAN, entity.name, version, settings)
+                    self.client.create_launch_plan(launch_plan_identifer=ident, launch_plan_spec=cp_entity)
+                elif isinstance(
+                    cp_entity,
+                    (
+                        workflow_model.Node,
+                        workflow_model.WorkflowNode,
+                        workflow_model.BranchNode,
+                        workflow_model.TaskNode,
+                    ),
+                ):
+                    remote_logger.debug(f"Ignoring node registrations")
+                else:
+                    raise AssertionError(f"Unknown entity of type {type(cp_entity)}")
+            except FlyteEntityAlreadyExistsException:
+                remote_logger.info(f"{entity.name} already exists")
+            except Exception as e:
+                remote_logger.info(f"Failed to register entity {entity.name} with error {e}")
+        return ident
+
     def register_task(
         self, entity: PythonTask, serialization_settings: SerializationSettings, version: typing.Optional[str] = None
     ) -> FlyteTask:
@@ -407,15 +468,12 @@ class FlyteRemote(object):
         :param version: version that will be used to register. If not specified will default to using the serialization settings default
         :return:
         """
-        m = OrderedDict()
-        task_spec = get_serializable_task(m, serialization_settings, entity)
-        ident = self._resolve_identifier(ResourceType.TASK, entity.name, version, serialization_settings)
-        self.client.create_task(ident, task_spec=task_spec)
+        ident = self._serialize_and_register(self, entity=entity, settings=serialization_settings, version=version)
         return self.fetch_task(
-            serialization_settings.project,
-            serialization_settings.domain,
-            entity.name,
-            version or serialization_settings.version,
+            ident.project,
+            ident.domain,
+            ident.name,
+            ident.version,
         )
 
     def register_workflow(
@@ -423,8 +481,7 @@ class FlyteRemote(object):
         entity: WorkflowBase,
         serialization_settings: SerializationSettings,
         version: typing.Optional[str] = None,
-        default_launch_plan: bool = True,
-        all_downstream: bool = True,
+        default_launch_plan: typing.Optional[bool] = True,
         options: typing.Optional[Options] = None,
     ) -> FlyteWorkflow:
         """
@@ -433,50 +490,44 @@ class FlyteRemote(object):
         :param entity: The workflow to be registered
         :param serialization_settings: The serialization settings to be used
         :param default_launch_plan: This should be true if a default launch plan should be created for the workflow
-        :param all_downstream: This should be true if all downstream entities should be registered, including tasks,
-                        subworkflows, launchplans
         :param options: Additional execution options that can be configured for the default launchplan
         :return:
         """
-        m = OrderedDict()
-        workflow_spec = get_serializable_workflow(m, serialization_settings, entity)
         ident = self._resolve_identifier(ResourceType.WORKFLOW, entity.name, version, serialization_settings)
-        self.client.create_workflow(ident, workflow_spec=workflow_spec)
+        b = serialization_settings.new_builder()
+        b.project = ident.project
+        b.domain = ident.domain
+        b.version = ident.version
+        ident = self._serialize_and_register(entity, b.build(), version)
         if default_launch_plan:
             default_lp = LaunchPlan.get_default_launch_plan(FlyteContextManager.current_context(), entity)
-            self.register_launch_plan(default_lp, serialization_settings, version=version, options=options)
-            remote_logger.debug("Created default launch plan for Workflow")
-
-        if all_downstream:
-            self._register_entity_if_not_exists(
-                entity, serialization_settings=serialization_settings, version=version, options=options
+            self.register_launch_plan(
+                default_lp, version=version, project=ident.project, domain=ident.domain, options=options
             )
+            remote_logger.debug("Created default launch plan for Workflow")
 
         return self.fetch_workflow(ident.project, ident.domain, ident.name, ident.version)
 
     def register_launch_plan(
         self,
         entity: LaunchPlan,
-        serialization_settings: typing.Optional[SerializationSettings] = None,
-        version: typing.Optional[str] = None,
+        version: str,
+        project: typing.Optional[str] = None,
+        domain: typing.Optional[str] = None,
         options: typing.Optional[Options] = None,
     ) -> FlyteLaunchPlan:
         """
         Register a given launchplan, possibly applying overrides from the provided options.
-        Note: In this case it is reasonable to have image_config in SerializationSettings to be None!
+
         :param entity: Launchplan to be registered
-        :param serialization_settings: Settings to use for Serialization
         :param version:
+        :param project: Optionally provide a project, if not already provided in flyteremote constructor or a separate one
+        :param domain: Optionally provide a domain, if not already provided in FlyteRemote constructor or a separate one
         :param options:
         :return:
         """
         if not options:
             options = Options()
-
-        if serialization_settings is None:
-            serialization_settings = SerializationSettings(
-                image_config=None, project=self.default_project, domain=self.default_domain
-            )
 
         raw = None
         if options.raw_data_prefix:
@@ -491,47 +542,17 @@ class FlyteRemote(object):
             labels=options.labels,
             annotations=options.annotations,
         )
-        ident = self._resolve_identifier(ResourceType.LAUNCH_PLAN, entity.name, version, serialization_settings)
-        m = OrderedDict()
-        idl_lp = get_serializable_launch_plan(m, serialization_settings, lp)
-        self.client.create_launch_plan(ident, idl_lp.spec)
-        return self.fetch_launch_plan(ident.project, ident.domain, ident.name, ident.version)
 
-    def _register_entity_if_not_exists(
-        self,
-        entity: WorkflowBase,
-        serialization_settings: SerializationSettings,
-        version: typing.Optional[str] = None,
-        options: typing.Optional[Options] = None,
-    ):
-        for node in entity.nodes:
-            try:
-                if isinstance(node.flyte_entity, WorkflowBase):
-                    self.register_workflow(
-                        node.flyte_entity,
-                        serialization_settings,
-                        version=version,
-                        default_launch_plan=True,
-                        all_downstream=True,
-                        options=options,
-                    )
-                elif isinstance(node.flyte_entity, PythonTask):
-                    self.register_task(
-                        node.flyte_entity, serialization_settings=serialization_settings, version=version
-                    )
-                elif isinstance(node.flyte_entity, LaunchPlan):
-                    self.register_launch_plan(
-                        node.flyte_entity,
-                        serialization_settings=serialization_settings,
-                        version=version,
-                        options=options,
-                    )
-                else:
-                    raise NotImplementedError(f"We don't support registering this kind of entity: {node.flyte_entity}")
-            except FlyteEntityAlreadyExistsException:
-                remote_logger.info(f"{entity.name} already exists")
-            except Exception as e:
-                remote_logger.info(f"Failed to register entity {entity.name} with error {e}")
+        ss = SerializationSettings(image_config=None, project=project, domain=domain, version=version)
+
+        ident = self._resolve_identifier(ResourceType.LAUNCH_PLAN, entity.name, version, ss)
+        m = OrderedDict()
+        idl_lp = get_serializable_launch_plan(m, ss, lp, recurse_downstream=False)
+        try:
+            self.client.create_launch_plan(ident, idl_lp.spec)
+        except FlyteEntityAlreadyExistsException:
+            remote_logger.debug(f"Launchplan already exists, ignoring")
+        return self.fetch_launch_plan(ident.project, ident.domain, ident.name, ident.version)
 
     ####################
     # Execute Entities #

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -210,11 +210,29 @@ def get_serializable_launch_plan(
     entity_mapping: OrderedDict,
     settings: SerializationSettings,
     entity: LaunchPlan,
+    recurse_downstream: bool = True,
 ) -> _launch_plan_models.LaunchPlan:
-    wf_spec = get_serializable(entity_mapping, settings, entity.workflow)
+    """
+    :param entity_mapping:
+    :param settings:
+    :param entity:
+    :param recurse_downstream: This boolean indicate is wf for the entity should also be recursed to
+    :return:
+    """
+    if recurse_downstream:
+        wf_spec = get_serializable(entity_mapping, settings, entity.workflow)
+        wf_id = wf_spec.template.id
+    else:
+        wf_id = _identifier_model.Identifier(
+            resource_type=_identifier_model.ResourceType.WORKFLOW,
+            project=settings.project,
+            domain=settings.domain,
+            name=entity.workflow.name,
+            version=settings.version,
+        )
 
     lps = _launch_plan_models.LaunchPlanSpec(
-        workflow_id=wf_spec.template.id,
+        workflow_id=wf_id,
         entity_metadata=_launch_plan_models.LaunchPlanMetadata(
             schedule=entity.schedule,
             notifications=entity.notifications,


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
This PR makes remote.register_* methods work correctly. They use the get_serializable_entity functions and in the case of workflow register all downstream.

Also fixes the `__main__` name in the workflow.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
Register will now register the workflow and all its downstream. Does not support fast-register yet

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2241

## Follow-up issue
_NA_

