### PR TITLE
bump hadoop-aws version

### DIFF
--- a/plugins/flytekit-spark/scripts/flytekit_install_spark3.sh
+++ b/plugins/flytekit-spark/scripts/flytekit_install_spark3.sh
@@ -43,5 +43,5 @@ rm -rf spark-dist
 
 # Hadoop dist (via Apache) has older AWS SDK version. Fetch required AWS jars from maven directly (not-ideal) to support IAM role
 # https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html
-wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.0/hadoop-aws-3.2.0.jar -P /opt/spark/jars
+wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.2/hadoop-aws-3.3.2.jar -P /opt/spark/jars
 wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.740/aws-java-sdk-bundle-1.11.740.jar -P /opt/spark/jars

--- a/plugins/flytekit-spark/scripts/flytekit_install_spark3.sh
+++ b/plugins/flytekit-spark/scripts/flytekit_install_spark3.sh
@@ -44,4 +44,4 @@ rm -rf spark-dist
 # Hadoop dist (via Apache) has older AWS SDK version. Fetch required AWS jars from maven directly (not-ideal) to support IAM role
 # https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html
 wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.2/hadoop-aws-3.3.2.jar -P /opt/spark/jars
-wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.740/aws-java-sdk-bundle-1.11.740.jar -P /opt/spark/jars
+wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.202/aws-java-sdk-bundle-1.12.202.jar -P /opt/spark/jars

--- a/plugins/flytekit-spark/scripts/flytekit_install_spark3.sh
+++ b/plugins/flytekit-spark/scripts/flytekit_install_spark3.sh
@@ -43,5 +43,5 @@ rm -rf spark-dist
 
 # Hadoop dist (via Apache) has older AWS SDK version. Fetch required AWS jars from maven directly (not-ideal) to support IAM role
 # https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html
-wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.2/hadoop-aws-3.3.2.jar -P /opt/spark/jars
-wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.202/aws-java-sdk-bundle-1.12.202.jar -P /opt/spark/jars
+wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.1/hadoop-aws-3.3.1.jar -P /opt/spark/jars
+wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.901/aws-java-sdk-bundle-1.11.901.jar -P /opt/spark/jars


### PR DESCRIPTION
Signed-off-by: Samhita Alla <aallasamhita@gmail.com>

# TL;DR
This PR bumps the hadoop-aws and aws-java-sdk versions from 3.2.0 and 1.11.740 to 3.3.1 and 1.11.901 in accordance with spark 3.2.1 and pyspark 3.2.1. The version compatibility is derived from the [maven repository](https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.13/3.2.1).

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
