### PR TITLE
Pickle in Union Type

### DIFF
--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -259,11 +259,11 @@ def transform_interface_to_list_interface(interface: Interface) -> Interface:
 def _change_unrecognized_type_to_pickle(t: Type[T]) -> Type[T]:
     try:
         if hasattr(t, "__origin__") and hasattr(t, "__args__"):
-            if get_origin(t) == list:
+            if get_origin(t) is list:
                 return typing.List[_change_unrecognized_type_to_pickle(t.__args__[0])]
-            elif get_origin(t) == dict and t.__args__[0] == str:
+            elif get_origin(t) is dict and t.__args__[0] == str:
                 return typing.Dict[str, _change_unrecognized_type_to_pickle(t.__args__[1])]
-            elif get_origin(t) == typing.Union:
+            elif get_origin(t) is typing.Union:
                 return typing.Union[tuple(_change_unrecognized_type_to_pickle(v) for v in get_args(t))]
             elif get_origin(t) is Annotated:
                 base_type, *config = get_args(t)
@@ -336,6 +336,7 @@ def transform_variable_map(
                 if hasattr(sub_type.python_type(), "__name__"):
                     res[k].type.metadata = {"python_class_name": sub_type.python_type().__name__}
                 elif hasattr(sub_type.python_type(), "_name"):
+                    # If the class doesn't have the __name__ attribute, like sequence, use _name instead.
                     res[k].type.metadata = {"python_class_name": sub_type.python_type()._name}
 
     return res

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -333,7 +333,10 @@ def transform_variable_map(
                 elif v.__origin__ is dict:
                     sub_type = v.__args__[1]
             if hasattr(sub_type, "__origin__") and sub_type.__origin__ is FlytePickle:
-                res[k].type.metadata = {"python_class_name": sub_type.python_type().__name__}
+                if hasattr(sub_type.python_type(), "__name__"):
+                    res[k].type.metadata = {"python_class_name": sub_type.python_type().__name__}
+                elif hasattr(sub_type.python_type(), "_name"):
+                    res[k].type.metadata = {"python_class_name": sub_type.python_type()._name}
 
     return res
 

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -267,7 +267,7 @@ def _change_unrecognized_type_to_pickle(t: Type[T]) -> Type[T]:
                 return typing.Union[tuple(_change_unrecognized_type_to_pickle(v) for v in get_args(t))]
             elif get_origin(t) is Annotated:
                 base_type, *config = get_args(t)
-                return Annotated[_change_unrecognized_type_to_pickle(base_type), config]
+                return Annotated[(_change_unrecognized_type_to_pickle(base_type), *config)]
             return FlytePickle[t]
         else:
             TypeEngine.get_transformer(t)

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -336,7 +336,7 @@ def transform_variable_map(
                 if hasattr(sub_type.python_type(), "__name__"):
                     res[k].type.metadata = {"python_class_name": sub_type.python_type().__name__}
                 elif hasattr(sub_type.python_type(), "_name"):
-                    # If the class doesn't have the __name__ attribute, like sequence, use _name instead.
+                    # If the class doesn't have the __name__ attribute, like typing.Sequence, use _name instead.
                     res[k].type.metadata = {"python_class_name": sub_type.python_type()._name}
 
     return res

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -261,10 +261,6 @@ def _change_unrecognized_type_to_pickle(t: Type[T]) -> Type[T]:
         if hasattr(t, "__origin__") and hasattr(t, "__args__"):
             if get_origin(t) == list:
                 return typing.List[_change_unrecognized_type_to_pickle(t.__args__[0])]
-            elif t == Dict:
-                # Dict in python < 3.9 has __args__ attribute, so add an additional if statement to
-                # make sure that we use the Dict transformer for typing.Dict instead of pickle transformer.
-                return t
             elif get_origin(t) == dict and t.__args__[0] == str:
                 return typing.Dict[str, _change_unrecognized_type_to_pickle(t.__args__[1])]
             elif get_origin(t) == typing.Union:
@@ -272,9 +268,7 @@ def _change_unrecognized_type_to_pickle(t: Type[T]) -> Type[T]:
             elif get_origin(t) is Annotated:
                 base_type, *config = get_args(t)
                 return Annotated[(_change_unrecognized_type_to_pickle(base_type), *config)]
-            return FlytePickle[t]
-        else:
-            TypeEngine.get_transformer(t)
+        TypeEngine.get_transformer(t)
     except ValueError:
         logger.warning(
             f"Unsupported Type {t} found, Flyte will default to use PickleFile as the transport. "

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -263,6 +263,10 @@ def _change_unrecognized_type_to_pickle(t: Type[T]) -> Type[T]:
                 return typing.List[_change_unrecognized_type_to_pickle(t.__args__[0])]
             elif t.__origin__ == dict and t.__args__[0] == str:
                 return typing.Dict[str, _change_unrecognized_type_to_pickle(t.__args__[1])]
+            elif t.__origin__ == typing.Union:
+                return typing.Union[tuple(_change_unrecognized_type_to_pickle(v) for v in get_args(t))]
+            else:
+                return FlytePickle[t]
         else:
             TypeEngine.get_transformer(t)
     except ValueError:

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -261,6 +261,10 @@ def _change_unrecognized_type_to_pickle(t: Type[T]) -> Type[T]:
         if hasattr(t, "__origin__") and hasattr(t, "__args__"):
             if get_origin(t) == list:
                 return typing.List[_change_unrecognized_type_to_pickle(t.__args__[0])]
+            elif t == Dict:
+                # Dict in python < 3.9 has __args__ attribute, so add an additional if statement to
+                # make sure that we use the Dict transformer for typing.Dict instead of pickle transformer.
+                return t
             elif get_origin(t) == dict and t.__args__[0] == str:
                 return typing.Dict[str, _change_unrecognized_type_to_pickle(t.__args__[1])]
             elif get_origin(t) == typing.Union:

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -265,8 +265,8 @@ def _change_unrecognized_type_to_pickle(t: Type[T]) -> Type[T]:
                 return typing.Dict[str, _change_unrecognized_type_to_pickle(t.__args__[1])]
             elif get_origin(t) == typing.Union:
                 return typing.Union[tuple(_change_unrecognized_type_to_pickle(v) for v in get_args(t))]
-            elif get_origin(t) == Annotated:
-                base_type, config = get_args(t)
+            elif get_origin(t) is Annotated:
+                base_type, *config = get_args(t)
                 return Annotated[_change_unrecognized_type_to_pickle(base_type), config]
             return FlytePickle[t]
         else:

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -267,7 +267,7 @@ def _change_unrecognized_type_to_pickle(t: Type[T]) -> Type[T]:
                 return typing.Union[tuple(_change_unrecognized_type_to_pickle(v) for v in get_args(t))]
             elif get_origin(t) == Annotated:
                 base_type, config = get_args(t)
-                return typing.Annotated[_change_unrecognized_type_to_pickle(base_type), config]
+                return Annotated[_change_unrecognized_type_to_pickle(base_type), config]
             return FlytePickle[t]
         else:
             TypeEngine.get_transformer(t)

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1007,7 +1007,7 @@ class UnionTransformer(TypeTransformer[T]):
                     # Should really never happen, sanity check
                     raise TypeError("Ambiguous choice of variant for union type")
                 found_res = True
-            except Exception as e:
+            except (TypeTransformerFailedError, AttributeError) as e:
                 logger.debug(f"Failed to convert from {python_val} to {t}", e)
                 continue
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1007,7 +1007,7 @@ class UnionTransformer(TypeTransformer[T]):
                     # Should really never happen, sanity check
                     raise TypeError("Ambiguous choice of variant for union type")
                 found_res = True
-            except (TypeTransformerFailedError, AttributeError) as e:
+            except Exception as e:
                 logger.debug(f"Failed to convert from {python_val} to {t}", e)
                 continue
 

--- a/flytekit/types/numpy/ndarray.py
+++ b/flytekit/types/numpy/ndarray.py
@@ -52,7 +52,7 @@ class NumpyArrayTransformer(TypeTransformer[np.ndarray]):
         try:
             uri = lv.scalar.blob.uri
         except AttributeError:
-            TypeTransformerFailedError(f"Cannot convert from {lv} to {expected_python_type}")
+            raise TypeTransformerFailedError(f"Cannot convert from {lv} to {expected_python_type}")
 
         local_path = ctx.file_access.get_random_local_path()
         ctx.file_access.get_data(uri, local_path, is_multipart=False)

--- a/tests/flytekit/unit/core/test_flyte_pickle.py
+++ b/tests/flytekit/unit/core/test_flyte_pickle.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from collections.abc import Sequence
-from typing import Annotated, Dict, List, Union
+from typing import Dict, List, Union
 
 import numpy as np
 import pandas as pd

--- a/tests/flytekit/unit/core/test_flyte_pickle.py
+++ b/tests/flytekit/unit/core/test_flyte_pickle.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Union
 
 import numpy as np
 import pandas as pd
+from typing_extensions import Annotated
 
 import flytekit.configuration
 from flytekit.configuration import Image, ImageConfig

--- a/tests/flytekit/unit/core/test_flyte_pickle.py
+++ b/tests/flytekit/unit/core/test_flyte_pickle.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from collections.abc import Sequence
-from typing import Dict, List, Union
+from typing import Annotated, Dict, List, Union
 
 import numpy as np
 import pandas as pd
@@ -88,16 +88,11 @@ def test_nested2():
 
 def test_union():
     @task
-    def t1(data: Union[np.ndarray, pd.DataFrame, Sequence[int]]):
+    def t1(data: Annotated[Union[np.ndarray, pd.DataFrame, Sequence[int]], "some annotation"]):
         print(data)
 
     task_spec = get_serializable(OrderedDict(), serialization_settings, t1)
-    assert task_spec.template.interface.inputs["data"].type.union_type.variants[0].blob.format == "NumpyArray"
-    assert (
-        task_spec.template.interface.inputs["data"].type.union_type.variants[1].structured_dataset_type.format
-        == "parquet"
-    )
-    assert (
-        task_spec.template.interface.inputs["data"].type.union_type.variants[2].blob.format
-        == FlytePickleTransformer.PYTHON_PICKLE_FORMAT
-    )
+    variants = task_spec.template.interface.inputs["data"].type.union_type.variants
+    assert variants[0].blob.format == "NumpyArray"
+    assert variants[1].structured_dataset_type.format == "parquet"
+    assert variants[2].blob.format == FlytePickleTransformer.PYTHON_PICKLE_FORMAT

--- a/tests/flytekit/unit/core/test_flyte_pickle.py
+++ b/tests/flytekit/unit/core/test_flyte_pickle.py
@@ -89,7 +89,7 @@ def test_nested2():
 
 def test_union():
     @task
-    def t1(data: Annotated[Union[np.ndarray, pd.DataFrame, Sequence[int]], "some annotation"]):
+    def t1(data: Annotated[Union[np.ndarray, pd.DataFrame, Sequence], "some annotation"]):
         print(data)
 
     task_spec = get_serializable(OrderedDict(), serialization_settings, t1)

--- a/tests/flytekit/unit/core/test_flyte_pickle.py
+++ b/tests/flytekit/unit/core/test_flyte_pickle.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
-from typing import Dict, List, Sequence, Union
+from collections.abc import Sequence
+from typing import Dict, List, Union
 
 import numpy as np
 import pandas as pd

--- a/tests/flytekit/unit/types/structured_dataset/test_structured_dataset_workflow.py
+++ b/tests/flytekit/unit/types/structured_dataset/test_structured_dataset_workflow.py
@@ -1,17 +1,12 @@
 import os
 import typing
 
-import pytest
-
-try:
-    from typing import Annotated
-except ImportError:
-    from typing_extensions import Annotated
-
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
+import pytest
+from typing_extensions import Annotated
 
 from flytekit import FlyteContext, FlyteContextManager, kwtypes, task, workflow
 from flytekit.models import literals


### PR DESCRIPTION
# TL;DR
Problems:
- Sequence wasn't converted to pickle
- Unknown type in Union wasn't converted to pickle

Both `Sequence` and `Union` have `__origin__` attribute, but we didn't handle these cases in [_change_unrecognized_type_to_pickle](https://github.com/flyteorg/flytekit/blob/22580d8ba63fe1842a9eb0de6281b2d5eb4bd588/flytekit/core/interface.py#L261-L265) 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2823

## Follow-up issue
_NA_