### PR TITLE
pyflyte run can now execute a task either locally or remote

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -507,7 +507,7 @@ class FlyteRemote(object):
 
     def register_script(
         self,
-        entity: WorkflowBase,
+        entity: typing.Union[WorkflowBase, PythonTask],
         image_config: typing.Optional[ImageConfig] = None,
         version: typing.Optional[str] = None,
         project: typing.Optional[str] = None,
@@ -515,7 +515,7 @@ class FlyteRemote(object):
         destination_dir: str = ".",
         default_launch_plan: typing.Optional[bool] = True,
         options: typing.Optional[Options] = None,
-    ) -> FlyteWorkflow:
+    ) -> typing.Union[FlyteWorkflow, FlyteTask]:
         """
         Use this method to register a workflow via script mode.
         :param destination_dir:
@@ -523,7 +523,7 @@ class FlyteRemote(object):
         :param project:
         :param image_config:
         :param version: version for the entity to be registered as
-        :param entity: The workflow to be registered
+        :param entity: The workflow to be registered or the task to be registered
         :param default_launch_plan: This should be true if a default launch plan should be created for the workflow
         :param options: Additional execution options that can be configured for the default launchplan
         :return:
@@ -565,6 +565,8 @@ class FlyteRemote(object):
             h.update(bytes(__version__, "utf-8"))
             version = base64.urlsafe_b64encode(h.digest())
 
+        if isinstance(entity, PythonTask):
+            return self.register_task(entity, serialization_settings, version)
         return self.register_workflow(entity, serialization_settings, version, default_launch_plan, options)
 
     def register_launch_plan(

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -3,11 +3,14 @@ import os
 from click.testing import CliRunner
 
 from flytekit.clis.sdk_in_container import pyflyte
+from flytekit.clis.sdk_in_container.run import get_entities_in_file
+
+WORKFLOW_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "workflow.py")
 
 
 def test_pyflyte_run_wf():
     runner = CliRunner()
-    module_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "workflow.py")
+    module_path = WORKFLOW_FILE
     result = runner.invoke(pyflyte.main, ["run", module_path, "my_wf", "--help"], catch_exceptions=False)
 
     assert result.exit_code == 0
@@ -52,3 +55,10 @@ def test_pyflyte_run_cli():
     )
     print(result.stdout)
     assert result.exit_code == 0
+
+
+def test_get_entities_in_file():
+    e = get_entities_in_file(WORKFLOW_FILE)
+    assert e.workflows == ["my_wf"]
+    assert e.tasks == ["get_subset_df", "print_all", "show_sd"]
+    assert e.all() == ["my_wf", "get_subset_df", "print_all", "show_sd"]


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
It is now possible to execute a single task from the command line

Example
```python
from flytekit import workflow, task
from typing import List, Dict

@task
def t1(l: str) -> List[str]:
    return [l]


@workflow
def wf(l: str = "") -> List[str]:
    return t1(l=l)


@task
def t2(i: Dict[str, int]) -> Dict[str, int]:
    return i

@workflow
def wf2m(i: Dict[str, int]) -> Dict[str, int]:
    return t2(i=i)
```
*To Execute*
```
pyflyte run --remote test2.py t1 --l hello
```

and help should show
```bash
➜ pyflyte run test2.py --help

Usage: pyflyte run test2.py [OPTIONS] COMMAND [ARGS]...

  Run a [workflow|task] in a file using script mode

Options:
  --help  Show this message and exit.

Commands:
  wf    Run test2.wf in script mode
  wf2m  Run test2.wf2m in script mode
  t1    Run test2.t1 in script mode
  t2    Run test2.t2 in script mode
```


## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue


## Tracking Issue
https://github.com/flyteorg/flyte/issues/2471

## Follow-up issue
_NA_

