### PR TITLE
Fix get client in flyte-cli commands

### DIFF
--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -4,6 +4,7 @@ import os
 import os as _os
 import stat as _stat
 import sys as _sys
+from dataclasses import replace
 from typing import Callable, Dict, List, Tuple, Union
 
 import click as _click
@@ -276,7 +277,7 @@ def _get_client(host: str, insecure: bool) -> _friendly_client.SynchronousFlyteC
     if parent_ctx.obj["cacert"]:
         kwargs["root_certificates"] = parent_ctx.obj["cacert"]
     cfg = parent_ctx.obj["config"]
-    cfg = cfg.with_parameters(endpoint=host, insecure=insecure)
+    cfg = replace(cfg, endpoint=host, insecure=insecure)
 
     return _friendly_client.SynchronousFlyteClient(cfg, **kwargs)
 

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -317,28 +317,6 @@ class PlatformConfig(object):
     scopes: List[str] = field(default_factory=list)
     auth_mode: AuthType = AuthType.STANDARD
 
-    def with_parameters(
-        self,
-        endpoint: str = "localhost:30081",
-        insecure: bool = False,
-        insecure_skip_verify: bool = False,
-        command: typing.Optional[typing.List[str]] = None,
-        client_id: typing.Optional[str] = None,
-        client_credentials_secret: typing.Optional[str] = None,
-        scopes: List[str] = None,
-        auth_mode: AuthType = AuthType.STANDARD,
-    ) -> PlatformConfig:
-        return PlatformConfig(
-            endpoint=endpoint,
-            insecure=insecure,
-            insecure_skip_verify=insecure_skip_verify,
-            command=command,
-            client_id=client_id,
-            client_credentials_secret=client_credentials_secret,
-            scopes=scopes if scopes else [],
-            auth_mode=auth_mode,
-        )
-
     @classmethod
     def auto(cls, config_file: typing.Optional[typing.Union[str, ConfigFile]] = None) -> PlatformConfig:
         """

--- a/tests/flytekit/unit/cli/pyflyte/test_main.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_main.py
@@ -1,0 +1,34 @@
+import mock
+
+from flytekit.clis.flyte_cli.main import _get_client
+from flytekit.configuration import AuthType, PlatformConfig
+
+
+@mock.patch("flytekit.clients.friendly.SynchronousFlyteClient")
+@mock.patch("click.get_current_context")
+def test_get_client(click_current_ctx, mock_flyte_client):
+    # This class helps in the process of overriding __getitem__ in an object.
+    class FlexiMock(mock.MagicMock):
+        def __init__(self, *args, **kwargs):
+            super(FlexiMock, self).__init__(*args, **kwargs)
+            self.__getitem__ = lambda obj, item: getattr(obj, item)  # set the mock for `[...]`
+
+        def get(self, x, default=None):
+            return getattr(self, x, default)
+
+    click_current_ctx = mock.MagicMock
+    obj_mock = FlexiMock(
+        config=PlatformConfig(auth_mode=AuthType.EXTERNAL_PROCESS),
+        cacert=None,
+    )
+    click_current_ctx.obj = obj_mock
+
+    _ = _get_client(host="some-host:12345", insecure=False)
+
+    expected_platform_config = PlatformConfig(
+        endpoint="some-host:12345",
+        insecure=False,
+        auth_mode=AuthType.EXTERNAL_PROCESS,
+    )
+
+    mock_flyte_client.assert_called_with(expected_platform_config)


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Fix copy of dataclass in get_client in flyte-cli commands

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Used `dataclasses.replace` to generate a copy of the PlatformConfig instead of the `with_parameters`.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2614

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
