### PR TITLE
Correctly fetch `typing.Annotated` metadata in `typing.NamedTuple`

### DIFF
--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -395,7 +395,7 @@ def extract_return_annotation(return_annotation: Union[Type, Tuple, None]) -> Di
         bases = return_annotation.__bases__  # type: ignore
         if len(bases) == 1 and bases[0] == tuple and hasattr(return_annotation, "_fields"):
             logger.debug(f"Task returns named tuple {return_annotation}")
-            return dict(typing.get_type_hints(return_annotation))
+            return dict(typing.get_type_hints(return_annotation, include_extras=True))
 
     if hasattr(return_annotation, "__origin__") and return_annotation.__origin__ is tuple:  # type: ignore
         # Handle option 3

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -7,7 +7,7 @@ import typing
 from collections import OrderedDict
 from typing import Any, Dict, Generator, List, Optional, Tuple, Type, TypeVar, Union
 
-from typing_extensions import get_args, get_origin
+from typing_extensions import get_args, get_origin, get_type_hints
 
 from flytekit.core import context_manager
 from flytekit.core.docstring import Docstring
@@ -283,11 +283,8 @@ def transform_function_to_interface(fn: typing.Callable, docstring: Optional[Doc
     For now the fancy object, maybe in the future a dumb object.
 
     """
-    try:
-        # include_extras can only be used in python >= 3.9
-        type_hints = typing.get_type_hints(fn, include_extras=True)
-    except TypeError:
-        type_hints = typing.get_type_hints(fn)
+
+    type_hints = get_type_hints(fn, include_extras=True)
     signature = inspect.signature(fn)
     return_annotation = type_hints.get("return", None)
 
@@ -395,7 +392,7 @@ def extract_return_annotation(return_annotation: Union[Type, Tuple, None]) -> Di
         bases = return_annotation.__bases__  # type: ignore
         if len(bases) == 1 and bases[0] == tuple and hasattr(return_annotation, "_fields"):
             logger.debug(f"Task returns named tuple {return_annotation}")
-            return dict(typing.get_type_hints(return_annotation, include_extras=True))
+            return dict(get_type_hints(return_annotation, include_extras=True))
 
     if hasattr(return_annotation, "__origin__") and return_annotation.__origin__ is tuple:  # type: ignore
         # Handle option 3

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -16,7 +16,7 @@ import pytest
 from dataclasses_json import dataclass_json
 from google.protobuf.struct_pb2 import Struct
 from pandas._testing import assert_frame_equal
-from typing_extensions import Annotated
+from typing_extensions import Annotated, get_origin
 
 import flytekit
 import flytekit.configuration
@@ -87,6 +87,14 @@ def test_forwardref_namedtuple_output():
 
     assert my_task(a=3) == (5, "hello world")
     assert context_manager.FlyteContextManager.size() == 1
+
+
+def test_annotated_namedtuple_output():
+    @task
+    def my_task() -> typing.NamedTuple("OutputA", a=Annotated[int, "metadata-a"]):
+        return 1
+
+    assert get_origin(my_task.python_interface.outputs["a"]) is Annotated
 
 
 def test_simple_input_no_output():

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -91,9 +91,10 @@ def test_forwardref_namedtuple_output():
 
 def test_annotated_namedtuple_output():
     @task
-    def my_task() -> typing.NamedTuple("OutputA", a=Annotated[int, "metadata-a"]):
-        return 1
+    def my_task(a: int) -> typing.NamedTuple("OutputA", a=Annotated[int, "metadata-a"]):
+        return a + 2
 
+    assert my_task(a=9) == (11,)
     assert get_origin(my_task.python_interface.outputs["a"]) is Annotated
 
 


### PR DESCRIPTION
Signed-off-by: Samhita Alla <aallasamhita@gmail.com>

# TL;DR
Annotated metadata isn't included in namedtuple typing. `include_extras` should fix the issue.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Modified the import of `get_type_hints` from  `typing` to `typing_extensions` since `include_extras` is available starting Python 3.9.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
