### PR TITLE
Fix serialization of tasks with environment variables set

### DIFF
--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -156,7 +156,10 @@ class PythonAutoContainerTask(PythonTask[T], ABC, metaclass=FlyteTrackedABC):
         return self._get_command_fn(settings)
 
     def get_container(self, settings: SerializationSettings) -> _task_model.Container:
-        env = {**settings.env, **self.environment} if self.environment else settings.env
+        env = {}
+        for elem in (settings.env, self.environment):
+            if elem:
+                env.update(elem)
         return _get_container_definition(
             image=get_registerable_container_image(self.container_image, settings.image_config),
             command=[],


### PR DESCRIPTION
# TL;DR
Fixes serialization of tasks with environment variables set.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Fixes `PythonAutoContainer.get_container` to handle the case where `SerializationSettings.env` is `None` (See: https://github.com/flyteorg/flytekit/blob/87d13903993d5339723ecd859bd362a64e780aec/flytekit/configuration/__init__.py#L638). Currently fails with:
```
Traceback (most recent call last):
  File "/fn/bin/pyflyte", line 8, in <module>
    sys.exit(main())
  File "/fn/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/fn/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/fn/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/fn/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/fn/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/fn/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/fn/lib/python3.9/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/fn/lib/python3.9/site-packages/flytekit/clis/sdk_in_container/serialize.py", line 139, in workflows
    serialize_all(
  File "/fn/lib/python3.9/site-packages/flytekit/exceptions/scopes.py", line 160, in system_entry_point
    return wrapped(*args, **kwargs)
  File "/fn/lib/python3.9/site-packages/flytekit/clis/sdk_in_container/serialize.py", line 69, in serialize_all
    serialize_to_folder(pkgs, serialization_settings, local_source_root, folder)
  File "/fn/lib/python3.9/site-packages/flytekit/tools/repo.py", line 61, in serialize_to_folder
    loaded_entities = serialize(pkgs, settings, local_source_root, options=options)
  File "/fn/lib/python3.9/site-packages/flytekit/tools/repo.py", line 46, in serialize
    registrable_entities = get_registrable_entities(ctx, options=options)
  File "/fn/lib/python3.9/site-packages/flytekit/tools/serialize_helpers.py", line 77, in get_registrable_entities
    get_serializable(new_api_serializable_entities, ctx.serialization_settings, entity, options=options)
  File "/fn/lib/python3.9/site-packages/flytekit/tools/translator.py", line 573, in get_serializable
    cp_entity = get_serializable_task(entity_mapping, settings, entity)
  File "/fn/lib/python3.9/site-packages/flytekit/tools/translator.py", line 173, in get_serializable_task
    container = entity.get_container(settings)
  File "/fn/lib/python3.9/site-packages/flytekit/core/python_auto_container.py", line 159, in get_container
    env = {**settings.env, **self.environment} if self.environment else settings.env
TypeError: 'NoneType' object is not a mapping
```