### PR TITLE
Fixing structured dataset for empty bq tables

### DIFF
--- a/flytekit/types/structured/bigquery.py
+++ b/flytekit/types/structured/bigquery.py
@@ -51,7 +51,14 @@ def _read_from_bq(
     frames = []
     for message in reader.rows().pages:
         frames.append(message.to_dataframe())
-    return pd.concat(frames)
+    if len(frames) > 0:
+        df = pd.concat(frames)
+    else:
+        schema = pa.ipc.read_schema(
+            pa.py_buffer(read_session.arrow_schema.serialized_schema)
+        )
+        df = schema.empty_table().to_pandas()
+    return df
 
 
 class PandasToBQEncodingHandlers(StructuredDatasetEncoder):


### PR DESCRIPTION
# TL;DR
Structured dataset bq read fails on empty table because `pandas.concat()` fails if the passed array is empty.  Fix it to create an empty dataframe with the required schema

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
