### PR TITLE
Use object type for execution identifier in ExecutionParameters

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -195,7 +195,7 @@ def setup_execution(
     """
     exe_project = get_one_of("FLYTE_INTERNAL_EXECUTION_PROJECT", "_F_PRJ")
     exe_domain = get_one_of("FLYTE_INTERNAL_EXECUTION_DOMAIN", "_F_DM")
-    exe_name = get_one_of("FLYTE_INTERNAL_EXECUTION_NAME", "_F_NM")
+    exe_name = get_one_of("FLYTE_INTERNAL_EXECUTION_ID", "_F_NM")
     exe_wf = get_one_of("FLYTE_INTERNAL_EXECUTION_WORKFLOW", "_F_WF")
     exe_lp = get_one_of("FLYTE_INTERNAL_EXECUTION_LAUNCHPLAN", "_F_LP")
 

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -216,7 +216,7 @@ class ExecutionParameters(object):
         return self._execution_date
 
     @property
-    def execution_id(self) -> str:
+    def execution_id(self) -> _identifier.WorkflowExecutionIdentifier:
         """
         This is the identifier of the workflow execution within the underlying engine.  It will be consistent across all
         task executions in a workflow or sub-workflow execution.

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -785,7 +785,7 @@ class FlyteContextManager(object):
         # are already acquainted with
         default_context = FlyteContext(file_access=default_local_file_access_provider)
         default_user_space_params = ExecutionParameters(
-            execution_id=str(WorkflowExecutionIdentifier.promote_from_model(default_execution_id)),
+            execution_id=WorkflowExecutionIdentifier.promote_from_model(default_execution_id),
             execution_date=_datetime.datetime.utcnow(),
             stats=mock_stats.MockStats(),
             logging=user_space_logger,

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -58,7 +58,7 @@ def test_default_wf_params_works():
     @task
     def my_task(a: int):
         wf_params = flytekit.current_context()
-        assert wf_params.execution_id == "ex:local:local:local"
+        assert str(wf_params.execution_id) == "ex:local:local:local"
         assert flyte_tmp_dir in wf_params.raw_output_prefix
 
     my_task(a=3)
@@ -69,7 +69,7 @@ def test_simple_input_output():
     @task
     def my_task(a: int) -> typing.NamedTuple("OutputsBC", b=int, c=str):
         ctx = flytekit.current_context()
-        assert ctx.execution_id == "ex:local:local:local"
+        assert str(ctx.execution_id) == "ex:local:local:local"
         return a + 2, "hello world"
 
     assert my_task(a=3) == (5, "hello world")


### PR DESCRIPTION
Signed-off-by: Yee Hing Tong <wild-endeavor@users.noreply.github.com>

# TL;DR
Use the same type whether running locally or in production.
Also the execution name was incorrect.  See [flyteplugins](https://github.com/flyteorg/flyteplugins/blob/82be16b9e39907e0842f06bc9f2918f5e1f8eedb/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds.go#L48) code for the env var added.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2449
