### PR TITLE
Strip newline from client secret

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -94,6 +94,7 @@ from docker_image import reference
 from flytekit.configuration import internal as _internal
 from flytekit.configuration.default_images import DefaultImages
 from flytekit.configuration.file import ConfigEntry, ConfigFile, get_config_file, read_file_if_exists, set_if_exists
+from flytekit.loggers import logger
 
 PROJECT_PLACEHOLDER = "{{ registration.project }}"
 DOMAIN_PLACEHOLDER = "{{ registration.domain }}"
@@ -340,7 +341,7 @@ class PlatformConfig(object):
             _internal.Credentials.CLIENT_CREDENTIALS_SECRET_LOCATION.read(config_file)
         )
         if client_credentials_secret and client_credentials_secret.endswith("\n"):
-            # TODO Add logging
+            logger.info("Newline stripped from client secret")
             client_credentials_secret = client_credentials_secret.strip()
         kwargs = set_if_exists(
             kwargs,

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -336,10 +336,16 @@ class PlatformConfig(object):
             kwargs, "client_credentials_secret", _internal.Credentials.CLIENT_CREDENTIALS_SECRET.read(config_file)
         )
 
+        client_credentials_secret = read_file_if_exists(
+            _internal.Credentials.CLIENT_CREDENTIALS_SECRET_LOCATION.read(config_file)
+        )
+        if client_credentials_secret and client_credentials_secret.endswith("\n"):
+            # TODO Add logging
+            client_credentials_secret = client_credentials_secret.strip()
         kwargs = set_if_exists(
             kwargs,
             "client_credentials_secret",
-            read_file_if_exists(_internal.Credentials.CLIENT_CREDENTIALS_SECRET_LOCATION.read(config_file)),
+            client_credentials_secret,
         )
         kwargs = set_if_exists(kwargs, "scopes", _internal.Credentials.SCOPES.read(config_file))
         kwargs = set_if_exists(kwargs, "auth_mode", _internal.Credentials.AUTH_MODE.read(config_file))

--- a/tests/flytekit/unit/configuration/configs/creds_secret_location.yaml
+++ b/tests/flytekit/unit/configuration/configs/creds_secret_location.yaml
@@ -1,7 +1,7 @@
 admin:
   # For GRPC endpoints you might want to use dns:///flyte.myexample.com
   endpoint: dns:///flyte.mycorp.io
-  clientSecretLocation: ../tests/flytekit/unit/configuration/configs/fake_secret
+  clientSecretLocation: configs/fake_secret
   authType: Pkce
   insecure: true
   clientId: propeller

--- a/tests/flytekit/unit/configuration/test_internal.py
+++ b/tests/flytekit/unit/configuration/test_internal.py
@@ -2,7 +2,7 @@ import os
 
 import mock
 
-from flytekit.configuration import get_config_file, read_file_if_exists
+from flytekit.configuration import PlatformConfig, get_config_file, read_file_if_exists
 from flytekit.configuration.internal import AWS, Credentials, Images
 
 
@@ -31,7 +31,19 @@ def test_client_secret_location():
         os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/creds_secret_location.yaml")
     )
     secret_location = Credentials.CLIENT_CREDENTIALS_SECRET_LOCATION.read(cfg)
-    assert secret_location == "../tests/flytekit/unit/configuration/configs/fake_secret"
+    assert secret_location == "configs/fake_secret"
+
+    # Modify the path to the secret inline
+    cfg._yaml_config["admin"]["clientSecretLocation"] = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "configs/fake_secret"
+    )
+
+    # Assert secret contains a newline
+    with open(cfg._yaml_config["admin"]["clientSecretLocation"], "rb") as f:
+        assert f.read() == b"hello\n"
+
+    platform_cfg = PlatformConfig.auto(cfg)
+    assert platform_cfg.client_credentials_secret == "hello"
 
 
 def test_read_file_if_exists():

--- a/tests/flytekit/unit/configuration/test_internal.py
+++ b/tests/flytekit/unit/configuration/test_internal.py
@@ -40,8 +40,9 @@ def test_client_secret_location():
 
     # Assert secret contains a newline
     with open(cfg._yaml_config["admin"]["clientSecretLocation"], "rb") as f:
-        assert f.read() == b"hello\n"
+        assert f.read().decode().endswith("\n") is True
 
+    # Assert that secret in platform config does not contain a newline
     platform_cfg = PlatformConfig.auto(cfg)
     assert platform_cfg.client_credentials_secret == "hello"
 


### PR DESCRIPTION
# TL;DR
Trailing newlines in secrets cause more hard than they are worth, so we strip them and tell the user that they worth  

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Remove newlines from the client secret files and log if that happens. 

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2849

## Follow-up issue
_NA_