### PR TITLE
Fix wrong version help string in `pyflyte register`

### DIFF
--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -97,7 +97,7 @@ Note: This command only works on regular Python packages, not namespace packages
     "--version",
     required=False,
     type=str,
-    help="Service account used when creating launch plans",
+    help="Version the package or module is registered with",
 )
 @click.argument("package-or-module", type=click.Path(exists=True, readable=True, resolve_path=True), nargs=-1)
 @click.pass_context


### PR DESCRIPTION
# TL;DR
The `click.option("-v", "--version", ..)` currently has the help string from `@click.option("--service-account", ...)`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
