### PR TITLE
Add assert_type in dataclass transformer

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -282,9 +282,9 @@ class DataclassTransformer(TypeTransformer[object]):
         # def t1(a: Foo):
         #     ...
         #
-        # we use guess_python_type (FooSchema) as our expected_type by default if using flyte remote to execute the above workflow.
-        # FooSchema is created by flytekit and it's not equal to the user-defined dataclass (Foo). Therefore, we can't
-        # use `assert type(v) == expected_type` here.
+        # we use guess_python_type (FooSchema) as our expected_type by default if using flyte remote to execute the above task.
+        # FooSchema is created by flytekit and it's not equal to the user-defined dataclass (Foo).
+        # Therefore, we can't use `assert type(v) == expected_type` here.
 
         expected_fields_dict = {}
         for f in dataclasses.fields(expected_type):

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -271,7 +271,7 @@ class DataclassTransformer(TypeTransformer[object]):
         super().__init__("Object-Dataclass-Transformer", object)
 
     def assert_type(self, expected_type: Type[DataClassJsonMixin], v: T):
-        # Skip iterating all attributes in the dataclasses if the type of v already matches the expected_type
+        # Skip iterating all attributes in the dataclass if the type of v already matches the expected_type
         if type(v) == expected_type:
             return
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -299,8 +299,9 @@ class DataclassTransformer(TypeTransformer[object]):
             if UnionTransformer.is_optional_type(expected_type):
                 expected_type = UnionTransformer.get_sub_type_in_optional(expected_type)
 
-            if dataclasses.is_dataclass(original_type):
-                self.assert_type(expected_type, v.__getattribute__(f.name))
+            val = v.__getattribute__(f.name)
+            if dataclasses.is_dataclass(val):
+                self.assert_type(expected_type, val)
             elif original_type != expected_type:
                 raise TypeTransformerFailedError(f"Type of Val '{original_type}' is not an instance of {expected_type}")
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -287,7 +287,7 @@ class DataclassTransformer(TypeTransformer[object]):
         # In above example, the type of v may not equal to the expected_type in some cases
         # For example,
         # 1. The input of t1 is another dataclass (bar), then we should raise an error
-        # 2. when Using flyte remote to execute the above task, the expected_type is guess_python_type (FooSchema) by default.
+        # 2. when using flyte remote to execute the above task, the expected_type is guess_python_type (FooSchema) by default.
         # However, FooSchema is created by flytekit and it's not equal to the user-defined dataclass (Foo).
         # Therefore, we should iterate all attributes in the dataclass and check the type of value in dataclass matches the expected_type.
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1014,9 +1014,7 @@ class UnionTransformer(TypeTransformer[T]):
 
     @staticmethod
     def is_optional_type(t: Type[T]) -> bool:
-        if get_origin(t) is typing.Union and type(None) in get_args(t):
-            return True
-        return False
+        return get_origin(t) is typing.Union and type(None) in get_args(t)
 
     @staticmethod
     def get_sub_type_in_optional(t: Type[T]) -> Type[T]:

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -791,6 +791,27 @@ def test_union_type():
     assert v == "hello"
 
 
+def test_assert_dataclass_type():
+    @dataclass_json
+    @dataclass
+    class Args(object):
+        x: int
+        y: typing.Optional[str]
+
+    @dataclass_json
+    @dataclass
+    class Schema(object):
+        x: typing.Optional[Args] = None
+
+    pt = Schema
+    lt = TypeEngine.to_literal_type(pt)
+    ctx = FlyteContextManager.current_context()
+    gt = TypeEngine.guess_python_type(lt)
+    pv = Schema(x=Args(x=3, y="hello"))
+    DataclassTransformer().assert_type(typing.cast(DataClassJsonMixin, gt), pv)
+    DataclassTransformer().assert_type(typing.cast(DataClassJsonMixin, Schema), pv)
+
+
 def test_union_type_with_annotated():
     pt = typing.Union[
         Annotated[str, FlyteAnnotation({"hello": "world"})], Annotated[int, FlyteAnnotation({"test": 123})]

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -811,6 +811,17 @@ def test_assert_dataclass_type():
     DataclassTransformer().assert_type(gt, pv)
     DataclassTransformer().assert_type(Schema, pv)
 
+    @dataclass_json
+    @dataclass
+    class Bar(object):
+        x: int
+
+    pv = Bar(x=3)
+    with pytest.raises(
+        TypeTransformerFailedError, match="Type of Val '<class 'int'>' is not an instance of <class 'types.ArgsSchema'>"
+    ):
+        DataclassTransformer().assert_type(gt, pv)
+
 
 def test_union_transformer():
     assert UnionTransformer.is_optional_type(typing.Optional[int])

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -806,7 +806,6 @@ def test_assert_dataclass_type():
 
     pt = Schema
     lt = TypeEngine.to_literal_type(pt)
-    ctx = FlyteContextManager.current_context()
     gt = TypeEngine.guess_python_type(lt)
     pv = Schema(x=Args(x=3, y="hello"))
     DataclassTransformer().assert_type(gt, pv)

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -35,6 +35,7 @@ from flytekit.core.type_engine import (
     TypeEngine,
     TypeTransformer,
     TypeTransformerFailedError,
+    UnionTransformer,
     convert_json_schema_to_python_class,
     dataclass_from_dict,
 )
@@ -808,8 +809,14 @@ def test_assert_dataclass_type():
     ctx = FlyteContextManager.current_context()
     gt = TypeEngine.guess_python_type(lt)
     pv = Schema(x=Args(x=3, y="hello"))
-    DataclassTransformer().assert_type(typing.cast(DataClassJsonMixin, gt), pv)
-    DataclassTransformer().assert_type(typing.cast(DataClassJsonMixin, Schema), pv)
+    DataclassTransformer().assert_type(gt, pv)
+    DataclassTransformer().assert_type(Schema, pv)
+
+
+def test_union_transformer():
+    assert UnionTransformer.is_optional_type(typing.Optional[int])
+    assert not UnionTransformer.is_optional_type(str)
+    assert UnionTransformer.get_sub_type_in_optional(typing.Optional[int]) == int
 
 
 def test_union_type_with_annotated():


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
[slack thread](https://flyte-org.slack.com/archives/CREL4QVAQ/p1661266231263149)

Add `assert_type()`in dataclass transformer, so we don't need to specify `type_hints` when using flyte remote.

We got an error when using dataclass as input in the flyte remote without passing `type_hints`, because `guess_python_type` is not equal to the user-defined dataclass type

```
@dataclass_json
@dataclass
class Foo(object):
    a: int = 0

@task
def t1(a: Foo):
    ...
```
In this example, we use guess_python_type (FooSchema) as our `expected_type` by default if using flyte remote to execute the above task.
However, FooSchema is created by flytekit and it's not equal to the user-defined dataclass (Foo), so [assert_type](https://github.com/flyteorg/flytekit/blob/aff19cb8bd59c5376cd638cef4ee39f05786a3a8/flytekit/core/type_engine.py#L95) raises an error.

We can override `assert_type` in the dataclass transformer, and check that the type of each attribute is the same as the `guess_type` by iterating all attributes in dataclass.


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

The code to reproduce

```python
from dataclasses import dataclass
from typing import Optional
from dataclasses_json import dataclass_json
from flytekit import task, workflow, dynamic


@dataclass_json
@dataclass
class Args(object):
    max_iter: int = 0
    init_eval: float = 0
    max_eval: str = 0


@dataclass_json
@dataclass
class Schema(object):
    kwargs: Optional[Args] = None


@task
def t11(schema: Schema):
    print(schema)


@workflow
def wf3(schema: Schema = Schema(Args(1, 2.0, "hello"))):
    t11(schema=schema)


if __name__ == "__main__":
    wf3(schema=Schema(Args(1, 2.0, "hello")))
```

```python
from flytekit.remote import FlyteRemote
from flytekit.configuration import Config
from example_dataclass import Args, Schema

remote = FlyteRemote(
    config=Config.auto("/Users/kevin/.flyte/config-remote.yaml"),
    default_project="flytesnacks",
    default_domain="development",
)

flyte_workflow = remote.fetch_workflow(
    name="example_dataclass.wf3", project="flytesnacks", domain="development"
)

execution = remote.execute(
    flyte_workflow, inputs={"schema": Schema(Args(1, 2, "hello"))}, wait=False,
)
```

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2844

## Follow-up issue
_NA_