### PR TITLE
Change default value for destination dir in run sub-command

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -66,8 +66,9 @@ from flytekit.types.structured.structured_dataset import (
     "destination_dir",
     required=False,
     type=str,
-    default="/root",
-    help="Directory inside the image where the tar file containing the code will be copied to",
+    # Notice how the default value assumes that the working directory is set appropriately in the docker file.
+    default=".",
+    help="Directory inside the image where the tar file containing the code will be copied to.",
 )
 @click.option(
     "-i",


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Change default value for destination dir in `run` sub-command

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
As of this PR we assume that the working directory is correctly set in the images used in invocations of `pyflyte run`. By leaning on that fact we can approximate `pyflyte run` to `flyteremote` (by requiring less a priori knowledge about other uses of `pyflyte run` for a given workflow+tasks and vice-versa).

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2380

## Follow-up issue
_NA_
