### PR TITLE
Fix port rewrite in the case of sandbox/demo cluster

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -569,7 +569,7 @@ class Config(object):
         :return: Config
         """
         return Config(
-            platform=PlatformConfig(insecure=True),
+            platform=PlatformConfig(auth_mode="Pkce", insecure=True),
             data_config=DataConfig(
                 s3=S3Config(endpoint="http://localhost:30084", access_key_id="minio", secret_access_key="miniostorage")
             ),

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -569,7 +569,7 @@ class Config(object):
         :return: Config
         """
         return Config(
-            platform=PlatformConfig(auth_mode="Pkce", insecure=True),
+            platform=PlatformConfig(endpoint="localhost:30081", auth_mode="Pkce", insecure=True),
             data_config=DataConfig(
                 s3=S3Config(endpoint="http://localhost:30084", access_key_id="minio", secret_access_key="miniostorage")
             ),

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -193,3 +193,21 @@ def test_more_stuff(mock_client):
     # should give a different thing
     computed_v3 = r._version_from_hash(b"", serialization_settings, "hi")
     assert computed_v2 != computed_v3
+
+
+@patch("flytekit.remote.remote.SynchronousFlyteClient")
+def test_generate_http_domain_sandbox_rewrite(mock_client):
+    _, temp_filename = tempfile.mkstemp(suffix=".yaml")
+    with open(temp_filename, "w") as f:
+        # This string is similar to the relevant configuration emitted by flytectl in the cases of both demo and sandbox.
+        flytectl_config_file = """admin:
+    endpoint: localhost:30081
+    authType: Pkce
+    insecure: true
+        """
+        f.write(flytectl_config_file)
+
+    remote = FlyteRemote(
+        config=Config.auto(config_file=temp_filename), default_project="project", default_domain="domain"
+    )
+    assert remote.generate_http_domain() == "http://localhost:30080"


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Fix port rewrite in the case of sandbox/demo cluster

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
We rewrite the flyteconsole port in case we detect that we're running on a sandbox/demo cluster. However, https://github.com/flyteorg/flytekit/pull/992/ made it so that `auth_type` is now read from the config file (as opposed to getting the default value). 

The fix is to ensure that the platform config for sandbox matches the one emitted by `flytectl`. 

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2615

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
