### PR TITLE
Return deck html string when calling get_deck()

### DIFF
--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -617,10 +617,10 @@ class FlyteContext(object):
         """
         return FlyteContextManager.current_context()
 
-    def get_deck(self):
+    def get_deck(self) -> str:
         from flytekit.deck.deck import _get_deck
 
-        _get_deck(self.execution_state.user_space_params)
+        return _get_deck(self.execution_state.user_space_params)
 
     @dataclass
     class Builder(object):

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -89,7 +89,7 @@ def _ipython_check() -> bool:
     return is_ipython
 
 
-def _get_deck(new_user_params: ExecutionParameters):
+def _get_deck(new_user_params: ExecutionParameters) -> str:
     """
     Get flyte deck html string
     """

--- a/tests/flytekit/unit/deck/test_deck.py
+++ b/tests/flytekit/unit/deck/test_deck.py
@@ -43,4 +43,5 @@ def test_deck_in_jupyter(mock_ipython_check):
 
     with flytekit.new_context() as ctx:
         t1(a=3)
-        ctx.get_deck()
+        deck = ctx.get_deck()
+        assert deck is not None


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
nit: We forgot return HTML string in get_deck()

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
