### PR TITLE
use security context instead of AuthRole

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -161,7 +161,7 @@ def run(
         if service_account:
             # options are only passed for the execution. This is to prevent errors when registering a duplicate workflow
             # It is assumed that the users expectations is to override the service account only for the execution
-            options = Options(AuthRole(kubernetes_service_account=service_account))
+            options = Options.default_from(k8s_service_account=service_account)
 
         execution = remote.execute(
             wf,


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
Security context should be used, auth-role is deprecated

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue


## Follow-up issue
_NA_
