### PR TITLE
Increase laziness of SerializationSettings

### DIFF
--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -195,7 +195,7 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):
             # This is the only circular dependency between the translator.py module and the rest of the flytekit
             # authoring experience.
             workflow_spec: admin_workflow_models.WorkflowSpec = get_serializable(
-                model_entities, ctx.serialization_settings, wf
+                model_entities, wf, ctx.serialization_settings
             )
 
             # If no nodes were produced, let's just return the strict outputs

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -368,7 +368,7 @@ class FlyteRemote(object):
         self,
         entity: FlyteLocalEntity,
         version: str,
-        settings: typing.Optional[SerializationSettings] = None,
+        settings: typing.Optional[SerializationSettings] = SerializationSettings(ImageConfig()),
         options: typing.Optional[Options] = None,
     ) -> Identifier:
         """
@@ -376,11 +376,6 @@ class FlyteRemote(object):
         :return: Identifier of the registered entity
         """
         m = OrderedDict()
-
-        if settings is None:
-            settings = SerializationSettings(
-                ImageConfig(), project=self.default_project, domain=self.default_domain, version=version
-            )
 
         _ = get_serializable(m, settings=settings, entity=entity, options=options)
 
@@ -447,7 +442,7 @@ class FlyteRemote(object):
     def register_task(
         self,
         entity: PythonTask,
-        serialization_settings: typing.Optional[SerializationSettings] = None,
+        serialization_settings: typing.Optional[SerializationSettings] = SerializationSettings(ImageConfig()),
         version: typing.Optional[str] = None,
     ) -> FlyteTask:
         """
@@ -472,7 +467,7 @@ class FlyteRemote(object):
     def register_workflow(
         self,
         entity: WorkflowBase,
-        serialization_settings: typing.Optional[SerializationSettings] = None,
+        serialization_settings: typing.Optional[SerializationSettings] = SerializationSettings(ImageConfig()),
         version: typing.Optional[str] = None,
         default_launch_plan: typing.Optional[bool] = True,
         options: typing.Optional[Options] = None,

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -621,6 +621,9 @@ class FlyteRemote(object):
             return self.register_task(entity, serialization_settings, version)
         return self.register_workflow(entity, serialization_settings, version, default_launch_plan, options)
 
+    # TODO: The function signature of `register_launch_plan` is different from `register_task` and `register_workflow`
+    # since the latter two have `SerializationSettings` in their arguments. This is inconsistent and ideally these 3
+    # should probably have similar API.
     def register_launch_plan(
         self,
         entity: LaunchPlan,

--- a/flytekit/tools/serialize_helpers.py
+++ b/flytekit/tools/serialize_helpers.py
@@ -72,11 +72,11 @@ def get_registrable_entities(
     #  object, which gets added to the FlyteEntities.entities list, which we're iterating over.
     for entity in flyte_context.FlyteEntities.entities.copy():
         if isinstance(entity, PythonTask) or isinstance(entity, WorkflowBase) or isinstance(entity, LaunchPlan):
-            get_serializable(new_api_serializable_entities, ctx.serialization_settings, entity, options=options)
+            get_serializable(new_api_serializable_entities, entity, ctx.serialization_settings, options=options)
 
             if isinstance(entity, WorkflowBase):
                 lp = LaunchPlan.get_default_launch_plan(ctx, entity)
-                get_serializable(new_api_serializable_entities, ctx.serialization_settings, lp, options)
+                get_serializable(new_api_serializable_entities, lp, ctx.serialization_settings, options)
 
     new_api_model_values = list(new_api_serializable_entities.values())
     entities_to_be_serialized = list(filter(_should_register_with_admin, new_api_model_values))

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 from flytekit import PythonFunctionTask
-from flytekit.configuration import ImageConfig, SerializationSettings
+from flytekit.configuration import SerializationSettings
 from flytekit.core import constants as _common_constants
 from flytekit.core.base_task import PythonTask
 from flytekit.core.condition import BranchNode
@@ -543,7 +543,7 @@ def get_reference_spec(
 def get_serializable(
     entity_mapping: OrderedDict,
     entity: FlyteLocalEntity,
-    settings: Optional[SerializationSettings] = SerializationSettings(ImageConfig()),
+    settings: Optional[SerializationSettings] = None,
     options: Optional[Options] = None,
 ) -> FlyteControlPlaneEntity:
     """

--- a/plugins/flytekit-aws-athena/tests/test_athena.py
+++ b/plugins/flytekit-aws-athena/tests/test_athena.py
@@ -36,7 +36,7 @@ def test_serialization():
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
         env={},
     )
-    task_spec = get_serializable(OrderedDict(), serialization_settings, athena_task)
+    task_spec = get_serializable(OrderedDict(), athena_task, serialization_settings)
     assert "{{ .rawOutputDataPrefix" in task_spec.template.custom["statement"]
     assert "insert overwrite directory" in task_spec.template.custom["statement"]
     assert "mnist" == task_spec.template.custom["schema"]
@@ -45,7 +45,7 @@ def test_serialization():
     assert len(task_spec.template.interface.inputs) == 1
     assert len(task_spec.template.interface.outputs) == 1
 
-    admin_workflow_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    admin_workflow_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert admin_workflow_spec.template.interface.outputs["o0"].type.schema is not None
     assert admin_workflow_spec.template.outputs[0].var == "o0"
     assert admin_workflow_spec.template.outputs[0].binding.promise.node_id == "n0"

--- a/plugins/flytekit-bigquery/tests/test_bigquery.py
+++ b/plugins/flytekit-bigquery/tests/test_bigquery.py
@@ -37,7 +37,7 @@ def test_serialization():
         env={},
     )
 
-    task_spec = get_serializable(OrderedDict(), serialization_settings, bigquery_task)
+    task_spec = get_serializable(OrderedDict(), bigquery_task, serialization_settings)
 
     assert "SELECT * FROM `bigquery-public-data.crypto_dogecoin.transactions`" in task_spec.template.sql.statement
     assert "@version" in task_spec.template.sql.statement
@@ -48,7 +48,7 @@ def test_serialization():
     assert len(task_spec.template.interface.inputs) == 1
     assert len(task_spec.template.interface.outputs) == 1
 
-    admin_workflow_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    admin_workflow_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert admin_workflow_spec.template.interface.outputs["o0"].type.structured_dataset_type is not None
     assert admin_workflow_spec.template.outputs[0].var == "o0"
     assert admin_workflow_spec.template.outputs[0].binding.promise.node_id == "n0"

--- a/plugins/flytekit-hive/tests/test_hive_task.py
+++ b/plugins/flytekit-hive/tests/test_hive_task.py
@@ -39,13 +39,13 @@ def test_serialization():
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
         env={},
     )
-    task_spec = get_serializable(OrderedDict(), serialization_settings, hive_task)
+    task_spec = get_serializable(OrderedDict(), hive_task, serialization_settings)
     assert "{{ .rawOutputDataPrefix" in task_spec.template.custom["query"]["query"]
     assert "insert overwrite directory" in task_spec.template.custom["query"]["query"]
     assert len(task_spec.template.interface.inputs) == 2
     assert len(task_spec.template.interface.outputs) == 1
 
-    admin_workflow_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    admin_workflow_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert admin_workflow_spec.template.interface.outputs["o0"].type.schema is not None
     assert admin_workflow_spec.template.outputs[0].var == "o0"
     assert admin_workflow_spec.template.outputs[0].binding.promise.node_id == "n0"
@@ -111,11 +111,11 @@ def test_query_no_inputs_or_outputs():
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
         env={},
     )
-    task_spec = get_serializable(OrderedDict(), serialization_settings, hive_task)
+    task_spec = get_serializable(OrderedDict(), hive_task, serialization_settings)
     assert len(task_spec.template.interface.inputs) == 0
     assert len(task_spec.template.interface.outputs) == 0
 
-    get_serializable(OrderedDict(), serialization_settings, my_wf)
+    get_serializable(OrderedDict(), my_wf, serialization_settings)
 
 
 def test_hive_select():

--- a/plugins/flytekit-k8s-pod/tests/test_pod.py
+++ b/plugins/flytekit-k8s-pod/tests/test_pod.py
@@ -290,7 +290,7 @@ def test_pod_task_serialized():
         env={"FOO": "baz"},
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
-    serialized = get_serializable(OrderedDict(), ssettings, simple_pod_task)
+    serialized = get_serializable(OrderedDict(), simple_pod_task, ssettings)
     assert serialized.template.task_type_version == 2
     assert serialized.template.config["primary_container_name"] == "an undefined container"
     assert serialized.template.k8s_pod.metadata.labels == {"label": "foo"}
@@ -364,7 +364,7 @@ def test_fast_pod_task_serialization():
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
         fast_serialization_settings=FastSerializationSettings(enabled=True),
     )
-    serialized = get_serializable(OrderedDict(), serialization_settings, simple_pod_task)
+    serialized = get_serializable(OrderedDict(), simple_pod_task, serialization_settings)
 
     assert serialized.template.k8s_pod.pod_spec["containers"][0]["args"] == [
         "pyflyte-fast-execute",

--- a/plugins/flytekit-snowflake/tests/test_snowflake.py
+++ b/plugins/flytekit-snowflake/tests/test_snowflake.py
@@ -41,7 +41,7 @@ def test_serialization():
         env={},
     )
 
-    task_spec = get_serializable(OrderedDict(), serialization_settings, snowflake_task)
+    task_spec = get_serializable(OrderedDict(), snowflake_task, serialization_settings)
 
     assert "{{ .rawOutputDataPrefix" in task_spec.template.sql.statement
     assert "insert overwrite directory" in task_spec.template.sql.statement
@@ -53,7 +53,7 @@ def test_serialization():
     assert len(task_spec.template.interface.inputs) == 1
     assert len(task_spec.template.interface.outputs) == 1
 
-    admin_workflow_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    admin_workflow_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert admin_workflow_spec.template.interface.outputs["o0"].type.schema is not None
     assert admin_workflow_spec.template.outputs[0].var == "o0"
     assert admin_workflow_spec.template.outputs[0].binding.promise.node_id == "n0"

--- a/plugins/flytekit-sqlalchemy/tests/test_sql_tracker.py
+++ b/plugins/flytekit-sqlalchemy/tests/test_sql_tracker.py
@@ -20,7 +20,7 @@ def test_sql_command():
         env=None,
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
-    srz_t = get_serializable(OrderedDict(), serialization_settings, not_tk)
+    srz_t = get_serializable(OrderedDict(), not_tk, serialization_settings)
     assert srz_t.template.container.args[-5:] == [
         "--resolver",
         "flytekit.core.python_customized_container_task.default_task_template_resolver",

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -123,7 +123,7 @@ def test_condition_tuple_branches():
     assert x == 5
     assert y == 1
 
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, math_ops)
+    wf_spec = get_serializable(OrderedDict(), math_ops, serialization_settings)
     assert len(wf_spec.template.nodes) == 1
     assert (
         wf_spec.template.nodes[0].branch_node.if_else.case.then_node.task_node.reference_id.name
@@ -241,7 +241,7 @@ def test_subworkflow_condition_serialization():
         (if_elif_else_branching, [fmt.format(x) for x in ("wf1", "wf2", "wf3", "wf4")]),
         (nested_branching, [fmt.format(x) for x in ("ifelse_branching", "wf1", "wf2", "wf5")]),
     ]:
-        wf_spec = get_serializable(OrderedDict(), serialization_settings, wf)
+        wf_spec = get_serializable(OrderedDict(), wf, serialization_settings)
         subworkflows = wf_spec.sub_workflows
 
         for sub_wf in subworkflows:
@@ -364,7 +364,7 @@ def test_nested_condition():
             .fail("The input must be between 0 and 10")
         )
 
-    srz_wf = get_serializable(OrderedDict(), serialization_settings, multiplier_2)
+    srz_wf = get_serializable(OrderedDict(), multiplier_2, serialization_settings)
     assert len(srz_wf.template.nodes) == 1
     fractions_branch = srz_wf.template.nodes[0]
     assert isinstance(fractions_branch, Node)
@@ -418,7 +418,7 @@ def test_nested_condition_2():
             .then(double(n=my_input))
         )
 
-    srz_wf = get_serializable(OrderedDict(), serialization_settings, multiplier_2)
+    srz_wf = get_serializable(OrderedDict(), multiplier_2, serialization_settings)
     assert len(srz_wf.template.nodes) == 1
     fractions_branch = srz_wf.template.nodes[0]
     assert isinstance(fractions_branch, Node)

--- a/tests/flytekit/unit/core/test_flyte_pickle.py
+++ b/tests/flytekit/unit/core/test_flyte_pickle.py
@@ -59,7 +59,7 @@ def test_nested():
     def t1(a: int) -> List[List[Foo]]:
         return [[Foo(number=a)]]
 
-    task_spec = get_serializable(OrderedDict(), serialization_settings, t1)
+    task_spec = get_serializable(OrderedDict(), t1, serialization_settings)
     assert (
         task_spec.template.interface.outputs["o0"].type.collection_type.collection_type.blob.format
         is FlytePickleTransformer.PYTHON_PICKLE_FORMAT
@@ -75,7 +75,7 @@ def test_nested2():
     def t1(a: int) -> List[Dict[str, Foo]]:
         return [{"a": Foo(number=a)}]
 
-    task_spec = get_serializable(OrderedDict(), serialization_settings, t1)
+    task_spec = get_serializable(OrderedDict(), t1, serialization_settings)
     assert (
         task_spec.template.interface.outputs["o0"].type.collection_type.map_value_type.blob.format
         is FlytePickleTransformer.PYTHON_PICKLE_FORMAT

--- a/tests/flytekit/unit/core/test_imperative.py
+++ b/tests/flytekit/unit/core/test_imperative.py
@@ -59,7 +59,7 @@ def test_imperative():
 
     assert wb(in1="hello") == "hello world"
 
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, wb)
+    wf_spec = get_serializable(OrderedDict(), wb, serialization_settings)
     assert len(wf_spec.template.nodes) == 2
     assert wf_spec.template.nodes[0].task_node is not None
     assert len(wf_spec.template.outputs) == 1
@@ -82,14 +82,14 @@ def test_imperative():
 
     # Create launch plan from wf, that can also be serialized.
     lp = LaunchPlan.create("test_wb", wb)
-    lp_model = get_serializable(OrderedDict(), serialization_settings, lp)
+    lp_model = get_serializable(OrderedDict(), lp, serialization_settings)
     assert lp_model.spec.workflow_id.name == "my_workflow"
 
     wb2 = ImperativeWorkflow(name="parent.imperative")
     p_in1 = wb2.add_workflow_input("p_in1", str)
     p_node0 = wb2.add_subwf(wb, in1=p_in1)
     wb2.add_workflow_output("parent_wf_output", p_node0.from_n0t1, str)
-    wb2_spec = get_serializable(OrderedDict(), serialization_settings, wb2)
+    wb2_spec = get_serializable(OrderedDict(), wb2, serialization_settings)
     assert len(wb2_spec.template.nodes) == 1
     assert len(wb2_spec.template.interface.inputs) == 1
     assert wb2_spec.template.interface.inputs["p_in1"].type.simple is not None
@@ -102,7 +102,7 @@ def test_imperative():
     p_in1 = wb3.add_workflow_input("p_in1", str)
     p_node0 = wb3.add_launch_plan(lp, in1=p_in1)
     wb3.add_workflow_output("parent_wf_output", p_node0.from_n0t1, str)
-    wb3_spec = get_serializable(OrderedDict(), serialization_settings, wb3)
+    wb3_spec = get_serializable(OrderedDict(), wb3, serialization_settings)
     assert len(wb3_spec.template.nodes) == 1
     assert len(wb3_spec.template.interface.inputs) == 1
     assert wb3_spec.template.interface.inputs["p_in1"].type.simple is not None
@@ -174,7 +174,7 @@ def test_imperative_wf_list_input():
 
     assert wb(in1=[5, 6, 7]) == 24
 
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, wb)
+    wf_spec = get_serializable(OrderedDict(), wb, serialization_settings)
     assert len(wf_spec.template.nodes) == 2
     assert wf_spec.template.nodes[0].task_node is not None
 
@@ -190,7 +190,7 @@ def test_imperative_scalar_bindings():
 
     assert wb() == {"a": 7, "b": 11}
 
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, wb)
+    wf_spec = get_serializable(OrderedDict(), wb, serialization_settings)
     assert len(wf_spec.template.nodes) == 1
     assert wf_spec.template.nodes[0].task_node is not None
 
@@ -365,7 +365,7 @@ def test_nonfunction_task_and_df_input():
     )
     wb.add_workflow_output("output_from_t3", node_t2.outputs["o0"], python_type=pd.DataFrame)
 
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, wb)
+    wf_spec = get_serializable(OrderedDict(), wb, serialization_settings)
     assert len(wf_spec.template.nodes) == 3
 
     assert len(wf_spec.template.interface.inputs) == 1

--- a/tests/flytekit/unit/core/test_launch_plan.py
+++ b/tests/flytekit/unit/core/test_launch_plan.py
@@ -379,7 +379,7 @@ def test_lp_nodes():
         return t, w
 
     all_entities = OrderedDict()
-    wf_spec = get_serializable(all_entities, serialization_settings, my_wf)
+    wf_spec = get_serializable(all_entities, my_wf, serialization_settings)
     assert wf_spec.template.nodes[1].workflow_node is not None
     assert (
         wf_spec.template.nodes[1].workflow_node.launchplan_ref.resource_type

--- a/tests/flytekit/unit/core/test_map_task.py
+++ b/tests/flytekit/unit/core/test_map_task.py
@@ -68,7 +68,7 @@ def test_map_task_types():
 
 def test_serialization(serialization_settings):
     maptask = map_task(t1, metadata=TaskMetadata(retries=1))
-    task_spec = get_serializable(OrderedDict(), serialization_settings, maptask)
+    task_spec = get_serializable(OrderedDict(), maptask, serialization_settings)
 
     # By default all map_task tasks will have their custom fields set.
     assert task_spec.template.custom["minSuccessRatio"] == 1.0
@@ -107,7 +107,7 @@ def test_serialization(serialization_settings):
 )
 def test_serialization_of_custom_fields(custom_fields_dict, expected_custom_fields, serialization_settings):
     maptask = map_task(t1, **custom_fields_dict)
-    task_spec = get_serializable(OrderedDict(), serialization_settings, maptask)
+    task_spec = get_serializable(OrderedDict(), maptask, serialization_settings)
 
     assert task_spec.template.custom == expected_custom_fields
 
@@ -129,11 +129,11 @@ def test_serialization_workflow_def(serialization_settings):
         return map_task(complex_task, metadata=TaskMetadata(retries=2))(a=a)
 
     serialized_control_plane_entities = OrderedDict()
-    wf1_spec = get_serializable(serialized_control_plane_entities, serialization_settings, w1)
+    wf1_spec = get_serializable(serialized_control_plane_entities, w1, serialization_settings)
     assert wf1_spec.template is not None
     assert len(wf1_spec.template.nodes) == 1
 
-    wf2_spec = get_serializable(serialized_control_plane_entities, serialization_settings, w2)
+    wf2_spec = get_serializable(serialized_control_plane_entities, w2, serialization_settings)
     assert wf2_spec.template is not None
     assert len(wf2_spec.template.nodes) == 1
 

--- a/tests/flytekit/unit/core/test_node_creation.py
+++ b/tests/flytekit/unit/core/test_node_creation.py
@@ -46,7 +46,7 @@ def test_normal_task():
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
         env={},
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    wf_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert len(wf_spec.template.nodes) == 2
     assert len(wf_spec.template.outputs) == 2
 
@@ -80,11 +80,11 @@ def test_normal_task():
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
         env={},
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, empty_wf)
+    wf_spec = get_serializable(OrderedDict(), empty_wf, serialization_settings)
     assert wf_spec.template.nodes[0].upstream_node_ids[0] == "n1"
     assert wf_spec.template.nodes[0].id == "n0"
 
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, empty_wf2)
+    wf_spec = get_serializable(OrderedDict(), empty_wf2, serialization_settings)
     assert wf_spec.template.nodes[0].upstream_node_ids[0] == "n1"
     assert wf_spec.template.nodes[0].id == "n0"
 
@@ -215,7 +215,7 @@ def test_resource_request_override():
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
         env={},
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    wf_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert len(wf_spec.template.nodes) == 1
     assert wf_spec.template.nodes[0].task_node.overrides is not None
     assert wf_spec.template.nodes[0].task_node.overrides.resources.requests == [
@@ -244,7 +244,7 @@ def test_resource_limits_override():
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
         env={},
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    wf_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert len(wf_spec.template.nodes) == 1
     assert wf_spec.template.nodes[0].task_node.overrides.resources.requests == []
     assert wf_spec.template.nodes[0].task_node.overrides.resources.limits == [
@@ -275,7 +275,7 @@ def test_resources_override():
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
         env={},
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    wf_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert len(wf_spec.template.nodes) == 1
     assert wf_spec.template.nodes[0].task_node.overrides is not None
     assert wf_spec.template.nodes[0].task_node.overrides.resources.requests == [
@@ -311,7 +311,7 @@ def test_timeout_override(timeout, expected):
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
         env={},
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    wf_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert len(wf_spec.template.nodes) == 1
     assert wf_spec.template.nodes[0].metadata.timeout == expected
 
@@ -347,7 +347,7 @@ def test_retries_override(retries, expected):
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
         env={},
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    wf_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert len(wf_spec.template.nodes) == 1
     assert wf_spec.template.nodes[0].metadata.retries == expected
 
@@ -369,6 +369,6 @@ def test_interruptible_override(interruptible):
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
         env={},
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    wf_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert len(wf_spec.template.nodes) == 1
     assert wf_spec.template.nodes[0].metadata.interruptible == interruptible

--- a/tests/flytekit/unit/core/test_numpy.py
+++ b/tests/flytekit/unit/core/test_numpy.py
@@ -57,5 +57,5 @@ def test_example():
     def t1(array: np.ndarray) -> np.ndarray:
         return array.flatten()
 
-    task_spec = get_serializable(OrderedDict(), serialization_settings, t1)
+    task_spec = get_serializable(OrderedDict(), t1, serialization_settings)
     assert task_spec.template.interface.outputs["o0"].type.blob.format is NumpyArrayTransformer.NUMPY_ARRAY_FORMAT

--- a/tests/flytekit/unit/core/test_references.py
+++ b/tests/flytekit/unit/core/test_references.py
@@ -66,7 +66,7 @@ def test_ref():
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
         env={},
     )
-    spec = get_serializable(OrderedDict(), serialization_settings, ref_t1)
+    spec = get_serializable(OrderedDict(), ref_t1, serialization_settings)
     assert isinstance(spec, ReferenceSpec)
     assert isinstance(spec.template, ReferenceTemplate)
     assert spec.template.id == ref_t1.id
@@ -255,7 +255,7 @@ def test_lps(resource_type):
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
         env={},
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, wf1)
+    wf_spec = get_serializable(OrderedDict(), wf1, serialization_settings)
     assert len(wf_spec.template.interface.inputs) == 2
     assert len(wf_spec.template.interface.outputs) == 0
     assert len(wf_spec.template.nodes) == 1
@@ -306,7 +306,7 @@ def test_ref_sub_wf():
         # Subworkflow as references don't work (probably ever). The reason is because we'd need to make a network call
         # to admin to get the structure of the subworkflow and the whole point of reference entities is that there
         # is no network call.
-        get_serializable(OrderedDict(), serialization_settings, wf1)
+        get_serializable(OrderedDict(), wf1, serialization_settings)
 
 
 def test_lp_with_output():
@@ -350,7 +350,7 @@ def test_lp_with_output():
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
         env={},
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, wf1)
+    wf_spec = get_serializable(OrderedDict(), wf1, serialization_settings)
     assert wf_spec.template.nodes[1].workflow_node.launchplan_ref.project == "proj"
     assert wf_spec.template.nodes[1].workflow_node.launchplan_ref.name == "app.other.flyte_entity"
 

--- a/tests/flytekit/unit/core/test_resolver.py
+++ b/tests/flytekit/unit/core/test_resolver.py
@@ -51,7 +51,7 @@ def test_wf_resolving():
 
     # The tasks should get the location the workflow was assigned to as the resolver.
     # The args are the index.
-    srz_t0_spec = get_serializable(OrderedDict(), serialization_settings, workflows_tasks[0])
+    srz_t0_spec = get_serializable(OrderedDict(), workflows_tasks[0], serialization_settings)
     assert srz_t0_spec.template.container.args[-4:] == [
         "--resolver",
         "tests.flytekit.unit.core.test_resolver.my_wf",
@@ -59,7 +59,7 @@ def test_wf_resolving():
         "0",
     ]
 
-    srz_t1_spec = get_serializable(OrderedDict(), serialization_settings, workflows_tasks[1])
+    srz_t1_spec = get_serializable(OrderedDict(), workflows_tasks[1], serialization_settings)
     assert srz_t1_spec.template.container.args[-4:] == [
         "--resolver",
         "tests.flytekit.unit.core.test_resolver.my_wf",

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -57,13 +57,13 @@ def test_serialization():
         env=None,
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, raw_container_wf)
+    wf_spec = get_serializable(OrderedDict(), raw_container_wf, serialization_settings)
     assert wf_spec is not None
     assert wf_spec.template is not None
     assert len(wf_spec.template.nodes) == 3
-    sqn_spec = get_serializable(OrderedDict(), serialization_settings, square)
+    sqn_spec = get_serializable(OrderedDict(), square, serialization_settings)
     assert sqn_spec.template.container.image == "alpine"
-    sumn_spec = get_serializable(OrderedDict(), serialization_settings, sum)
+    sumn_spec = get_serializable(OrderedDict(), sum, serialization_settings)
     assert sumn_spec.template.container.image == "alpine"
 
 
@@ -91,7 +91,7 @@ def test_serialization_branch_complex():
         f = conditional("test2").if_(d == "hello ").then(t2(a="It is hello")).else_().then(t2(a="Not Hello!"))
         return x, f
 
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    wf_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert wf_spec is not None
     assert len(wf_spec.template.nodes) == 3
     assert wf_spec.template.nodes[1].branch_node is not None
@@ -112,7 +112,7 @@ def test_serialization_branch_sub_wf():
         d = conditional("test1").if_(a > 3).then(t1(a=a)).else_().then(my_sub_wf(a=a))
         return d
 
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    wf_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert wf_spec is not None
     assert len(wf_spec.template.nodes[0].inputs) == 1
     assert wf_spec.template.nodes[0].inputs[0].var == ".a"
@@ -145,7 +145,7 @@ def test_serialization_branch_compound_conditions():
         env=None,
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    wf_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert wf_spec is not None
     assert len(wf_spec.template.nodes[0].inputs) == 1
     assert wf_spec.template.nodes[0].inputs[0].var == ".a"
@@ -183,7 +183,7 @@ def test_serialization_branch_complex_2():
         env=None,
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    wf_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert wf_spec is not None
     assert wf_spec.template.nodes[1].inputs[0].var == "n0.t1_int_output"
 
@@ -217,7 +217,7 @@ def test_serialization_branch():
         env=None,
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    wf_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert wf_spec is not None
     assert len(wf_spec.template.nodes) == 2
     assert wf_spec.template.nodes[1].branch_node is not None
@@ -265,20 +265,20 @@ def test_serialization_images():
         env=None,
         image_config=imgs,
     )
-    t1_spec = get_serializable(OrderedDict(), rs, t1)
+    t1_spec = get_serializable(OrderedDict(), t1, rs)
     assert t1_spec.template.container.image == "docker.io/xyz:latest"
     t1_spec.to_flyte_idl()
 
-    t2_spec = get_serializable(OrderedDict(), rs, t2)
+    t2_spec = get_serializable(OrderedDict(), t2, rs)
     assert t2_spec.template.container.image == "docker.io/abc:latest"
 
-    t4_spec = get_serializable(OrderedDict(), rs, t4)
+    t4_spec = get_serializable(OrderedDict(), t4, rs)
     assert t4_spec.template.container.image == "docker.io/org/myimage:latest"
 
-    t5_spec = get_serializable(OrderedDict(), rs, t5)
+    t5_spec = get_serializable(OrderedDict(), t5, rs)
     assert t5_spec.template.container.image == "docker.io/org/myimage:latest"
 
-    t5_spec = get_serializable(OrderedDict(), rs, t6)
+    t5_spec = get_serializable(OrderedDict(), t6, rs)
     assert t5_spec.template.container.image == "docker.io/xyz_123:v1"
 
 
@@ -287,7 +287,7 @@ def test_serialization_command1():
     def t1(a: str) -> str:
         return a
 
-    task_spec = get_serializable(OrderedDict(), serialization_settings, t1)
+    task_spec = get_serializable(OrderedDict(), t1, serialization_settings)
     assert task_spec.template.container.args[-7:] == [
         "--resolver",
         "flytekit.core.python_auto_container.default_task_resolver",
@@ -312,9 +312,9 @@ def test_serialization_types():
         compute_square_result = squared(value=input_integer)
         return compute_square_result
 
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, compute_square_wf)
+    wf_spec = get_serializable(OrderedDict(), compute_square_wf, serialization_settings)
     assert wf_spec.template.interface.outputs["o0"].type.collection_type.map_value_type.simple == SimpleType.INTEGER
-    task_spec = get_serializable(OrderedDict(), serialization_settings, squared)
+    task_spec = get_serializable(OrderedDict(), squared, serialization_settings)
     assert task_spec.template.interface.outputs["o0"].type.collection_type.map_value_type.simple == SimpleType.INTEGER
 
 
@@ -327,7 +327,7 @@ def test_serialization_named_return():
     def wf() -> typing.NamedTuple("OP", a=str, b=str):
         return t1(), t1()
 
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, wf)
+    wf_spec = get_serializable(OrderedDict(), wf, serialization_settings)
     assert len(wf_spec.template.interface.outputs) == 2
     assert list(wf_spec.template.interface.outputs.keys()) == ["a", "b"]
 
@@ -370,7 +370,7 @@ def test_serialization_nested_subwf():
         l1, l2 = leaf_subwf().with_overrides(node_name="foo-node")
         return m1, m2, l1, l2
 
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, parent_wf)
+    wf_spec = get_serializable(OrderedDict(), parent_wf, serialization_settings)
     assert wf_spec is not None
     assert len(wf_spec.sub_workflows) == 2
     subwf = {v.id.name: v for v in wf_spec.sub_workflows}
@@ -397,7 +397,7 @@ def test_serialization_named_outputs_single():
     def wf() -> typing.NamedTuple("OP", a=str):
         return t1().a
 
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, wf)
+    wf_spec = get_serializable(OrderedDict(), wf, serialization_settings)
     assert len(wf_spec.template.interface.outputs) == 1
     assert list(wf_spec.template.interface.outputs.keys()) == ["a"]
     a = wf()
@@ -452,7 +452,7 @@ def test_serialized_docstrings():
         """
         ...
 
-    task_spec = get_serializable(OrderedDict(), serialization_settings, z)
+    task_spec = get_serializable(OrderedDict(), z, serialization_settings)
     assert task_spec.template.interface.inputs["a"].description == "foo"
     assert task_spec.template.interface.inputs["b"].description == "bar"
     assert task_spec.template.interface.outputs["o0"].description == "ramen"

--- a/tests/flytekit/unit/core/test_shim_task.py
+++ b/tests/flytekit/unit/core/test_shim_task.py
@@ -37,7 +37,7 @@ def test_resolver_load_task():
     )
 
     resolver = TaskTemplateResolver()
-    ts = get_serializable(OrderedDict(), serialization_settings, square)
+    ts = get_serializable(OrderedDict(), square, serialization_settings)
     file = tempfile.NamedTemporaryFile().name
     # load_task should create an instance of the path to the object given, doesn't need to be a real executor
     write_proto_to_file(ts.template.to_flyte_idl(), file)

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -888,12 +888,12 @@ def test_lp_serialize():
         image_config=ImageConfig(Image(name="name", fqn="asdf/fdsa", tag="123")),
         env={},
     )
-    lp_model = get_serializable(OrderedDict(), serialization_settings, lp)
+    lp_model = get_serializable(OrderedDict(), lp, serialization_settings)
     assert len(lp_model.spec.default_inputs.parameters) == 1
     assert lp_model.spec.default_inputs.parameters["a"].required
     assert len(lp_model.spec.fixed_inputs.literals) == 0
 
-    lp_model = get_serializable(OrderedDict(), serialization_settings, lp_with_defaults)
+    lp_model = get_serializable(OrderedDict(), lp_with_defaults, serialization_settings)
     assert len(lp_model.spec.default_inputs.parameters) == 1
     assert not lp_model.spec.default_inputs.parameters["a"].required
     assert lp_model.spec.default_inputs.parameters["a"].default == _literal_models.Literal(
@@ -1275,7 +1275,7 @@ def test_environment():
     with context_manager.FlyteContextManager.with_context(
         context_manager.FlyteContextManager.current_context().with_new_compilation_state()
     ):
-        task_spec = get_serializable(OrderedDict(), serialization_settings, t1)
+        task_spec = get_serializable(OrderedDict(), t1, serialization_settings)
         assert task_spec.template.container.env == {"FOO": "foofoo", "BAR": "bar", "BAZ": "baz"}
 
 
@@ -1308,7 +1308,7 @@ def test_resources():
     with context_manager.FlyteContextManager.with_context(
         context_manager.FlyteContextManager.current_context().with_new_compilation_state()
     ):
-        task_spec = get_serializable(OrderedDict(), serialization_settings, t1)
+        task_spec = get_serializable(OrderedDict(), t1, serialization_settings)
         assert task_spec.template.container.resources.requests == [
             _resource_models.ResourceEntry(_resource_models.ResourceName.EPHEMERAL_STORAGE, "500Mi"),
             _resource_models.ResourceEntry(_resource_models.ResourceName.CPU, "1"),
@@ -1319,7 +1319,7 @@ def test_resources():
             _resource_models.ResourceEntry(_resource_models.ResourceName.MEMORY, "400M"),
         ]
 
-        task_spec2 = get_serializable(OrderedDict(), serialization_settings, t2)
+        task_spec2 = get_serializable(OrderedDict(), t2, serialization_settings)
         assert task_spec2.template.container.resources.requests == [
             _resource_models.ResourceEntry(_resource_models.ResourceName.CPU, "3")
         ]
@@ -1507,7 +1507,7 @@ def test_guess_dict():
     def t2(a: dict) -> str:
         return ", ".join([f"K: {k} V: {v}" for k, v in a.items()])
 
-    task_spec = get_serializable(OrderedDict(), serialization_settings, t2)
+    task_spec = get_serializable(OrderedDict(), t2, serialization_settings)
     assert task_spec.template.interface.inputs["a"].type.simple == SimpleType.STRUCT
 
     pt = TypeEngine.guess_python_type(task_spec.template.interface.inputs["a"].type)
@@ -1532,7 +1532,7 @@ def test_guess_dict2():
             strs.append(", ".join([f"K: {k} V: {v}" for k, v in input_dict.items()]))
         return " ".join(strs)
 
-    task_spec = get_serializable(OrderedDict(), serialization_settings, t2)
+    task_spec = get_serializable(OrderedDict(), t2, serialization_settings)
     assert task_spec.template.interface.inputs["a"].type.collection_type.simple == SimpleType.STRUCT
     pt_map = TypeEngine.guess_python_types(task_spec.template.interface.inputs)
     assert pt_map == {"a": typing.List[dict]}
@@ -1543,7 +1543,7 @@ def test_guess_dict3():
     def t2() -> dict:
         return {"k1": "v1", "k2": 3, 4: {"one": [1, "two", [3]]}}
 
-    task_spec = get_serializable(OrderedDict(), serialization_settings, t2)
+    task_spec = get_serializable(OrderedDict(), t2, serialization_settings)
 
     pt_map = TypeEngine.guess_python_types(task_spec.template.interface.outputs)
     assert pt_map["o0"] is dict
@@ -1574,7 +1574,7 @@ def test_guess_dict4():
     def t1() -> Foo:
         return Foo(x=1, y="foo", z={"hello": "world"})
 
-    task_spec = get_serializable(OrderedDict(), serialization_settings, t1)
+    task_spec = get_serializable(OrderedDict(), t1, serialization_settings)
     pt_map = TypeEngine.guess_python_types(task_spec.template.interface.outputs)
     assert dataclasses.is_dataclass(pt_map["o0"])
 
@@ -1588,7 +1588,7 @@ def test_guess_dict4():
     def t2() -> Bar:
         return Bar(x=1, y={"hello": "world"}, z=Foo(x=1, y="foo", z={"hello": "world"}))
 
-    task_spec = get_serializable(OrderedDict(), serialization_settings, t2)
+    task_spec = get_serializable(OrderedDict(), t2, serialization_settings)
     pt_map = TypeEngine.guess_python_types(task_spec.template.interface.outputs)
     assert dataclasses.is_dataclass(pt_map["o0"])
 

--- a/tests/flytekit/unit/core/test_typing_annotation.py
+++ b/tests/flytekit/unit/core/test_typing_annotation.py
@@ -37,7 +37,7 @@ def y1(a: typing_extensions.Annotated[typing.List[int], FlyteAnnotation({"foo": 
 
 
 def test_get_variable_descriptions():
-    x_tsk = get_serializable(entity_mapping, serialization_settings, x)
+    x_tsk = get_serializable(entity_mapping, x, serialization_settings)
     x_input_vars = x_tsk.template.interface.inputs
 
     a_ann = x_input_vars["a"].type.annotation
@@ -48,14 +48,14 @@ def test_get_variable_descriptions():
     assert b_ann is None
 
     # Annotated simple type within list generic
-    y0_tsk = get_serializable(entity_mapping, serialization_settings, y0)
+    y0_tsk = get_serializable(entity_mapping, y0, serialization_settings)
     y0_input_vars = y0_tsk.template.interface.inputs
     y0_a_ann = y0_input_vars["a"].type.collection_type.annotation
     assert isinstance(y0_a_ann, TypeAnnotation)
     assert y0_a_ann.annotations["foo"] == {"bar": 1}
 
     # Annotated list generic
-    y1_tsk = get_serializable(entity_mapping, serialization_settings, y1)
+    y1_tsk = get_serializable(entity_mapping, y1, serialization_settings)
     y1_input_vars = y1_tsk.template.interface.inputs
     y1_a_ann = y1_input_vars["a"].type.annotation
     assert isinstance(y1_a_ann, TypeAnnotation)

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -58,7 +58,7 @@ def test_workflow_values():
         u, v = t1(a=x)
         return y, v
 
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, wf)
+    wf_spec = get_serializable(OrderedDict(), wf, serialization_settings)
     assert wf_spec.template.metadata_defaults.interruptible
     assert wf_spec.template.metadata.on_failure == 1
 
@@ -192,7 +192,7 @@ def test_wf_nested_comp():
     assert (8, 10) == outer()
     entity_mapping = OrderedDict()
 
-    model_wf = get_serializable(entity_mapping, serialization_settings, outer)
+    model_wf = get_serializable(entity_mapping, outer, serialization_settings)
 
     assert len(model_wf.template.interface.outputs) == 2
     assert len(model_wf.template.nodes) == 2
@@ -245,7 +245,7 @@ def test_all_node_types():
     assert my_wf_example(a=1) == (6, 16)
     entity_mapping = OrderedDict()
 
-    model_wf = get_serializable(entity_mapping, serialization_settings, my_wf_example)
+    model_wf = get_serializable(entity_mapping, my_wf_example, serialization_settings)
 
     assert len(model_wf.template.interface.outputs) == 2
     assert len(model_wf.template.nodes) == 4
@@ -258,7 +258,7 @@ def test_all_node_types():
 
 
 def test_wf_docstring():
-    model_wf = get_serializable(OrderedDict(), serialization_settings, my_wf_example)
+    model_wf = get_serializable(OrderedDict(), my_wf_example, serialization_settings)
 
     assert len(model_wf.template.interface.outputs) == 2
     assert model_wf.template.interface.outputs["o0"].description == "outputs"

--- a/tests/flytekit/unit/extras/sqlite3/test_sql_tracker.py
+++ b/tests/flytekit/unit/extras/sqlite3/test_sql_tracker.py
@@ -19,7 +19,7 @@ def test_sql_command():
         env=None,
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
-    srz_t = get_serializable(OrderedDict(), serialization_settings, not_tk)
+    srz_t = get_serializable(OrderedDict(), not_tk, serialization_settings)
     assert srz_t.template.container.args[-5:] == [
         "--resolver",
         "flytekit.core.python_customized_container_task.default_task_template_resolver",

--- a/tests/flytekit/unit/remote/test_calling.py
+++ b/tests/flytekit/unit/remote/test_calling.py
@@ -46,7 +46,7 @@ def sub_wf(a: int, b: str) -> (int, str):
     return x, d
 
 
-t1_spec = get_serializable(OrderedDict(), serialization_settings, t1)
+t1_spec = get_serializable(OrderedDict(), t1, serialization_settings)
 ft = FlyteTask.promote_from_model(t1_spec.template)
 
 
@@ -61,7 +61,7 @@ def test_fetched_task():
 
     # Should have one task template
     serialized = OrderedDict()
-    wf_spec = get_serializable(serialized, serialization_settings, wf)
+    wf_spec = get_serializable(serialized, wf, serialization_settings)
     vals = [v for v in serialized.values()]
     tts = [f for f in filter(lambda x: isinstance(x, TaskTemplate), vals)]
     assert len(tts) == 1
@@ -80,7 +80,7 @@ def test_misnamed():
 def test_calling_lp():
     sub_wf_lp = LaunchPlan.get_or_create(sub_wf)
     serialized = OrderedDict()
-    lp_model = get_serializable(serialized, serialization_settings, sub_wf_lp)
+    lp_model = get_serializable(serialized, sub_wf_lp, serialization_settings)
     task_templates, wf_specs, lp_specs = gather_dependent_entities(serialized)
     for wf_id, spec in wf_specs.items():
         break
@@ -95,7 +95,7 @@ def test_calling_lp():
     def wf2(a: int) -> typing.Tuple[int, str]:
         return remote_lp(a=a, b="hello")
 
-    wf_spec = get_serializable(serialized, serialization_settings, wf2)
+    wf_spec = get_serializable(serialized, wf2, serialization_settings)
     print(wf_spec.template.nodes[0].workflow_node.launchplan_ref)
     assert wf_spec.template.nodes[0].workflow_node.launchplan_ref == lp_model.id
 
@@ -143,7 +143,7 @@ def test_dynamic():
 def test_calling_wf():
     # No way to fetch from Admin in unit tests so we serialize and then promote back
     serialized = OrderedDict()
-    wf_spec = get_serializable(serialized, serialization_settings, sub_wf)
+    wf_spec = get_serializable(serialized, sub_wf, serialization_settings)
     task_templates, wf_specs, lp_specs = gather_dependent_entities(serialized)
     fwf = FlyteWorkflow.promote_from_model(wf_spec.template, tasks=task_templates)
 
@@ -154,7 +154,7 @@ def test_calling_wf():
 
     # No way to fetch from Admin in unit tests so we serialize and then promote back
     serialized = OrderedDict()
-    wf_spec = get_serializable(serialized, serialization_settings, parent_1)
+    wf_spec = get_serializable(serialized, parent_1, serialization_settings)
     # Get task_specs from the second one, merge with the first one. Admin normally would be the one to do this.
     task_templates_p1, wf_specs, lp_specs = gather_dependent_entities(serialized)
     for k, v in task_templates.items():
@@ -172,6 +172,6 @@ def test_calling_wf():
         return z, y
 
     serialized = OrderedDict()
-    wf_spec = get_serializable(serialized, serialization_settings, parent_2)
+    wf_spec = get_serializable(serialized, parent_2, serialization_settings)
     # Make sure both were picked up.
     assert len(wf_spec.sub_workflows) == 2

--- a/tests/flytekit/unit/remote/test_with_responses.py
+++ b/tests/flytekit/unit/remote/test_with_responses.py
@@ -3,14 +3,15 @@ import typing
 from collections import OrderedDict
 
 import mock
+import pytest
 from flyteidl.admin import launch_plan_pb2, task_pb2, workflow_pb2
 
 import flytekit.configuration
+from flytekit import task, workflow
 from flytekit.configuration import Config, ImageConfig
 from flytekit.configuration.default_images import DefaultImages
 from flytekit.core.node_creation import create_node
 from flytekit.core.utils import load_proto_from_file
-from flytekit.core.workflow import workflow
 from flytekit.models import launch_plan as launch_plan_models
 from flytekit.models import task as task_models
 from flytekit.models.admin import workflow as admin_workflow_models
@@ -56,6 +57,51 @@ def test_task(mock_client):
     ft = rr.fetch_task(name="merge_sort_remotely", version="tst")
     assert len(ft.interface.inputs) == 2
     assert len(ft.interface.outputs) == 1
+
+
+@mock.patch("flytekit.remote.remote.FlyteRemote.client")
+def test_workflow_from_fetched_tasks_registration_without_serialization_settings(mock_client):
+    merge_sort_remotely = load_proto_from_file(
+        task_pb2.Task,
+        os.path.join(responses_dir, "admin.task_pb2.Task.pb"),
+    )
+    admin_task = task_models.Task.from_flyte_idl(merge_sort_remotely)
+    mock_client.get_task.return_value = admin_task
+    ft = rr.fetch_task(name="merge_sort_remotely", version="tst")
+    assert len(ft.interface.inputs) == 2
+    assert len(ft.interface.outputs) == 1
+
+    @workflow
+    def wf_from_ft(numbers: typing.List[int], run_local_at_count: int) -> typing.List[int]:
+        return ft(numbers=numbers, run_local_at_count=run_local_at_count)
+
+    rr.register_workflow(entity=wf_from_ft, version="v1")
+
+
+@mock.patch("flytekit.remote.remote.FlyteRemote.client")
+def test_workflow_from_fetched_tasks_and_local_task_registration_without_serialization_settings(mock_client):
+    merge_sort_remotely = load_proto_from_file(
+        task_pb2.Task,
+        os.path.join(responses_dir, "admin.task_pb2.Task.pb"),
+    )
+    admin_task = task_models.Task.from_flyte_idl(merge_sort_remotely)
+    mock_client.get_task.return_value = admin_task
+    ft = rr.fetch_task(name="merge_sort_remotely", version="tst")
+    assert len(ft.interface.inputs) == 2
+    assert len(ft.interface.outputs) == 1
+
+    @task
+    def sum_list(inp: typing.List[int]) -> int:
+        return sum(inp)
+
+    @workflow
+    def wf_from_ft_and_lt(numbers: typing.List[int], run_local_at_count: int) -> int:
+        return sum_list(inp=ft(numbers=numbers, run_local_at_count=run_local_at_count))
+
+    with pytest.raises(ValueError) as excinfo:
+        rr.register_workflow(entity=wf_from_ft_and_lt, version="v1")
+
+    assert str(excinfo.value) == "An image is required for PythonAutoContainer tasks"
 
 
 @mock.patch("flytekit.remote.remote.FlyteRemote.client")

--- a/tests/flytekit/unit/remote/test_with_responses.py
+++ b/tests/flytekit/unit/remote/test_with_responses.py
@@ -126,5 +126,5 @@ def test_normal_task(mock_client):
         env=None,
         image_config=ImageConfig.auto(img_name=DefaultImages.default_image()),
     )
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    wf_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert wf_spec.template.nodes[0].task_node.reference_id.name == "merge_sort_remotely"

--- a/tests/flytekit/unit/remote/test_wrapper_classes.py
+++ b/tests/flytekit/unit/remote/test_wrapper_classes.py
@@ -37,7 +37,7 @@ def test_wf_cond():
         d = conditional("test1").if_(a > 3).then(t1(a=a)).else_().then(my_sub_wf(a=a))
         return d
 
-    get_serializable(OrderedDict(), serialization_settings, my_wf)
+    get_serializable(OrderedDict(), my_wf, serialization_settings)
 
 
 def test_wf_promote_subwf_lps():
@@ -57,7 +57,7 @@ def test_wf_promote_subwf_lps():
         return subwf(a=b)
 
     serialized = OrderedDict()
-    wf_spec = get_serializable(serialized, serialization_settings, wf)
+    wf_spec = get_serializable(serialized, wf, serialization_settings)
     sub_wf_dict = {s.id: s for s in wf_spec.sub_workflows}
     task_templates, wf_specs, lp_specs = gather_dependent_entities(serialized)
 
@@ -75,7 +75,7 @@ def test_wf_promote_subwf_lps():
         return sub_lp(a=b)
 
     serialized = OrderedDict()
-    wf_spec = get_serializable(serialized, serialization_settings, wf2)
+    wf_spec = get_serializable(serialized, wf2, serialization_settings)
     task_templates, wf_specs, lp_specs = gather_dependent_entities(serialized)
 
     fwf = FlyteWorkflow.promote_from_model(
@@ -107,7 +107,7 @@ def test_upstream():
         return t2(a=t1(a=a))
 
     serialized = OrderedDict()
-    wf_spec = get_serializable(serialized, serialization_settings, my_wf)
+    wf_spec = get_serializable(serialized, my_wf, serialization_settings)
     task_templates, wf_specs, lp_specs = gather_dependent_entities(serialized)
 
     fwf = FlyteWorkflow.promote_from_model(
@@ -124,7 +124,7 @@ def test_upstream():
         return first, second
 
     serialized = OrderedDict()
-    wf_spec = get_serializable(serialized, serialization_settings, parent)
+    wf_spec = get_serializable(serialized, parent, serialization_settings)
     sub_wf_dict = {s.id: s for s in wf_spec.sub_workflows}
     task_templates, wf_specs, lp_specs = gather_dependent_entities(serialized)
 

--- a/tests/flytekit/unit/test_translator.py
+++ b/tests/flytekit/unit/test_translator.py
@@ -24,21 +24,21 @@ serialization_settings = flytekit.configuration.SerializationSettings(
 
 def test_references():
     rlp = ReferenceLaunchPlan("media", "stg", "some.name", "cafe", inputs=kwtypes(in1=str), outputs=kwtypes())
-    lp_model = get_serializable(OrderedDict(), serialization_settings, rlp)
+    lp_model = get_serializable(OrderedDict(), rlp, serialization_settings)
     assert isinstance(lp_model, ReferenceSpec)
     assert isinstance(lp_model.template, ReferenceTemplate)
     assert lp_model.template.id == rlp.reference.id
     assert lp_model.template.resource_type == identifier_models.ResourceType.LAUNCH_PLAN
 
     rt = ReferenceTask("media", "stg", "some.name", "cafe", inputs=kwtypes(in1=str), outputs=kwtypes())
-    task_spec = get_serializable(OrderedDict(), serialization_settings, rt)
+    task_spec = get_serializable(OrderedDict(), rt, serialization_settings)
     assert isinstance(task_spec, ReferenceSpec)
     assert isinstance(task_spec.template, ReferenceTemplate)
     assert task_spec.template.id == rt.reference.id
     assert task_spec.template.resource_type == identifier_models.ResourceType.TASK
 
     rw = ReferenceWorkflow("media", "stg", "some.name", "cafe", inputs=kwtypes(in1=str), outputs=kwtypes())
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, rw)
+    wf_spec = get_serializable(OrderedDict(), rw, serialization_settings)
     assert isinstance(wf_spec, ReferenceSpec)
     assert isinstance(wf_spec.template, ReferenceTemplate)
     assert wf_spec.template.id == rw.reference.id
@@ -60,7 +60,7 @@ def test_basics():
         d = t2(a=y, b=b)
         return x, d
 
-    wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    wf_spec = get_serializable(OrderedDict(), my_wf, serialization_settings)
     assert len(wf_spec.template.interface.inputs) == 2
     assert len(wf_spec.template.interface.outputs) == 2
     assert len(wf_spec.template.nodes) == 2
@@ -72,14 +72,14 @@ def test_basics():
         .with_fast_serialization_settings(FastSerializationSettings(enabled=True))
         .build()
     )
-    task_spec = get_serializable(OrderedDict(), ssettings, t1)
+    task_spec = get_serializable(OrderedDict(), t1, ssettings)
     assert "pyflyte-execute" in task_spec.template.container.args
 
     lp = LaunchPlan.create(
         "testlp",
         my_wf,
     )
-    lp_model = get_serializable(OrderedDict(), serialization_settings, lp)
+    lp_model = get_serializable(OrderedDict(), lp, serialization_settings)
     assert lp_model.id.name == "testlp"
 
 
@@ -97,7 +97,7 @@ def test_fast():
         .with_fast_serialization_settings(FastSerializationSettings(enabled=True))
         .build()
     )
-    task_spec = get_serializable(OrderedDict(), ssettings, t1)
+    task_spec = get_serializable(OrderedDict(), t1, ssettings)
     assert "pyflyte-fast-execute" in task_spec.template.container.args
 
 
@@ -122,7 +122,7 @@ def test_container():
         .with_fast_serialization_settings(FastSerializationSettings(enabled=True))
         .build()
     )
-    task_spec = get_serializable(OrderedDict(), ssettings, t2)
+    task_spec = get_serializable(OrderedDict(), t2, ssettings)
     assert "pyflyte" not in task_spec.template.container.args
 
 
@@ -154,7 +154,7 @@ def test_launch_plan_with_fixed_input():
         .with_fast_serialization_settings(FastSerializationSettings(enabled=True))
         .build()
     )
-    task_spec = get_serializable(OrderedDict(), settings, morning_greeter_caller)
+    task_spec = get_serializable(OrderedDict(), morning_greeter_caller, settings)
     assert len(task_spec.template.interface.inputs) == 1
     assert len(task_spec.template.interface.outputs) == 1
     assert len(task_spec.template.nodes) == 1


### PR DESCRIPTION
# TL;DR

This PR makes passing of `SerializationSettings` for APIs like `register_task` and `register_workflow` lazy aka a user may not pass them. This is helpful in cases like:

1. Using a task which doesn't explicitly require a container, eg: `SQLTask`
2. Using a fetched task in a workflow, which is already registered and thus doesn't require the use of `SerializationSettings`

In cases where it is required, the error is bubbled up to `translator.py` which throws a `ValueError` at some point.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
1. The approach is to make `SerializationSettings` optional. But since we cannot change the API i.e. function signatures -- a dummy `SerializationSettings` object is created when the user doesn't pass one (i.e. it is None). This dummy object doesn't have any image associated with it. Hence, the error of not having an image is bubbled up and is handled later in `translator.py`

2. The following cases are tested (without passing `SerializationSettings` of course):
- Registering a SQL Task -- should allow
- Registering a Python based task -- should throw an error
- Registering a Workflow that only has SQL Tasks (or tasks used to fetch something etc.) -- should allow
- Registering a Workflow that uses both SQL based Tasks and Python based Tasks -- should throw an error
- Registering a Workflow only based on fetched tasks (even if they were originally Python based) -- should allow
- Registering a Workflow based on fetched tasks as well as some local Python Tasks -- should throw an error

## Some other observations
1. `register_launch_plan` is inconsistent with `register_task` and `register_workflow` — the latter 2 have `SerializationSettings` in their arguments, but the former does not. In my opinion, these 3 functions should be consistent aka have similar function signatures. But this is out of scope for the given task. I have added a TODO comment.

2. Inside the function `register_task`, the call to `_serialize_and_register` can probably replaced by the following snippet:
```
from flytekit.tools.translator import  get_serializable_task
...
...
ident = self._resolve_identifier(ResourceType.TASK, entity.name, version, serialization_settings)
m = OrderedDict()
idl_task = get_serializable_task(m, serialization_settings, entity)
self.client.create_task(task_identifer=ident, task_spec=idl_task.spec)
```
Similar stuff can be done for `register_workflow`.
But I am not sure if this is even required. But if this is indeed done, we can possibly eliminate the use of `_serialize_and_register` altogether.
Regardless, this PR doesn't attempt to do this.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2647

## Follow-up issue
_NA_
