### PR TITLE
Fix how ShellTask retrieves the Pod class name

### DIFF
--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -132,7 +132,8 @@ class ShellTask(PythonInstanceTask[T]):
             script_file = os.path.abspath(script_file)
 
         if task_config is not None:
-            if str(type(task_config)) != "flytekitplugins.pod.task.Pod":
+            fully_qualified_class_name = task_config.__module__ + '.' + task_config.__class__.__name__
+            if not fully_qualified_class_name == "flytekitplugins.pod.task.Pod":
                 raise ValueError("TaskConfig can either be empty - indicating simple container task or a PodConfig.")
 
         # Each instance of NotebookTask instantiates an underlying task with a dummy function that will only be used

--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -15,9 +15,6 @@ from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import FlyteFile
 
 
-FLYTEPLUGINS_POD_TYPE_CLASS_NAME = "flytekitplugins.pod.task.Pod"
-
-
 @dataclass
 class OutputLocation:
     """
@@ -136,7 +133,7 @@ class ShellTask(PythonInstanceTask[T]):
 
         if task_config is not None:
             fully_qualified_class_name = task_config.__module__ + '.' + task_config.__class__.__name__
-            if not fully_qualified_class_name == FLYTEPLUGINS_POD_TYPE_CLASS_NAME:
+            if not fully_qualified_class_name == "flytekitplugins.pod.task.Pod":
                 raise ValueError("TaskConfig can either be empty - indicating simple container task or a PodConfig.")
 
         # Each instance of NotebookTask instantiates an underlying task with a dummy function that will only be used

--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -15,6 +15,9 @@ from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import FlyteFile
 
 
+FLYTEPLUGINS_POD_TYPE_CLASS_NAME = "flytekitplugins.pod.task.Pod"
+
+
 @dataclass
 class OutputLocation:
     """
@@ -133,7 +136,7 @@ class ShellTask(PythonInstanceTask[T]):
 
         if task_config is not None:
             fully_qualified_class_name = task_config.__module__ + '.' + task_config.__class__.__name__
-            if not fully_qualified_class_name == "flytekitplugins.pod.task.Pod":
+            if not fully_qualified_class_name == FLYTEPLUGINS_POD_TYPE_CLASS_NAME:
                 raise ValueError("TaskConfig can either be empty - indicating simple container task or a PodConfig.")
 
         # Each instance of NotebookTask instantiates an underlying task with a dummy function that will only be used

--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -132,7 +132,7 @@ class ShellTask(PythonInstanceTask[T]):
             script_file = os.path.abspath(script_file)
 
         if task_config is not None:
-            fully_qualified_class_name = task_config.__module__ + '.' + task_config.__class__.__name__
+            fully_qualified_class_name = task_config.__module__ + "." + task_config.__class__.__name__
             if not fully_qualified_class_name == "flytekitplugins.pod.task.Pod":
                 raise ValueError("TaskConfig can either be empty - indicating simple container task or a PodConfig.")
 


### PR DESCRIPTION
# TL;DR
This PR fixes the type check executed at package time of shell tasks with specified task configurations.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description

The `task_config` parameter passed to a shell task must be of type `None` or `flytekitplugins.pod.task.Pod`. Right now, this check is being made with the following logic:

```python
if task_config is not None:
    if str(type(task_config)) != "flytekitplugins.pod.task.Pod":
        raise ValueError("TaskConfig can either be empty - indicating simple container task or a PodConfig.")
```

The nested if condition always returns true, because `str(type(task_config))` returns the string `"<class 'flytekitplugins.pod.task.Pod'>"`.

The proposed solution uses the `__module__` and `__class__.__name__` dunder methods to build the fully qualified class name for the parameter since it appears it shouldn't import `flytekitplugins`.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2765

## Follow-up issue
_NA_
