### PR TITLE
Supporting repo-level operations

### DIFF
--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -9,12 +9,10 @@ import click
 from flytekit.clis.sdk_in_container import constants
 from flytekit.clis.sdk_in_container.constants import CTX_PACKAGES
 from flytekit.configuration import FastSerializationSettings, ImageConfig, SerializationSettings
-from flytekit.core import context_manager as flyte_context
 from flytekit.exceptions.scopes import system_entry_point
 from flytekit.tools.fast_registration import compute_digest as _compute_digest
 from flytekit.tools.fast_registration import filter_tar_file_fn as _filter_tar_file_fn
-from flytekit.tools.module_loader import trigger_loading
-from flytekit.tools.serialize_helpers import get_registrable_entities, persist_registrable_entities
+from flytekit.tools.repo import serialize_to_folder
 
 CTX_IMAGE = "image"
 CTX_LOCAL_SRC_ROOT = "local_source_root"
@@ -70,16 +68,7 @@ def serialize_all(
         python_interpreter=python_interpreter,
     )
 
-    ctx = flyte_context.FlyteContextManager.current_context().with_serialization_settings(serialization_settings)
-    with flyte_context.FlyteContextManager.with_context(ctx) as ctx:
-        trigger_loading(pkgs, local_source_root=local_source_root)
-        click.echo(f"Found {len(flyte_context.FlyteEntities.entities)} tasks/workflows")
-        loaded_entities = get_registrable_entities(ctx)
-        if folder is None:
-            folder = "."
-        persist_registrable_entities(loaded_entities, folder)
-
-        click.secho(f"Successfully serialized {len(loaded_entities)} flyte objects", fg="green")
+    serialize_to_folder(pkgs, serialization_settings, local_source_root, folder)
 
 
 @click.group("serialize")

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -187,7 +187,12 @@ class ImageConfig(object):
         is provided. a default image, is one that is specified as
           default=img or just img. All other images should be provided with a name, in the format
           name=img
-        This method can be used wit the CLI
+        This method can be used with the CLI
+
+        :param _: click argument, ignored here.
+        :param param: the click argument, here should be "image"
+        :param values: user-supplied images
+        :return:
         """
         default_image = None
         images = []

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -187,6 +187,7 @@ class ImageConfig(object):
         is provided. a default image, is one that is specified as
           default=img or just img. All other images should be provided with a name, in the format
           name=img
+        This method can be used wit the CLI
         """
         default_image = None
         images = []
@@ -206,7 +207,7 @@ class ImageConfig(object):
             else:
                 images.append(img)
 
-        return ImageConfig(default_image, images)
+        return ImageConfig.create_from(default_image=default_image, images=images)
 
     @classmethod
     def create_from(cls, default_image: Image, other_images: typing.Optional[typing.List[Image]] = None) -> ImageConfig:

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -207,7 +207,7 @@ class ImageConfig(object):
             else:
                 images.append(img)
 
-        return ImageConfig.create_from(default_image=default_image, images=images)
+        return ImageConfig.create_from(default_image=default_image, other_images=images)
 
     @classmethod
     def create_from(cls, default_image: Image, other_images: typing.Optional[typing.List[Image]] = None) -> ImageConfig:

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -1,0 +1,158 @@
+import os
+import tarfile
+import tempfile
+import typing
+
+import click
+
+from flytekit import FlyteContextManager, logger
+from flytekit.clients.friendly import SynchronousFlyteClient
+from flytekit.configuration import SerializationSettings
+from flytekit.exceptions.user import FlyteEntityAlreadyExistsException
+from flytekit.models import launch_plan as launch_plan_models
+from flytekit.models import task as task_models
+from flytekit.models.admin import workflow as admin_workflow_models
+from flytekit.models.core.identifier import Identifier, ResourceType
+from flytekit.tools import fast_registration, module_loader
+from flytekit.tools.serialize_helpers import RegistrableEntity, get_registrable_entities, persist_registrable_entities
+from flytekit.tools.translator import Options
+
+
+class NoSerializableEntitiesError(Exception):
+    pass
+
+
+def serialize(
+    pkgs: typing.List[str],
+    settings: SerializationSettings,
+    local_source_root: typing.Optional[str] = None,
+    options: typing.Optional[Options] = None,
+) -> typing.List[RegistrableEntity]:
+    """
+    See :py:class:`flytekit.models.core.identifier.ResourceType` to match the trailing index in the file name with the
+    entity type.
+    :param options:
+    :param settings: SerializationSettings to be used
+    :param pkgs: Dot-delimited Python packages/subpackages to look into for serialization.
+    :param local_source_root: Where to start looking for the code.
+    """
+
+    ctx = FlyteContextManager.current_context().with_serialization_settings(settings)
+    with FlyteContextManager.with_context(ctx) as ctx:
+        # Scan all modules. the act of loading populates the global singleton that contains all objects
+        with module_loader.add_sys_path(local_source_root):
+            click.secho(f"Loading packages {pkgs} under source root {local_source_root}", fg="yellow")
+            module_loader.just_load_modules(pkgs=pkgs)
+
+        registrable_entities = get_registrable_entities(ctx, options=options)
+        click.secho(f"Successfully serialized {len(registrable_entities)} flyte objects", fg="green")
+        return registrable_entities
+
+
+def serialize_to_folder(
+    pkgs: typing.List[str],
+    settings: SerializationSettings,
+    local_source_root: typing.Optional[str] = None,
+    folder: str = ".",
+    options: typing.Optional[Options] = None,
+):
+    """
+    Serialize the given set of python packages to a folder
+    """
+    loaded_entities = serialize(pkgs, settings, local_source_root, options=options)
+    persist_registrable_entities(loaded_entities, folder)
+
+
+def package(
+    registrable_entities: typing.List[RegistrableEntity],
+    source: str = ".",
+    output: str = "./flyte-package.tgz",
+    fast: bool = False,
+):
+    """
+    Package the given entities and the source code (if fast is enabled) into a package with the given name in output
+    :param registrable_entities: Entities that can be serialized
+    :param source: source folder
+    :param output: output package name with suffix
+    :param fast: fast enabled implies source code is bundled
+    """
+    if not registrable_entities:
+        raise NoSerializableEntitiesError("Nothing to package")
+
+    with tempfile.TemporaryDirectory() as output_tmpdir:
+        persist_registrable_entities(registrable_entities, output_tmpdir)
+
+        # If Fast serialization is enabled, then an archive is also created and packaged
+        if fast:
+            digest = fast_registration.compute_digest(source)
+            archive_fname = os.path.join(output_tmpdir, f"{digest}.tar.gz")
+            click.secho(f"Fast mode enabled: compressed archive {archive_fname}", dim=True)
+            # Write using gzip
+            with tarfile.open(archive_fname, "w:gz") as tar:
+                tar.add(source, arcname="", filter=fast_registration.filter_tar_file_fn)
+
+        with tarfile.open(output, "w:gz") as tar:
+            tar.add(output_tmpdir, arcname="")
+
+    click.secho(f"Successfully packaged {len(registrable_entities)} flyte objects into {output}", fg="green")
+
+
+def serialize_and_package(
+    pkgs: typing.List[str],
+    settings: SerializationSettings,
+    source: str = ".",
+    output: str = "./flyte-package.tgz",
+    fast: bool = False,
+    options: typing.Optional[Options] = None,
+):
+    """
+    Fist serialize and then package all entities
+    """
+    registrable_entities = serialize(pkgs, settings, source, options=options)
+    package(registrable_entities, source, output, fast)
+
+
+def register(
+    registrable_entities: typing.List[RegistrableEntity],
+    project: str,
+    domain: str,
+    version: str,
+    client: SynchronousFlyteClient,
+    source: str = ".",
+    fast: bool = False,
+):
+    if fast:
+        # TODO handle fast
+        raise AssertionError("Fast not handled yet!")
+    for entity, cp_entity in registrable_entities:
+        try:
+            if isinstance(cp_entity, task_models.TaskSpec):
+                ident = Identifier(
+                    resource_type=ResourceType.TASK, project=project, domain=domain, name=entity.name, version=version
+                )
+                client.create_task(task_identifer=ident, task_spec=cp_entity)
+            elif isinstance(cp_entity, admin_workflow_models.WorkflowSpec):
+                ident = Identifier(
+                    resource_type=ResourceType.WORKFLOW,
+                    project=project,
+                    domain=domain,
+                    name=entity.name,
+                    version=version,
+                )
+                client.create_workflow(workflow_identifier=ident, workflow_spec=cp_entity)
+            elif isinstance(cp_entity, launch_plan_models.LaunchPlanSpec):
+                ident = Identifier(
+                    resource_type=ResourceType.LAUNCH_PLAN,
+                    project=project,
+                    domain=domain,
+                    name=entity.name,
+                    version=version,
+                )
+                client.create_launch_plan(launch_plan_identifer=ident, launch_plan_spec=cp_entity)
+            else:
+                raise AssertionError(f"Unknown entity of type {type(cp_entity)}")
+        except FlyteEntityAlreadyExistsException:
+            logger.info(f"{entity.name} already exists")
+        except Exception as e:
+            logger.info(f"Failed to register entity {entity.name} with error {e}")
+            raise e

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -1,4 +1,6 @@
+import typing
 from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 from flytekit import PythonFunctionTask
@@ -15,8 +17,10 @@ from flytekit.core.task import ReferenceTask
 from flytekit.core.utils import _dnsify
 from flytekit.core.workflow import ReferenceWorkflow, WorkflowBase
 from flytekit.models import common as _common_models
+from flytekit.models import common as common_models
 from flytekit.models import interface as interface_models
 from flytekit.models import launch_plan as _launch_plan_models
+from flytekit.models import security
 from flytekit.models import task as task_models
 from flytekit.models.admin import workflow as admin_workflow_models
 from flytekit.models.core import identifier as _identifier_model
@@ -43,6 +47,40 @@ FlyteControlPlaneEntity = Union[
     workflow_model.Node,
     BranchNodeModel,
 ]
+
+
+@dataclass
+class Options(object):
+    """
+    These are options that can be configured for a launchplan during registration or overridden during an execution.
+    For instance two people may want to run the same workflow but have the offloaded data stored in two different
+    buckets. Or you may want labels or annotations to be different. This object is used when launching an execution
+    in a Flyte backend, and also when registering launch plans.
+
+    Args:
+        raw_data_prefix: str -> remote prefix for storage location of the form ``s3://<bucket>/key...`` or
+           ``gcs://...`` or ``file://...``. If not specified will use the platform configured default. This is where
+           the data for offloaded types is stored.
+        auth_role: Specifies the Kubernetes Service account,
+           IAM role etc to be used. If not specified defaults will be used.
+        labels: Custom labels to be applied to the execution resource
+        annotations: Custom annotations to be applied to the execution resource
+        security_context: Indicates security context for permissions triggered with this launch plan
+        raw_output_data_config: Optional location of offloaded data for things like S3, etc.
+        max_parallelism: Controls the maximum number of tasknodes that can be run in parallel for the entire workflow.
+        notifications: List of notifications for this execution
+        disable_notifications: This should be set to true if all notifications are intended to be disabled for this execution.
+    """
+
+    raw_data_prefix: typing.Optional[str] = None
+    auth_role: typing.Optional[common_models.AuthRole] = None
+    labels: typing.Optional[common_models.Labels] = None
+    annotations: typing.Optional[common_models.Annotations] = None
+    raw_output_data_config: typing.Optional[common_models.RawOutputDataConfig] = None
+    security_context: typing.Optional[security.SecurityContext] = None
+    max_parallelism: typing.Optional[int] = None
+    notifications: typing.Optional[typing.List[common_models.Notification]] = None
+    disable_notifications: typing.Optional[bool] = None
 
 
 def to_serializable_case(
@@ -211,11 +249,13 @@ def get_serializable_launch_plan(
     settings: SerializationSettings,
     entity: LaunchPlan,
     recurse_downstream: bool = True,
+    options: Optional[Options] = None,
 ) -> _launch_plan_models.LaunchPlan:
     """
     :param entity_mapping:
     :param settings:
     :param entity:
+    :param options:
     :param recurse_downstream: This boolean indicate is wf for the entity should also be recursed to
     :return:
     """
@@ -231,19 +271,26 @@ def get_serializable_launch_plan(
             version=settings.version,
         )
 
+    if not options:
+        options = Options()
+
+    raw = None
+    if options.raw_data_prefix:
+        raw = common_models.RawOutputDataConfig(options.raw_data_prefix)
+
     lps = _launch_plan_models.LaunchPlanSpec(
         workflow_id=wf_id,
         entity_metadata=_launch_plan_models.LaunchPlanMetadata(
             schedule=entity.schedule,
-            notifications=entity.notifications,
+            notifications=options.notifications or entity.notifications,
         ),
         default_inputs=entity.parameters,
         fixed_inputs=entity.fixed_inputs,
-        labels=entity.labels or _common_models.Labels({}),
-        annotations=entity.annotations or _common_models.Annotations({}),
-        auth_role=entity._auth_role or _common_models.AuthRole(),
-        raw_output_data_config=entity.raw_output_data_config or _common_models.RawOutputDataConfig(""),
-        max_parallelism=entity.max_parallelism,
+        labels=options.labels or entity.labels or _common_models.Labels({}),
+        annotations=options.annotations or entity.annotations or _common_models.Annotations({}),
+        auth_role=options.auth_role or entity._auth_role or _common_models.AuthRole(),
+        raw_output_data_config=raw or entity.raw_output_data_config or _common_models.RawOutputDataConfig(""),
+        max_parallelism=options.max_parallelism or entity.max_parallelism,
     )
     lp_id = _identifier_model.Identifier(
         resource_type=_identifier_model.ResourceType.LAUNCH_PLAN,
@@ -442,6 +489,7 @@ def get_serializable(
     entity_mapping: OrderedDict,
     settings: SerializationSettings,
     entity: FlyteLocalEntity,
+    options: Optional[Options] = None,
 ) -> FlyteControlPlaneEntity:
     """
     The flytekit authoring code produces objects representing Flyte entities (tasks, workflows, etc.). In order to
@@ -456,6 +504,7 @@ def get_serializable(
       the parent entity this function is called with.
     :param settings: used to pick up project/domain/name - to be deprecated.
     :param entity: The local flyte entity to try to convert (along with its dependencies)
+    :param options: Optionally pass in a set of options that can be used to add additional metadata for Launchplans
     :return: The resulting control plane entity, in addition to being added to the mutable entity_mapping parameter
       is also returned.
     """
@@ -480,7 +529,7 @@ def get_serializable(
         cp_entity = get_serializable_node(entity_mapping, settings, entity)
 
     elif isinstance(entity, LaunchPlan):
-        cp_entity = get_serializable_launch_plan(entity_mapping, settings, entity)
+        cp_entity = get_serializable_launch_plan(entity_mapping, settings, entity, options=options)
 
     elif isinstance(entity, BranchNode):
         cp_entity = get_serializable_branch_node(entity_mapping, settings, entity)

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -90,8 +90,8 @@ def test_validate_image():
     ic = ImageConfig.validate_image(None, "image", (img3_cli, img4_cli))
     assert ic
     assert ic.default_image.full == img3
-    assert len(ic.images) == 1
-    assert ic.images[0].full == img4
+    assert len(ic.images) == 2
+    assert ic.images[1].full == img4
 
 
 def test_secrets_manager_default():

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -6,7 +6,8 @@ from flytekit.exceptions import user as user_exceptions
 from flytekit.models import common as common_models
 from flytekit.models.core.identifier import ResourceType, WorkflowExecutionIdentifier
 from flytekit.models.execution import Execution
-from flytekit.remote.remote import FlyteRemote, Options
+from flytekit.remote.remote import FlyteRemote
+from flytekit.tools.translator import Options
 
 CLIENT_METHODS = {
     ResourceType.WORKFLOW: "list_workflows_paginated",


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
 - creates a central tool for all repo level operations to register all workflows, tasks etc programmatically
 - Also fixes a bug in registration of a workflow in remote, where the underlying launchplan will not use the options.

Goal:
```
repo.serialize_and_package(...)
repo.register()
repo.serialize_and_register()
```
 
Tests need to be done

## Type
 - [x] Bug Fix & housekeeping
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue


## Tracking Issue
NA

## Follow-up issue
_NA_

