### PR TITLE
Allow None protocol to mean all data persistence supported storage options in Structured Dataset

### DIFF
--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -171,6 +171,10 @@ class DataPersistencePlugins(object):
         """
         return protocol in cls._PLUGINS
 
+    @classmethod
+    def supported_protocols(cls) -> typing.List[str]:
+        return [k for k in cls._PLUGINS.keys()]
+
 
 class DiskPersistence(DataPersistence):
     """

--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -7,16 +7,11 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from flytekit import FlyteContext
-from flytekit.core.data_persistence import DataPersistencePlugins
 from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
-    ABFS,
-    GCS,
-    LOCAL,
     PARQUET,
-    S3,
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
@@ -27,10 +22,8 @@ T = TypeVar("T")
 
 
 class PandasToParquetEncodingHandler(StructuredDatasetEncoder):
-    def __init__(self, protocol: str):
-        super().__init__(pd.DataFrame, protocol, PARQUET)
-        # todo: Use this somehow instead of relaying ont he ctx file_access
-        self._persistence = DataPersistencePlugins.find_plugin(protocol)()
+    def __init__(self):
+        super().__init__(pd.DataFrame, None, PARQUET)
 
     def encode(
         self,
@@ -50,8 +43,8 @@ class PandasToParquetEncodingHandler(StructuredDatasetEncoder):
 
 
 class ParquetToPandasDecodingHandler(StructuredDatasetDecoder):
-    def __init__(self, protocol: str):
-        super().__init__(pd.DataFrame, protocol, PARQUET)
+    def __init__(self):
+        super().__init__(pd.DataFrame, None, PARQUET)
 
     def decode(
         self,
@@ -69,8 +62,8 @@ class ParquetToPandasDecodingHandler(StructuredDatasetDecoder):
 
 
 class ArrowToParquetEncodingHandler(StructuredDatasetEncoder):
-    def __init__(self, protocol: str):
-        super().__init__(pa.Table, protocol, PARQUET)
+    def __init__(self):
+        super().__init__(pa.Table, None, PARQUET)
 
     def encode(
         self,
@@ -88,8 +81,8 @@ class ArrowToParquetEncodingHandler(StructuredDatasetEncoder):
 
 
 class ParquetToArrowDecodingHandler(StructuredDatasetDecoder):
-    def __init__(self, protocol: str):
-        super().__init__(pa.Table, protocol, PARQUET)
+    def __init__(self):
+        super().__init__(pa.Table, None, PARQUET)
 
     def decode(
         self,
@@ -106,9 +99,7 @@ class ParquetToArrowDecodingHandler(StructuredDatasetDecoder):
         return pq.read_table(local_dir)
 
 
-# Don't override default protocol
-for protocol in [LOCAL, S3, GCS, ABFS]:
-    StructuredDatasetTransformerEngine.register(PandasToParquetEncodingHandler(protocol), default_for_type=False)
-    StructuredDatasetTransformerEngine.register(ParquetToPandasDecodingHandler(protocol), default_for_type=False)
-    StructuredDatasetTransformerEngine.register(ArrowToParquetEncodingHandler(protocol), default_for_type=False)
-    StructuredDatasetTransformerEngine.register(ParquetToArrowDecodingHandler(protocol), default_for_type=False)
+StructuredDatasetTransformerEngine.register(PandasToParquetEncodingHandler())
+StructuredDatasetTransformerEngine.register(ParquetToPandasDecodingHandler())
+StructuredDatasetTransformerEngine.register(ArrowToParquetEncodingHandler())
+StructuredDatasetTransformerEngine.register(ParquetToArrowDecodingHandler())

--- a/flytekit/types/structured/bigquery.py
+++ b/flytekit/types/structured/bigquery.py
@@ -111,7 +111,7 @@ class BQToArrowDecodingHandler(StructuredDatasetDecoder):
         return pa.Table.from_pandas(_read_from_bq(flyte_value, current_task_metadata))
 
 
-StructuredDatasetTransformerEngine.register(PandasToBQEncodingHandlers(), default_for_type=False)
-StructuredDatasetTransformerEngine.register(BQToPandasDecodingHandler(), default_for_type=False)
-StructuredDatasetTransformerEngine.register(ArrowToBQEncodingHandlers(), default_for_type=False)
-StructuredDatasetTransformerEngine.register(BQToArrowDecodingHandler(), default_for_type=False)
+StructuredDatasetTransformerEngine.register(PandasToBQEncodingHandlers())
+StructuredDatasetTransformerEngine.register(BQToPandasDecodingHandler())
+StructuredDatasetTransformerEngine.register(ArrowToBQEncodingHandlers())
+StructuredDatasetTransformerEngine.register(BQToArrowDecodingHandler())

--- a/flytekit/types/structured/bigquery.py
+++ b/flytekit/types/structured/bigquery.py
@@ -10,13 +10,14 @@ from flytekit import FlyteContext
 from flytekit.models import literals
 from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
-    BIGQUERY,
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
     StructuredDatasetMetadata,
     StructuredDatasetTransformerEngine,
 )
+
+BIGQUERY = "bq"
 
 
 def _write_to_bq(structured_dataset: StructuredDataset):

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -416,7 +416,7 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
                 try:
                     cls.register_for_protocol(h, stripped, False, override)
                 except DuplicateHandlerError:
-                    ...
+                    logger.debug(f"Skipping {persistence_protocol}/{stripped} for {h} because duplicate")
 
         elif h.protocol == "":
             raise ValueError(f"Use None instead of empty string for registering handler {h}")

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import collections
 import importlib
 import os
-import re
 import types
 import typing
 from abc import ABC, abstractmethod

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -277,11 +277,6 @@ class StructuredDatasetDecoder(ABC):
 def protocol_prefix(uri: str) -> str:
     p = DataPersistencePlugins.get_protocol(uri)
     return p
-    # g = re.search(r"([\w]+)://.*", uri)
-    # if g and g.groups():
-    #     return g.groups()[0]
-    #
-    # return "/"
 
 
 def convert_schema_type_to_structured_dataset_type(
@@ -750,12 +745,12 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
         return result
 
     def _get_dataset_column_literal_type(self, t: Type) -> type_models.LiteralType:
-        if t in self._SUPPORTED_TYPES:
-            return self._SUPPORTED_TYPES[t]
         if hasattr(t, "__origin__") and t.__origin__ == list:
             return type_models.LiteralType(collection_type=self._get_dataset_column_literal_type(t.__args__[0]))
-        if hasattr(t, "__origin__") and t.__origin__ == dict:
+        if hasattr(t, "__origin__") and t.__origin__ == dict or isinstance(t, collections.OrderedDict):
             return type_models.LiteralType(map_value_type=self._get_dataset_column_literal_type(t.__args__[1]))
+        if t in self._SUPPORTED_TYPES:
+            return self._SUPPORTED_TYPES[t]
         raise AssertionError(f"type {t} is currently not supported by StructuredDataset")
 
     def _convert_ordered_dict_of_columns_to_list(

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -279,7 +279,7 @@ def protocol_prefix(uri: str) -> str:
     if g and g.groups():
         return g.groups()[0]
 
-    return DiskPersistence.PROTOCOL
+    return "/"
 
 
 def convert_schema_type_to_structured_dataset_type(

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -172,6 +172,8 @@ class StructuredDatasetEncoder(ABC):
         :param python_type: The dataframe class in question that you want to register this encoder with
         :param protocol: A prefix representing the storage driver (e.g. 's3, 'gs', 'bq', etc.). You can use either
           "s3" or "s3://". They are the same since the "://" will just be stripped by the constructor.
+          If None, this encoder will be registered with all protocols that flytekit's data persistence layer
+          is capable of handling.
         :param supported_format: Arbitrary string representing the format. If not supplied then an empty string
           will be used. An empty string implies that the encoder works with any format. If the format being asked
           for does not exist, the transformer enginer will look for the "" endcoder instead and write a warning.
@@ -231,6 +233,8 @@ class StructuredDatasetDecoder(ABC):
         :param python_type: The dataframe class in question that you want to register this decoder with
         :param protocol: A prefix representing the storage driver (e.g. 's3, 'gs', 'bq', etc.). You can use either
           "s3" or "s3://". They are the same since the "://" will just be stripped by the constructor.
+          If None, this decoder will be registered with all protocols that flytekit's data persistence layer
+          is capable of handling.
         :param supported_format: Arbitrary string representing the format. If not supplied then an empty string
           will be used. An empty string implies that the decoder works with any format. If the format being asked
           for does not exist, the transformer enginer will look for the "" decoder instead and write a warning.
@@ -413,8 +417,6 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
                     cls.register_for_protocol(h, stripped, False, override)
                 except DuplicateHandlerError:
                     ...
-            # Add this?
-            # cls.register_for_protocol(h, "/", False, override)
 
         elif h.protocol == "":
             raise ValueError(f"Use None instead of empty string for registering handler {h}")

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -403,6 +403,9 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
         :param override: Override any previous registrations. If default_for_type is also set, this will also override
           the default.
         """
+        if not (isinstance(h, StructuredDatasetEncoder) or isinstance(h, StructuredDatasetDecoder)):
+            raise TypeError(f"We don't support this type of handler {h}")
+
         if h.protocol is None:
             if default_for_type:
                 raise ValueError(f"Registering SD handler {h} with all protocols should never have default specified.")

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -15,7 +15,7 @@ import numpy as _np
 import pandas as pd
 import pyarrow as pa
 
-from flytekit.core.data_persistence import DataPersistencePlugins, DiskPersistence
+from flytekit.core.data_persistence import DataPersistencePlugins
 
 if importlib.util.find_spec("pyspark") is not None:
     import pyspark

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -751,7 +751,7 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
             return self._SUPPORTED_TYPES[t]
         if hasattr(t, "__origin__") and t.__origin__ == list:
             return type_models.LiteralType(collection_type=self._get_dataset_column_literal_type(t.__args__[0]))
-        if hasattr(t, "__origin__") and t.__origin__ == dict or isinstance(t, collections.OrderedDict):
+        if hasattr(t, "__origin__") and t.__origin__ == dict:
             return type_models.LiteralType(map_value_type=self._get_dataset_column_literal_type(t.__args__[1]))
         raise AssertionError(f"type {t} is currently not supported by StructuredDataset")
 

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -15,7 +15,7 @@ import numpy as _np
 import pandas as pd
 import pyarrow as pa
 
-from flytekit.core.data_persistence import DataPersistencePlugins
+from flytekit.core.data_persistence import DataPersistencePlugins, DiskPersistence
 
 if importlib.util.find_spec("pyspark") is not None:
     import pyspark
@@ -278,7 +278,8 @@ def protocol_prefix(uri: str) -> str:
     g = re.search(r"([\w]+)://.*", uri)
     if g and g.groups():
         return g.groups()[0]
-    return LOCAL
+
+    return DiskPersistence.PROTOCOL
 
 
 def convert_schema_type_to_structured_dataset_type(

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -745,12 +745,12 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
         return result
 
     def _get_dataset_column_literal_type(self, t: Type) -> type_models.LiteralType:
+        if t in self._SUPPORTED_TYPES:
+            return self._SUPPORTED_TYPES[t]
         if hasattr(t, "__origin__") and t.__origin__ == list:
             return type_models.LiteralType(collection_type=self._get_dataset_column_literal_type(t.__args__[0]))
         if hasattr(t, "__origin__") and t.__origin__ == dict or isinstance(t, collections.OrderedDict):
             return type_models.LiteralType(map_value_type=self._get_dataset_column_literal_type(t.__args__[1]))
-        if t in self._SUPPORTED_TYPES:
-            return self._SUPPORTED_TYPES[t]
         raise AssertionError(f"type {t} is currently not supported by StructuredDataset")
 
     def _convert_ordered_dict_of_columns_to_list(

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -432,7 +432,9 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
             protocol = DataPersistencePlugins.get_protocol(DiskPersistence.PROTOCOL)
         lowest_level = cls._handler_finder(h, protocol)
         if h.supported_format in lowest_level and override is False:
-            raise DuplicateHandlerError(f"Already registered a handler for {(h.python_type, protocol, h.supported_format)}")
+            raise DuplicateHandlerError(
+                f"Already registered a handler for {(h.python_type, protocol, h.supported_format)}"
+            )
         lowest_level[h.supported_format] = h
         logger.debug(f"Registered {h} as handler for {h.python_type}, protocol {protocol}, fmt {h.supported_format}")
 

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -37,13 +37,6 @@ from flytekit.models.types import LiteralType, SchemaType, StructuredDatasetType
 T = typing.TypeVar("T")  # StructuredDataset type or a dataframe type
 DF = typing.TypeVar("DF")  # Dataframe type
 
-# Protocols
-BIGQUERY = "bq"
-S3 = "s3"
-ABFS = "abfs"
-GCS = "gs"
-LOCAL = "/"
-
 # For specifying the storage formats of StructuredDatasets. It's just a string, nothing fancy.
 StructuredDatasetFormat: TypeAlias = str
 

--- a/plugins/flytekit-data-fsspec/flytekitplugins/fsspec/__init__.py
+++ b/plugins/flytekit-data-fsspec/flytekitplugins/fsspec/__init__.py
@@ -25,12 +25,14 @@ __all__ = [
 import importlib
 
 from flytekit import StructuredDatasetTransformerEngine, logger
-from flytekit.configuration import internal
-from flytekit.types.structured.structured_dataset import ABFS, GCS, S3
 
 from .arrow import ArrowToParquetEncodingHandler, ParquetToArrowDecodingHandler
 from .pandas import PandasToParquetEncodingHandler, ParquetToPandasDecodingHandler
 from .persist import FSSpecPersistence
+
+S3 = "s3"
+ABFS = "abfs"
+GCS = "gs"
 
 
 def _register(protocol: str):

--- a/plugins/flytekit-data-fsspec/flytekitplugins/fsspec/pandas.py
+++ b/plugins/flytekit-data-fsspec/flytekitplugins/fsspec/pandas.py
@@ -13,7 +13,6 @@ from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
     PARQUET,
-    S3,
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
@@ -22,7 +21,7 @@ from flytekit.types.structured.structured_dataset import (
 
 def get_storage_options(cfg: DataConfig, uri: str) -> typing.Optional[typing.Dict]:
     protocol = FSSpecPersistence.get_protocol(uri)
-    if protocol == S3:
+    if protocol == "s3":
         kwargs = s3_setup_args(cfg.s3)
         if kwargs:
             return kwargs

--- a/plugins/flytekit-papermill/dev-requirements.in
+++ b/plugins/flytekit-papermill/dev-requirements.in
@@ -1,3 +1,3 @@
 flyteidl>=1.0.0
-git+https://github.com/flyteorg/flytekit@master#egg=flytekitplugins-spark&subdirectory=plugins/flytekit-spark
+git+https://github.com/flyteorg/flytekit@sd-data-persistence#egg=flytekitplugins-spark&subdirectory=plugins/flytekit-spark
 # vcs+protocol://repo_url/#egg=pkg&subdirectory=flyte

--- a/plugins/flytekit-papermill/dev-requirements.txt
+++ b/plugins/flytekit-papermill/dev-requirements.txt
@@ -44,7 +44,7 @@ flyteidl==1.0.0.post1
     #   flytekit
 flytekit==1.1.0b0
     # via flytekitplugins-spark
-flytekitplugins-spark @ git+https://github.com/flyteorg/flytekit@master#subdirectory=plugins/flytekit-spark
+flytekitplugins-spark @ git+https://github.com/flyteorg/flytekit@sd-data-persistence#subdirectory=plugins/flytekit-spark
     # via -r dev-requirements.in
 googleapis-common-protos==1.55.0
     # via

--- a/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
+++ b/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
@@ -7,11 +7,7 @@ from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
-    ABFS,
-    GCS,
-    LOCAL,
     PARQUET,
-    S3,
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
@@ -20,8 +16,8 @@ from flytekit.types.structured.structured_dataset import (
 
 
 class PolarsDataFrameToParquetEncodingHandler(StructuredDatasetEncoder):
-    def __init__(self, protocol: str):
-        super().__init__(pl.DataFrame, protocol, PARQUET)
+    def __init__(self):
+        super().__init__(pl.DataFrame, None, PARQUET)
 
     def encode(
         self,
@@ -45,8 +41,8 @@ class PolarsDataFrameToParquetEncodingHandler(StructuredDatasetEncoder):
 
 
 class ParquetToPolarsDataFrameDecodingHandler(StructuredDatasetDecoder):
-    def __init__(self, protocol: str):
-        super().__init__(pl.DataFrame, protocol, PARQUET)
+    def __init__(self):
+        super().__init__(pl.DataFrame, None, PARQUET)
 
     def decode(
         self,
@@ -63,10 +59,5 @@ class ParquetToPolarsDataFrameDecodingHandler(StructuredDatasetDecoder):
         return pl.read_parquet(path)
 
 
-for protocol in [LOCAL, S3, GCS, ABFS]:
-    StructuredDatasetTransformerEngine.register(
-        PolarsDataFrameToParquetEncodingHandler(protocol), default_for_type=False
-    )
-    StructuredDatasetTransformerEngine.register(
-        ParquetToPolarsDataFrameDecodingHandler(protocol), default_for_type=False
-    )
+StructuredDatasetTransformerEngine.register(PolarsDataFrameToParquetEncodingHandler())
+StructuredDatasetTransformerEngine.register(ParquetToPolarsDataFrameDecodingHandler())

--- a/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
@@ -7,11 +7,7 @@ from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
-    ABFS,
-    GCS,
-    LOCAL,
     PARQUET,
-    S3,
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
@@ -20,8 +16,8 @@ from flytekit.types.structured.structured_dataset import (
 
 
 class SparkToParquetEncodingHandler(StructuredDatasetEncoder):
-    def __init__(self, protocol: str):
-        super().__init__(DataFrame, protocol, PARQUET)
+    def __init__(self):
+        super().__init__(DataFrame, None, PARQUET)
 
     def encode(
         self,
@@ -36,8 +32,8 @@ class SparkToParquetEncodingHandler(StructuredDatasetEncoder):
 
 
 class ParquetToSparkDecodingHandler(StructuredDatasetDecoder):
-    def __init__(self, protocol: str):
-        super().__init__(DataFrame, protocol, PARQUET)
+    def __init__(self):
+        super().__init__(DataFrame, None, PARQUET)
 
     def decode(
         self,
@@ -52,6 +48,5 @@ class ParquetToSparkDecodingHandler(StructuredDatasetDecoder):
         return user_ctx.spark_session.read.parquet(flyte_value.uri)
 
 
-for protocol in [LOCAL, S3, GCS, ABFS]:
-    StructuredDatasetTransformerEngine.register(SparkToParquetEncodingHandler(protocol), default_for_type=False)
-    StructuredDatasetTransformerEngine.register(ParquetToSparkDecodingHandler(protocol), default_for_type=False)
+StructuredDatasetTransformerEngine.register(SparkToParquetEncodingHandler())
+StructuredDatasetTransformerEngine.register(ParquetToSparkDecodingHandler())

--- a/tests/flytekit/unit/core/test_data_persistence.py
+++ b/tests/flytekit/unit/core/test_data_persistence.py
@@ -18,6 +18,6 @@ def test_is_remote():
 
 def test_lister():
     x = DataPersistencePlugins.supported_protocols()
-    main_protocols = set(["file", "/", "gs", "http", "https", "s3"])
+    main_protocols = {"file", "/", "gs", "http", "https", "s3"}
     all_protocols = set([y.replace("://", "") for y in x])
     assert main_protocols.issubset(all_protocols)

--- a/tests/flytekit/unit/core/test_data_persistence.py
+++ b/tests/flytekit/unit/core/test_data_persistence.py
@@ -1,4 +1,4 @@
-from flytekit.core.data_persistence import FileAccessProvider
+from flytekit.core.data_persistence import DataPersistencePlugins, FileAccessProvider
 
 
 def test_get_random_remote_path():
@@ -14,3 +14,8 @@ def test_is_remote():
     assert fp.is_remote("/tmp/foo/bar") is False
     assert fp.is_remote("file://foo/bar") is False
     assert fp.is_remote("s3://my-bucket/foo/bar") is True
+
+
+def test_lister():
+    x = DataPersistencePlugins.supported_protocols()
+    assert [y.replace("://", "") for y in x] == ["file", "/", "gs", "http", "https", "s3"]

--- a/tests/flytekit/unit/core/test_data_persistence.py
+++ b/tests/flytekit/unit/core/test_data_persistence.py
@@ -18,4 +18,6 @@ def test_is_remote():
 
 def test_lister():
     x = DataPersistencePlugins.supported_protocols()
-    assert [y.replace("://", "") for y in x] == ["file", "/", "gs", "http", "https", "s3"]
+    main_protocols = set(["file", "/", "gs", "http", "https", "s3"])
+    all_protocols = set([y.replace("://", "") for y in x])
+    assert main_protocols.issubset(all_protocols)

--- a/tests/flytekit/unit/core/test_structured_dataset.py
+++ b/tests/flytekit/unit/core/test_structured_dataset.py
@@ -22,7 +22,6 @@ import pyarrow as pa
 
 from flytekit import kwtypes, task
 from flytekit.types.structured.structured_dataset import (
-    LOCAL,
     PARQUET,
     StructuredDataset,
     StructuredDatasetDecoder,
@@ -338,7 +337,7 @@ def test_to_python_value_without_incoming_columns():
 def test_format_correct():
     class TempEncoder(StructuredDatasetEncoder):
         def __init__(self):
-            super().__init__(pd.DataFrame, LOCAL, "avro")
+            super().__init__(pd.DataFrame, "/", "avro")
 
         def encode(
             self,

--- a/tests/flytekit/unit/core/test_structured_dataset.py
+++ b/tests/flytekit/unit/core/test_structured_dataset.py
@@ -394,8 +394,6 @@ def test_protocol_detection():
     assert pd.DataFrame not in StructuredDatasetTransformerEngine.DEFAULT_PROTOCOLS
     e = StructuredDatasetTransformerEngine()
     ctx = FlyteContextManager.current_context()
-    x = StructuredDatasetTransformerEngine.ENCODERS
-    y = StructuredDatasetTransformerEngine.DECODERS
     protocol = e._protocol_from_type_or_prefix(ctx, pd.DataFrame)
     assert protocol == "file"
 

--- a/tests/flytekit/unit/core/test_structured_dataset.py
+++ b/tests/flytekit/unit/core/test_structured_dataset.py
@@ -49,23 +49,6 @@ def generate_pandas() -> pd.DataFrame:
     return pd.DataFrame({"name": ["Tom", "Joseph"], "age": [20, 22]})
 
 
-# from flytekit.remote.remote import FlyteRemote
-# from flytekit.configuration import Config
-# from flytekit.core.data_persistence import DataPersistencePlugins
-# import pandas as pd
-#
-#
-# def test_locfdsa():
-#     df = pd.DataFrame({"name": ["Tom", "Joseph"], "age": [20, 22]})
-#     rr = FlyteRemote(
-#         Config.auto(config_file="/Users/ytong/.flyte/dev-uniondemo.yaml"),
-#         default_project="flytesnacks",
-#         default_domain="development",
-#     )
-#     f_print_wf = rr.fetch_workflow(name="core.sd.print_wf")
-#     rr.execute(f_print_wf, inputs={"df": df})
-
-
 def test_types_pandas():
     pt = pd.DataFrame
     lt = TypeEngine.to_literal_type(pt)

--- a/tests/flytekit/unit/core/test_structured_dataset.py
+++ b/tests/flytekit/unit/core/test_structured_dataset.py
@@ -409,15 +409,3 @@ def test_protocol_detection():
 
         protocol = e._protocol_from_type_or_prefix(ctx2, pd.DataFrame, "bq://foo")
         assert protocol == "bq"
-
-
-def test_fds():
-    # cols = kwtypes(name={"firstname": str, "middlename": str, "lastname": str}, state=str, gender=str)
-    # cols = kwtypes(name=kwtypes(firstname=str, middlename=str, lastname=str), state=str, gender=str)
-    cols = kwtypes(name=kwtypes(firstname=str, middlename=str, lastname=str), state=str, gender=str)
-    tt = Annotated[pd.DataFrame, cols]
-
-    lt = StructuredDatasetTransformerEngine().get_literal_type(tt)
-    print(lt)
-
-

--- a/tests/flytekit/unit/core/test_structured_dataset.py
+++ b/tests/flytekit/unit/core/test_structured_dataset.py
@@ -1,9 +1,13 @@
 import tempfile
 import typing
 
+import pandas as pd
+import pyarrow as pa
 import pytest
+from typing_extensions import Annotated
 
 import flytekit.configuration
+from flytekit import kwtypes, task
 from flytekit.configuration import Image, ImageConfig
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.data_persistence import FileAccessProvider
@@ -11,13 +15,6 @@ from flytekit.core.type_engine import TypeEngine
 from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import SchemaType, SimpleType, StructuredDatasetType
-
-from typing_extensions import Annotated
-
-import pandas as pd
-import pyarrow as pa
-
-from flytekit import kwtypes, task
 from flytekit.types.structured.structured_dataset import (
     PARQUET,
     StructuredDataset,
@@ -50,6 +47,7 @@ def test_protocol():
 
 def generate_pandas() -> pd.DataFrame:
     return pd.DataFrame({"name": ["Tom", "Joseph"], "age": [20, 22]})
+
 
 # from flytekit.remote.remote import FlyteRemote
 # from flytekit.configuration import Config

--- a/tests/flytekit/unit/core/test_structured_dataset.py
+++ b/tests/flytekit/unit/core/test_structured_dataset.py
@@ -12,10 +12,7 @@ from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import SchemaType, SimpleType, StructuredDatasetType
 
-try:
-    from typing import Annotated
-except ImportError:
-    from typing_extensions import Annotated
+from typing_extensions import Annotated
 
 import pandas as pd
 import pyarrow as pa
@@ -54,21 +51,21 @@ def test_protocol():
 def generate_pandas() -> pd.DataFrame:
     return pd.DataFrame({"name": ["Tom", "Joseph"], "age": [20, 22]})
 
-from flytekit.remote.remote import FlyteRemote
-from flytekit.configuration import Config
-from flytekit.core.data_persistence import DataPersistencePlugins
-import pandas as pd
-
-
-def test_locfdsa():
-    df = pd.DataFrame({"name": ["Tom", "Joseph"], "age": [20, 22]})
-    rr = FlyteRemote(
-        Config.auto(config_file="/Users/ytong/.flyte/dev-uniondemo.yaml"),
-        default_project="flytesnacks",
-        default_domain="development",
-    )
-    f_print_wf = rr.fetch_workflow(name="core.sd.print_wf")
-    rr.execute(f_print_wf, inputs={"df": df})
+# from flytekit.remote.remote import FlyteRemote
+# from flytekit.configuration import Config
+# from flytekit.core.data_persistence import DataPersistencePlugins
+# import pandas as pd
+#
+#
+# def test_locfdsa():
+#     df = pd.DataFrame({"name": ["Tom", "Joseph"], "age": [20, 22]})
+#     rr = FlyteRemote(
+#         Config.auto(config_file="/Users/ytong/.flyte/dev-uniondemo.yaml"),
+#         default_project="flytesnacks",
+#         default_domain="development",
+#     )
+#     f_print_wf = rr.fetch_workflow(name="core.sd.print_wf")
+#     rr.execute(f_print_wf, inputs={"df": df})
 
 
 def test_types_pandas():
@@ -412,3 +409,15 @@ def test_protocol_detection():
 
         protocol = e._protocol_from_type_or_prefix(ctx2, pd.DataFrame, "bq://foo")
         assert protocol == "bq"
+
+
+def test_fds():
+    # cols = kwtypes(name={"firstname": str, "middlename": str, "lastname": str}, state=str, gender=str)
+    # cols = kwtypes(name=kwtypes(firstname=str, middlename=str, lastname=str), state=str, gender=str)
+    cols = kwtypes(name=kwtypes(firstname=str, middlename=str, lastname=str), state=str, gender=str)
+    tt = Annotated[pd.DataFrame, cols]
+
+    lt = StructuredDatasetTransformerEngine().get_literal_type(tt)
+    print(lt)
+
+

--- a/tests/flytekit/unit/core/test_structured_dataset_handlers.py
+++ b/tests/flytekit/unit/core/test_structured_dataset_handlers.py
@@ -23,8 +23,8 @@ arrow_schema = pa.schema(fields)
 
 def test_pandas():
     df = pd.DataFrame({"Name": ["Tom", "Joseph"], "Age": [20, 22]})
-    encoder = basic_dfs.PandasToParquetEncodingHandler("/")
-    decoder = basic_dfs.ParquetToPandasDecodingHandler("/")
+    encoder = basic_dfs.PandasToParquetEncodingHandler()
+    decoder = basic_dfs.ParquetToPandasDecodingHandler()
 
     ctx = context_manager.FlyteContextManager.current_context()
     sd = StructuredDataset(dataframe=df)

--- a/tests/flytekit/unit/core/test_structured_dataset_handlers.py
+++ b/tests/flytekit/unit/core/test_structured_dataset_handlers.py
@@ -13,6 +13,7 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
+    StructuredDatasetTransformerEngine,
 )
 
 my_cols = kwtypes(w=typing.Dict[str, typing.Dict[str, int]], x=typing.List[typing.List[int]], y=int, z=str)
@@ -41,3 +42,13 @@ def test_base_isnt_instantiable():
 
     with pytest.raises(TypeError):
         StructuredDatasetDecoder(pd.DataFrame, "", "")
+
+
+def test_arrow():
+    encoder = basic_dfs.ArrowToParquetEncodingHandler()
+    decoder = basic_dfs.ParquetToArrowDecodingHandler()
+    assert encoder.protocol is None
+    assert decoder.protocol is None
+    assert encoder.python_type is decoder.python_type
+    d = StructuredDatasetTransformerEngine.DECODERS[encoder.python_type]["s3"]["parquet"]
+    assert d is not None

--- a/tests/flytekit/unit/types/structured_dataset/test_structured_dataset_workflow.py
+++ b/tests/flytekit/unit/types/structured_dataset/test_structured_dataset_workflow.py
@@ -18,11 +18,8 @@ from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
 from flytekit.types.structured.structured_dataset import (
-    BIGQUERY,
     DF,
-    LOCAL,
     PARQUET,
-    S3,
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
@@ -41,7 +38,7 @@ pd_df = pd.DataFrame({"Name": ["Tom", "Joseph"], "Age": [20, 22]})
 
 class MockBQEncodingHandlers(StructuredDatasetEncoder):
     def __init__(self):
-        super().__init__(pd.DataFrame, BIGQUERY, "")
+        super().__init__(pd.DataFrame, "bq", "")
 
     def encode(
         self,
@@ -56,7 +53,7 @@ class MockBQEncodingHandlers(StructuredDatasetEncoder):
 
 class MockBQDecodingHandlers(StructuredDatasetDecoder):
     def __init__(self):
-        super().__init__(pd.DataFrame, BIGQUERY, "")
+        super().__init__(pd.DataFrame, "bq", "")
 
     def decode(
         self,
@@ -104,7 +101,7 @@ def numpy_type():
             table = pq.read_table(local_dir)
             return table.to_pandas().to_numpy()
 
-    for protocol in [LOCAL, S3]:
+    for protocol in ["/", "s3"]:
         StructuredDatasetTransformerEngine.register(NumpyEncodingHandlers(np.ndarray, protocol, PARQUET))
         StructuredDatasetTransformerEngine.register(NumpyDecodingHandlers(np.ndarray, protocol, PARQUET))
 


### PR DESCRIPTION
# TL;DR
Contributors of dataframe handling plugins use the `StructuredDatasetTransformerEngine.register` method to make the system aware of specific encoders and decoders.  Up until now, the user was asked to specify the "protocol" associated with each handler.

This is awkward for two reasons:
* If your encoder/decoder just relies on the base data persistence layer flytekit provides, there is no reason to ask the contributor to register once per protocol.  If we add a new protocol to the persistence layer, then someone would have to go through and update all these.
* Registering multiple protocols while having the default_for_type option in the signature makes it awkward.  The impression is that you have to somehow decide a priori which protocol should be the default.  This doesn't make sense - the protocol to pick should default to the storage layer determined by the raw output prefix instead.

We are:
* making the `protocol` field optional now.
* when `None`, all protocols that the data persistence layer knows about will be registered with that handler.
* default_for_type will now default to False.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2755
