### PR TITLE
Housekeeping for pyflyte package and register commands

### DIFF
--- a/flytekit/clis/helpers.py
+++ b/flytekit/clis/helpers.py
@@ -1,5 +1,7 @@
+import sys
 from typing import Tuple, Union
 
+import click
 from flyteidl.admin.launch_plan_pb2 import LaunchPlan
 from flyteidl.admin.task_pb2 import TaskSpec
 from flyteidl.admin.workflow_pb2 import WorkflowSpec
@@ -125,3 +127,9 @@ def hydrate_registration_parameters(
     del entity.sub_workflows[:]
     entity.sub_workflows.extend(refreshed_sub_workflows)
     return identifier, entity
+
+
+def display_help_with_error(ctx: click.Context, message: str):
+    click.echo(f"{ctx.get_help()}\n")
+    click.secho(message, fg="red")
+    sys.exit(1)

--- a/flytekit/clis/sdk_in_container/package.py
+++ b/flytekit/clis/sdk_in_container/package.py
@@ -100,6 +100,7 @@ def package(ctx, image_config, source, output, force, fast, in_container_source_
 
     pkgs = ctx.obj[constants.CTX_PACKAGES]
     if not pkgs:
+        click.echo(f"{ctx.get_help()}\n")
         click.secho("No packages to scan for flyte entities. Aborting!", fg="red")
         sys.exit(-1)
 

--- a/flytekit/clis/sdk_in_container/package.py
+++ b/flytekit/clis/sdk_in_container/package.py
@@ -102,7 +102,7 @@ def package(ctx, image_config, source, output, force, fast, in_container_source_
     if not pkgs:
         click.echo(f"{ctx.get_help()}\n")
         click.secho("No packages to scan for flyte entities. Aborting!", fg="red")
-        sys.exit(-1)
+        sys.exit(1)
 
     try:
         serialize_and_package(pkgs, serialization_settings, source, output, fast)

--- a/flytekit/clis/sdk_in_container/package.py
+++ b/flytekit/clis/sdk_in_container/package.py
@@ -41,7 +41,7 @@ from flytekit.tools.repo import NoSerializableEntitiesError, serialize_and_packa
     "--output",
     required=False,
     type=click.Path(dir_okay=False, writable=True, resolve_path=True, allow_dash=True),
-    default="flyte-package.tgz",
+    default=None,
     help="filesystem path to the source of the python package (from where the pkgs will start).",
 )
 @click.option(
@@ -86,7 +86,7 @@ def package(ctx, image_config, source, output, force, fast, in_container_source_
         object contains the WorkflowTemplate, along with the relevant tasks for that workflow.
         This serialization step will set the name of the tasks to the fully qualified name of the task function.
     """
-    if os.path.exists(output) and not force:
+    if output is not None and os.path.exists(output) and not force:
         raise click.BadParameter(click.style(f"Output file {output} already exists, specify -f to override.", fg="red"))
 
     serialization_settings = SerializationSettings(

--- a/flytekit/clis/sdk_in_container/package.py
+++ b/flytekit/clis/sdk_in_container/package.py
@@ -41,7 +41,7 @@ from flytekit.tools.repo import NoSerializableEntitiesError, serialize_and_packa
     "--output",
     required=False,
     type=click.Path(dir_okay=False, writable=True, resolve_path=True, allow_dash=True),
-    default=None,
+    default="flyte-package.tgz",
     help="filesystem path to the source of the python package (from where the pkgs will start).",
 )
 @click.option(
@@ -86,7 +86,7 @@ def package(ctx, image_config, source, output, force, fast, in_container_source_
         object contains the WorkflowTemplate, along with the relevant tasks for that workflow.
         This serialization step will set the name of the tasks to the fully qualified name of the task function.
     """
-    if output is not None and os.path.exists(output) and not force:
+    if os.path.exists(output) and not force:
         raise click.BadParameter(click.style(f"Output file {output} already exists, specify -f to override.", fg="red"))
 
     serialization_settings = SerializationSettings(

--- a/flytekit/clis/sdk_in_container/package.py
+++ b/flytekit/clis/sdk_in_container/package.py
@@ -1,8 +1,8 @@
 import os
-import sys
 
 import click
 
+from flytekit.clis.helpers import display_help_with_error
 from flytekit.clis.sdk_in_container import constants
 from flytekit.configuration import (
     DEFAULT_RUNTIME_PYTHON_INTERPRETER,
@@ -100,9 +100,7 @@ def package(ctx, image_config, source, output, force, fast, in_container_source_
 
     pkgs = ctx.obj[constants.CTX_PACKAGES]
     if not pkgs:
-        click.echo(f"{ctx.get_help()}\n")
-        click.secho("No packages to scan for flyte entities. Aborting!", fg="red")
-        sys.exit(1)
+        display_help_with_error(ctx, "No packages to scan for flyte entities. Aborting!")
 
     try:
         serialize_and_package(pkgs, serialization_settings, source, output, fast)

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -1,10 +1,10 @@
 import os
 import pathlib
-import sys
 import typing
 
 import click
 
+from flytekit.clis.helpers import display_help_with_error
 from flytekit.clis.sdk_in_container import constants
 from flytekit.clis.sdk_in_container.helpers import get_and_save_remote_with_click_context
 from flytekit.configuration import FastSerializationSettings, ImageConfig, SerializationSettings
@@ -123,12 +123,10 @@ def register(
         raise ValueError("Unimplemented, just specify pkgs like folder/files as args at the end of the command")
 
     if len(package_or_module) == 0:
-        click.echo(f"{ctx.get_help()}\n")
-        click.secho(
+        display_help_with_error(
+            ctx,
             "Missing argument 'PACKAGE_OR_MODULE...', at least one PACKAGE_OR_MODULE is required but multiple can be passed",
-            fg="red",
         )
-        sys.exit(1)
 
     cli_logger.debug(
         f"Running pyflyte register from {os.getcwd()} "
@@ -170,9 +168,7 @@ def register(
         serialization_settings, detected_root, list(package_or_module), options
     )
     if len(registerable_entities) == 0:
-        click.echo(f"{ctx.get_help()}\n")
-        click.secho("No Flyte entities were detected. Aborting!", fg="red")
-        sys.exit(1)
+        display_help_with_error(ctx, "No Flyte entities were detected. Aborting!")
     cli_logger.info(f"Found and serialized {len(registerable_entities)} entities")
 
     if not version:

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -128,7 +128,7 @@ def register(
             "Missing argument 'PACKAGE_OR_MODULE...', at least one PACKAGE_OR_MODULE is required but multiple can be passed",
             fg="red",
         )
-        sys.exit(-1)
+        sys.exit(1)
 
     cli_logger.debug(
         f"Running pyflyte register from {os.getcwd()} "
@@ -170,6 +170,7 @@ def register(
         serialization_settings, detected_root, list(package_or_module), options
     )
     if len(registerable_entities) == 0:
+        click.echo(f"{ctx.get_help()}\n")
         click.secho("No Flyte entities were detected. Aborting!", fg="red")
         sys.exit(1)
     cli_logger.info(f"Found and serialized {len(registerable_entities)} entities")

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -122,6 +122,14 @@ def register(
     if pkgs:
         raise ValueError("Unimplemented, just specify pkgs like folder/files as args at the end of the command")
 
+    if len(package_or_module) == 0:
+        click.echo(f"{ctx.get_help()}\n")
+        click.secho(
+            "Missing argument 'PACKAGE_OR_MODULE...', at least one PACKAGE_OR_MODULE is required but multiple can be passed",
+            fg="red",
+        )
+        sys.exit(-1)
+
     cli_logger.debug(
         f"Running pyflyte register from {os.getcwd()} "
         f"with images {image_config} "

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -149,13 +149,6 @@ def register(
     md5_bytes, native_url = remote._upload_file(pathlib.Path(zip_file))
     cli_logger.debug(f"Uploaded zip {zip_file} to {native_url}")
 
-    # Clean-up temporary directory that was used for fast registration
-    if zip_file.startswith(tempfile.gettempdir()):
-        os.remove(zip_file)
-        tempdir_path = zip_file[: zip_file.rfind(os.sep)]
-        click.secho(f"Deleting the temporary directory at {tempdir_path} used for fast registration", fg="yellow")
-        os.rmdir(tempdir_path)
-
     # Create serialization settings
     # Todo: Rely on default Python interpreter for now, this will break custom Spark containers
     serialization_settings = SerializationSettings(

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import tempfile
 import typing
 
 import click
@@ -67,7 +68,7 @@ Note: This command only works on regular Python packages, not namespace packages
     "--output",
     required=False,
     type=click.Path(dir_okay=True, file_okay=False, writable=True, resolve_path=True),
-    default=".",
+    default=None,
     help="Directory to write the output zip file containing the protobuf definitions",
 )
 @click.option(
@@ -147,6 +148,13 @@ def register(
     # Upload zip file to Admin using FlyteRemote.
     md5_bytes, native_url = remote._upload_file(pathlib.Path(zip_file))
     cli_logger.debug(f"Uploaded zip {zip_file} to {native_url}")
+
+    # Clean-up temporary directory that was used for fast registration
+    if zip_file.startswith(tempfile.gettempdir()):
+        os.remove(zip_file)
+        tempdir_path = zip_file[: zip_file.rfind(os.sep)]
+        click.secho(f"Deleting the temporary directory at {tempdir_path} used for fast registration", fg="yellow")
+        os.rmdir(tempdir_path)
 
     # Create serialization settings
     # Todo: Rely on default Python interpreter for now, this will break custom Spark containers

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -1,6 +1,5 @@
 import os
 import pathlib
-import tempfile
 import typing
 
 import click

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -9,6 +9,8 @@ import tarfile
 import tempfile
 from typing import Optional
 
+import click
+
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.tools.ignore import DockerIgnore, GitIgnore, IgnoreGroup, StandardIgnore
 from flytekit.tools.script_mode import tar_strip_file_attributes
@@ -31,8 +33,11 @@ def fast_package(source: os.PathLike, output_dir: os.PathLike) -> os.PathLike:
     digest = compute_digest(source, ignore.is_ignored)
     archive_fname = f"{FAST_PREFIX}{digest}{FAST_FILEENDING}"
 
-    if output_dir:
-        archive_fname = os.path.join(output_dir, archive_fname)
+    if output_dir is None:
+        output_dir = tempfile.mkdtemp()
+        click.secho(f"Output given as {None}, using a temporary directory at {output_dir} instead", fg="yellow")
+
+    archive_fname = os.path.join(output_dir, archive_fname)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         tar_path = os.path.join(tmp_dir, "tmp.tar")

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -91,6 +91,10 @@ def package(
 
         # If Fast serialization is enabled, then an archive is also created and packaged
         if fast:
+            # If output exists and is a path within source, delete it so as to not re-bundle it again.
+            if os.path.abspath(output).startswith(os.path.abspath(source)) and os.path.exists(output):
+                click.secho(f"{output} already exists within {source}, deleting and re-creating it", fg="yellow")
+                os.remove(output)
             archive_fname = fast_registration.fast_package(source, output_tmpdir)
             click.secho(f"Fast mode enabled: compressed archive {archive_fname}", dim=True)
 

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -73,7 +73,7 @@ def serialize_to_folder(
 def package(
     registrable_entities: typing.List[RegistrableEntity],
     source: str = ".",
-    output: str = "./flyte-package.tgz",
+    output: typing.Optional[str] = None,
     fast: bool = False,
 ):
     """
@@ -85,6 +85,14 @@ def package(
     """
     if not registrable_entities:
         raise NoSerializableEntitiesError("Nothing to package")
+
+    if output is None:
+        # Avoiding use of context manager as the directory will be deleted once the context completes
+        output_res_tmpdir = tempfile.TemporaryDirectory()
+        click.secho(
+            f"Output given as {output}, using a temporary directory at {output_res_tmpdir.name} instead", fg="yellow"
+        )
+        output = os.path.join(output_res_tmpdir.name, "flyte-package.tgz")
 
     with tempfile.TemporaryDirectory() as output_tmpdir:
         persist_registrable_entities(registrable_entities, output_tmpdir)
@@ -108,7 +116,7 @@ def serialize_and_package(
     pkgs: typing.List[str],
     settings: SerializationSettings,
     source: str = ".",
-    output: str = "./flyte-package.tgz",
+    output: typing.Optional[str] = None,
     fast: bool = False,
     options: typing.Optional[Options] = None,
 ):

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -73,7 +73,7 @@ def serialize_to_folder(
 def package(
     registrable_entities: typing.List[RegistrableEntity],
     source: str = ".",
-    output: typing.Optional[str] = None,
+    output: str = "./flyte-package.tgz",
     fast: bool = False,
 ):
     """
@@ -85,14 +85,6 @@ def package(
     """
     if not registrable_entities:
         raise NoSerializableEntitiesError("Nothing to package")
-
-    if output is None:
-        # Avoiding use of context manager as the directory will be deleted once the context completes
-        output_res_tmpdir = tempfile.TemporaryDirectory()
-        click.secho(
-            f"Output given as {output}, using a temporary directory at {output_res_tmpdir.name} instead", fg="yellow"
-        )
-        output = os.path.join(output_res_tmpdir.name, "flyte-package.tgz")
 
     with tempfile.TemporaryDirectory() as output_tmpdir:
         persist_registrable_entities(registrable_entities, output_tmpdir)
@@ -116,7 +108,7 @@ def serialize_and_package(
     pkgs: typing.List[str],
     settings: SerializationSettings,
     source: str = ".",
-    output: typing.Optional[str] = None,
+    output: str = "./flyte-package.tgz",
     fast: bool = False,
     options: typing.Optional[Options] = None,
 ):

--- a/tests/flytekit/unit/cli/pyflyte/conftest.py
+++ b/tests/flytekit/unit/cli/pyflyte/conftest.py
@@ -18,7 +18,7 @@ def _fake_module_load(names):
     yield simple
 
 
-@pytest.yield_fixture(
+@pytest.fixture(
     scope="function",
     params=[
         os.path.join(

--- a/tests/flytekit/unit/cli/pyflyte/test_package.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_package.py
@@ -44,6 +44,21 @@ def test_get_registrable_entities():
         assert False, f"found unknown entity {type(e)}"
 
 
+def test_package_with_fast_registration():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(pyflyte.main, ["--pkgs", "core", "package", "--image", "core:v1", "--fast"])
+        assert result.exit_code == 0
+        assert "Successfully serialized" in result.output
+        assert "Successfully packaged" in result.output
+        result = runner.invoke(pyflyte.main, ["--pkgs", "core", "package", "--image", "core:v1", "--fast"])
+        assert result.exit_code == 2
+        assert "flyte-package.tgz already exists, specify -f to override" in result.output
+        result = runner.invoke(pyflyte.main, ["--pkgs", "core", "package", "--image", "core:v1", "--fast", "--force"])
+        assert result.exit_code == 0
+        assert "deleting and re-creating it" in result.output
+
+
 def test_duplicate_registrable_entities():
     @flytekit.task
     def t_1():

--- a/tests/flytekit/unit/cli/pyflyte/test_package.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_package.py
@@ -70,20 +70,16 @@ def test_package_with_fast_registration():
         with open(os.path.join("core", "sample.py"), "w") as f:
             f.write(sample_file_contents)
             f.close()
-        result = runner.invoke(
-            pyflyte.main, ["--pkgs", "core", "package", "--image", "core:v1", "--fast", "-o", "flyte-package.tgz"]
-        )
+        result = runner.invoke(pyflyte.main, ["--pkgs", "core", "package", "--image", "core:v1", "--fast"])
         assert result.exit_code == 0
         assert "Successfully serialized" in result.output
         assert "Successfully packaged" in result.output
-        result = runner.invoke(
-            pyflyte.main, ["--pkgs", "core", "package", "--image", "core:v1", "--fast", "-o", "flyte-package.tgz"]
-        )
+        result = runner.invoke(pyflyte.main, ["--pkgs", "core", "package", "--image", "core:v1", "--fast"])
         assert result.exit_code == 2
         assert "flyte-package.tgz already exists, specify -f to override" in result.output
         result = runner.invoke(
             pyflyte.main,
-            ["--pkgs", "core", "package", "--image", "core:v1", "--fast", "--force", "-o", "flyte-package.tgz"],
+            ["--pkgs", "core", "package", "--image", "core:v1", "--fast", "--force"],
         )
         assert result.exit_code == 0
         assert "deleting and re-creating it" in result.output

--- a/tests/flytekit/unit/cli/pyflyte/test_package.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_package.py
@@ -120,5 +120,5 @@ def test_package_with_no_pkgs():
     runner = CliRunner()
     with runner.isolated_filesystem():
         result = runner.invoke(pyflyte.main, ["package"])
-        assert result.exit_code == -1
+        assert result.exit_code == 1
         assert "No packages to scan for flyte entities. Aborting!" in result.output

--- a/tests/flytekit/unit/cli/pyflyte/test_package.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_package.py
@@ -114,3 +114,11 @@ def test_package():
 def test_pkgs():
     pp = pyflyte.validate_package(None, None, ["a.b", "a.c,b.a", "cc.a"])
     assert pp == ["a.b", "a.c", "b.a", "cc.a"]
+
+
+def test_package_with_no_pkgs():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(pyflyte.main, ["package"])
+        assert result.exit_code == -1
+        assert "No packages to scan for flyte entities. Aborting!" in result.output

--- a/tests/flytekit/unit/cli/pyflyte/test_register.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_register.py
@@ -1,5 +1,7 @@
 import mock
+from click.testing import CliRunner
 
+from flytekit.clis.sdk_in_container import pyflyte
 from flytekit.clis.sdk_in_container.helpers import get_and_save_remote_with_click_context
 
 
@@ -9,3 +11,14 @@ def test_saving_remote(mock_remote):
     mock_context.obj = {}
     get_and_save_remote_with_click_context(mock_context, "p", "d")
     assert mock_context.obj["flyte_remote"] is not None
+
+
+def test_register_with_no_package_or_module_argument():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(pyflyte.main, ["register"])
+        assert result.exit_code == -1
+        assert (
+            "Missing argument 'PACKAGE_OR_MODULE...', at least one PACKAGE_OR_MODULE is required but multiple can be passed"
+            in result.output
+        )

--- a/tests/flytekit/unit/cli/pyflyte/test_register.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_register.py
@@ -17,7 +17,7 @@ def test_register_with_no_package_or_module_argument():
     runner = CliRunner()
     with runner.isolated_filesystem():
         result = runner.invoke(pyflyte.main, ["register"])
-        assert result.exit_code == -1
+        assert result.exit_code == 1
         assert (
             "Missing argument 'PACKAGE_OR_MODULE...', at least one PACKAGE_OR_MODULE is required but multiple can be passed"
             in result.output

--- a/tests/flytekit/unit/cli/pyflyte/test_register.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_register.py
@@ -62,5 +62,4 @@ def test_register_with_no_output_dir_passed(mock_client, mock_remote):
             f.close()
         result = runner.invoke(pyflyte.main, ["register", "core"])
         assert "Output given as None, using a temporary directory at" in result.output
-        assert "Deleting the temporary directory at" in result.output
         shutil.rmtree("core")

--- a/tests/flytekit/unit/cli/pyflyte/test_register.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_register.py
@@ -1,8 +1,30 @@
+import os
+import shutil
+import subprocess
+
 import mock
 from click.testing import CliRunner
 
+from flytekit.clients.friendly import SynchronousFlyteClient
 from flytekit.clis.sdk_in_container import pyflyte
 from flytekit.clis.sdk_in_container.helpers import get_and_save_remote_with_click_context
+from flytekit.remote.remote import FlyteRemote
+
+sample_file_contents = """
+from flytekit import task, workflow
+
+@task(cache=True, cache_version="1", retries=3)
+def sum(x: int, y: int) -> int:
+    return x + y
+
+@task(cache=True, cache_version="1", retries=3)
+def square(z: int) -> int:
+    return z*z
+
+@workflow
+def my_workflow(x: int, y: int) -> int:
+    return sum(x=square(z=x), y=square(z=y))
+"""
 
 
 @mock.patch("flytekit.clis.sdk_in_container.helpers.FlyteRemote")
@@ -22,3 +44,23 @@ def test_register_with_no_package_or_module_argument():
             "Missing argument 'PACKAGE_OR_MODULE...', at least one PACKAGE_OR_MODULE is required but multiple can be passed"
             in result.output
         )
+
+
+@mock.patch("flytekit.clis.sdk_in_container.helpers.FlyteRemote", spec=FlyteRemote)
+@mock.patch("flytekit.clients.friendly.SynchronousFlyteClient", spec=SynchronousFlyteClient)
+def test_register_with_no_output_dir_passed(mock_client, mock_remote):
+    mock_remote._client = mock_client
+    mock_remote.return_value._version_from_hash.return_value = "dummy_version_from_hash"
+    mock_remote.return_value._upload_file.return_value = "dummy_md5_bytes", "dummy_native_url"
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        out = subprocess.run(["git", "init"], capture_output=True)
+        assert out.returncode == 0
+        os.makedirs("core", exist_ok=True)
+        with open(os.path.join("core", "sample.py"), "w") as f:
+            f.write(sample_file_contents)
+            f.close()
+        result = runner.invoke(pyflyte.main, ["register", "core"])
+        assert "Output given as None, using a temporary directory at" in result.output
+        assert "Deleting the temporary directory at" in result.output
+        shutil.rmtree("core")


### PR DESCRIPTION
# TL;DR

This PR shows a help message along with showing a nice error at the bottom, while also exiting with a non-zero exit code for commands such as `pyflyte package` and `pyflyte register` when they fail. It also fixes the issue of rebundling an existing `.tgz` file while using fast registration.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
1. A simple fix for `pyflyte register` when its argument `package_or_module` is not supplied, would have been to add `required=True` in its definition. This would have resulted in the following output after running `pyflyte register`:
```
Usage: pyflyte register [OPTIONS] PACKAGE_OR_MODULE...
Try 'pyflyte register --help' for help.

Error: Missing argument 'PACKAGE_OR_MODULE...'.
```

But, the documentation of `click` here: https://click.palletsprojects.com/en/8.1.x/arguments/#variadic-arguments in the section `Note on Non-Empty Variadic Arguments` doesn't recommend it.

Thus, an explicit check is done instead with the condition of `len(package_or_module) == 0`

2. Although the `help` message is displayed along with the error, it can be quite verbose. So we can also display only `usage` if required, for brevity. But for now, I have still chosen displaying of `help` for now as the original issue demands.

3. `Help` is only displayed for errors and not warnings aka things that lead to an exit with a non-zero status code, where error is displayed in Red. So it doesn't cover other cases where for eg: we display warning messages in Yellow and exit with a zero status code.

4. Initially, I wasn't able to reproduce the issue of doubling file size of the `.tgz` file during fast registration. The steps I followed are:
    - Make a directory called `core`, have a `sample.py` file in it with the contents from https://github.com/flyteorg/flytekit#a-simple-example
    - Use `pyflyte --pkgs core package --image core:v1 --fast` in the terminal to get a `flyte-package.tgz` in my current directory.
    - Use the same command again, but this time instead of getting a new `.tgz` file with double the size, I get the following:
    ```
    Usage: pyflyte package [OPTIONS]
    Try 'pyflyte package --help' for help.

    Error: Invalid value: Output file /Users/madhur/Desktop/unionml/flytekit/flyte-package.tgz already exists, specify -f to
    override.
    ```
    which is good I guess.
    - I then tried the same command again but with additional `--force` flag upon which I was able to reproduce the issue.

5. The idea of using temporary files for storing the `.tgz` files as suggested by the issue isn't the best one. According to the link here: https://stackoverflow.com/questions/18249314/are-tempfile-directories-eventually-cleared-by-system, it is suggested to handle the cleanup ourselves. On investigating a bit, it seems like the issue only occurs when the path of the `.tgz` file is present within the directory whose contents have to be packaged. A simple check for this along with an existence check for the `.tgz` file will resolve this, provided we clean-up the previous file when the above checks pass. I have also added logging and tests for this.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2638

## Follow-up issue
_NA_