### PR TITLE
[WIP]: using cloudpickle to run a task

### DIFF
--- a/flytekit/extras/cloud_pickle_resolver.py
+++ b/flytekit/extras/cloud_pickle_resolver.py
@@ -1,8 +1,9 @@
 import gzip
 import os
+import pathlib
 import pickle
 import tempfile
-from typing import List
+from typing import List, Optional
 
 import cloudpickle
 
@@ -11,6 +12,7 @@ from flytekit.core.base_task import TaskResolverMixin
 from flytekit.core.python_auto_container import PythonAutoContainerTask
 from flytekit.core.tracker import TrackedInstance
 from flytekit.loggers import remote_logger
+from flytekit.remote import FlyteRemote
 
 
 class CloudPickleResolver(TrackedInstance, TaskResolverMixin):
@@ -18,26 +20,31 @@ class CloudPickleResolver(TrackedInstance, TaskResolverMixin):
     Pickles the task (using cloudpickle) and ships it off for Data Persistence (S3, etc.)
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, remote: Optional[FlyteRemote] = None, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._remote = remote
 
     def name(self) -> str:
         return "CloudPickleResolver"
 
     def load_task(self, loader_args: List[str]) -> PythonAutoContainerTask:
-        uri = loader_args[0]
+        if len(loader_args) != 1:
+            raise RuntimeError(f"Unable to load task, received ambiguous loader args {loader_args}, expected only one")
 
-        # TODO: get gzipped file from data persistence using URI from loader_args
-        filename = ...
+        uri = loader_args[0]
+        t_file = tempfile.NamedTemporaryFile(delete=False)
+        filename = t_file.name
+        self._remote._ctx.file_access.get_data(loader_args[0], filename)
 
         with gzip.open(filename, mode="rb") as fg:
             t_bytes = fg.read()
 
         remote_logger.info(f"Task of size {len(t_bytes)} bytes downloaded from {uri}")
-
         return pickle.loads(t_bytes)
 
     def loader_args(self, settings: SerializationSettings, t: PythonAutoContainerTask) -> List[str]:
+        if self._remote is None:
+            raise ValueError("Cannot retrieve loader args without a FlyteRemote object.")
         with tempfile.TemporaryDirectory() as tmp_dir:
             t_bytes = cloudpickle.dumps(t)
             t_fname = os.path.join(tmp_dir, "task.pickle")
@@ -48,13 +55,15 @@ class CloudPickleResolver(TrackedInstance, TaskResolverMixin):
                 with open(t_fname, "rb") as fd:
                     gzipped.write(fd.read())
 
-            # TODO: Upload gzipped file for data persistence and get its URI
-            uri = ...
+            _, uri = self._remote._upload_file(
+                pathlib.Path(t_fname_gzipped),
+                settings.project or self._remote.default_project,
+                settings.domain or self._remote.default_domain,
+            )
 
             remote_logger.info(
                 f"Task {t.name} zipped, pickled and persisted to {uri} from temporary file {t_fname_gzipped}"
             )
-
             return [uri]
 
     def get_all_tasks(self) -> List[PythonAutoContainerTask]:

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -34,6 +34,7 @@ from flytekit.core.type_engine import LiteralsResolver, TypeEngine
 from flytekit.core.workflow import WorkflowBase
 from flytekit.exceptions import user as user_exceptions
 from flytekit.exceptions.user import FlyteEntityAlreadyExistsException, FlyteEntityNotExistException
+from flytekit.extras.cloud_pickle_resolver import CloudPickleResolver
 from flytekit.loggers import remote_logger
 from flytekit.models import common as common_models
 from flytekit.models import filters as filter_models
@@ -119,6 +120,7 @@ class FlyteRemote(object):
         default_project: typing.Optional[str] = None,
         default_domain: typing.Optional[str] = None,
         data_upload_location: str = "s3://my-s3-bucket/data",
+        use_cloudpickle: bool = False,
         **kwargs,
     ):
         """Initialize a FlyteRemote object.
@@ -144,6 +146,8 @@ class FlyteRemote(object):
             raw_output_prefix=data_upload_location,
             data_config=config.data_config,
         )
+
+        self._resolver = CloudPickleResolver() if use_cloudpickle else None
 
         # Save the file access object locally, build a context for it and save that as well.
         self._ctx = FlyteContextManager.current_context().with_file_access(self._file_access).build()


### PR DESCRIPTION
# TL;DR

Implements a new `CloudPickleResolver` that should allow us to zip, pickle and ship a task for data persistence.
This PR is a work in progress as of writing this comment.

Things that need to be figured out are:

1. How to upload / download (put / get) file from the data persistence store?
    - Hunch is that it is related to the `DataPersistence` class or perhaps the `file_access` object.
2. How to use a different task resolver i.e. what is the mechanism to plug in the new resolver and override the default one?

Unit tests are also remaining.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

Documentation exploring the issue and the approach here:
https://docs.google.com/document/d/19Y6mj_tPKRgzfkqQz1UoLHGavMb_rzqjtpeoLUlalNI/edit?usp=sharing

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2481

## Follow-up issue
_NA_
