### PR TITLE
Properly raise `TypeTransformerFailedError` in `NumpyArrayTransformer`

### DIFF
--- a/flytekit/types/numpy/ndarray.py
+++ b/flytekit/types/numpy/ndarray.py
@@ -52,7 +52,7 @@ class NumpyArrayTransformer(TypeTransformer[np.ndarray]):
         try:
             uri = lv.scalar.blob.uri
         except AttributeError:
-            TypeTransformerFailedError(f"Cannot convert from {lv} to {expected_python_type}")
+            raise TypeTransformerFailedError(f"Cannot convert from {lv} to {expected_python_type}")
 
         local_path = ctx.file_access.get_random_local_path()
         ctx.file_access.get_data(uri, local_path, is_multipart=False)


### PR DESCRIPTION
Signed-off-by: Rahul Mehta <rahul@theoremlp.com>

# TL;DR
The `NumpyArrayTransformer` incorrectly omits `raise` before `TypeTransformerFailedError`. Fix this.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
See TLDR

## Tracking Issue
None

## Follow-up issue
_NA_

