### PR TITLE
Added AzureBlobFileSystem support for StructuredDatasets

### DIFF
--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -12,6 +12,7 @@ from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
+    ABFS,
     GCS,
     LOCAL,
     PARQUET,
@@ -106,7 +107,7 @@ class ParquetToArrowDecodingHandler(StructuredDatasetDecoder):
 
 
 # Don't override default protocol
-for protocol in [LOCAL, S3, GCS]:
+for protocol in [LOCAL, S3, GCS, ABFS]:
     StructuredDatasetTransformerEngine.register(PandasToParquetEncodingHandler(protocol), default_for_type=False)
     StructuredDatasetTransformerEngine.register(ParquetToPandasDecodingHandler(protocol), default_for_type=False)
     StructuredDatasetTransformerEngine.register(ArrowToParquetEncodingHandler(protocol), default_for_type=False)

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -39,6 +39,7 @@ DF = typing.TypeVar("DF")  # Dataframe type
 # Protocols
 BIGQUERY = "bq"
 S3 = "s3"
+ABFS = "abfs"
 GCS = "gs"
 LOCAL = "/"
 

--- a/plugins/flytekit-data-fsspec/flytekitplugins/fsspec/__init__.py
+++ b/plugins/flytekit-data-fsspec/flytekitplugins/fsspec/__init__.py
@@ -26,7 +26,7 @@ import importlib
 
 from flytekit import StructuredDatasetTransformerEngine, logger
 from flytekit.configuration import internal
-from flytekit.types.structured.structured_dataset import GCS, S3
+from flytekit.types.structured.structured_dataset import ABFS, GCS, S3
 
 from .arrow import ArrowToParquetEncodingHandler, ParquetToArrowDecodingHandler
 from .pandas import PandasToParquetEncodingHandler, ParquetToPandasDecodingHandler
@@ -40,6 +40,9 @@ def _register(protocol: str):
     StructuredDatasetTransformerEngine.register(ArrowToParquetEncodingHandler(protocol), True, True)
     StructuredDatasetTransformerEngine.register(ParquetToArrowDecodingHandler(protocol), True, True)
 
+
+if importlib.util.find_spec("adlfs"):
+    _register(ABFS)
 
 if importlib.util.find_spec("s3fs"):
     _register(S3)

--- a/plugins/flytekit-data-fsspec/setup.py
+++ b/plugins/flytekit-data-fsspec/setup.py
@@ -22,6 +22,7 @@ setup(
     install_requires=plugin_requires,
     extras_require={
         # https://github.com/fsspec/filesystem_spec/blob/master/setup.py#L36
+        "abfs": ["adlfs>=2022.2.0"],
         "aws": ["s3fs>=2021.7.0"],
         "gcp": ["gcsfs>=2021.7.0"],
     },

--- a/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
+++ b/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
@@ -7,6 +7,7 @@ from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
+    ABFS,
     GCS,
     LOCAL,
     PARQUET,
@@ -62,7 +63,7 @@ class ParquetToPolarsDataFrameDecodingHandler(StructuredDatasetDecoder):
         return pl.read_parquet(path)
 
 
-for protocol in [LOCAL, S3, GCS]:
+for protocol in [LOCAL, S3, GCS, ABFS]:
     StructuredDatasetTransformerEngine.register(
         PolarsDataFrameToParquetEncodingHandler(protocol), default_for_type=False
     )

--- a/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
@@ -7,7 +7,11 @@ from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
+    ABFS,
+    GCS,
+    LOCAL,
     PARQUET,
+    S3,
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
@@ -48,6 +52,6 @@ class ParquetToSparkDecodingHandler(StructuredDatasetDecoder):
         return user_ctx.spark_session.read.parquet(flyte_value.uri)
 
 
-for protocol in ["/", "s3"]:
+for protocol in [LOCAL, S3, GCS, ABFS]:
     StructuredDatasetTransformerEngine.register(SparkToParquetEncodingHandler(protocol), default_for_type=False)
     StructuredDatasetTransformerEngine.register(ParquetToSparkDecodingHandler(protocol), default_for_type=False)


### PR DESCRIPTION
# TL;DR
This PR adds support for storing `StructuredDatasets` using AzureBlobFileSystem (`abfs`).

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
As discussed before, we've added support for `abfs` (using `adlfs`/`stow` under the hood) for `StructuredDatasets` by adding it to the registered protocols for transformers.
I've also noticed one file (`plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py`) which still used string constants and didn't support GCS either. As we're currently not using Spark anywhere, I wasn't able to verify this change though, so I can revert those lines if you'd prefer.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2709

## Follow-up issue
_NA_
