### PR TITLE
Correctly resolve forwardrefs in namedtuple typing

### DIFF
--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -386,7 +386,7 @@ def extract_return_annotation(return_annotation: Union[Type, Tuple, None]) -> Di
         bases = return_annotation.__bases__  # type: ignore
         if len(bases) == 1 and bases[0] == tuple and hasattr(return_annotation, "_fields"):
             logger.debug(f"Task returns named tuple {return_annotation}")
-            return return_annotation.__annotations__
+            return dict(typing.get_type_hints(return_annotation))
 
     if hasattr(return_annotation, "__origin__") and return_annotation.__origin__ is tuple:  # type: ignore
         # Handle option 3

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -76,6 +76,19 @@ def test_simple_input_output():
     assert context_manager.FlyteContextManager.size() == 1
 
 
+def test_forwardref_namedtuple_output():
+    # This test case tests typing.NamedTuple outputs for cases where eg.
+    # from __future__ import annotations is enabled, such that all type hints become ForwardRef
+    @task
+    def my_task(a: int) -> typing.NamedTuple("OutputsBC", b=typing.ForwardRef('int'), c=typing.ForwardRef('str')):
+        ctx = flytekit.current_context()
+        assert str(ctx.execution_id) == "ex:local:local:local"
+        return a + 2, "hello world"
+
+    assert my_task(a=3) == (5, "hello world")
+    assert context_manager.FlyteContextManager.size() == 1
+
+
 def test_simple_input_no_output():
     @task
     def my_task(a: int):

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -80,7 +80,7 @@ def test_forwardref_namedtuple_output():
     # This test case tests typing.NamedTuple outputs for cases where eg.
     # from __future__ import annotations is enabled, such that all type hints become ForwardRef
     @task
-    def my_task(a: int) -> typing.NamedTuple("OutputsBC", b=typing.ForwardRef('int'), c=typing.ForwardRef('str')):
+    def my_task(a: int) -> typing.NamedTuple("OutputsBC", b=typing.ForwardRef("int"), c=typing.ForwardRef("str")):
         ctx = flytekit.current_context()
         assert str(ctx.execution_id) == "ex:local:local:local"
         return a + 2, "hello world"


### PR DESCRIPTION
# TL;DR
Fix typing edge case where `typing.ForwardRef`s get transformed into `FlytePickle` types and fail rather than resolving.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [X] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_
When using `from __future__ import annotations` all type annotations are `typing.ForwardRef`s and need to always be resolved with `typing.get_type_hints()`. Additionally, the returned dict may be mutated, so should be copied rather than still referring to static information (eg. global type annotations dict).

Fixed by `x.__annotations__` -> `dict(typing.get_type_hints(x))`, + unit test.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
