### PR TITLE
Open HashMethod to all types

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -62,13 +62,10 @@ class TypeTransformer(typing.Generic[T]):
     Base transformer type that should be implemented for every python native type that can be handled by flytekit
     """
 
-    def __init__(self, name: str, t: Type[T], enable_type_assertions: bool = True, hash_overridable: bool = False):
+    def __init__(self, name: str, t: Type[T], enable_type_assertions: bool = True):
         self._t = t
         self._name = name
         self._type_assertions_enabled = enable_type_assertions
-        # `hash_overridable` indicates that the literals produced by this type transformer can set their hashes if needed.
-        # See (link to documentation where this feature is explained).
-        self._hash_overridable = hash_overridable
 
     @property
     def name(self):
@@ -87,10 +84,6 @@ class TypeTransformer(typing.Generic[T]):
         Indicates if the transformer wants type assertions to be enabled at the core type engine layer
         """
         return self._type_assertions_enabled
-
-    @property
-    def hash_overridable(self) -> bool:
-        return self._hash_overridable
 
     def assert_type(self, t: Type[T], v: T):
         if not hasattr(t, "__origin__") and not isinstance(v, t):
@@ -742,7 +735,7 @@ class TypeEngine(typing.Generic[T]):
 
         # In case the value is an annotated type we inspect the annotations and look for hash-related annotations.
         hash = None
-        if transformer.hash_overridable and get_origin(python_type) is Annotated:
+        if get_origin(python_type) is Annotated:
             # We are now dealing with one of two cases:
             # 1. The annotated type is a `HashMethod`, which indicates that we should we should produce the hash using
             #    the method indicated in the annotation.

--- a/flytekit/types/schema/types_pandas.py
+++ b/flytekit/types/schema/types_pandas.py
@@ -81,7 +81,6 @@ class PandasDataFrameTransformer(TypeTransformer[pandas.DataFrame]):
     def __init__(self):
         super().__init__("PandasDataFrame<->GenericSchema", pandas.DataFrame)
         self._parquet_engine = ParquetIO()
-        self._hash_overridable = True
 
     @staticmethod
     def _get_schema_type() -> SchemaType:

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -376,9 +376,6 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
         super().__init__("StructuredDataset Transformer", StructuredDataset)
         self._type_assertions_enabled = False
 
-        # Instances of StructuredDataset opt-in to the ability of being cached.
-        self._hash_overridable = True
-
     @classmethod
     def register_renderer(cls, python_type: Type, renderer: Renderable):
         cls.Renderers[python_type] = renderer

--- a/tests/flytekit/unit/core/test_local_cache.py
+++ b/tests/flytekit/unit/core/test_local_cache.py
@@ -261,9 +261,9 @@ def test_dict_wf_with_constants():
     assert n_cached_task_calls == 2
 
 
-def test_set_integer_literal_hash_is_not_cached():
+def test_set_integer_literal_hash_is_cached():
     """
-    Test to confirm that the local cache is not set in the case of integers, even if we
+    Test to confirm that the local cache is set in the case of integers, even if we
     return an annotated integer. In order to make this very explicit, we define a constant hash
     function, i.e. the same value is returned by it regardless of the input.
     """
@@ -289,13 +289,13 @@ def test_set_integer_literal_hash_is_not_cached():
     assert n_cached_task_calls == 0
     assert wf(a=3) == 3
     assert n_cached_task_calls == 1
-    # Confirm that the value is not cached, even though we set a hash function that
-    # returns a constant value and that the task has only one input.
-    assert wf(a=2) == 2
-    assert n_cached_task_calls == 2
+    # Confirm that the value is cached due to the fact the hash value is constant, regardless
+    # of the value passed to the cacheable task.
+    assert wf(a=2) == 3
+    assert n_cached_task_calls == 1
     # Confirm that the cache is hit if we execute the workflow with the same value as previous run.
-    assert wf(a=2) == 2
-    assert n_cached_task_calls == 2
+    assert wf(a=2) == 3
+    assert n_cached_task_calls == 1
 
 
 def test_pass_annotated_to_downstream_tasks():

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1254,17 +1254,16 @@ def test_pass_annotated_to_downstream_tasks():
     assert t1(a=3) == 9
 
 
-def test_literal_hash_int_not_set():
+def test_literal_hash_int_can_be_set():
     """
-    Test to confirm that annotating an integer with `HashMethod` does not force the literal to have its
-    hash set.
+    Test to confirm that annotating an integer with `HashMethod` is allowed.
     """
     ctx = FlyteContext.current_context()
     lv = TypeEngine.to_literal(
         ctx, 42, Annotated[int, HashMethod(str)], LiteralType(simple=model_types.SimpleType.INTEGER)
     )
     assert lv.scalar.primitive.integer == 42
-    assert lv.hash is None
+    assert lv.hash == "42"
 
 
 def test_literal_hash_to_python_value():

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1811,11 +1811,11 @@ def test_union_type_ambiguity_resolution():
     del TypeEngine._REGISTRY[MyInt]
 
 
-def test_task_annotate_primitive_type_has_no_effect():
+def test_task_annotate_primitive_type_is_allowed():
     @task
     def plus_two(
         a: int,
-    ) -> Annotated[int, HashMethod(str)]:  # Note the use of `str` as the hash function for ints. This has no effect.
+    ) -> Annotated[int, HashMethod(lambda x: str(x + 1))]:
         return a + 2
 
     assert plus_two(a=1) == 3
@@ -1832,7 +1832,7 @@ def test_task_annotate_primitive_type_has_no_effect():
         ),
     )
     assert output_lm.literals["o0"].scalar.primitive.integer == 5
-    assert output_lm.literals["o0"].hash is None
+    assert output_lm.literals["o0"].hash == "6"
 
 
 def test_task_hash_return_pandas_dataframe():


### PR DESCRIPTION
# TL;DR
Ensure all types can have their hash values overriden

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 Initially we made it so that only pandas dataframes and StructuredDatasets could leverage the ability to override their hash values for the purpose of producing cache keys. This PR lifts that restriction and opens up that feature to all types. 

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2912

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
