### PR TITLE
Remove py.typed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,6 @@ recursive-include plugins *
 
 # include specific files
 include README.md
-include flytekit/py.typed  # marker file for PEP 561
 include flytekit/deck/html/template.html
 
 include CHANGELOG.md


### PR DESCRIPTION
# TL;DR
It seems there is was a py.typed file that was inadvertently added as part of https://github.com/flyteorg/flytekit/pull/1088.  This is causing issues.

There are lots of places where we need to clean up mypy before adding this file.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Remove file.
