### PR TITLE
handle ImportError and OSError in extras.pytorch

### DIFF
--- a/flytekit/extras/pytorch/__init__.py
+++ b/flytekit/extras/pytorch/__init__.py
@@ -14,9 +14,18 @@ from flytekit.loggers import logger
 # TODO: abstract this out so that there's an established pattern for registering plugins
 # that have soft dependencies
 try:
+    # isolate the exception to the torch import
+    import torch
+
+    _torch_installed = True
+except (ImportError, OSError):
+    _torch_installed = False
+
+
+if _torch_installed:
     from .checkpoint import PyTorchCheckpoint, PyTorchCheckpointTransformer
     from .native import PyTorchModuleTransformer, PyTorchTensorTransformer
-except (ImportError, OSError):
+else:
     logger.info(
         "We won't register PyTorchCheckpointTransformer, PyTorchTensorTransformer, and PyTorchModuleTransformer because torch is not installed."
     )

--- a/flytekit/extras/pytorch/__init__.py
+++ b/flytekit/extras/pytorch/__init__.py
@@ -11,10 +11,12 @@ Flytekit PyTorch
 """
 from flytekit.loggers import logger
 
+# TODO: abstract this out so that there's an established pattern for registering plugins
+# that have soft dependencies
 try:
     from .checkpoint import PyTorchCheckpoint, PyTorchCheckpointTransformer
     from .native import PyTorchModuleTransformer, PyTorchTensorTransformer
-except ImportError:
+except (ImportError, OSError):
     logger.info(
         "We won't register PyTorchCheckpointTransformer, PyTorchTensorTransformer, and PyTorchModuleTransformer because torch is not installed."
     )


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

# TL;DR

The introduction of "soft" dependencies in `flytekit.extras` to support pytorch types leads to an OSError when trying to `import torch`: https://github.com/flyteorg/flytekit/pull/1032. This PR adds `OSError` as a potential exception raised when installing pytorch.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

For context, see this slack thread: https://unionai.slack.com/archives/C01H0FN1NJX/p1661365911337069

Flytekit has a plugin system, hosted as separate packages in [this directory](https://github.com/flyteorg/flytekit/tree/master/plugins) of the flytekit repo. However, since Flyte is a ML- and Data-aware orchestration tool, it would make sense for the core ML frameworks to have first class support without having to install any plugins.

Therefore, we're establishing a new pattern for plugins in `flytekit.extras` that has "soft" dependencies on packages. For example, if the user has pytorch installed, the type plugins should automatically be registered. If the user doesn't, it should gracefully handle errors that might result from importing `torch`.

## Tracking Issue
NA

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
