### PR TITLE
Set to remote when dealing with remote files

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -88,7 +88,7 @@ class FileParamType(click.ParamType):
         self, value: typing.Any, param: typing.Optional[click.Parameter], ctx: typing.Optional[click.Context]
     ) -> typing.Any:
         if FileAccessProvider.is_remote(value):
-            return FileParam(filepath=value)
+            return FileParam(filepath=value, local=False)
         p = pathlib.Path(value)
         if p.exists() and p.is_file():
             return FileParam(filepath=str(p.resolve()))

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -8,7 +8,13 @@ from click.testing import CliRunner
 from flytekit.clis.sdk_in_container import pyflyte
 from flytekit.clis.sdk_in_container.constants import CTX_CONFIG_FILE
 from flytekit.clis.sdk_in_container.helpers import FLYTE_REMOTE_INSTANCE_KEY
-from flytekit.clis.sdk_in_container.run import REMOTE_FLAG_KEY, RUN_LEVEL_PARAMS_KEY, get_entities_in_file, run_command
+from flytekit.clis.sdk_in_container.run import (
+    REMOTE_FLAG_KEY,
+    RUN_LEVEL_PARAMS_KEY,
+    FileParamType,
+    get_entities_in_file,
+    run_command,
+)
 from flytekit.configuration import Image, ImageConfig
 from flytekit.core.task import task
 
@@ -241,3 +247,11 @@ def test_pyflyte_run_run(image_string, leaf_configuration_file_name, final_image
     mock_remote.register_script.side_effect = check_image
 
     run_command(mock_click_ctx, a)()
+
+
+def test_file_param():
+    m = mock.MagicMock()
+    l = FileParamType().convert(__file__, m, m)
+    assert l.local
+    r = FileParamType().convert("https://tmp/file", m, m)
+    assert r.local is False


### PR DESCRIPTION
# TL;DR
Should be local false when dealing with remote files, otherwise flytekit run will try to hash it.

This happens when you have a wf locally with a signature like

```
@workflow
from flytekit.types.file import PNGImageFile
def demo_wf(b: PNGImageFile) -> str:
```
and you pass `--b "https:..."` to `pyflyte run`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

