### PR TITLE
Fix tar permisison override

### DIFF
--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -83,9 +83,6 @@ def tar_strip_file_attributes(tar_info: tarfile.TarInfo) -> tarfile.TarInfo:
     # note that when extracting this tarfile, this time will be shown as the modified date
     tar_info.mtime = 0
 
-    # file permissions, probably don't want to remove this, but for some use cases you could
-    tar_info.mode = 0
-
     # user/group info
     tar_info.uid = 0
     tar_info.uname = ""


### PR DESCRIPTION
# TL;DR
This fixes an issue where unpacked fast-registered tar archives end up having `d---------` as file permissions. Root doesn't care but we prefer not to run as root. With that line removed, the permissions end up `drwx------` which works. `uid` and `gid` are overridden when unpacking so that part is no problem. 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
