### PR TITLE
add name property to ExecutableTemplateShimTask

### DIFF
--- a/flytekit/core/shim_task.py
+++ b/flytekit/core/shim_task.py
@@ -42,6 +42,10 @@ class ExecutableTemplateShimTask(object):
         super().__init__(*args, **kwargs)
 
     @property
+    def name(self) -> str:
+        return self._task_template.id.name
+
+    @property
     def task_template(self) -> _task_model.TaskTemplate:
         return self._task_template
 

--- a/flytekit/core/shim_task.py
+++ b/flytekit/core/shim_task.py
@@ -43,7 +43,8 @@ class ExecutableTemplateShimTask(object):
 
     @property
     def name(self) -> str:
-        return self._task_template.id.name
+        # The subclasses that inherit from this class should have _name defined
+        return self._name
 
     @property
     def task_template(self) -> _task_model.TaskTemplate:


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

# TL;DR
Adds a name property to the ExecuteableShimTask, where the cli entrypoint.py complains that the name attribute is not defined (see [execution](https://demo.nuclyde.io/console/projects/flytesnacks/domains/development/executions/f65f24c3ffc674c25adb?duration=all))

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
