### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "keyring>=18.0.1",
         "requests>=2.18.4,<3.0.0",
         "responses>=0.10.7",
-        "sortedcontainers>=1.5.9<3.0.0",
+        "sortedcontainers>=1.5.9,<3.0.0",
         "statsd>=3.0.0,<4.0.0",
         "urllib3>=1.22,<2.0.0",
         "wrapt>=1.0.0,<2.0.0",


### PR DESCRIPTION
correct sortedversion python spec

# TL;DR

flytekit's setup.py has a subtle error in the version specification for sortedcontainers. conda has a pretty strict parser for versions which trips up on the fact this is missing a comma.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

The existing METADATA file for the flytekit pip package has this for sorted containers:

```
Requires-Dist: sortedcontainers (>=1.5.9<3.0.0)
```

With that as it is, when I run `conda env export` I get the following error:

```shell
❯ conda env export

InvalidVersionSpec: Invalid version '1.5.9<3.0.0': invalid character(s)
```

When I search for that specifier I find: 

```shell
❯ grep -r '1.5.9<3.0.0' `find  $CONDA_PREFIX -name 'site-packages'`

/home/ubuntu/.asdf/installs/python/mambaforge/envs/plaster/lib/python3.9/site-packages/flytekit-0.31.0.dist-info/METADATA:Requires-Dist: sortedcontainers (>=1.5.9<3.0.0)
```

When I update the specification with a ",":

```shell
❯ grep sortedcontainers /home/ubuntu/.asdf/installs/python/mambaforge/envs/plaster/lib/python3.9/site-packages/flytekit-0.31.0.dist-info/METADATA
Requires-Dist: sortedcontainers (>=1.5.9,<3.0.0)
```

conda export then works:

```shell
❯ conda env export > /dev/null
❯ echo $?
0
```

