### PR TITLE
pass fileaccess data config to data persistence plugin

### DIFF
--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -440,7 +440,9 @@ class FileAccessProvider(object):
         """
         try:
             with PerformanceTimer(f"Writing ({local_path} -> {remote_path})"):
-                DataPersistencePlugins.find_plugin(remote_path)().put(local_path, remote_path, recursive=is_multipart)
+                DataPersistencePlugins.find_plugin(remote_path)(data_config=self.data_config).put(
+                    local_path, remote_path, recursive=is_multipart
+                )
         except Exception as ex:
             raise FlyteAssertion(
                 f"Failed to put data from {local_path} to {remote_path} (recursive={is_multipart}).\n\n"


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

# TL;DR

Prior to this change, the data persistence plugin used in the `FileAccessProvider.put_data` method would not use the correct data config (effectively it was empty). This PR passes the FileAccessProvider object's data_config into the appropriate plugin.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
