### PR TITLE
Added support for insecureSkipVerify on pyflyte

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -65,7 +65,7 @@ cookiecutter==1.7.3
     # via
     #   -c requirements.txt
     #   flytekit
-coverage[toml]==6.3.3
+coverage[toml]==6.4
     # via -r dev-requirements.in
 croniter==1.3.5
     # via
@@ -75,6 +75,7 @@ cryptography==37.0.2
     # via
     #   -c requirements.txt
     #   paramiko
+    #   pyopenssl
     #   secretstorage
 dataclasses-json==0.5.7
     # via
@@ -151,14 +152,14 @@ googleapis-common-protos==1.56.1
     #   flyteidl
     #   google-api-core
     #   grpcio-status
-grpcio==1.46.1
+grpcio==1.46.3
     # via
     #   -c requirements.txt
     #   flytekit
     #   google-api-core
     #   google-cloud-bigquery
     #   grpcio-status
-grpcio-status==1.46.1
+grpcio-status==1.46.3
     # via
     #   -c requirements.txt
     #   flytekit
@@ -169,7 +170,7 @@ idna==3.3
     # via
     #   -c requirements.txt
     #   requests
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via
     #   -c requirements.txt
     #   click
@@ -206,7 +207,7 @@ jsonschema==3.2.0
     # via
     #   -c requirements.txt
     #   docker-compose
-keyring==23.5.0
+keyring==23.5.1
     # via
     #   -c requirements.txt
     #   flytekit
@@ -326,6 +327,10 @@ pygments==2.12.0
     # via ipython
 pynacl==1.5.0
     # via paramiko
+pyopenssl==22.0.0
+    # via
+    #   -c requirements.txt
+    #   flytekit
 pyparsing==3.0.9
     # via
     #   -c requirements.txt
@@ -445,7 +450,7 @@ traitlets==5.2.1.post0
     # via
     #   ipython
     #   matplotlib-inline
-typed-ast==1.5.3
+typed-ast==1.5.4
     # via mypy
 typing-extensions==4.2.0
     # via

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -233,7 +233,7 @@ matplotlib-inline==0.1.3
     # via ipython
 mock==4.0.3
     # via -r dev-requirements.in
-mypy==0.950
+mypy==0.960
     # via -r dev-requirements.in
 mypy-extensions==0.4.3
     # via
@@ -395,7 +395,7 @@ requests==2.27.1
     #   google-api-core
     #   google-cloud-bigquery
     #   responses
-responses==0.20.0
+responses==0.21.0
     # via
     #   -c requirements.txt
     #   flytekit
@@ -459,6 +459,7 @@ typing-extensions==4.2.0
     #   flytekit
     #   importlib-metadata
     #   mypy
+    #   responses
     #   typing-inspect
 typing-inspect==0.7.1
     # via

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -42,7 +42,7 @@ binaryornot==0.4.4
     # via cookiecutter
 bleach==5.0.0
     # via nbconvert
-botocore==1.26.7
+botocore==1.26.8
     # via -r doc-requirements.in
 cachetools==5.1.0
     # via google-auth

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -42,7 +42,7 @@ binaryornot==0.4.4
     # via cookiecutter
 bleach==5.0.0
     # via nbconvert
-botocore==1.26.5
+botocore==1.26.7
     # via -r doc-requirements.in
 cachetools==5.1.0
     # via google-auth
@@ -76,6 +76,7 @@ cryptography==36.0.2
     # via
     #   -r doc-requirements.in
     #   great-expectations
+    #   pyopenssl
     #   secretstorage
 css-html-js-minify==2.5.5
     # via sphinx-material
@@ -160,14 +161,14 @@ great-expectations==0.15.6
     # via -r doc-requirements.in
 greenlet==1.1.2
     # via sqlalchemy
-grpcio==1.46.1
+grpcio==1.46.3
     # via
     #   -r doc-requirements.in
     #   flytekit
     #   google-api-core
     #   google-cloud-bigquery
     #   grpcio-status
-grpcio-status==1.46.1
+grpcio-status==1.46.3
     # via
     #   flytekit
     #   google-api-core
@@ -179,7 +180,7 @@ imagehash==4.2.1
     # via visions
 imagesize==1.3.0
     # via sphinx
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via
     #   click
     #   great-expectations
@@ -266,7 +267,7 @@ jupyterlab-pygments==0.2.2
     # via nbconvert
 jupyterlab-widgets==1.1.0
     # via ipywidgets
-keyring==23.5.0
+keyring==23.5.1
     # via flytekit
 kiwisolver==1.4.2
     # via matplotlib
@@ -438,7 +439,7 @@ protobuf==3.20.1
     #   protoc-gen-swagger
 protoc-gen-swagger==0.1.0
     # via flyteidl
-psutil==5.9.0
+psutil==5.9.1
     # via ipykernel
 ptyprocess==0.7.0
     # via
@@ -467,12 +468,15 @@ pydantic==1.9.1
     #   pandera
 pygments==2.12.0
     # via
+    #   furo
     #   ipython
     #   jupyter-console
     #   nbconvert
     #   qtconsole
     #   sphinx
     #   sphinx-prompt
+pyopenssl==22.0.0
+    # via flytekit
 pyparsing==2.4.7
     # via
     #   great-expectations
@@ -546,7 +550,7 @@ requests==2.27.1
     #   sphinx
 requests-oauthlib==1.3.1
     # via kubernetes
-responses==0.20.0
+responses==0.21.0
     # via flytekit
 retry==0.9.2
     # via flytekit
@@ -595,6 +599,7 @@ sphinx==4.5.0
     #   -r doc-requirements.in
     #   furo
     #   sphinx-autoapi
+    #   sphinx-basic-ng
     #   sphinx-code-include
     #   sphinx-copybutton
     #   sphinx-fontawesome
@@ -605,6 +610,8 @@ sphinx==4.5.0
     #   sphinxcontrib-yt
 sphinx-autoapi==1.8.4
     # via -r doc-requirements.in
+sphinx-basic-ng==0.0.1a10
+    # via furo
 sphinx-code-include==1.1.1
     # via -r doc-requirements.in
 sphinx-copybutton==0.5.0
@@ -681,7 +688,7 @@ traitlets==5.2.1.post0
     #   nbformat
     #   notebook
     #   qtconsole
-typed-ast==1.5.3
+typed-ast==1.5.4
     # via astroid
 typing-extensions==4.2.0
     # via
@@ -695,6 +702,7 @@ typing-extensions==4.2.0
     #   kiwisolver
     #   pandera
     #   pydantic
+    #   responses
     #   typing-inspect
 typing-inspect==0.7.1
     # via

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -115,7 +115,7 @@ class RawSynchronousFlyteClient(object):
         elif cfg.insecure_skip_verify:
             # Get port from endpoint or use 443
             try:
-                port = int(cfg.endpoint.rsplit(":", 1))[1]
+                port = int(cfg.endpoint.rsplit(":", 1)[1])
             except (IndexError, ValueError):
                 port = 443
             cert = ssl.get_server_certificate((cfg.endpoint, port))

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -114,7 +114,7 @@ class RawSynchronousFlyteClient(object):
             self._channel = grpc.insecure_channel(cfg.endpoint, **kwargs)
         elif cfg.insecure_skip_verify:
             # Get port from endpoint or use 443
-            endpoint_parts = cfg.endpoint.split(":", 1)
+            endpoint_parts = cfg.endpoint.rsplit(":", 1)
             if len(endpoint_parts) == 2 and endpoint_parts[1].isdigit():
                 server_address = tuple(endpoint_parts)
             else:

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -349,7 +349,9 @@ class PlatformConfig(object):
         config_file = get_config_file(config_file)
         kwargs = {}
         kwargs = set_if_exists(kwargs, "insecure", _internal.Platform.INSECURE.read(config_file))
-        kwargs = set_if_exists(kwargs, "insecure_skip_verify", _internal.Platform.INSECURE_SKIP_VERIFY.read(config_file))
+        kwargs = set_if_exists(
+            kwargs, "insecure_skip_verify", _internal.Platform.INSECURE_SKIP_VERIFY.read(config_file)
+        )
         kwargs = set_if_exists(kwargs, "command", _internal.Credentials.COMMAND.read(config_file))
         kwargs = set_if_exists(kwargs, "client_id", _internal.Credentials.CLIENT_ID.read(config_file))
         kwargs = set_if_exists(

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -297,6 +297,7 @@ class PlatformConfig(object):
 
     :param endpoint: DNS for Flyte backend
     :param insecure: Whether or not to use SSL
+    :param insecure_skip_verify: Wether to skip SSL certificate verification
     :param command: This command is executed to return a token using an external process.
     :param client_id: This is the public identifier for the app which handles authorization for a Flyte deployment.
       More details here: https://www.oauth.com/oauth2-servers/client-registration/client-id-secret/.
@@ -309,6 +310,7 @@ class PlatformConfig(object):
 
     endpoint: str = "localhost:30081"
     insecure: bool = False
+    insecure_skip_verify: bool = False
     command: typing.Optional[typing.List[str]] = None
     client_id: typing.Optional[str] = None
     client_credentials_secret: typing.Optional[str] = None
@@ -319,6 +321,7 @@ class PlatformConfig(object):
         self,
         endpoint: str = "localhost:30081",
         insecure: bool = False,
+        insecure_skip_verify: bool = False,
         command: typing.Optional[typing.List[str]] = None,
         client_id: typing.Optional[str] = None,
         client_credentials_secret: typing.Optional[str] = None,
@@ -328,6 +331,7 @@ class PlatformConfig(object):
         return PlatformConfig(
             endpoint=endpoint,
             insecure=insecure,
+            insecure_skip_verify=insecure_skip_verify,
             command=command,
             client_id=client_id,
             client_credentials_secret=client_credentials_secret,
@@ -345,6 +349,7 @@ class PlatformConfig(object):
         config_file = get_config_file(config_file)
         kwargs = {}
         kwargs = set_if_exists(kwargs, "insecure", _internal.Platform.INSECURE.read(config_file))
+        kwargs = set_if_exists(kwargs, "insecure_skip_verify", _internal.Platform.INSECURE_SKIP_VERIFY.read(config_file))
         kwargs = set_if_exists(kwargs, "command", _internal.Credentials.COMMAND.read(config_file))
         kwargs = set_if_exists(kwargs, "client_id", _internal.Credentials.CLIENT_ID.read(config_file))
         kwargs = set_if_exists(

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -105,6 +105,7 @@ class Platform(object):
         LegacyConfigEntry(SECTION, "url"), YamlConfigEntry("admin.endpoint"), lambda x: x.replace("dns:///", "")
     )
     INSECURE = ConfigEntry(LegacyConfigEntry(SECTION, "insecure", bool), YamlConfigEntry("admin.insecure", bool))
+    INSECURE_SKIP_VERIFY = ConfigEntry(LegacyConfigEntry(SECTION, "insecure_skip_verify", bool), YamlConfigEntry("admin.insecureSkipVerify", bool))
 
 
 class LocalSDK(object):

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -105,7 +105,9 @@ class Platform(object):
         LegacyConfigEntry(SECTION, "url"), YamlConfigEntry("admin.endpoint"), lambda x: x.replace("dns:///", "")
     )
     INSECURE = ConfigEntry(LegacyConfigEntry(SECTION, "insecure", bool), YamlConfigEntry("admin.insecure", bool))
-    INSECURE_SKIP_VERIFY = ConfigEntry(LegacyConfigEntry(SECTION, "insecure_skip_verify", bool), YamlConfigEntry("admin.insecureSkipVerify", bool))
+    INSECURE_SKIP_VERIFY = ConfigEntry(
+        LegacyConfigEntry(SECTION, "insecure_skip_verify", bool), YamlConfigEntry("admin.insecureSkipVerify", bool)
+    )
 
 
 class LocalSDK(object):

--- a/requirements-spark2.txt
+++ b/requirements-spark2.txt
@@ -35,7 +35,9 @@ cookiecutter==1.7.3
 croniter==1.3.5
     # via flytekit
 cryptography==37.0.2
-    # via secretstorage
+    # via
+    #   pyopenssl
+    #   secretstorage
 dataclasses-json==0.5.7
     # via flytekit
 decorator==5.1.1
@@ -56,15 +58,15 @@ googleapis-common-protos==1.56.1
     # via
     #   flyteidl
     #   grpcio-status
-grpcio==1.46.1
+grpcio==1.46.3
     # via
     #   flytekit
     #   grpcio-status
-grpcio-status==1.46.1
+grpcio-status==1.46.3
     # via flytekit
 idna==3.3
     # via requests
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via
     #   click
     #   jsonschema
@@ -81,7 +83,7 @@ jinja2-time==0.2.0
     # via cookiecutter
 jsonschema==3.2.0
     # via -r requirements.in
-keyring==23.5.0
+keyring==23.5.1
     # via flytekit
 markupsafe==2.1.1
     # via jinja2
@@ -127,6 +129,8 @@ pyarrow==6.0.1
     # via flytekit
 pycparser==2.21
     # via cffi
+pyopenssl==22.0.0
+    # via flytekit
 pyparsing==3.0.9
     # via packaging
 pyrsistent==0.18.1
@@ -159,7 +163,7 @@ requests==2.27.1
     #   docker
     #   flytekit
     #   responses
-responses==0.20.0
+responses==0.21.0
     # via flytekit
 retry==0.9.2
     # via flytekit
@@ -185,6 +189,7 @@ typing-extensions==4.2.0
     #   arrow
     #   flytekit
     #   importlib-metadata
+    #   responses
     #   typing-inspect
 typing-inspect==0.7.1
     # via dataclasses-json

--- a/requirements.txt
+++ b/requirements.txt
@@ -161,7 +161,7 @@ requests==2.27.1
     #   docker
     #   flytekit
     #   responses
-responses==0.20.0
+responses==0.21.0
     # via flytekit
 retry==0.9.2
     # via flytekit
@@ -187,6 +187,7 @@ typing-extensions==4.2.0
     #   arrow
     #   flytekit
     #   importlib-metadata
+    #   responses
     #   typing-inspect
 typing-inspect==0.7.1
     # via dataclasses-json

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,9 @@ cookiecutter==1.7.3
 croniter==1.3.5
     # via flytekit
 cryptography==37.0.2
-    # via secretstorage
+    # via
+    #   pyopenssl
+    #   secretstorage
 dataclasses-json==0.5.7
     # via flytekit
 decorator==5.1.1
@@ -54,15 +56,15 @@ googleapis-common-protos==1.56.1
     # via
     #   flyteidl
     #   grpcio-status
-grpcio==1.46.1
+grpcio==1.46.3
     # via
     #   flytekit
     #   grpcio-status
-grpcio-status==1.46.1
+grpcio-status==1.46.3
     # via flytekit
 idna==3.3
     # via requests
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via
     #   click
     #   jsonschema
@@ -79,7 +81,7 @@ jinja2-time==0.2.0
     # via cookiecutter
 jsonschema==3.2.0
     # via -r requirements.in
-keyring==23.5.0
+keyring==23.5.1
     # via flytekit
 markupsafe==2.1.1
     # via jinja2
@@ -125,6 +127,8 @@ pyarrow==6.0.1
     # via flytekit
 pycparser==2.21
     # via cffi
+pyopenssl==22.0.0
+    # via flytekit
 pyparsing==3.0.9
     # via packaging
 pyrsistent==0.18.1

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "python-dateutil>=2.1",
         "grpcio>=1.43.0,!=1.45.0,<2.0",
         "grpcio-status>=1.43,!=1.45.0",
+        "pyopenssl",
         "protobuf>=3.6.1,<4",
         "python-json-logger>=2.0.0",
         "pytimeparse>=1.1.8,<2.0.0",

--- a/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
+++ b/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
@@ -46,7 +46,7 @@ docstring-parser==0.14.1
     # via flytekit
 flyteidl==1.0.1
     # via flytekit
-flytekit==1.0.2
+flytekit==1.0.3
     # via -r tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.in
 fonttools==4.33.3
     # via matplotlib
@@ -54,15 +54,15 @@ googleapis-common-protos==1.56.1
     # via
     #   flyteidl
     #   grpcio-status
-grpcio==1.46.1
+grpcio==1.46.3
     # via
     #   flytekit
     #   grpcio-status
-grpcio-status==1.46.1
+grpcio-status==1.46.3
     # via flytekit
 idna==3.3
     # via requests
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via
     #   click
     #   keyring
@@ -78,7 +78,7 @@ jinja2-time==0.2.0
     # via cookiecutter
 joblib==1.1.0
     # via -r tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.in
-keyring==23.5.0
+keyring==23.5.1
     # via flytekit
 kiwisolver==1.4.2
     # via matplotlib
@@ -164,7 +164,7 @@ requests==2.27.1
     #   docker
     #   flytekit
     #   responses
-responses==0.20.0
+responses==0.21.0
     # via flytekit
 retry==0.9.2
     # via flytekit
@@ -189,6 +189,7 @@ typing-extensions==4.2.0
     #   flytekit
     #   importlib-metadata
     #   kiwisolver
+    #   responses
     #   typing-inspect
 typing-inspect==0.7.1
     # via dataclasses-json


### PR DESCRIPTION
# TL;DR
Enables the insecureSkipVerify config flag on pyflyte. Allows bypassing SSL certificate verification, allowing connections with self-signed certificates.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
When insecureSkipVerify is set to true, fetches the SSL cert from the endpoint and creates a grpc secure channel with the 'ssl_target_name_override' option set.

Similar to https://stackoverflow.com/a/52855472

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2531

## Follow-up issue
_NA_
