### PR TITLE
Set flytekit<2.0 in plugins

### DIFF
--- a/plugins/flytekit-aws-athena/setup.py
+++ b/plugins/flytekit-aws-athena/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "athena"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-aws-batch/setup.py
+++ b/plugins/flytekit-aws-batch/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "awsbatch"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-aws-sagemaker/setup.py
+++ b/plugins/flytekit-aws-sagemaker/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "awssagemaker"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0", "sagemaker-training>=3.6.2,<4.0.0"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0", "sagemaker-training>=3.6.2,<4.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-bigquery/setup.py
+++ b/plugins/flytekit-bigquery/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "bigquery"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0", "google-cloud-bigquery"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0", "google-cloud-bigquery"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-data-fsspec/setup.py
+++ b/plugins/flytekit-data-fsspec/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "fsspec"
 
 microlib_name = f"flytekitplugins-data-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0", "fsspec>=2021.7.0", "botocore>=1.7.48", "pandas>=1.2.0"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0", "fsspec>=2021.7.0", "botocore>=1.7.48", "pandas>=1.2.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-deck-standard/setup.py
+++ b/plugins/flytekit-deck-standard/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "deck"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}-standard"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0", "markdown", "plotly", "pandas_profiling"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0", "markdown", "plotly", "pandas_profiling"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-dolt/setup.py
+++ b/plugins/flytekit-dolt/setup.py
@@ -6,7 +6,7 @@ PLUGIN_NAME = "dolt"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0", "dolt_integrations>=0.1.5"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0", "dolt_integrations>=0.1.5"]
 dev_requires = ["pytest-mock>=3.6.1"]
 
 __version__ = "0.0.0+develop"

--- a/plugins/flytekit-greatexpectations/setup.py
+++ b/plugins/flytekit-greatexpectations/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "great_expectations"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0", "great-expectations>=0.13.30", "sqlalchemy>=1.4.23"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0", "great-expectations>=0.13.30", "sqlalchemy>=1.4.23"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-hive/setup.py
+++ b/plugins/flytekit-hive/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "hive"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-k8s-pod/setup.py
+++ b/plugins/flytekit-k8s-pod/setup.py
@@ -5,7 +5,7 @@ PLUGIN_NAME = "pod"
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 plugin_requires = [
-    "flytekit>=1.1.0b0,<1.2.0",
+    "flytekit>=1.1.0b0,<2.0.0",
     "kubernetes>=12.0.1",
 ]
 

--- a/plugins/flytekit-kf-mpi/setup.py
+++ b/plugins/flytekit-kf-mpi/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "kfmpi"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0", "flyteidl>=0.21.4"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0", "flyteidl>=0.21.4"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-kf-pytorch/setup.py
+++ b/plugins/flytekit-kf-pytorch/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "kfpytorch"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-kf-tensorflow/setup.py
+++ b/plugins/flytekit-kf-tensorflow/setup.py
@@ -5,7 +5,7 @@ PLUGIN_NAME = "kftensorflow"
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 # TODO: Requirements are missing, add them back in later.
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-modin/setup.py
+++ b/plugins/flytekit-modin/setup.py
@@ -5,7 +5,7 @@ PLUGIN_NAME = "modin"
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 plugin_requires = [
-    "flytekit>=1.1.0b0,<1.2.0",
+    "flytekit>=1.1.0b0,<2.0.0",
     "modin>=0.13.0",
     "fsspec",
     "ray",

--- a/plugins/flytekit-onnx-pytorch/setup.py
+++ b/plugins/flytekit-onnx-pytorch/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "onnxpytorch"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.0.0b0,<1.2.0", "torch>=1.11.0"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0", "torch>=1.11.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-onnx-scikitlearn/setup.py
+++ b/plugins/flytekit-onnx-scikitlearn/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "onnxscikitlearn"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.0.0b0,<1.2.0", "skl2onnx>=1.10.3"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0", "skl2onnx>=1.10.3"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-onnx-tensorflow/setup.py
+++ b/plugins/flytekit-onnx-tensorflow/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "onnxtensorflow"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.0.0b0,<1.2.0", "tf2onnx>=1.9.3", "tensorflow>=2.7.0"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0", "tf2onnx>=1.9.3", "tensorflow>=2.7.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-pandera/setup.py
+++ b/plugins/flytekit-pandera/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "pandera"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0", "pandera>=0.7.1"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0", "pandera>=0.7.1"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-papermill/setup.py
+++ b/plugins/flytekit-papermill/setup.py
@@ -5,7 +5,7 @@ PLUGIN_NAME = "papermill"
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 plugin_requires = [
-    "flytekit>=1.1.0b0,<1.2.0",
+    "flytekit>=1.1.0b0,<2.0.0",
     "papermill>=1.2.0",
     "nbconvert>=6.0.7",
     "ipykernel>=5.0.0",

--- a/plugins/flytekit-polars/setup.py
+++ b/plugins/flytekit-polars/setup.py
@@ -5,7 +5,7 @@ PLUGIN_NAME = "polars"
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 plugin_requires = [
-    "flytekit>=1.1.0b0,<1.2.0",
+    "flytekit>=1.1.0b0,<2.0.0",
     "polars>=0.8.27",
 ]
 

--- a/plugins/flytekit-ray/setup.py
+++ b/plugins/flytekit-ray/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "ray"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["ray", "flytekit>=1.1.0b0,<1.2.0", "flyteidl>=1.1.10"]
+plugin_requires = ["ray", "flytekit>=1.1.0b0,<2.0.0", "flyteidl>=1.1.10"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-snowflake/setup.py
+++ b/plugins/flytekit-snowflake/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "snowflake"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-spark/setup.py
+++ b/plugins/flytekit-spark/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "spark"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0", "pyspark>=3.0.0"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0", "pyspark>=3.0.0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-sqlalchemy/setup.py
+++ b/plugins/flytekit-sqlalchemy/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "sqlalchemy"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0", "sqlalchemy>=1.4.7"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0", "sqlalchemy>=1.4.7"]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Change the upper bound flytekit version in plugins to '<2.0.0' 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The official flytekit docker images failed to build when we released the beta version flytekit 1.2.0b0 [last week](https://github.com/flyteorg/flytekit/runs/7887779364?check_suite_focus=true) because of this error:
```
ERROR: Cannot install flytekit==1.2.0b0 and flytekitplugins-pod==1.2.0b0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested flytekit==1.2.0b0
    flytekitplugins-pod 1.2.0b0 depends on flytekit<1.2.0 and >=1.1.0b0
```

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2855

## Follow-up issue
_NA_
