### PR TITLE
Skip config checking if no ini config file present

### DIFF
--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -19,7 +19,7 @@ class Images(object):
         :returns a dictionary of name: image<fqn+version> Version is optional
         """
         images: typing.Dict[str, str] = {}
-        if cfg is None:
+        if cfg is None or not cfg.legacy_config:
             return images
         try:
             image_names = cfg.legacy_config.options("images")


### PR DESCRIPTION
Signed-off-by: Yee Hing Tong <wild-endeavor@users.noreply.github.com>

# TL;DR
User reported issue when running a command like

```bash
pyflyte -c ~/.flyte/config.yaml --pkgs core serialize --in-container-config-path /root/config.yaml --image my_image:123 workflows -f /tmp
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
