### PR TITLE
Make wfs completely comprised of remote entities not take settings

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -403,7 +403,12 @@ class FlyteRemote(object):
             ):
                 remote_logger.debug("Ignoring nodes for registration.")
                 continue
+            elif isinstance(cp_entity, ReferenceSpec):
+                remote_logger.debug(f"Skipping registration of Reference entity, name: {entity.name}")
+                continue
+
             if not isinstance(cp_entity, admin_workflow_models.WorkflowSpec) and not settings:
+                # Only in the case of workflows can we use the dummy serialization settings.
                 raise user_exceptions.FlyteValueException(
                     settings,
                     f"No serialization settings set, but workflow contains entities that need to be "
@@ -433,9 +438,6 @@ class FlyteRemote(object):
                 elif isinstance(cp_entity, launch_plan_models.LaunchPlan):
                     ident = self._resolve_identifier(ResourceType.LAUNCH_PLAN, entity.name, version, settings)
                     self.client.create_launch_plan(launch_plan_identifer=ident, launch_plan_spec=cp_entity.spec)
-                elif isinstance(cp_entity, ReferenceSpec):
-                    remote_logger.debug(f"Skipping registration of Reference entity, name: {entity.name}")
-                    continue
                 else:
                     raise AssertionError(f"Unknown entity of type {type(cp_entity)}")
             except FlyteEntityAlreadyExistsException:

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -387,7 +387,7 @@ class FlyteRemote(object):
             if not settings:
                 raise user_exceptions.FlyteValueException(
                     settings,
-                    f"No serialization settings set, but workflow " "contains entities that need to be registered.",
+                    f"No serialization settings set, but workflow contains entities that need to be registered.",
                 )
             try:
                 if isinstance(cp_entity, task_models.TaskSpec):


### PR DESCRIPTION
Signed-off-by: Yee Hing Tong <wild-endeavor@users.noreply.github.com>

# TL;DR
If you have a local `@workflow` that is comprised only of fetched or reference entities, then should not need a serialization settings object.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
