### PR TITLE
Checkout code before invoking `whoan/docker-build-with-cache-action@v5` action

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -55,10 +55,14 @@ jobs:
 
   build-and-push-docker-images:
     runs-on: ubuntu-latest
+    needs: deploy
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: "0"
       - name: Build & Push Flytekit Python${{ matrix.python-version }} Docker Image to Github Registry
         uses: whoan/docker-build-with-cache-action@v5
         with:
@@ -66,10 +70,10 @@ jobs:
           username: "${{ secrets.FLYTE_BOT_USERNAME }}"
           password: "${{ secrets.FLYTE_BOT_PAT }}"
           image_name: ${{ github.repository_owner }}/flytekit
-          image_tag: py${{ matrix.python-version }}-latest,py${{ matrix.python-version }}-${{ github.sha }},py${{ matrix.python-version }}-${{ steps.bump.outputs.version }}
+          image_tag: py${{ matrix.python-version }}-latest,py${{ matrix.python-version }}-${{ github.sha }},py${{ matrix.python-version }}-${{ deploy.steps.bump.outputs.version }}
           push_git_tag: true
           push_image_and_stages: true
           registry: ghcr.io
-          build_extra_args: "--compress=true --build-arg=VERSION=${{ steps.bump.outputs.version }} --build-arg=DOCKER_IMAGE=ghcr.io/flyteorg/flytekit:py${{ matrix.python-version }}-${{ steps.bump.outputs.version }}"
+          build_extra_args: "--compress=true --build-arg=VERSION=${{ deploy.steps.bump.outputs.version }} --build-arg=DOCKER_IMAGE=ghcr.io/flyteorg/flytekit:py${{ matrix.python-version }}-${{ steps.bump.outputs.version }}"
           context: .
           dockerfile: Dockerfile.py${{ matrix.python-version }}


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
The `build-and-push-docker-images` job runs in a separate container, which requires to checkout the code before building the image.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
https://github.com/flyteorg/flytekit/pull/915 was not enough to build the docker images. Upon publishing v0.32.0b1 we were still [seeing](https://github.com/flyteorg/flytekit/runs/5858541047?check_suite_focus=true) this error:
```
...
+ docker build --cache-from=ghcr.io/flyteorg/flytekit-stages:1 --tag my_awesome_image --file ./Dockerfile.py3.10 --compress=true --build-arg=VERSION= --build-arg=DOCKER_IMAGE=ghcr.io/flyteorg/flytekit:py3.10- .
+ tee build-output.log
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /github/workspace/Dockerfile.py3.10: no such file or directory
...
```
This indicates that the code is not present at the moment `docker build` is invoked, even though the file exists in the repo. 

I'm also getting the version from the previous step as that dependency has to be expressed using the full path, in other words, instead of referring to the version using `steps.bump.outputs.version` we use `deploy.steps.bump.outputs.version`.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
