### PR TITLE
Install flytekitplugins-pod in the default images

### DIFF
--- a/Dockerfile.py3.10
+++ b/Dockerfile.py3.10
@@ -12,6 +12,7 @@ RUN pip install gsutil
 ARG VERSION
 ARG DOCKER_IMAGE
 
-RUN pip install -U flytekit==$VERSION
+# Pod tasks should be exposed in the default image
+RUN pip install -U flytekitplugins-pod==$VERSION
 
 ENV FLYTE_INTERNAL_IMAGE "$DOCKER_IMAGE"

--- a/Dockerfile.py3.10
+++ b/Dockerfile.py3.10
@@ -13,6 +13,6 @@ ARG VERSION
 ARG DOCKER_IMAGE
 
 # Pod tasks should be exposed in the default image
-RUN pip install -U flytekitplugins-pod==$VERSION
+RUN pip install -U flytekit==$VERSION flytekitplugins-pod==$VERSION
 
 ENV FLYTE_INTERNAL_IMAGE "$DOCKER_IMAGE"

--- a/Dockerfile.py3.7
+++ b/Dockerfile.py3.7
@@ -12,6 +12,7 @@ RUN pip install gsutil
 ARG VERSION
 ARG DOCKER_IMAGE
 
-RUN pip install -U flytekit==$VERSION
+# Pod tasks should be exposed in the default image
+RUN pip install -U flytekitplugins-pod==$VERSION
 
 ENV FLYTE_INTERNAL_IMAGE "$DOCKER_IMAGE"

--- a/Dockerfile.py3.7
+++ b/Dockerfile.py3.7
@@ -13,6 +13,6 @@ ARG VERSION
 ARG DOCKER_IMAGE
 
 # Pod tasks should be exposed in the default image
-RUN pip install -U flytekitplugins-pod==$VERSION
+RUN pip install -U flytekit==$VERSION flytekitplugins-pod==$VERSION
 
 ENV FLYTE_INTERNAL_IMAGE "$DOCKER_IMAGE"

--- a/Dockerfile.py3.8
+++ b/Dockerfile.py3.8
@@ -12,6 +12,7 @@ RUN pip install gsutil
 ARG VERSION
 ARG DOCKER_IMAGE
 
-RUN pip install -U flytekit==$VERSION
+# Pod tasks should be exposed in the default image
+RUN pip install -U flytekitplugins-pod==$VERSION
 
 ENV FLYTE_INTERNAL_IMAGE "$DOCKER_IMAGE"

--- a/Dockerfile.py3.8
+++ b/Dockerfile.py3.8
@@ -13,6 +13,6 @@ ARG VERSION
 ARG DOCKER_IMAGE
 
 # Pod tasks should be exposed in the default image
-RUN pip install -U flytekitplugins-pod==$VERSION
+RUN pip install -U flytekit==$VERSION flytekitplugins-pod==$VERSION
 
 ENV FLYTE_INTERNAL_IMAGE "$DOCKER_IMAGE"

--- a/Dockerfile.py3.9
+++ b/Dockerfile.py3.9
@@ -12,6 +12,7 @@ RUN pip install gsutil
 ARG VERSION
 ARG DOCKER_IMAGE
 
-RUN pip install -U flytekit==$VERSION
+# Pod tasks should be exposed in the default image
+RUN pip install -U flytekitplugins-pod==$VERSION
 
 ENV FLYTE_INTERNAL_IMAGE "$DOCKER_IMAGE"

--- a/Dockerfile.py3.9
+++ b/Dockerfile.py3.9
@@ -13,6 +13,6 @@ ARG VERSION
 ARG DOCKER_IMAGE
 
 # Pod tasks should be exposed in the default image
-RUN pip install -U flytekitplugins-pod==$VERSION
+RUN pip install -U flytekit==$VERSION flytekitplugins-pod==$VERSION
 
 ENV FLYTE_INTERNAL_IMAGE "$DOCKER_IMAGE"


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Pod tasks should be usable in the default image

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 Install the pod plugin in all default images.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
