### PR TITLE
Allow using underscores and numeric in the image name

### DIFF
--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -253,4 +253,4 @@ def get_registerable_container_image(img: Optional[str], cfg: ImageConfig) -> st
 # fqn will access the fully qualified name of the image (e.g. registry/imagename:version -> registry/imagename)
 # version will access the version part of the image (e.g. registry/imagename:version -> version)
 # With empty attribute, it'll access the full image path (e.g. registry/imagename:version -> registry/imagename:version)
-_IMAGE_REPLACE_REGEX = re.compile(r"({{\s*\.image[s]?(?:\.([a-zA-Z]+))(?:\.([a-zA-Z]+))?\s*}})", re.IGNORECASE)
+_IMAGE_REPLACE_REGEX = re.compile(r"({{\s*\.image[s]?(?:\.([a-zA-Z0-9_]+))(?:\.([a-zA-Z0-9_]+))?\s*}})", re.IGNORECASE)

--- a/tests/flytekit/unit/core/configs/images.config
+++ b/tests/flytekit/unit/core/configs/images.config
@@ -1,3 +1,4 @@
 [images]
 xyz=docker.io/xyz:latest
 abc=docker.io/abc
+xyz_123=docker.io/xyz_123:v1

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -250,6 +250,10 @@ def test_serialization_images():
     def t5(a: int) -> int:
         return a
 
+    @task(container_image="{{.image.xyz_123.fqn}}:{{.image.xyz_123.version}}")
+    def t6(a: int) -> int:
+        return a
+
     os.environ["FLYTE_INTERNAL_IMAGE"] = "docker.io/default:version"
     imgs = ImageConfig.auto(
         config_file=os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/images.config")
@@ -273,6 +277,9 @@ def test_serialization_images():
 
     t5_spec = get_serializable(OrderedDict(), rs, t5)
     assert t5_spec.template.container.image == "docker.io/org/myimage:latest"
+
+    t5_spec = get_serializable(OrderedDict(), rs, t6)
+    assert t5_spec.template.container.image == "docker.io/xyz_123:v1"
 
 
 def test_serialization_command1():


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Failed to run this example https://github.com/flyteorg/flytesnacks/pull/750 because we can't use underscores inside image_name `{{ .image.trainer_image.fqn }}.` 

Error message in the sandbox:
```bash=
containers with unready status: [ag2544qfr4zg4tprq6tq-n0-0]|Failed to apply default image tag "
{{.image.trainer_image.fqn}}:{{.image.trainer_image.version}}": couldn't parse image reference "
{{.image.trainer_image.fqn}}:{{.image.trainer_image.version}}": invalid reference format
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
updated regex

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_