### PR TITLE
Use MD5Sum of the tarfile as the task version

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -94,16 +94,16 @@ from flytekit.types.structured.structured_dataset import StructuredDataset
 )
 @click.pass_context
 def run(
-    click_ctx,
-    file_and_workflow,
-    is_remote,
-    project,
-    domain,
-    destination_dir,
-    image_config,
-    service_account,
-    wait_execution,
-    dump_snippet,
+        click_ctx,
+        file_and_workflow,
+        is_remote,
+        project,
+        domain,
+        destination_dir,
+        image_config,
+        service_account,
+        wait_execution,
+        dump_snippet,
 ):
     """
     Run command, a.k.a. script mode. It allows for a a single script to be registered and run from the command line
@@ -128,7 +128,7 @@ def run(
             functools.partial(client.get_upload_signed_url, project=project, domain=domain),
             is_remote=True,
         )
-        _, version = script_mode.hash_file(filename)
+
         remote = FlyteRemote(Config.auto(), default_project=project, default_domain=domain)
         wf = remote.register_script(
             wf_entity,
@@ -136,7 +136,6 @@ def run(
             domain=domain,
             image_config=image_config,
             destination_dir=destination_dir,
-            version=version,
         )
 
         options = Options(AuthRole(kubernetes_service_account=service_account))

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -104,16 +104,16 @@ from flytekit.types.structured.structured_dataset import (
 )
 @click.pass_context
 def run(
-        click_ctx,
-        file_and_workflow,
-        is_remote,
-        project,
-        domain,
-        destination_dir,
-        image_config,
-        service_account,
-        wait_execution,
-        dump_snippet,
+    click_ctx,
+    file_and_workflow,
+    is_remote,
+    project,
+    domain,
+    destination_dir,
+    image_config,
+    service_account,
+    wait_execution,
+    dump_snippet,
 ):
     """
     Run command, a.k.a. script mode. It allows for a a single script to be registered and run from the command line
@@ -272,10 +272,10 @@ class PandasToParquetDataProxyEncodingHandler(StructuredDatasetEncoder):
         self._create_upload_fn = create_upload_fn
 
     def encode(
-            self,
-            ctx: context_manager.FlyteContext,
-            structured_dataset: StructuredDataset,
-            structured_dataset_type: StructuredDatasetType,
+        self,
+        ctx: context_manager.FlyteContext,
+        structured_dataset: StructuredDataset,
+        structured_dataset_type: StructuredDatasetType,
     ) -> literals.StructuredDataset:
         local_path = structured_dataset.dataframe
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -55,7 +55,6 @@ from flytekit.remote.launch_plan import FlyteLaunchPlan
 from flytekit.remote.nodes import FlyteNode
 from flytekit.remote.task import FlyteTask
 from flytekit.remote.workflow import FlyteWorkflow
-from flytekit.tools import script_mode
 from flytekit.tools.script_mode import fast_register_single_script
 from flytekit.tools.translator import FlyteLocalEntity, Options, get_serializable, get_serializable_launch_plan
 
@@ -86,12 +85,12 @@ def _get_latest_version(list_entities_method: typing.Callable, project: str, dom
 
 
 def _get_entity_identifier(
-    list_entities_method: typing.Callable,
-    resource_type: int,  # from flytekit.models.core.identifier.ResourceType
-    project: str,
-    domain: str,
-    name: str,
-    version: typing.Optional[str] = None,
+        list_entities_method: typing.Callable,
+        resource_type: int,  # from flytekit.models.core.identifier.ResourceType
+        project: str,
+        domain: str,
+        name: str,
+        version: typing.Optional[str] = None,
 ):
     return Identifier(
         resource_type,
@@ -115,12 +114,12 @@ class FlyteRemote(object):
     """
 
     def __init__(
-        self,
-        config: Config,
-        default_project: typing.Optional[str] = None,
-        default_domain: typing.Optional[str] = None,
-        file_access: typing.Optional[FileAccessProvider] = None,
-        **kwargs,
+            self,
+            config: Config,
+            default_project: typing.Optional[str] = None,
+            default_domain: typing.Optional[str] = None,
+            file_access: typing.Optional[FileAccessProvider] = None,
+            **kwargs,
     ):
         """Initialize a FlyteRemote object.
         # todo: should we add a version? instead of having it in each command.
@@ -209,7 +208,7 @@ class FlyteRemote(object):
         return flyte_task
 
     def fetch_workflow(
-        self, project: str = None, domain: str = None, name: str = None, version: str = None
+            self, project: str = None, domain: str = None, name: str = None, version: str = None
     ) -> FlyteWorkflow:
         """Fetch a workflow entity from flyte admin.
 
@@ -242,7 +241,7 @@ class FlyteRemote(object):
         return FlyteWorkflow.promote_from_closure(compiled_wf, node_launch_plans)
 
     def fetch_launch_plan(
-        self, project: str = None, domain: str = None, name: str = None, version: str = None
+            self, project: str = None, domain: str = None, name: str = None, version: str = None
     ) -> FlyteLaunchPlan:
         """Fetch a launchplan entity from flyte admin.
 
@@ -302,10 +301,10 @@ class FlyteRemote(object):
     ######################
 
     def recent_executions(
-        self,
-        project: typing.Optional[str] = None,
-        domain: typing.Optional[str] = None,
-        limit: typing.Optional[int] = 100,
+            self,
+            project: typing.Optional[str] = None,
+            domain: typing.Optional[str] = None,
+            limit: typing.Optional[int] = 100,
     ) -> typing.List[FlyteWorkflowExecution]:
         # Ignore token for now
         exec_models, _ = self.client.list_executions_paginated(
@@ -317,11 +316,11 @@ class FlyteRemote(object):
         return [FlyteWorkflowExecution.promote_from_model(e) for e in exec_models]
 
     def list_tasks_by_version(
-        self,
-        version: str,
-        project: typing.Optional[str] = None,
-        domain: typing.Optional[str] = None,
-        limit: typing.Optional[int] = 100,
+            self,
+            version: str,
+            project: typing.Optional[str] = None,
+            domain: typing.Optional[str] = None,
+            limit: typing.Optional[int] = 100,
     ) -> typing.List[FlyteTask]:
         if not version:
             raise ValueError("Must specify a version")
@@ -358,11 +357,11 @@ class FlyteRemote(object):
         return ident
 
     def _serialize_and_register(
-        self,
-        entity: FlyteLocalEntity,
-        settings: SerializationSettings,
-        version: str,
-        options: typing.Optional[Options] = None,
+            self,
+            entity: FlyteLocalEntity,
+            settings: SerializationSettings,
+            version: str,
+            options: typing.Optional[Options] = None,
     ) -> Identifier:
         """
         This method serializes and register the given Flyte entity
@@ -404,13 +403,13 @@ class FlyteRemote(object):
                     ident = self._resolve_identifier(ResourceType.LAUNCH_PLAN, entity.name, version, settings)
                     self.client.create_launch_plan(launch_plan_identifer=ident, launch_plan_spec=cp_entity.spec)
                 elif isinstance(
-                    cp_entity,
-                    (
-                        workflow_model.Node,
-                        workflow_model.WorkflowNode,
-                        workflow_model.BranchNode,
-                        workflow_model.TaskNode,
-                    ),
+                        cp_entity,
+                        (
+                                workflow_model.Node,
+                                workflow_model.WorkflowNode,
+                                workflow_model.BranchNode,
+                                workflow_model.TaskNode,
+                        ),
                 ):
                     remote_logger.debug("Ignoring nodes for registration.")
                 else:
@@ -423,7 +422,8 @@ class FlyteRemote(object):
         return ident
 
     def register_task(
-        self, entity: PythonTask, serialization_settings: SerializationSettings, version: typing.Optional[str] = None
+            self, entity: PythonTask, serialization_settings: SerializationSettings,
+            version: typing.Optional[str] = None
     ) -> FlyteTask:
         """
         Register a qualified task (PythonTask) with Remote
@@ -443,12 +443,12 @@ class FlyteRemote(object):
         )
 
     def register_workflow(
-        self,
-        entity: WorkflowBase,
-        serialization_settings: SerializationSettings,
-        version: typing.Optional[str] = None,
-        default_launch_plan: typing.Optional[bool] = True,
-        options: typing.Optional[Options] = None,
+            self,
+            entity: WorkflowBase,
+            serialization_settings: SerializationSettings,
+            version: typing.Optional[str] = None,
+            default_launch_plan: typing.Optional[bool] = True,
+            options: typing.Optional[Options] = None,
     ) -> FlyteWorkflow:
         """
         Use this method to register a workflow.
@@ -475,15 +475,15 @@ class FlyteRemote(object):
         return self.fetch_workflow(ident.project, ident.domain, ident.name, ident.version)
 
     def register_script(
-        self,
-        entity: WorkflowBase,
-        image_config: typing.Optional[ImageConfig] = None,
-        version: typing.Optional[str] = None,
-        project: typing.Optional[str] = None,
-        domain: typing.Optional[str] = None,
-        destination_dir: str = ".",
-        default_launch_plan: typing.Optional[bool] = True,
-        options: typing.Optional[Options] = None,
+            self,
+            entity: WorkflowBase,
+            image_config: typing.Optional[ImageConfig] = None,
+            version: typing.Optional[str] = None,
+            project: typing.Optional[str] = None,
+            domain: typing.Optional[str] = None,
+            destination_dir: str = ".",
+            default_launch_plan: typing.Optional[bool] = True,
+            options: typing.Optional[Options] = None,
     ) -> FlyteWorkflow:
         """
         Use this method to register a workflow via script mode.
@@ -498,23 +498,22 @@ class FlyteRemote(object):
         :return:
         """
         _, _, _, fname = tracker.extract_task_module(entity)
-        _, md5_hex = script_mode.hash_file(fname)
-        if version is None:
-            version = md5_hex
 
         if image_config is None:
             image_config = ImageConfig.auto_default_image()
 
-        upload_location = fast_register_single_script(
-            version,
+        upload_location, md5_version = fast_register_single_script(
             entity,
             functools.partial(
                 self.client.get_upload_signed_url,
                 project=project or self.default_project,
                 domain=domain or self.default_domain,
-                filename=f"scriptmode-{version}.tar.gz",
+                filename=f"scriptmode.tar.gz",
             ),
         )
+
+        if version is None:
+            version = md5_version
 
         serialization_settings = SerializationSettings(
             project=project,
@@ -530,12 +529,12 @@ class FlyteRemote(object):
         return self.register_workflow(entity, serialization_settings, version, default_launch_plan, options)
 
     def register_launch_plan(
-        self,
-        entity: LaunchPlan,
-        version: str,
-        project: typing.Optional[str] = None,
-        domain: typing.Optional[str] = None,
-        options: typing.Optional[Options] = None,
+            self,
+            entity: LaunchPlan,
+            version: str,
+            project: typing.Optional[str] = None,
+            domain: typing.Optional[str] = None,
+            options: typing.Optional[Options] = None,
     ) -> FlyteLaunchPlan:
         """
         Register a given launchplan, possibly applying overrides from the provided options.
@@ -562,15 +561,15 @@ class FlyteRemote(object):
     ####################
 
     def _execute(
-        self,
-        entity: typing.Union[FlyteTask, FlyteWorkflow, FlyteLaunchPlan],
-        inputs: typing.Dict[str, typing.Any],
-        project: str = None,
-        domain: str = None,
-        execution_name: str = None,
-        options: typing.Optional[Options] = None,
-        wait: bool = False,
-        type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
+            self,
+            entity: typing.Union[FlyteTask, FlyteWorkflow, FlyteLaunchPlan],
+            inputs: typing.Dict[str, typing.Any],
+            project: str = None,
+            domain: str = None,
+            execution_name: str = None,
+            options: typing.Optional[Options] = None,
+            wait: bool = False,
+            type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
     ) -> FlyteWorkflowExecution:
         """Common method for execution across all entities.
 
@@ -653,12 +652,12 @@ class FlyteRemote(object):
         return execution
 
     def _resolve_identifier_kwargs(
-        self,
-        entity: typing.Any,
-        project: str,
-        domain: str,
-        name: str,
-        version: str,
+            self,
+            entity: typing.Any,
+            project: str,
+            domain: str,
+            name: str,
+            version: str,
     ) -> ResolvedIdentifiers:
         """
         Resolves the identifier attributes based on user input, falling back on the default project/domain and
@@ -678,18 +677,18 @@ class FlyteRemote(object):
         return ident
 
     def execute(
-        self,
-        entity: typing.Union[FlyteTask, FlyteLaunchPlan, FlyteWorkflow, PythonTask, WorkflowBase, LaunchPlan],
-        inputs: typing.Dict[str, typing.Any],
-        project: str = None,
-        domain: str = None,
-        name: str = None,
-        version: str = None,
-        execution_name: str = None,
-        image_config: typing.Optional[ImageConfig] = None,
-        options: typing.Optional[Options] = None,
-        wait: bool = False,
-        type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
+            self,
+            entity: typing.Union[FlyteTask, FlyteLaunchPlan, FlyteWorkflow, PythonTask, WorkflowBase, LaunchPlan],
+            inputs: typing.Dict[str, typing.Any],
+            project: str = None,
+            domain: str = None,
+            name: str = None,
+            version: str = None,
+            execution_name: str = None,
+            image_config: typing.Optional[ImageConfig] = None,
+            options: typing.Optional[Options] = None,
+            wait: bool = False,
+            type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
     ) -> FlyteWorkflowExecution:
         """
         Execute a task, workflow, or launchplan, either something that's been declared locally, or a fetched entity.
@@ -793,15 +792,15 @@ class FlyteRemote(object):
     # ---------------------
 
     def execute_remote_task_lp(
-        self,
-        entity: typing.Union[FlyteTask, FlyteLaunchPlan],
-        inputs: typing.Dict[str, typing.Any],
-        project: str = None,
-        domain: str = None,
-        execution_name: str = None,
-        options: typing.Optional[Options] = None,
-        wait: bool = False,
-        type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
+            self,
+            entity: typing.Union[FlyteTask, FlyteLaunchPlan],
+            inputs: typing.Dict[str, typing.Any],
+            project: str = None,
+            domain: str = None,
+            execution_name: str = None,
+            options: typing.Optional[Options] = None,
+            wait: bool = False,
+            type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
     ) -> FlyteWorkflowExecution:
         """Execute a FlyteTask, or FlyteLaunchplan.
 
@@ -819,15 +818,15 @@ class FlyteRemote(object):
         )
 
     def execute_remote_wf(
-        self,
-        entity: FlyteWorkflow,
-        inputs: typing.Dict[str, typing.Any],
-        project: str = None,
-        domain: str = None,
-        execution_name: str = None,
-        options: typing.Optional[Options] = None,
-        wait: bool = False,
-        type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
+            self,
+            entity: FlyteWorkflow,
+            inputs: typing.Dict[str, typing.Any],
+            project: str = None,
+            domain: str = None,
+            execution_name: str = None,
+            options: typing.Optional[Options] = None,
+            wait: bool = False,
+            type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
     ) -> FlyteWorkflowExecution:
         """Execute a FlyteWorkflow.
 
@@ -849,16 +848,16 @@ class FlyteRemote(object):
     # -----------------
 
     def execute_local_task(
-        self,
-        entity: PythonTask,
-        inputs: typing.Dict[str, typing.Any],
-        project: str = None,
-        domain: str = None,
-        name: str = None,
-        version: str = None,
-        execution_name: str = None,
-        image_config: typing.Optional[ImageConfig] = None,
-        wait: bool = False,
+            self,
+            entity: PythonTask,
+            inputs: typing.Dict[str, typing.Any],
+            project: str = None,
+            domain: str = None,
+            name: str = None,
+            version: str = None,
+            execution_name: str = None,
+            image_config: typing.Optional[ImageConfig] = None,
+            wait: bool = False,
     ) -> FlyteWorkflowExecution:
         """
         Execute an @task-decorated function or TaskTemplate task.
@@ -902,17 +901,17 @@ class FlyteRemote(object):
         )
 
     def execute_local_workflow(
-        self,
-        entity: WorkflowBase,
-        inputs: typing.Dict[str, typing.Any],
-        project: str = None,
-        domain: str = None,
-        name: str = None,
-        version: str = None,
-        execution_name: str = None,
-        image_config: typing.Optional[ImageConfig] = None,
-        options: typing.Optional[Options] = None,
-        wait: bool = False,
+            self,
+            entity: WorkflowBase,
+            inputs: typing.Dict[str, typing.Any],
+            project: str = None,
+            domain: str = None,
+            name: str = None,
+            version: str = None,
+            execution_name: str = None,
+            image_config: typing.Optional[ImageConfig] = None,
+            options: typing.Optional[Options] = None,
+            wait: bool = False,
     ) -> FlyteWorkflowExecution:
         """
         Execute an @workflow decorated function.
@@ -974,15 +973,15 @@ class FlyteRemote(object):
         )
 
     def execute_local_launch_plan(
-        self,
-        entity: LaunchPlan,
-        inputs: typing.Dict[str, typing.Any],
-        version: str,
-        project: typing.Optional[str] = None,
-        domain: typing.Optional[str] = None,
-        execution_name: typing.Optional[str] = None,
-        options: typing.Optional[Options] = None,
-        wait: bool = False,
+            self,
+            entity: LaunchPlan,
+            inputs: typing.Dict[str, typing.Any],
+            version: str,
+            project: typing.Optional[str] = None,
+            domain: typing.Optional[str] = None,
+            execution_name: typing.Optional[str] = None,
+            options: typing.Optional[Options] = None,
+            wait: bool = False,
     ) -> FlyteWorkflowExecution:
         """
 
@@ -1026,11 +1025,11 @@ class FlyteRemote(object):
     ###################################
 
     def wait(
-        self,
-        execution: FlyteWorkflowExecution,
-        timeout: typing.Optional[timedelta] = None,
-        poll_interval: typing.Optional[timedelta] = None,
-        sync_nodes: bool = True,
+            self,
+            execution: FlyteWorkflowExecution,
+            timeout: typing.Optional[timedelta] = None,
+            poll_interval: typing.Optional[timedelta] = None,
+            sync_nodes: bool = True,
     ) -> FlyteWorkflowExecution:
         """Wait for an execution to finish.
 
@@ -1055,10 +1054,10 @@ class FlyteRemote(object):
     ########################
 
     def sync(
-        self,
-        execution: FlyteWorkflowExecution,
-        entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None,
-        sync_nodes: bool = False,
+            self,
+            execution: FlyteWorkflowExecution,
+            entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None,
+            sync_nodes: bool = False,
     ) -> FlyteWorkflowExecution:
         """
         This function was previously a singledispatchmethod. We've removed that but this function remains
@@ -1076,10 +1075,10 @@ class FlyteRemote(object):
         return self.sync_execution(execution, entity_definition, sync_nodes)
 
     def sync_execution(
-        self,
-        execution: FlyteWorkflowExecution,
-        entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None,
-        sync_nodes: bool = False,
+            self,
+            execution: FlyteWorkflowExecution,
+            entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None,
+            sync_nodes: bool = False,
     ) -> FlyteWorkflowExecution:
         """
         Sync a FlyteWorkflowExecution object with its corresponding remote state.
@@ -1143,9 +1142,9 @@ class FlyteRemote(object):
         return self._assign_inputs_and_outputs(execution, execution_data, node_interface)
 
     def sync_node_execution(
-        self,
-        execution: FlyteNodeExecution,
-        node_mapping: typing.Dict[str, FlyteNode],
+            self,
+            execution: FlyteNodeExecution,
+            node_mapping: typing.Dict[str, FlyteNode],
     ) -> FlyteNodeExecution:
         """
         Get data backing a node execution. These FlyteNodeExecution objects should've come from Admin with the model
@@ -1231,9 +1230,9 @@ class FlyteRemote(object):
                 # TODO: Inspect branch nodes for launch plans
                 for node in FlyteWorkflow.get_non_system_nodes(compiled_wf.primary.template.nodes):
                     if (
-                        node.workflow_node is not None
-                        and node.workflow_node.launchplan_ref is not None
-                        and node.workflow_node.launchplan_ref not in node_launch_plans
+                            node.workflow_node is not None
+                            and node.workflow_node.launchplan_ref is not None
+                            and node.workflow_node.launchplan_ref not in node_launch_plans
                     ):
                         node_launch_plans[node.workflow_node.launchplan_ref] = self.client.get_launch_plan(
                             node.workflow_node.launchplan_ref
@@ -1291,7 +1290,7 @@ class FlyteRemote(object):
         return execution
 
     def sync_task_execution(
-        self, execution: FlyteTaskExecution, entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None
+            self, execution: FlyteTaskExecution, entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None
     ) -> FlyteTaskExecution:
         """Sync a FlyteTaskExecution object with its corresponding remote state."""
         if entity_definition is not None:
@@ -1320,10 +1319,10 @@ class FlyteRemote(object):
     ##################
 
     def _assign_inputs_and_outputs(
-        self,
-        execution: typing.Union[FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution],
-        execution_data,
-        interface: TypedInterface,
+            self,
+            execution: typing.Union[FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution],
+            execution_data,
+            interface: TypedInterface,
     ):
         """Helper for assigning synced inputs and outputs to an execution object."""
         with self.remote_context():
@@ -1362,6 +1361,6 @@ class FlyteRemote(object):
         return literal_models.LiteralMap({})
 
     def generate_console_url(
-        self, execution: typing.Union[FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution]
+            self, execution: typing.Union[FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution]
     ):
         return f"http://localhost:30081/console/projects/{execution.id.project}/domains/{execution.id.domain}/executions/{execution.id.name}"

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -85,12 +85,12 @@ def _get_latest_version(list_entities_method: typing.Callable, project: str, dom
 
 
 def _get_entity_identifier(
-        list_entities_method: typing.Callable,
-        resource_type: int,  # from flytekit.models.core.identifier.ResourceType
-        project: str,
-        domain: str,
-        name: str,
-        version: typing.Optional[str] = None,
+    list_entities_method: typing.Callable,
+    resource_type: int,  # from flytekit.models.core.identifier.ResourceType
+    project: str,
+    domain: str,
+    name: str,
+    version: typing.Optional[str] = None,
 ):
     return Identifier(
         resource_type,
@@ -114,12 +114,12 @@ class FlyteRemote(object):
     """
 
     def __init__(
-            self,
-            config: Config,
-            default_project: typing.Optional[str] = None,
-            default_domain: typing.Optional[str] = None,
-            file_access: typing.Optional[FileAccessProvider] = None,
-            **kwargs,
+        self,
+        config: Config,
+        default_project: typing.Optional[str] = None,
+        default_domain: typing.Optional[str] = None,
+        file_access: typing.Optional[FileAccessProvider] = None,
+        **kwargs,
     ):
         """Initialize a FlyteRemote object.
         # todo: should we add a version? instead of having it in each command.
@@ -208,7 +208,7 @@ class FlyteRemote(object):
         return flyte_task
 
     def fetch_workflow(
-            self, project: str = None, domain: str = None, name: str = None, version: str = None
+        self, project: str = None, domain: str = None, name: str = None, version: str = None
     ) -> FlyteWorkflow:
         """Fetch a workflow entity from flyte admin.
 
@@ -241,7 +241,7 @@ class FlyteRemote(object):
         return FlyteWorkflow.promote_from_closure(compiled_wf, node_launch_plans)
 
     def fetch_launch_plan(
-            self, project: str = None, domain: str = None, name: str = None, version: str = None
+        self, project: str = None, domain: str = None, name: str = None, version: str = None
     ) -> FlyteLaunchPlan:
         """Fetch a launchplan entity from flyte admin.
 
@@ -301,10 +301,10 @@ class FlyteRemote(object):
     ######################
 
     def recent_executions(
-            self,
-            project: typing.Optional[str] = None,
-            domain: typing.Optional[str] = None,
-            limit: typing.Optional[int] = 100,
+        self,
+        project: typing.Optional[str] = None,
+        domain: typing.Optional[str] = None,
+        limit: typing.Optional[int] = 100,
     ) -> typing.List[FlyteWorkflowExecution]:
         # Ignore token for now
         exec_models, _ = self.client.list_executions_paginated(
@@ -316,11 +316,11 @@ class FlyteRemote(object):
         return [FlyteWorkflowExecution.promote_from_model(e) for e in exec_models]
 
     def list_tasks_by_version(
-            self,
-            version: str,
-            project: typing.Optional[str] = None,
-            domain: typing.Optional[str] = None,
-            limit: typing.Optional[int] = 100,
+        self,
+        version: str,
+        project: typing.Optional[str] = None,
+        domain: typing.Optional[str] = None,
+        limit: typing.Optional[int] = 100,
     ) -> typing.List[FlyteTask]:
         if not version:
             raise ValueError("Must specify a version")
@@ -357,11 +357,11 @@ class FlyteRemote(object):
         return ident
 
     def _serialize_and_register(
-            self,
-            entity: FlyteLocalEntity,
-            settings: SerializationSettings,
-            version: str,
-            options: typing.Optional[Options] = None,
+        self,
+        entity: FlyteLocalEntity,
+        settings: SerializationSettings,
+        version: str,
+        options: typing.Optional[Options] = None,
     ) -> Identifier:
         """
         This method serializes and register the given Flyte entity
@@ -403,13 +403,13 @@ class FlyteRemote(object):
                     ident = self._resolve_identifier(ResourceType.LAUNCH_PLAN, entity.name, version, settings)
                     self.client.create_launch_plan(launch_plan_identifer=ident, launch_plan_spec=cp_entity.spec)
                 elif isinstance(
-                        cp_entity,
-                        (
-                                workflow_model.Node,
-                                workflow_model.WorkflowNode,
-                                workflow_model.BranchNode,
-                                workflow_model.TaskNode,
-                        ),
+                    cp_entity,
+                    (
+                        workflow_model.Node,
+                        workflow_model.WorkflowNode,
+                        workflow_model.BranchNode,
+                        workflow_model.TaskNode,
+                    ),
                 ):
                     remote_logger.debug("Ignoring nodes for registration.")
                 else:
@@ -422,8 +422,7 @@ class FlyteRemote(object):
         return ident
 
     def register_task(
-            self, entity: PythonTask, serialization_settings: SerializationSettings,
-            version: typing.Optional[str] = None
+        self, entity: PythonTask, serialization_settings: SerializationSettings, version: typing.Optional[str] = None
     ) -> FlyteTask:
         """
         Register a qualified task (PythonTask) with Remote
@@ -445,12 +444,12 @@ class FlyteRemote(object):
         return ft
 
     def register_workflow(
-            self,
-            entity: WorkflowBase,
-            serialization_settings: SerializationSettings,
-            version: typing.Optional[str] = None,
-            default_launch_plan: typing.Optional[bool] = True,
-            options: typing.Optional[Options] = None,
+        self,
+        entity: WorkflowBase,
+        serialization_settings: SerializationSettings,
+        version: typing.Optional[str] = None,
+        default_launch_plan: typing.Optional[bool] = True,
+        options: typing.Optional[Options] = None,
     ) -> FlyteWorkflow:
         """
         Use this method to register a workflow.
@@ -479,15 +478,15 @@ class FlyteRemote(object):
         return fwf
 
     def register_script(
-            self,
-            entity: WorkflowBase,
-            image_config: typing.Optional[ImageConfig] = None,
-            version: typing.Optional[str] = None,
-            project: typing.Optional[str] = None,
-            domain: typing.Optional[str] = None,
-            destination_dir: str = ".",
-            default_launch_plan: typing.Optional[bool] = True,
-            options: typing.Optional[Options] = None,
+        self,
+        entity: WorkflowBase,
+        image_config: typing.Optional[ImageConfig] = None,
+        version: typing.Optional[str] = None,
+        project: typing.Optional[str] = None,
+        domain: typing.Optional[str] = None,
+        destination_dir: str = ".",
+        default_launch_plan: typing.Optional[bool] = True,
+        options: typing.Optional[Options] = None,
     ) -> FlyteWorkflow:
         """
         Use this method to register a workflow via script mode.
@@ -533,12 +532,12 @@ class FlyteRemote(object):
         return self.register_workflow(entity, serialization_settings, version, default_launch_plan, options)
 
     def register_launch_plan(
-            self,
-            entity: LaunchPlan,
-            version: str,
-            project: typing.Optional[str] = None,
-            domain: typing.Optional[str] = None,
-            options: typing.Optional[Options] = None,
+        self,
+        entity: LaunchPlan,
+        version: str,
+        project: typing.Optional[str] = None,
+        domain: typing.Optional[str] = None,
+        options: typing.Optional[Options] = None,
     ) -> FlyteLaunchPlan:
         """
         Register a given launchplan, possibly applying overrides from the provided options.
@@ -567,15 +566,15 @@ class FlyteRemote(object):
     ####################
 
     def _execute(
-            self,
-            entity: typing.Union[FlyteTask, FlyteWorkflow, FlyteLaunchPlan],
-            inputs: typing.Dict[str, typing.Any],
-            project: str = None,
-            domain: str = None,
-            execution_name: str = None,
-            options: typing.Optional[Options] = None,
-            wait: bool = False,
-            type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
+        self,
+        entity: typing.Union[FlyteTask, FlyteWorkflow, FlyteLaunchPlan],
+        inputs: typing.Dict[str, typing.Any],
+        project: str = None,
+        domain: str = None,
+        execution_name: str = None,
+        options: typing.Optional[Options] = None,
+        wait: bool = False,
+        type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
     ) -> FlyteWorkflowExecution:
         """Common method for execution across all entities.
 
@@ -658,12 +657,12 @@ class FlyteRemote(object):
         return execution
 
     def _resolve_identifier_kwargs(
-            self,
-            entity: typing.Any,
-            project: str,
-            domain: str,
-            name: str,
-            version: str,
+        self,
+        entity: typing.Any,
+        project: str,
+        domain: str,
+        name: str,
+        version: str,
     ) -> ResolvedIdentifiers:
         """
         Resolves the identifier attributes based on user input, falling back on the default project/domain and
@@ -683,18 +682,18 @@ class FlyteRemote(object):
         return ident
 
     def execute(
-            self,
-            entity: typing.Union[FlyteTask, FlyteLaunchPlan, FlyteWorkflow, PythonTask, WorkflowBase, LaunchPlan],
-            inputs: typing.Dict[str, typing.Any],
-            project: str = None,
-            domain: str = None,
-            name: str = None,
-            version: str = None,
-            execution_name: str = None,
-            image_config: typing.Optional[ImageConfig] = None,
-            options: typing.Optional[Options] = None,
-            wait: bool = False,
-            type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
+        self,
+        entity: typing.Union[FlyteTask, FlyteLaunchPlan, FlyteWorkflow, PythonTask, WorkflowBase, LaunchPlan],
+        inputs: typing.Dict[str, typing.Any],
+        project: str = None,
+        domain: str = None,
+        name: str = None,
+        version: str = None,
+        execution_name: str = None,
+        image_config: typing.Optional[ImageConfig] = None,
+        options: typing.Optional[Options] = None,
+        wait: bool = False,
+        type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
     ) -> FlyteWorkflowExecution:
         """
         Execute a task, workflow, or launchplan, either something that's been declared locally, or a fetched entity.
@@ -800,15 +799,15 @@ class FlyteRemote(object):
     # ---------------------
 
     def execute_remote_task_lp(
-            self,
-            entity: typing.Union[FlyteTask, FlyteLaunchPlan],
-            inputs: typing.Dict[str, typing.Any],
-            project: str = None,
-            domain: str = None,
-            execution_name: str = None,
-            options: typing.Optional[Options] = None,
-            wait: bool = False,
-            type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
+        self,
+        entity: typing.Union[FlyteTask, FlyteLaunchPlan],
+        inputs: typing.Dict[str, typing.Any],
+        project: str = None,
+        domain: str = None,
+        execution_name: str = None,
+        options: typing.Optional[Options] = None,
+        wait: bool = False,
+        type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
     ) -> FlyteWorkflowExecution:
         """Execute a FlyteTask, or FlyteLaunchplan.
 
@@ -826,15 +825,15 @@ class FlyteRemote(object):
         )
 
     def execute_remote_wf(
-            self,
-            entity: FlyteWorkflow,
-            inputs: typing.Dict[str, typing.Any],
-            project: str = None,
-            domain: str = None,
-            execution_name: str = None,
-            options: typing.Optional[Options] = None,
-            wait: bool = False,
-            type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
+        self,
+        entity: FlyteWorkflow,
+        inputs: typing.Dict[str, typing.Any],
+        project: str = None,
+        domain: str = None,
+        execution_name: str = None,
+        options: typing.Optional[Options] = None,
+        wait: bool = False,
+        type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
     ) -> FlyteWorkflowExecution:
         """Execute a FlyteWorkflow.
 
@@ -856,16 +855,16 @@ class FlyteRemote(object):
     # -----------------
 
     def execute_local_task(
-            self,
-            entity: PythonTask,
-            inputs: typing.Dict[str, typing.Any],
-            project: str = None,
-            domain: str = None,
-            name: str = None,
-            version: str = None,
-            execution_name: str = None,
-            image_config: typing.Optional[ImageConfig] = None,
-            wait: bool = False,
+        self,
+        entity: PythonTask,
+        inputs: typing.Dict[str, typing.Any],
+        project: str = None,
+        domain: str = None,
+        name: str = None,
+        version: str = None,
+        execution_name: str = None,
+        image_config: typing.Optional[ImageConfig] = None,
+        wait: bool = False,
     ) -> FlyteWorkflowExecution:
         """
         Execute an @task-decorated function or TaskTemplate task.
@@ -909,17 +908,17 @@ class FlyteRemote(object):
         )
 
     def execute_local_workflow(
-            self,
-            entity: WorkflowBase,
-            inputs: typing.Dict[str, typing.Any],
-            project: str = None,
-            domain: str = None,
-            name: str = None,
-            version: str = None,
-            execution_name: str = None,
-            image_config: typing.Optional[ImageConfig] = None,
-            options: typing.Optional[Options] = None,
-            wait: bool = False,
+        self,
+        entity: WorkflowBase,
+        inputs: typing.Dict[str, typing.Any],
+        project: str = None,
+        domain: str = None,
+        name: str = None,
+        version: str = None,
+        execution_name: str = None,
+        image_config: typing.Optional[ImageConfig] = None,
+        options: typing.Optional[Options] = None,
+        wait: bool = False,
     ) -> FlyteWorkflowExecution:
         """
         Execute an @workflow decorated function.
@@ -981,15 +980,15 @@ class FlyteRemote(object):
         )
 
     def execute_local_launch_plan(
-            self,
-            entity: LaunchPlan,
-            inputs: typing.Dict[str, typing.Any],
-            version: str,
-            project: typing.Optional[str] = None,
-            domain: typing.Optional[str] = None,
-            execution_name: typing.Optional[str] = None,
-            options: typing.Optional[Options] = None,
-            wait: bool = False,
+        self,
+        entity: LaunchPlan,
+        inputs: typing.Dict[str, typing.Any],
+        version: str,
+        project: typing.Optional[str] = None,
+        domain: typing.Optional[str] = None,
+        execution_name: typing.Optional[str] = None,
+        options: typing.Optional[Options] = None,
+        wait: bool = False,
     ) -> FlyteWorkflowExecution:
         """
 
@@ -1033,11 +1032,11 @@ class FlyteRemote(object):
     ###################################
 
     def wait(
-            self,
-            execution: FlyteWorkflowExecution,
-            timeout: typing.Optional[timedelta] = None,
-            poll_interval: typing.Optional[timedelta] = None,
-            sync_nodes: bool = True,
+        self,
+        execution: FlyteWorkflowExecution,
+        timeout: typing.Optional[timedelta] = None,
+        poll_interval: typing.Optional[timedelta] = None,
+        sync_nodes: bool = True,
     ) -> FlyteWorkflowExecution:
         """Wait for an execution to finish.
 
@@ -1062,10 +1061,10 @@ class FlyteRemote(object):
     ########################
 
     def sync(
-            self,
-            execution: FlyteWorkflowExecution,
-            entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None,
-            sync_nodes: bool = False,
+        self,
+        execution: FlyteWorkflowExecution,
+        entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None,
+        sync_nodes: bool = False,
     ) -> FlyteWorkflowExecution:
         """
         This function was previously a singledispatchmethod. We've removed that but this function remains
@@ -1083,10 +1082,10 @@ class FlyteRemote(object):
         return self.sync_execution(execution, entity_definition, sync_nodes)
 
     def sync_execution(
-            self,
-            execution: FlyteWorkflowExecution,
-            entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None,
-            sync_nodes: bool = False,
+        self,
+        execution: FlyteWorkflowExecution,
+        entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None,
+        sync_nodes: bool = False,
     ) -> FlyteWorkflowExecution:
         """
         Sync a FlyteWorkflowExecution object with its corresponding remote state.
@@ -1150,9 +1149,9 @@ class FlyteRemote(object):
         return self._assign_inputs_and_outputs(execution, execution_data, node_interface)
 
     def sync_node_execution(
-            self,
-            execution: FlyteNodeExecution,
-            node_mapping: typing.Dict[str, FlyteNode],
+        self,
+        execution: FlyteNodeExecution,
+        node_mapping: typing.Dict[str, FlyteNode],
     ) -> FlyteNodeExecution:
         """
         Get data backing a node execution. These FlyteNodeExecution objects should've come from Admin with the model
@@ -1238,9 +1237,9 @@ class FlyteRemote(object):
                 # TODO: Inspect branch nodes for launch plans
                 for node in FlyteWorkflow.get_non_system_nodes(compiled_wf.primary.template.nodes):
                     if (
-                            node.workflow_node is not None
-                            and node.workflow_node.launchplan_ref is not None
-                            and node.workflow_node.launchplan_ref not in node_launch_plans
+                        node.workflow_node is not None
+                        and node.workflow_node.launchplan_ref is not None
+                        and node.workflow_node.launchplan_ref not in node_launch_plans
                     ):
                         node_launch_plans[node.workflow_node.launchplan_ref] = self.client.get_launch_plan(
                             node.workflow_node.launchplan_ref
@@ -1298,7 +1297,7 @@ class FlyteRemote(object):
         return execution
 
     def sync_task_execution(
-            self, execution: FlyteTaskExecution, entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None
+        self, execution: FlyteTaskExecution, entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None
     ) -> FlyteTaskExecution:
         """Sync a FlyteTaskExecution object with its corresponding remote state."""
         if entity_definition is not None:
@@ -1327,10 +1326,10 @@ class FlyteRemote(object):
     ##################
 
     def _assign_inputs_and_outputs(
-            self,
-            execution: typing.Union[FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution],
-            execution_data,
-            interface: TypedInterface,
+        self,
+        execution: typing.Union[FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution],
+        execution_data,
+        interface: TypedInterface,
     ):
         """Helper for assigning synced inputs and outputs to an execution object."""
         with self.remote_context():
@@ -1369,6 +1368,6 @@ class FlyteRemote(object):
         return literal_models.LiteralMap({})
 
     def generate_console_url(
-            self, execution: typing.Union[FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution]
+        self, execution: typing.Union[FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution]
     ):
         return f"http://localhost:30081/console/projects/{execution.id.project}/domains/{execution.id.domain}/executions/{execution.id.name}"

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -511,7 +511,7 @@ class FlyteRemote(object):
                 self.client.get_upload_signed_url,
                 project=project or self.default_project,
                 domain=domain or self.default_domain,
-                filename=f"scriptmode.tar.gz",
+                filename="scriptmode.tar.gz",
             ),
         )
 

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -85,9 +85,9 @@ def tar_strip_file_attributes(tar_info: tarfile.TarInfo) -> tarfile.TarInfo:
 
     # user/group info
     tar_info.uid = 0
-    tar_info.uname = ''
+    tar_info.uname = ""
     tar_info.gid = 0
-    tar_info.gname = ''
+    tar_info.gname = ""
 
     # stripping paxheaders may not be required
     # see https://stackoverflow.com/questions/34688392/paxheaders-in-tarball
@@ -96,8 +96,9 @@ def tar_strip_file_attributes(tar_info: tarfile.TarInfo) -> tarfile.TarInfo:
     return tar_info
 
 
-def fast_register_single_script(wf_entity: WorkflowBase, create_upload_location_fn: typing.Callable) -> (
-        _data_proxy_pb2.CreateUploadLocationResponse, str):
+def fast_register_single_script(
+    wf_entity: WorkflowBase, create_upload_location_fn: typing.Callable
+) -> (_data_proxy_pb2.CreateUploadLocationResponse, str):
     _, mod_name, _, script_full_path = extract_task_module(wf_entity)
     # Find project root by moving up the folder hierarchy until you cannot find a __init__.py file.
     source_path = _find_project_root(script_full_path)


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
In script mode, we rely on the hash of the generated tar file to idempotent-ly register tasks/workflows. Because tar file metadata changes every time, we end up with a different version S3 path for the task. Because we use the script md5 hash as the task version, admin rejects the registration because the content of the task proto changed.

This PR unifies versioning logic to rely on the tar file content md5 for the task version

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

