### PR TITLE
read packages from environment variables

### DIFF
--- a/flytekit/clis/sdk_in_container/pyflyte.py
+++ b/flytekit/clis/sdk_in_container/pyflyte.py
@@ -51,8 +51,8 @@ def main(ctx, pkgs=None, config=None):
     """
     ctx.obj = dict()
 
-    # Handle package management - get from config if not specified on the command line
-    pkgs = pkgs or []
+    # Handle package management - get from the command line, the environment variables, then the config file.
+    pkgs = pkgs or LocalSDK.WORKFLOW_PACKAGES.read() or []
     if config:
         ctx.obj[CTX_CONFIG_FILE] = config
         cfg = configuration.ConfigFile(config)


### PR DESCRIPTION
# TL;DR
Read packages from the `FLYTE_SDK_WORKFLOW_PACKAGES` environment variable for backwards compatibility.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue
[Slack reported](https://flyte-org.slack.com/archives/CREL4QVAQ/p1652275530635879) issue.
