### PR TITLE
Remove suffix _old from pyflyte run help

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -571,6 +571,6 @@ class RunCommand(click.MultiCommand):
 
 run = RunCommand(
     name="run",
-    help="Run_old command, a.k.a. script mode. It allows for a a single script to be "
+    help="Run command, a.k.a. script mode. It allows for a a single script to be "
     + "registered and run from the command line (e.g. Jupyter notebooks).",
 )


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
_Please replace this text with a description of what this PR accomplishes._

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
