### PR TITLE
Fix the type of optional[int] in dataclass

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -451,7 +451,7 @@ class DataclassTransformer(TypeTransformer[object]):
     def _fix_val_int(self, t: typing.Type, val: typing.Any) -> typing.Any:
         if val is None:
             return val
-        if t == int:
+        if t == int or t == typing.Optional[int]:
             return int(val)
 
         if isinstance(val, list):
@@ -1314,7 +1314,7 @@ def _get_element_type(element_property: typing.Dict[str, str]) -> Type[T]:
 
     if type(element_type) == list:
         # Element type of Optional[int] is [integer, None]
-        element_type = element_type[0]
+        return typing.Optional[_get_element_type({"type": element_type[0]})]
 
     if element_type == "string":
         return str

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1309,6 +1309,11 @@ def convert_json_schema_to_python_class(schema: dict, schema_name) -> Type[datac
 def _get_element_type(element_property: typing.Dict[str, str]) -> Type[T]:
     element_type = element_property["type"]
     element_format = element_property["format"] if "format" in element_property else None
+
+    if type(element_type) == list:
+        # Element type of Optional[int] is [integer, None]
+        element_type = element_type[0]
+
     if element_type == "string":
         return str
     elif element_type == "integer":

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -449,6 +449,8 @@ class DataclassTransformer(TypeTransformer[object]):
             return python_val
 
     def _fix_val_int(self, t: typing.Type, val: typing.Any) -> typing.Any:
+        if val is None:
+            return val
         if t == int:
             return int(val)
 

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -155,13 +155,14 @@ def test_list_of_dataclass_getting_python_value():
     @dataclass_json
     @dataclass()
     class Foo(object):
+        u: typing.Optional[int]
         v: typing.Optional[int]
         w: int
         x: typing.List[int]
         y: typing.Dict[str, str]
         z: Bar
 
-    foo = Foo(v=5, w=1, x=[1], y={"hello": "10"}, z=Bar(w=None, x=1.0, y="hello", z={"world": False}))
+    foo = Foo(u=5, v=None, w=1, x=[1], y={"hello": "10"}, z=Bar(w=None, x=1.0, y="hello", z={"world": False}))
     generic = _json_format.Parse(typing.cast(DataClassJsonMixin, foo).to_json(), _struct.Struct())
     lv = Literal(collection=LiteralCollection(literals=[Literal(scalar=Scalar(generic=generic))]))
 
@@ -173,12 +174,14 @@ def test_list_of_dataclass_getting_python_value():
 
     pv = transformer.to_python_value(ctx, lv, expected_python_type=typing.List[foo_class])
     assert isinstance(pv, list)
+    assert pv[0].u == foo.u
     assert pv[0].v == foo.v
     assert pv[0].w == foo.w
     assert pv[0].x == foo.x
     assert pv[0].y == foo.y
     assert pv[0].z.x == foo.z.x
-    assert type(pv[0].v) == int
+    assert type(pv[0].u) == int
+    assert pv[0].v is None
     assert type(pv[0].w) == int
     assert type(pv[0].z.x) == float
     assert pv[0].z.y == foo.z.y
@@ -1178,6 +1181,7 @@ def test_pass_annotated_to_downstream_tasks():
     """
     Test to confirm that the loaded dataframe is not affected and can be used in @dynamic.
     """
+
     # pandas dataframe hash function
     def hash_pandas_dataframe(df: pd.DataFrame) -> str:
         return str(pd.util.hash_pandas_object(df))

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -155,12 +155,13 @@ def test_list_of_dataclass_getting_python_value():
     @dataclass_json
     @dataclass()
     class Foo(object):
+        v: typing.Optional[int]
         w: int
         x: typing.List[int]
         y: typing.Dict[str, str]
         z: Bar
 
-    foo = Foo(w=1, x=[1], y={"hello": "10"}, z=Bar(w=None, x=1.0, y="hello", z={"world": False}))
+    foo = Foo(v=5, w=1, x=[1], y={"hello": "10"}, z=Bar(w=None, x=1.0, y="hello", z={"world": False}))
     generic = _json_format.Parse(typing.cast(DataClassJsonMixin, foo).to_json(), _struct.Struct())
     lv = Literal(collection=LiteralCollection(literals=[Literal(scalar=Scalar(generic=generic))]))
 
@@ -172,10 +173,13 @@ def test_list_of_dataclass_getting_python_value():
 
     pv = transformer.to_python_value(ctx, lv, expected_python_type=typing.List[foo_class])
     assert isinstance(pv, list)
+    assert pv[0].v == foo.v
     assert pv[0].w == foo.w
     assert pv[0].x == foo.x
     assert pv[0].y == foo.y
     assert pv[0].z.x == foo.z.x
+    assert type(pv[0].v) == int
+    assert type(pv[0].w) == int
     assert type(pv[0].z.x) == float
     assert pv[0].z.y == foo.z.y
     assert pv[0].z.z == foo.z.z

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -172,21 +172,23 @@ def test_list_of_dataclass_getting_python_value():
     schema = JSONSchema().dump(typing.cast(DataClassJsonMixin, Foo).schema())
     foo_class = convert_json_schema_to_python_class(schema["definitions"], "FooSchema")
 
-    pv = transformer.to_python_value(ctx, lv, expected_python_type=typing.List[foo_class])
-    assert isinstance(pv, list)
-    assert pv[0].u == foo.u
-    assert pv[0].v == foo.v
-    assert pv[0].w == foo.w
-    assert pv[0].x == foo.x
-    assert pv[0].y == foo.y
-    assert pv[0].z.x == foo.z.x
-    assert type(pv[0].u) == int
-    assert pv[0].v is None
-    assert type(pv[0].w) == int
-    assert type(pv[0].z.x) == float
-    assert pv[0].z.y == foo.z.y
-    assert pv[0].z.z == foo.z.z
-    assert foo == dataclass_from_dict(Foo, asdict(pv[0]))
+    guessed_pv = transformer.to_python_value(ctx, lv, expected_python_type=typing.List[foo_class])
+    print("=====")
+    pv = transformer.to_python_value(ctx, lv, expected_python_type=typing.List[Foo])
+    assert isinstance(guessed_pv, list)
+    assert guessed_pv[0].u == pv[0].u
+    assert guessed_pv[0].v == pv[0].v
+    assert guessed_pv[0].w == pv[0].w
+    assert guessed_pv[0].x == pv[0].x
+    assert guessed_pv[0].y == pv[0].y
+    assert guessed_pv[0].z.x == pv[0].z.x
+    assert type(guessed_pv[0].u) == int
+    assert guessed_pv[0].v is None
+    assert type(guessed_pv[0].w) == int
+    assert type(guessed_pv[0].z.x) == float
+    assert guessed_pv[0].z.y == pv[0].z.y
+    assert guessed_pv[0].z.z == pv[0].z.z
+    assert pv[0] == dataclass_from_dict(Foo, asdict(guessed_pv[0]))
 
 
 def test_file_no_downloader_default():


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
https://flyte-org.slack.com/archives/C037MMU74FN/p1660670745909239

```
@dataclass
class MyDataclass(DataClassJsonMixin):
    value: Optional[int] = None

my_dataclass = MyDataclass(value=1)
```

`my_dataclass.value` appears to be converted to float and becomes 1.0 instead of remaining int and 1 as I expected.

Explicitly convert the `value` to int as well.


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2775

## Follow-up issue
_NA_

