### PR TITLE
Fix executable shim task

### DIFF
--- a/flytekit/core/shim_task.py
+++ b/flytekit/core/shim_task.py
@@ -46,7 +46,7 @@ class ExecutableTemplateShimTask(object):
         """Return the name of the underlying task."""
         if self._task_template is not None:
             return self._task_template.id.name
-        # if not access the subclass's name, with the class name as fall-back
+        # if not access the subclass's name, with a fall-back if it's not defined
         return getattr(self, "_name", "executable_template_shim_task")
 
     @property

--- a/flytekit/core/shim_task.py
+++ b/flytekit/core/shim_task.py
@@ -43,8 +43,11 @@ class ExecutableTemplateShimTask(object):
 
     @property
     def name(self) -> str:
-        # The subclasses that inherit from this class should have _name defined
-        return self._name
+        """Return the name of the underlying task."""
+        if self._task_template is not None:
+            return self._task_template.id.name
+        # if not access the subclass's name, with the class name as fall-back
+        return getattr(self, "_name", "executable_template_shim_task")
 
     @property
     def task_template(self) -> _task_model.TaskTemplate:

--- a/flytekit/core/shim_task.py
+++ b/flytekit/core/shim_task.py
@@ -46,8 +46,8 @@ class ExecutableTemplateShimTask(object):
         """Return the name of the underlying task."""
         if self._task_template is not None:
             return self._task_template.id.name
-        # if not access the subclass's name, with a fall-back if it's not defined
-        return getattr(self, "_name", "executable_template_shim_task")
+        # if not access the subclass's name
+        return self._name
 
     @property
     def task_template(self) -> _task_model.TaskTemplate:


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

# TL;DR
When `pyflyte run` executes a customized container task, the task resolver returns a `ExecutableTemplateShimTask` directly with the task template model as one of its attributes. This PR fixes the `name` property by first trying to get the name based on the task template id, otherwise it assumes a `Task` subclass, which should have a `_name` attribute defined.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
