### PR TITLE
Use latest (as of 2022-07-11) version of codecov action

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           coverage run -m pytest tests/flytekit/unit -m "not sandbox_test"
       - name: Codecov
-        uses: codecov/codecov-action@v1.5.2
+        uses: codecov/codecov-action@v3.1.0
         with:
           fail_ci_if_error: true # optional (default = false)
 

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -49,7 +49,7 @@ jobs:
           pip freeze
       - name: Test with coverage
         run: |
-          coverage run -m pytest tests/flytekit/unit -m "not sandbox_test"
+          pytest tests/flytekit/unit -m "not sandbox_test" --cov=./ --cov-report=xml
       - name: Codecov
         uses: codecov/codecov-action@v3.1.0
         with:

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -5,6 +5,7 @@ coverage[toml]
 joblib
 mock
 pytest
+pytest-cov
 mypy
 pre-commit
 codespell

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -66,7 +66,9 @@ cookiecutter==2.1.1
     #   -c requirements.txt
     #   flytekit
 coverage[toml]==6.4.1
-    # via -r dev-requirements.in
+    # via
+    #   -r dev-requirements.in
+    #   pytest-cov
 croniter==1.3.5
     # via
     #   -c requirements.txt
@@ -136,7 +138,7 @@ google-auth==2.9.0
     #   google-cloud-core
 google-cloud-bigquery==3.2.0
     # via -r dev-requirements.in
-google-cloud-bigquery-storage==2.13.2
+google-cloud-bigquery-storage==2.14.0
     # via
     #   -r dev-requirements.in
     #   google-cloud-bigquery
@@ -275,7 +277,7 @@ platformdirs==2.5.2
     # via virtualenv
 pluggy==1.0.0
     # via pytest
-pre-commit==2.19.0
+pre-commit==2.20.0
     # via -r dev-requirements.in
 prompt-toolkit==3.0.30
     # via ipython
@@ -340,8 +342,11 @@ pyrsistent==0.18.1
 pytest==7.1.2
     # via
     #   -r dev-requirements.in
+    #   pytest-cov
     #   pytest-docker
     #   pytest-flyte
+pytest-cov==3.0.0
+    # via -r dev-requirements.in
 pytest-docker==0.12.0
     # via pytest-flyte
 pytest-flyte @ git+https://github.com/flyteorg/pytest-flyte@main
@@ -356,7 +361,7 @@ python-dateutil==2.8.2
     #   pandas
 python-dotenv==0.20.0
     # via docker-compose
-python-json-logger==2.0.2
+python-json-logger==2.0.4
     # via
     #   -c requirements.txt
     #   flytekit
@@ -380,7 +385,7 @@ pyyaml==5.4.1
     #   docker-compose
     #   flytekit
     #   pre-commit
-regex==2022.6.2
+regex==2022.7.9
     # via
     #   -c requirements.txt
     #   docker-image-py
@@ -444,7 +449,7 @@ tomli==2.0.1
     #   coverage
     #   mypy
     #   pytest
-torch==1.11.0
+torch==1.12.0
     # via -r dev-requirements.in
 traitlets==5.3.0
     # via
@@ -466,7 +471,7 @@ typing-inspect==0.7.1
     # via
     #   -c requirements.txt
     #   dataclasses-json
-urllib3==1.26.9
+urllib3==1.26.10
     # via
     #   -c requirements.txt
     #   flytekit

--- a/requirements-spark2.txt
+++ b/requirements-spark2.txt
@@ -140,7 +140,7 @@ python-dateutil==2.8.2
     #   croniter
     #   flytekit
     #   pandas
-python-json-logger==2.0.2
+python-json-logger==2.0.4
     # via flytekit
 python-slugify==6.1.2
     # via cookiecutter
@@ -155,7 +155,7 @@ pyyaml==5.4.1
     #   -r requirements.in
     #   cookiecutter
     #   flytekit
-regex==2022.6.2
+regex==2022.7.9
     # via docker-image-py
 requests==2.28.1
     # via
@@ -192,7 +192,7 @@ typing-extensions==4.3.0
     #   typing-inspect
 typing-inspect==0.7.1
     # via dataclasses-json
-urllib3==1.26.9
+urllib3==1.26.10
     # via
     #   flytekit
     #   requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -138,7 +138,7 @@ python-dateutil==2.8.2
     #   croniter
     #   flytekit
     #   pandas
-python-json-logger==2.0.2
+python-json-logger==2.0.4
     # via flytekit
 python-slugify==6.1.2
     # via cookiecutter
@@ -153,7 +153,7 @@ pyyaml==5.4.1
     #   -r requirements.in
     #   cookiecutter
     #   flytekit
-regex==2022.6.2
+regex==2022.7.9
     # via docker-image-py
 requests==2.28.1
     # via
@@ -190,7 +190,7 @@ typing-extensions==4.3.0
     #   typing-inspect
 typing-inspect==0.7.1
     # via dataclasses-json
-urllib3==1.26.9
+urllib3==1.26.10
     # via
     #   flytekit
     #   requests


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Use v3 of codecov github action

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The number #1 failure in flytekit PRs (e.g. [1](https://github.com/flyteorg/flytekit/runs/7285489312?check_suite_focus=true)) is transient failures in the codecov action, this is supposed to be fixed in later versions. 

Also, v1 was officially [deprecated in February-2022](https://github.com/codecov/codecov-action/#%EF%B8%8F--deprecation-of-v1). The one property we set was migrated to v3, so no change is needed.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
