### PR TITLE
Add deck to papermill plugin task

### DIFF
--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -11,6 +11,7 @@ from nbconvert import HTMLExporter
 
 from flytekit import FlyteContext, PythonInstanceTask
 from flytekit.core.context_manager import ExecutionParameters
+from flytekit.deck.deck import Deck
 from flytekit.extend import Interface, TaskPlugins, TypeEngine
 from flytekit.loggers import logger
 from flytekit.models.literals import LiteralMap
@@ -109,6 +110,7 @@ class NotebookTask(PythonInstanceTask[T]):
         self,
         name: str,
         notebook_path: str,
+        render_deck: bool = False,
         task_config: T = None,
         inputs: typing.Optional[typing.Dict[str, typing.Type]] = None,
         outputs: typing.Optional[typing.Dict[str, typing.Type]] = None,
@@ -127,6 +129,8 @@ class NotebookTask(PythonInstanceTask[T]):
         self._config_task_instance._name = f"{PAPERMILL_TASK_PREFIX}.{name}"
         task_type = f"nb-{self._config_task_instance.task_type}"
         self._notebook_path = os.path.abspath(notebook_path)
+
+        self._render_deck = render_deck
 
         if not os.path.exists(self._notebook_path):
             raise ValueError(f"Illegal notebook path passed in {self._notebook_path}")
@@ -225,6 +229,15 @@ class NotebookTask(PythonInstanceTask[T]):
         return tuple(output_list)
 
     def post_execute(self, user_params: ExecutionParameters, rval: Any) -> Any:
+        if self._render_deck:
+            nb_deck = Deck(self._IMPLICIT_RENDERED_NOTEBOOK)
+            with open(self.rendered_output_path, "r") as f:
+                notebook_html = f.read()
+            nb_deck.append(notebook_html)
+            # Since user_params is passed by reference, this modifies the object in the outside scope
+            # which then causes the deck to be rendered later during the dispatch_execute function.
+            user_params.decks.append(nb_deck)
+
         return self._config_task_instance.post_execute(user_params, rval)
 
 

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -64,6 +64,7 @@ class NotebookTask(PythonInstanceTask[T]):
             name="modulename.my_notebook_task", # the name should be unique within all your tasks, usually it is a good
                                                # idea to use the modulename
             notebook_path="../path/to/my_notebook",
+            render_deck=True,
             inputs=kwtypes(v=int),
             outputs=kwtypes(x=int, y=str),
             metadata=TaskMetadata(retries=3, cache=True, cache_version="1.0"),
@@ -77,7 +78,7 @@ class NotebookTask(PythonInstanceTask[T]):
 
     #. It captures the executed notebook in its entirety and is available from Flyte with the name ``out_nb``.
     #. It also converts the captured notebook into an ``html`` page, which the FlyteConsole will render called -
-       ``out_rendered_nb``
+       ``out_rendered_nb``. If ``render_deck=True`` is passed, this html content will be inserted into a deck.
 
     .. note:
 

--- a/plugins/flytekit-papermill/tests/test_task.py
+++ b/plugins/flytekit-papermill/tests/test_task.py
@@ -69,3 +69,17 @@ def test_notebook_task_complex():
     assert nb.python_interface.outputs.keys() == {"h", "w", "x", "out_nb", "out_rendered_nb"}
     assert nb.output_notebook_path == out == _get_nb_path(nb_name, suffix="-out")
     assert nb.rendered_output_path == render == _get_nb_path(nb_name, suffix="-out", ext=".html")
+
+
+def test_notebook_deck_local_execution_doesnt_fail():
+    nb_name = "nb-simple"
+    nb = NotebookTask(
+        name="test",
+        notebook_path=_get_nb_path(nb_name, abs=False),
+        render_deck=True,
+        inputs=kwtypes(pi=float),
+        outputs=kwtypes(square=float),
+    )
+    sqr, out, render = nb.execute(pi=4)
+    # This is largely a no assert test to ensure render_deck never inhibits local execution.
+    assert nb._render_deck, "Passing render deck to init should result in private attribute being set"


### PR DESCRIPTION
# TL;DR
This PR modifies the papermill plugin so that, if render_deck=True is passed to __init__, the rendered output html is inserted as a flyte deck.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
This PR modifies the papermill plugin so that, if a kwarg render_deck is passed, the flyte deck is added automatically, without need for a follow up task. The render_deck kwarg was used to ensure backwards compatibility, by default, the behaviour of the papermill plugin won't be changed (i.e., this deck support is opt-in).

Note that this won't happen for cached execution, there is an open issue out for fixing flyte decks for cached execution.

I tested this change by installing this branch of flytekit into a container and registering one of our company's test notebook tasks, and running it. It gets a deck as intended:
<img width="1546" alt="image" src="https://user-images.githubusercontent.com/6288302/181396064-897133e3-3b3e-43a0-ad9b-5f3391c10492.png">


<img width="1546" alt="image" src="https://user-images.githubusercontent.com/6288302/181396045-e43bf762-9fae-4a75-a398-9c35fe01f260.png">

Not 100% happy with how I tested this plugin. Since the unit tests use local execution, the deck/context functionality I think isn't getting used. Let me know if there is a better way to do test this.

## Tracking Issue
n/a (can open an issue if you like, JFDI'd this after discussing with Ketan [here](https://flyte-org.slack.com/archives/CP2HDHKE1/p1658958351388009?thread_ts=1658863230.650909&cid=CP2HDHKE1))

## Follow-up issue
_NA_
