### PR TITLE
Add restriction for pandas to be >=1.2 for fsspec plugin

### DIFF
--- a/plugins/flytekit-data-fsspec/setup.py
+++ b/plugins/flytekit-data-fsspec/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "fsspec"
 
 microlib_name = f"flytekitplugins-data-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0", "fsspec>=2021.7.0", "botocore>=1.7.48"]
+plugin_requires = ["flytekit>=1.1.0b0,<1.2.0", "fsspec>=2021.7.0", "botocore>=1.7.48", "pandas>=1.2.0"]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
# TL;DR
The fsspec plugin uses the `storage_options` argument in the `to_parquet` call.  This option was not in until 1.2. 
See https://pandas.pydata.org/pandas-docs/version/1.3.5/reference/api/pandas.DataFrame.to_parquet.html

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 Just bump the plugin requirements.

## Tracking Issue
User reported issue.
