### PR TITLE
Update get_serializable_workflow to consistently generate the same subworkflow order

### DIFF
--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -289,7 +289,9 @@ def get_serializable_workflow(
         nodes=upstream_node_models,
         outputs=entity.output_bindings,
     )
-    return admin_workflow_models.WorkflowSpec(template=wf_t, sub_workflows=sorted(set(sub_wfs), key=lambda x: x.short_string()))
+    return admin_workflow_models.WorkflowSpec(
+        template=wf_t, sub_workflows=sorted(set(sub_wfs), key=lambda x: x.short_string())
+    )
 
 
 def get_serializable_launch_plan(

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -289,7 +289,7 @@ def get_serializable_workflow(
         nodes=upstream_node_models,
         outputs=entity.output_bindings,
     )
-    return admin_workflow_models.WorkflowSpec(template=wf_t, sub_workflows=list(set(sub_wfs)))
+    return admin_workflow_models.WorkflowSpec(template=wf_t, sub_workflows=sorted(set(sub_wfs), key=lambda x: x.short_string()))
 
 
 def get_serializable_launch_plan(


### PR DESCRIPTION
# TL;DR
We observed a bug when registering a workflow that directly calls one or more workflows. The first time I register it, it completes successfully. In subsequent times, we would expect it to skip the workflow / tasks, because there are no changes and the registration already happened. However, sometimes when you go to register again, instead of skipping, it produces an error that "workflow with different structure already exists with id resource_type". This is because the serialized versions of the parent workflow are different across calls to registration.

This PR this issue by ensuring that `get_serializable_workflow` returns the `subworkflow` dictionaries in the same order every time it is called.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The main open question I have is is this the correct place for this change to be made? Or should this be made on the flyteadmin side?

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2508

## Follow-up issue
_NA_