### PR TITLE
Handle: arcname="", unhandled dataclass derivative types and improved error messaging

### DIFF
--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -68,7 +68,7 @@ def compress_single_script(absolute_project_path: str, destination: str, full_mo
             script_file_destination,
         )
         with tarfile.open(destination, "w:gz") as tar:
-            tar.add(os.path.join(tmp_dir, "code"), filter=tar_strip_file_attributes)
+            tar.add(os.path.join(tmp_dir, "code"), arcname="", filter=tar_strip_file_attributes)
 
 
 # Takes in a TarInfo and returns the modified TarInfo:


### PR DESCRIPTION
# TL;DR
- currently `pyflyte run` does not handle any flyte derivative classes - like flytefile etc
- Also fixes usage of `tar` to add `arcname=""`
- better error messaging
- 
## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue


