### PR TITLE
Override voidPromise resource

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -679,6 +679,11 @@ class VoidPromise(object):
         if self.ref:
             self.ref.node.runs_before(other.ref.node)
 
+    def with_overrides(self, *args, **kwargs):
+        if self.ref:
+            self.ref.node.with_overrides(*args, **kwargs)
+        return self
+
     @property
     def task_name(self):
         return self._task_name


### PR DESCRIPTION
# TL;DR
https://flyte-org.slack.com/archives/CP2HDHKE1/p1659712233906449?thread_ts=1659445048.597709&cid=CP2HDHKE1

We should support overriding the resource of voidPromise

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
