### PR TITLE
Set default format of structured dataset to empty

### DIFF
--- a/tests/flytekit/unit/core/test_structured_dataset.py
+++ b/tests/flytekit/unit/core/test_structured_dataset.py
@@ -53,8 +53,12 @@ def test_types_pandas():
     pt = pd.DataFrame
     lt = TypeEngine.to_literal_type(pt)
     assert lt.structured_dataset_type is not None
-    assert lt.structured_dataset_type.format == PARQUET
+    assert lt.structured_dataset_type.format == ""
     assert lt.structured_dataset_type.columns == []
+
+    pt = Annotated[pd.DataFrame, "csv"]
+    lt = TypeEngine.to_literal_type(pt)
+    assert lt.structured_dataset_type.format == "csv"
 
 
 def test_annotate_extraction():


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
https://github.com/flyteorg/flyte/issues/2864

The current default format type is `Parquet,` and it leads to some issues

1. SD transformer will always convert dataframe to parquet instead of [cls.DEFAULT_FORMATS[df_type]](https://github.com/flyteorg/flytekit/blob/28ffc6346fd87c19f15d922e654280146ab3a40c/flytekit/types/structured/structured_dataset.py#L332)
```python
def t1() -> StructuredDataset: # The default format of structured dataset is Parquet here
```

2. Failed to run BQ task if the cache is enabled because [type validation](https://github.com/flyteorg/flytepropeller/blob/9cf5368793e5d60113cb819a6e496a7b6accd619/pkg/compiler/validators/typing.go#L157) is failing.
```python
@task(cache=True, cache_version="1.0")
def t1() -> StructuredDataset: # The default format of structured dataset is Parquet here
    df = pd.DataFrame({"len": [len(sd.open(pd.DataFrame).all())]})
    return StructuredDataset(df, uri=bq_uri) # The format of structured dataset is "" 
```

In this PR, we set the default format to ""
```python
def t1() -> StructuredDataset: # The default format of structured dataset is "" here
```

1. By default, we use `handlers[df_type][protocol][""]` to encode a dataframe. if `handlers[df_type][protocol][""]` doesn't exist, then use `handlers[df_type][protocol][cls.DEFAULT_FORMATS[df_type]]`.


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
^^^

## Follow-up issue
_NA_
