### PR TITLE
Add default list transformer for legacy config

### DIFF
--- a/flytekit/configuration/file.py
+++ b/flytekit/configuration/file.py
@@ -91,6 +91,13 @@ def bool_transformer(config_val: typing.Any):
         return config_val
 
 
+def comma_list_transformer(config_val: typing.Any):
+    if type(config_val) is str:
+        return config_val.split(",")
+    else:
+        return config_val
+
+
 @dataclass
 class ConfigEntry(object):
     """
@@ -105,6 +112,7 @@ class ConfigEntry(object):
 
     legacy_default_transforms = {
         bool: bool_transformer,
+        list: comma_list_transformer,
     }
 
     def __post_init__(self):

--- a/flytekit/configuration/file.py
+++ b/flytekit/configuration/file.py
@@ -98,6 +98,15 @@ def comma_list_transformer(config_val: typing.Any):
         return config_val
 
 
+def int_transformer(config_val: typing.Any):
+    if type(config_val) is str:
+        try:
+            return int(config_val)
+        except ValueError:
+            logger.warning(f"Couldn't convert configuration setting {config_val} into {int}, leaving as is.")
+    return config_val
+
+
 @dataclass
 class ConfigEntry(object):
     """
@@ -113,6 +122,7 @@ class ConfigEntry(object):
     legacy_default_transforms = {
         bool: bool_transformer,
         list: comma_list_transformer,
+        int: int_transformer,
     }
 
     def __post_init__(self):

--- a/tests/flytekit/unit/configuration/test_internal.py
+++ b/tests/flytekit/unit/configuration/test_internal.py
@@ -1,5 +1,7 @@
 import os
 
+import mock
+
 from flytekit.configuration import get_config_file, read_file_if_exists
 from flytekit.configuration.internal import Credentials, Images
 
@@ -41,3 +43,11 @@ def test_command():
     cfg = get_config_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/good.config"))
     res = Credentials.COMMAND.read(cfg)
     assert res == ["aws", "sso", "get-token"]
+
+
+@mock.patch("flytekit.configuration.file.os")
+def test_command3(mocked):
+    mocked.environ.get.return_value = "a,b,c"
+    cfg = get_config_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/good.config"))
+    res = Credentials.COMMAND.read(cfg)
+    assert res == ["a", "b", "c"]

--- a/tests/flytekit/unit/configuration/test_internal.py
+++ b/tests/flytekit/unit/configuration/test_internal.py
@@ -3,7 +3,7 @@ import os
 import mock
 
 from flytekit.configuration import get_config_file, read_file_if_exists
-from flytekit.configuration.internal import Credentials, Images
+from flytekit.configuration.internal import AWS, Credentials, Images
 
 
 def test_load_images():
@@ -46,8 +46,17 @@ def test_command():
 
 
 @mock.patch("flytekit.configuration.file.os")
-def test_command3(mocked):
+def test_command_2(mocked):
     mocked.environ.get.return_value = "a,b,c"
     cfg = get_config_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/good.config"))
     res = Credentials.COMMAND.read(cfg)
     assert res == ["a", "b", "c"]
+
+
+@mock.patch("flytekit.configuration.file.os")
+def test_some_int(mocked):
+    mocked.environ.get.side_effect = "5"
+    cfg = get_config_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/good.config"))
+    res = AWS.RETRIES.read(cfg)
+    assert type(res) is int
+    assert res == 5


### PR DESCRIPTION
# TL;DR
User reported some issues around external command auth.  Don't think this was the issue, but found it during investigation.

Basically the config object was correctly splitting a comma separated string when it was being passed in by a config file, but not when it was being read from env.

That is, when `ConfigEntry` calls `LegacyConfigEntry`, that class's `read_from_file` will apply a list transform, whereas its `read_from_env` does not.  This adds a default transform for the list type for legacy config if the returned value is a string and not a list but the legacy subtype is a list.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

