### PR TITLE
Add deck_uri to NodeExecution

### DIFF
--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -1004,3 +1004,17 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
                 expires_in=expires_in_pb,
             )
         )
+
+    def get_download_signed_url(
+        self, native_url: str, expires_in: datetime.timedelta = None
+    ) -> _data_proxy_pb2.CreateUploadLocationResponse:
+        expires_in_pb = None
+        if expires_in:
+            expires_in_pb = Duration()
+            expires_in_pb.FromTimedelta(expires_in)
+        return super(SynchronousFlyteClient, self).create_download_location(
+            _data_proxy_pb2.CreateDownloadLocationRequest(
+                native_url=native_url,
+                expires_in=expires_in_pb,
+            )
+        )

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -833,6 +833,17 @@ class RawSynchronousFlyteClient(object):
         """
         return self._dataproxy_stub.CreateUploadLocation(create_upload_location_request, metadata=self._metadata)
 
+    @_handle_rpc_error(retry=True)
+    def create_download_location(
+        self, create_download_location_request: _dataproxy_pb2.CreateDownloadLocationRequest
+    ) -> _dataproxy_pb2.CreateDownloadLocationResponse:
+        """
+        Get a signed url to be used during fast registration
+        :param flyteidl.service.dataproxy_pb2.CreateDownloadLocationRequest create_download_location_request:
+        :rtype: flyteidl.service.dataproxy_pb2.CreateDownloadLocationResponse
+        """
+        return self._dataproxy_stub.CreateDownloadLocation(create_download_location_request, metadata=self._metadata)
+
 
 def get_token(token_endpoint, authorization_header, scope):
     """

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from jinja2 import Environment, FileSystemLoader
 
-from flytekit.core.context_manager import ExecutionParameters, FlyteContext, FlyteContextManager
+from flytekit.core.context_manager import ExecutionParameters, ExecutionState, FlyteContext, FlyteContextManager
 from flytekit.loggers import logger
 
 OUTPUT_DIR_JUPYTER_PREFIX = "jupyter"
@@ -98,7 +98,11 @@ def _get_deck(new_user_params: ExecutionParameters):
 
 
 def _output_deck(task_name: str, new_user_params: ExecutionParameters):
-    output_dir = FlyteContext.current_context().file_access.get_random_local_directory()
+    ctx = FlyteContext.current_context()
+    if ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
+        output_dir = ctx.execution_state.engine_dir
+    else:
+        output_dir = ctx.file_access.get_random_local_directory()
     deck_path = os.path.join(output_dir, DECK_FILE_NAME)
     with open(deck_path, "w") as f:
         f.write(_get_deck(new_user_params))

--- a/flytekit/deck/html/template.html
+++ b/flytekit/deck/html/template.html
@@ -21,13 +21,21 @@
 
         #flyte-frame-tabs {
             display: flex;
+            width: 100%;
+            justify-content: center;
+            margin-block: 0;
+            padding-inline-start: 0;
         }
 
         #flyte-frame-tabs li {
             cursor: pointer;
-            flex: auto;
-            padding: 2rem;
-            margin: 0 1rem;
+            padding: 10px 10px;
+            margin: 0;
+            margin-right: 10px;
+        }
+
+        #flyte-frame-tabs li:last-child {
+            margin-right: 0;
         }
 
         #flyte-frame-tabs li.active {
@@ -44,7 +52,7 @@
 
         #flyte-frame-container > div.active {
             display: block;
-            padding: 1rem 4rem;
+            padding: 2rem 4rem;
         }
     </style>
 

--- a/flytekit/deck/html/template.html
+++ b/flytekit/deck/html/template.html
@@ -39,6 +39,8 @@
             font-style: normal;
             font-family: Open Sans, helvetica, arial, sans-serif;
             color: #666666;
+            width: 126px;
+            text-align: center;
         }
 
         #flyte-frame-tabs li:last-child {

--- a/flytekit/deck/html/template.html
+++ b/flytekit/deck/html/template.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>User Content</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700%7COpen+Sans:400,700" rel="stylesheet">
     <style>
         ol, ul {
             list-style: none;
@@ -29,9 +30,15 @@
 
         #flyte-frame-tabs li {
             cursor: pointer;
-            padding: 10px 10px;
+            padding: 8px;
             margin: 0;
-            margin-right: 10px;
+            margin-right: 12px;
+            font-size: 14px;
+            line-height: 20px;
+            font-weight: 700;
+            font-style: normal;
+            font-family: Open Sans, helvetica, arial, sans-serif;
+            color: #666666;
         }
 
         #flyte-frame-tabs li:last-child {
@@ -39,7 +46,8 @@
         }
 
         #flyte-frame-tabs li.active {
-            border-bottom: 3px solid rgb(163, 26, 255);
+            border-bottom: 4px solid rgb(163, 26, 255);
+            color: #333333;
         }
 
         #flyte-frame-container {
@@ -57,7 +65,6 @@
     </style>
 
 </head>
-
 <body>
     <nav id="flyte-frame-nav">
         <ul id="flyte-frame-tabs">

--- a/flytekit/models/node_execution.py
+++ b/flytekit/models/node_execution.py
@@ -195,7 +195,7 @@ class NodeExecutionClosure(_common_models.FlyteIdlEntity):
         return cls(
             phase=p.phase,
             output_uri=p.output_uri if p.HasField("output_uri") else None,
-            deck_uri=p.deck_uri if p.deck_uri else None,
+            deck_uri=p.deck_uri if p.HasField("output_uri") else None,
             error=_core_execution.ExecutionError.from_flyte_idl(p.error) if p.HasField("error") else None,
             started_at=p.started_at.ToDatetime().replace(tzinfo=_pytz.UTC),
             duration=p.duration.ToTimedelta(),

--- a/flytekit/models/node_execution.py
+++ b/flytekit/models/node_execution.py
@@ -92,6 +92,7 @@ class NodeExecutionClosure(_common_models.FlyteIdlEntity):
         started_at,
         duration,
         output_uri=None,
+        deck_uri=None,
         error=None,
         workflow_node_metadata: typing.Optional[WorkflowNodeMetadata] = None,
         task_node_metadata: typing.Optional[TaskNodeMetadata] = None,
@@ -107,6 +108,7 @@ class NodeExecutionClosure(_common_models.FlyteIdlEntity):
         self._started_at = started_at
         self._duration = duration
         self._output_uri = output_uri
+        self._deck_uri = deck_uri
         self._error = error
         self._workflow_node_metadata = workflow_node_metadata
         self._task_node_metadata = task_node_metadata
@@ -141,6 +143,13 @@ class NodeExecutionClosure(_common_models.FlyteIdlEntity):
         return self._output_uri
 
     @property
+    def deck_uri(self):
+        """
+        :rtype: str
+        """
+        return self._deck_uri
+
+    @property
     def error(self):
         """
         :rtype: flytekit.models.core.execution.ExecutionError
@@ -166,6 +175,7 @@ class NodeExecutionClosure(_common_models.FlyteIdlEntity):
         obj = _node_execution_pb2.NodeExecutionClosure(
             phase=self.phase,
             output_uri=self.output_uri,
+            deck_uri=self.deck_uri,
             error=self.error.to_flyte_idl() if self.error is not None else None,
             workflow_node_metadata=self.workflow_node_metadata.to_flyte_idl()
             if self.workflow_node_metadata is not None
@@ -185,6 +195,7 @@ class NodeExecutionClosure(_common_models.FlyteIdlEntity):
         return cls(
             phase=p.phase,
             output_uri=p.output_uri if p.HasField("output_uri") else None,
+            deck_uri=p.deck_uri if p.deck_uri else None,
             error=_core_execution.ExecutionError.from_flyte_idl(p.error) if p.HasField("error") else None,
             started_at=p.started_at.ToDatetime().replace(tzinfo=_pytz.UTC),
             duration=p.duration.ToTimedelta(),


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
- Added deck_uri to NodeExecution
- Added `get_download_signed_url` to get a signed url from data proxy
- Updated HTML template 
- Upload deck file to s3 if running remotely

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
New HTML template
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/37936015/172500671-10e759ce-1118-4805-ac40-7bb0fb994f5a.png">


## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
