### PR TITLE
Don't override target name when using self-signed certs

### DIFF
--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -120,7 +120,6 @@ class RawSynchronousFlyteClient(object):
             else:
                 server_address = (cfg.endpoint, "443")
             cert = ssl.get_server_certificate(server_address)
-            x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert)
             credentials = grpc.ssl_channel_credentials(str.encode(cert))
             options = kwargs.get("options", [])
             self._channel = grpc.secure_channel(

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -119,13 +119,11 @@ class RawSynchronousFlyteClient(object):
                 server_address = tuple(endpoint_parts)
             else:
                 server_address = (cfg.endpoint, "443")
-
             cert = ssl.get_server_certificate(server_address)
             x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert)
             cn = x509.get_subject().CN
             credentials = grpc.ssl_channel_credentials(str.encode(cert))
             options = kwargs.get("options", [])
-            options.append(("grpc.ssl_target_name_override", cn))
             self._channel = grpc.secure_channel(
                 target=cfg.endpoint,
                 credentials=credentials,

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -121,7 +121,6 @@ class RawSynchronousFlyteClient(object):
                 server_address = (cfg.endpoint, "443")
             cert = ssl.get_server_certificate(server_address)
             x509 = OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert)
-            cn = x509.get_subject().CN
             credentials = grpc.ssl_channel_credentials(str.encode(cert))
             options = kwargs.get("options", [])
             self._channel = grpc.secure_channel(

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -8,7 +8,6 @@ import typing
 from typing import Optional
 
 import grpc
-import OpenSSL
 import requests as _requests
 from flyteidl.admin.project_pb2 import ProjectListRequest
 from flyteidl.service import admin_pb2_grpc as _admin_service


### PR DESCRIPTION
# TL;DR
We were getting
```
Error getpublicclient config <_InactiveRpcError of RPC that terminated with:
        status = StatusCode.UNKNOWN
        details = "Stream removed"
        debug_error_string = "{"created":"@1657750494.962014000","description":"Error received from peer ipv4:54.80.18.147:443","file":"src/core/lib/surface/call.cc","file_line":967,"grpc_message":"Stream removed","grpc_status":2}"
>
```
when using the admin client with a self-signed cert.

The reason is because the `cn` from the x509 subject had a * in it.  `*.elb.us-east-1.amazonaws.com` which was causing the ssl check to fail in nginx ingress.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2420
