### PR TITLE
TypeTransformer for Numpy

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -189,7 +189,7 @@ from flytekit.models.core.execution import WorkflowExecutionPhase
 from flytekit.models.core.types import BlobType
 from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
-from flytekit.types import directory, file, schema
+from flytekit.types import directory, file, numpy, schema
 from flytekit.types.structured.structured_dataset import (
     StructuredDataset,
     StructuredDatasetFormat,

--- a/flytekit/types/numpy/__init__.py
+++ b/flytekit/types/numpy/__init__.py
@@ -1,0 +1,13 @@
+"""
+Flytekit Numpy
+==============
+.. currentmodule:: flytekit.types.numpy
+
+.. autosummary::
+   :template: custom.rst
+   :toctree: generated/
+
+   NumpyArrayTransformer
+"""
+
+from .ndarray import NumpyArrayTransformer

--- a/flytekit/types/numpy/ndarray.py
+++ b/flytekit/types/numpy/ndarray.py
@@ -1,0 +1,74 @@
+import pathlib
+import typing
+from typing import Type
+
+import numpy as np
+
+from flytekit.core.context_manager import FlyteContext
+from flytekit.core.type_engine import TypeEngine, TypeTransformer, TypeTransformerFailedError
+from flytekit.models.core import types as _core_types
+from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
+from flytekit.models.types import LiteralType
+
+
+class NumpyArrayTransformer(TypeTransformer[np.ndarray]):
+    """
+    TypeTransformer that supports np.ndarray as a native type.
+    """
+
+    NUMPY_ARRAY_FORMAT = "NumpyArray"
+
+    def __init__(self):
+        super().__init__(name="Numpy Array", t=np.ndarray)
+
+    def get_literal_type(self, t: Type[np.ndarray]) -> LiteralType:
+        return LiteralType(
+            blob=_core_types.BlobType(
+                format=self.NUMPY_ARRAY_FORMAT, dimensionality=_core_types.BlobType.BlobDimensionality.SINGLE
+            )
+        )
+
+    def to_literal(
+        self, ctx: FlyteContext, python_val: np.ndarray, python_type: Type[np.ndarray], expected: LiteralType
+    ) -> Literal:
+        meta = BlobMetadata(
+            type=_core_types.BlobType(
+                format=self.NUMPY_ARRAY_FORMAT, dimensionality=_core_types.BlobType.BlobDimensionality.SINGLE
+            )
+        )
+
+        local_path = ctx.file_access.get_random_local_path() + ".npy"
+        pathlib.Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+
+        # save numpy array to a file
+        # allow_pickle=False prevents numpy from trying to save object arrays (dtype=object) using pickle
+        np.save(file=local_path, arr=python_val, allow_pickle=False)
+
+        remote_path = ctx.file_access.get_random_remote_path(local_path)
+        ctx.file_access.put_data(local_path, remote_path, is_multipart=False)
+        return Literal(scalar=Scalar(blob=Blob(metadata=meta, uri=remote_path)))
+
+    def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[np.ndarray]) -> np.ndarray:
+        try:
+            uri = lv.scalar.blob.uri
+        except AttributeError:
+            TypeTransformerFailedError(f"Cannot convert from {lv} to {expected_python_type}")
+
+        local_path = ctx.file_access.get_random_local_path()
+        ctx.file_access.get_data(uri, local_path, is_multipart=False)
+
+        # load numpy array from a file
+        return np.load(file=local_path)
+
+    def guess_python_type(self, literal_type: LiteralType) -> typing.Type[np.ndarray]:
+        if (
+            literal_type.blob is not None
+            and literal_type.blob.dimensionality == _core_types.BlobType.BlobDimensionality.SINGLE
+            and literal_type.blob.format == self.NUMPY_ARRAY_FORMAT
+        ):
+            return np.ndarray
+
+        raise ValueError(f"Transformer {self} cannot reverse {literal_type}")
+
+
+TypeEngine.register(NumpyArrayTransformer())

--- a/plugins/flytekit-greatexpectations/tests/test_schema.py
+++ b/plugins/flytekit-greatexpectations/tests/test_schema.py
@@ -6,7 +6,7 @@ import typing
 import pandas as pd
 import pytest
 from flytekitplugins.great_expectations import BatchRequestConfig, GreatExpectationsFlyteConfig, GreatExpectationsType
-from great_expectations.exceptions import ValidationError
+from great_expectations.exceptions import InvalidBatchRequestError, ValidationError
 
 from flytekit import task, workflow
 from flytekit.types.file import CSVFile
@@ -144,7 +144,7 @@ def test_invalid_ge_schema_batchrequest_pandas_config():
         my_task(directory="my_assets")
 
     # Capture IndexError
-    with pytest.raises(IndexError):
+    with pytest.raises(InvalidBatchRequestError):
         my_wf()
 
 

--- a/plugins/flytekit-greatexpectations/tests/test_task.py
+++ b/plugins/flytekit-greatexpectations/tests/test_task.py
@@ -6,7 +6,7 @@ import typing
 import pandas as pd
 import pytest
 from flytekitplugins.great_expectations import BatchRequestConfig, GreatExpectationsTask
-from great_expectations.exceptions import ValidationError
+from great_expectations.exceptions import InvalidBatchRequestError, ValidationError
 
 from flytekit import kwtypes, task, workflow
 from flytekit.types.file import CSVFile, FlyteFile
@@ -82,7 +82,7 @@ def test_invalid_ge_batchrequest_pandas_config():
     )
 
     # Capture IndexError
-    with pytest.raises(IndexError):
+    with pytest.raises(InvalidBatchRequestError):
         task_object(data="my_assets")
 
 

--- a/tests/flytekit/unit/core/test_numpy.py
+++ b/tests/flytekit/unit/core/test_numpy.py
@@ -1,0 +1,61 @@
+from collections import OrderedDict
+
+import numpy as np
+from numpy.testing import assert_array_equal
+
+import flytekit
+from flytekit import task
+from flytekit.configuration import Image, ImageConfig
+from flytekit.core import context_manager
+from flytekit.models.core.types import BlobType
+from flytekit.models.literals import BlobMetadata
+from flytekit.models.types import LiteralType
+from flytekit.tools.translator import get_serializable
+from flytekit.types.numpy import NumpyArrayTransformer
+
+default_img = Image(name="default", fqn="test", tag="tag")
+serialization_settings = flytekit.configuration.SerializationSettings(
+    project="project",
+    domain="domain",
+    version="version",
+    env=None,
+    image_config=ImageConfig(default_image=default_img, images=[default_img]),
+)
+
+
+def test_get_literal_type():
+    tf = NumpyArrayTransformer()
+    lt = tf.get_literal_type(np.ndarray)
+    assert lt == LiteralType(
+        blob=BlobType(
+            format=NumpyArrayTransformer.NUMPY_ARRAY_FORMAT, dimensionality=BlobType.BlobDimensionality.SINGLE
+        )
+    )
+
+
+def test_to_python_value_and_literal():
+    ctx = context_manager.FlyteContext.current_context()
+    tf = NumpyArrayTransformer()
+    python_val = np.array([1, 2, 3])
+    lt = tf.get_literal_type(np.ndarray)
+
+    lv = tf.to_literal(ctx, python_val, type(python_val), lt)  # type: ignore
+    assert lv.scalar.blob.metadata == BlobMetadata(
+        type=BlobType(
+            format=NumpyArrayTransformer.NUMPY_ARRAY_FORMAT,
+            dimensionality=BlobType.BlobDimensionality.SINGLE,
+        )
+    )
+    assert lv.scalar.blob.uri is not None
+
+    output = tf.to_python_value(ctx, lv, np.ndarray)
+    assert_array_equal(output, python_val)
+
+
+def test_example():
+    @task
+    def t1(array: np.ndarray) -> np.ndarray:
+        return array.flatten()
+
+    task_spec = get_serializable(OrderedDict(), serialization_settings, t1)
+    assert task_spec.template.interface.outputs["o0"].type.blob.format is NumpyArrayTransformer.NUMPY_ARRAY_FORMAT

--- a/tests/flytekit/unit/types/numpy/test_ndarray.py
+++ b/tests/flytekit/unit/types/numpy/test_ndarray.py
@@ -1,0 +1,71 @@
+import numpy as np
+
+from flytekit import task, workflow
+
+
+@task
+def generate_numpy_1d() -> np.ndarray:
+    return np.array([1, 2, 3, 4, 5, 6], dtype=int)
+
+
+@task
+def generate_numpy_2d() -> np.ndarray:
+    return np.array([[1.8, 2.9, 3.1], [5.4, 6.0, 7.7]])
+
+
+@task
+def generate_numpy_dtype_object() -> np.ndarray:
+    # dtype=object cannot be serialized
+    return np.array(
+        [
+            [
+                405,
+                162,
+                414,
+                0,
+                np.array([list([1, 9, 2]), 18, (405, 18, 207), 64, "Universal"], dtype=object),
+                0,
+                0,
+                0,
+            ]
+        ],
+        dtype=object,
+    )
+
+
+@task
+def t1(array: np.ndarray) -> np.ndarray:
+    assert array.dtype == int
+    output = np.empty(len(array))
+    for i in range(len(array)):
+        output[i] = 1.0 / array[i]
+    return output
+
+
+@task
+def t2(array: np.ndarray) -> np.ndarray:
+    return array.flatten()
+
+
+@task
+def t3(array: np.ndarray) -> np.ndarray:
+    # convert 1D numpy array to 3D
+    return array.reshape(2, 3)
+
+
+@workflow
+def wf():
+    array_1d = generate_numpy_1d()
+    array_2d = generate_numpy_2d()
+    try:
+        generate_numpy_dtype_object()
+    except Exception as e:
+        assert isinstance(e, TypeError)
+    t1(array=array_1d)
+    t2(array=array_2d)
+    t3(array=array_1d)
+
+
+@workflow
+def test_wf():
+    wf()


### PR DESCRIPTION
Signed-off-by: Samhita Alla <aallasamhita@gmail.com>

# TL;DR
This PR adds support for `numpy.ndarray` as a native Flyte type.
**One caveat: object Numpy arrays cannot be serialized and unserialized.** 

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [x] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2544

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
