### PR TITLE
Add literal type to union literal

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -264,7 +264,6 @@ class FlyteLiteralConverter(object):
                 # and then use flyte converter to convert it to literal.
                 python_val = converter._click_type.convert(value, param, ctx)
                 literal = converter.convert_to_literal(ctx, param, python_val)
-                self._python_type = python_type
                 return Literal(scalar=Scalar(union=Union(literal, variant)))
             except (Exception or AttributeError) as e:
                 logging.debug(f"Failed to convert python type {python_type} to literal type {variant}", e)

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -27,7 +27,7 @@ from flytekit.core.type_engine import TypeEngine
 from flytekit.core.workflow import PythonFunctionWorkflow, WorkflowBase
 from flytekit.models import literals
 from flytekit.models.interface import Variable
-from flytekit.models.literals import Blob, BlobMetadata, Primitive
+from flytekit.models.literals import Blob, BlobMetadata, Primitive, Union
 from flytekit.models.types import LiteralType, SimpleType
 from flytekit.remote.executions import FlyteWorkflowExecution
 from flytekit.tools import module_loader, script_mode
@@ -265,7 +265,7 @@ class FlyteLiteralConverter(object):
                 python_val = converter._click_type.convert(value, param, ctx)
                 literal = converter.convert_to_literal(ctx, param, python_val)
                 self._python_type = python_type
-                return literal
+                return Literal(scalar=Scalar(union=Union(literal, variant)))
             except (Exception or AttributeError) as e:
                 logging.debug(f"Failed to convert python type {python_type} to literal type {variant}", e)
         raise ValueError(f"Failed to convert python type {self._python_type} to literal type {lt}")

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -1,10 +1,15 @@
+import functools
 import os
 import pathlib
+import typing
+from enum import Enum
 
+import click
 import mock
 import pytest
 from click.testing import CliRunner
 
+from flytekit import FlyteContextManager
 from flytekit.clis.sdk_in_container import pyflyte
 from flytekit.clis.sdk_in_container.constants import CTX_CONFIG_FILE
 from flytekit.clis.sdk_in_container.helpers import FLYTE_REMOTE_INSTANCE_KEY
@@ -12,11 +17,14 @@ from flytekit.clis.sdk_in_container.run import (
     REMOTE_FLAG_KEY,
     RUN_LEVEL_PARAMS_KEY,
     FileParamType,
+    FlyteLiteralConverter,
     get_entities_in_file,
     run_command,
 )
-from flytekit.configuration import Image, ImageConfig
+from flytekit.configuration import Config, Image, ImageConfig
 from flytekit.core.task import task
+from flytekit.core.type_engine import TypeEngine
+from flytekit.remote import FlyteRemote
 
 WORKFLOW_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "workflow.py")
 DIR_NAME = os.path.dirname(os.path.realpath(__file__))
@@ -255,3 +263,34 @@ def test_file_param():
     assert l.local
     r = FileParamType().convert("https://tmp/file", m, m)
     assert r.local is False
+
+
+class Color(Enum):
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+
+
+@pytest.mark.parametrize(
+    "python_type, python_value",
+    [
+        (typing.Union[typing.List[int], str, Color], "flyte"),
+        (typing.Union[typing.List[int], str, Color], "red"),
+        (typing.Union[typing.List[int], str, Color], [1, 2, 3]),
+        (typing.List[int], [1, 2, 3]),
+        (typing.Dict[str, int], {"flyte": 2}),
+    ],
+)
+def test_literal_converter(python_type, python_value):
+    get_upload_url_fn = functools.partial(
+        FlyteRemote(Config.auto()).client.get_upload_signed_url, project="p", domain="d"
+    )
+    click_ctx = click.Context(click.Command("test_command"), obj={"remote": True})
+    ctx = FlyteContextManager.current_context()
+    lt = TypeEngine.to_literal_type(python_type)
+
+    lc = FlyteLiteralConverter(
+        click_ctx, ctx, literal_type=lt, python_type=python_type, get_upload_url_fn=get_upload_url_fn
+    )
+
+    assert lc.convert(click_ctx, ctx, python_value) == TypeEngine.to_literal(ctx, python_value, python_type, lt)

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -24,6 +24,7 @@ from flytekit.clis.sdk_in_container.run import (
 from flytekit.configuration import Config, Image, ImageConfig
 from flytekit.core.task import task
 from flytekit.core.type_engine import TypeEngine
+from flytekit.models.types import SimpleType
 from flytekit.remote import FlyteRemote
 
 WORKFLOW_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "workflow.py")
@@ -294,3 +295,25 @@ def test_literal_converter(python_type, python_value):
     )
 
     assert lc.convert(click_ctx, ctx, python_value) == TypeEngine.to_literal(ctx, python_value, python_type, lt)
+
+
+def test_enum_converter():
+    pt = typing.Union[str, Color]
+
+    get_upload_url_fn = functools.partial(FlyteRemote(Config.auto()).client.get_upload_signed_url)
+    click_ctx = click.Context(click.Command("test_command"), obj={"remote": True})
+    ctx = FlyteContextManager.current_context()
+    lt = TypeEngine.to_literal_type(pt)
+    lc = FlyteLiteralConverter(click_ctx, ctx, literal_type=lt, python_type=pt, get_upload_url_fn=get_upload_url_fn)
+    union_lt = lc.convert(click_ctx, ctx, "red").scalar.union
+
+    assert union_lt.stored_type.simple == SimpleType.STRING
+    assert union_lt.stored_type.enum_type is None
+
+    pt = typing.Union[Color, str]
+    lt = TypeEngine.to_literal_type(typing.Union[Color, str])
+    lc = FlyteLiteralConverter(click_ctx, ctx, literal_type=lt, python_type=pt, get_upload_url_fn=get_upload_url_fn)
+    union_lt = lc.convert(click_ctx, ctx, "red").scalar.union
+
+    assert union_lt.stored_type.simple is None
+    assert union_lt.stored_type.enum_type.values == ["red", "green", "blue"]


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
https://github.com/flyteorg/flyte/issues/2817

```python=
class Color(Enum):
    RED = "red"
    GREEN = "green"
    BLUE = "blue"


@task
def coalesce(a:  Union[List[str], str, Color]) -> str:
    if type(a) == Color:
        print(a.name)
        return a.name
    print(a)
    return a


@workflow
def wf(a:  Union[List[str], str, Color]) -> str:
    coalesced = coalesce(a=a)
    return coalesced


if __name__ == "__main__":
    wf(a=Color("red"))
```
Take the above code as an example. If we run `pyflyte run --remote example_union.py wf --a "flyte"`, we'll get the below error.

```bash
Request failed with status code 400 invalid a input wrong type, expected union_type:<variants:<collection_type:
<simple:STRING > structure:<tag:"Typed List" > > variants:<simple:STRING structure:<tag:"str" > > variants:<enum_type:
<values:"red" values:"green" values:"blue" > structure:<tag:"DefaultEnumTransformer" > > > , got simple:STRING instead
```
That's because literal(string) can be converted to str or enum, which is [ambiguous](https://github.com/flyteorg/flytepropeller/blob/0301f2a216001bdb988eef4ae58293f525076ad3/pkg/compiler/validators/typing.go#L214-L222). To address this, we should add [literal type](https://github.com/flyteorg/flyteidl/blob/master/protos/flyteidl/core/literals.proto#L58) in Union type, and it can force [validator](https://github.com/flyteorg/flytepropeller/blob/0301f2a216001bdb988eef4ae58293f525076ad3/pkg/compiler/validators/typing.go#L33-L35) to cast "flyte" to string 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
