### PR TITLE
Client credentials should never be cleared

### DIFF
--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -177,6 +177,7 @@ class RawSynchronousFlyteClient(object):
                 "Raw Flyte client attempting client credentials flow but no response from Admin detected. "
                 "Check your Admin server's .well-known endpoints to make sure they're working as expected."
             )
+
         client = _credentials_access.get_client(
             redirect_endpoint=self.public_client_config.redirect_uri,
             client_id=self.public_client_config.client_id,
@@ -184,6 +185,7 @@ class RawSynchronousFlyteClient(object):
             auth_endpoint=self.oauth2_metadata.authorization_endpoint,
             token_endpoint=self.oauth2_metadata.token_endpoint,
         )
+
         if client.has_valid_credentials and not self.check_access_token(client.credentials.access_token):
             # When Python starts up, if credentials have been stored in the keyring, then the AuthorizationClient
             # will have read them into its _credentials field, but it won't be in the RawSynchronousFlyteClient's
@@ -193,7 +195,6 @@ class RawSynchronousFlyteClient(object):
             # scenario where the stored credentials in the keyring are expired. If that's the case, then we only try
             # them once (because client here is a singleton), and the next time, we'll do one of the two other conditions
             # below.
-            client.clear()
             return
         elif client.can_refresh_token:
             client.refresh_access_token()

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -41,7 +41,7 @@ def _handle_rpc_error(retry=False):
                         if i == (max_retries - 1):
                             # Exit the loop and wrap the authentication error.
                             raise _user_exceptions.FlyteAuthenticationException(str(e))
-                        cli_logger.error(f"Unauthenticated RPC error {e}, refreshing credentials and retrying\n")
+                        cli_logger.debug(f"Unauthenticated RPC error {e}, refreshing credentials and retrying\n")
                         args[0].refresh_credentials()
                     elif e.code() == grpc.StatusCode.ALREADY_EXISTS:
                         # There are two cases that we should throw error immediately
@@ -191,10 +191,6 @@ class RawSynchronousFlyteClient(object):
             # will have read them into its _credentials field, but it won't be in the RawSynchronousFlyteClient's
             # metadata field yet. Therefore, if there's a mismatch, copy it over.
             self.set_access_token(client.credentials.access_token, authorization_header_key)
-            # However, after copying over credentials from the AuthorizationClient, we have to clear it to avoid the
-            # scenario where the stored credentials in the keyring are expired. If that's the case, then we only try
-            # them once (because client here is a singleton), and the next time, we'll do one of the two other conditions
-            # below.
             return
         elif client.can_refresh_token:
             client.refresh_access_token()

--- a/tests/flytekit/unit/cli/auth/test_auth.py
+++ b/tests/flytekit/unit/cli/auth/test_auth.py
@@ -1,14 +1,8 @@
+import http.server as _BaseHTTPServer
 import re
 from multiprocessing import Queue as _Queue
 
-from mock import patch
-
 from flytekit.clis.auth import auth as _auth
-
-try:  # Python 3
-    import http.server as _BaseHTTPServer
-except ImportError:  # Python 2
-    import BaseHTTPServer as _BaseHTTPServer
 
 
 def test_generate_code_verifier():
@@ -35,12 +29,3 @@ def test_oauth_http_server():
     server.handle_authorization_code(test_auth_code)
     auth_code = queue.get()
     assert test_auth_code == auth_code
-
-
-@patch("flytekit.clis.auth.auth._keyring.get_password")
-def test_clear(mock_get_password):
-    mock_get_password.return_value = "token"
-    ac = _auth.AuthorizationClient()
-    ac.clear()
-    assert ac.credentials is None
-    assert not ac.can_refresh_token


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
In the case when client credentials have expired or corrupted, the
default `_refresh_credentials_standard` flow will automatically force
the client to `refresh_access_token`.

But, in a happy case, the clear, unnecessarily removes the client creds,
thus forcing an auth to be retriggered

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue


