### PR TITLE
Return None for SyncCheckpoint.read() when src is empty

### DIFF
--- a/flytekit/core/checkpointer.py
+++ b/flytekit/core/checkpointer.py
@@ -146,7 +146,9 @@ class SyncCheckpoint(Checkpoint):
         if p is None:
             return None
         files = list(p.iterdir())
-        if len(files) == 0 or len(files) > 1:
+        if len(files) == 0:
+            return None
+        if len(files) > 1:
             raise ValueError(f"Expected exactly one checkpoint - found {len(files)}")
         f = files[0]
         return f.read_bytes()

--- a/tests/flytekit/unit/core/test_checkpoint.py
+++ b/tests/flytekit/unit/core/test_checkpoint.py
@@ -83,6 +83,16 @@ def test_sync_checkpoint_restore_default_path(tmpdir):
     assert cp.restore() == cp._prev_download_path
 
 
+def test_sync_checkpoint_read_empty_dir(tmpdir):
+    td_path = Path(tmpdir)
+    dest = td_path.joinpath("dest")
+    dest.mkdir()
+    src = td_path.joinpath("src")
+    src.mkdir()
+    cp = SyncCheckpoint(checkpoint_dest=str(dest), checkpoint_src=str(src))
+    assert cp.read() is None
+
+
 def test_sync_checkpoint_read_multiple_files(tmpdir):
     """
     Read can only work with one file.


### PR DESCRIPTION
Signed-off-by: Andrew Dye <andrewwdye@gmail.com>

# TL;DR
`SyncCheckpoint.read()` should return `None` when src path is empty rather than raising an exception

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Intra task checkpointing in Flyte passes a src path to the task in all attempts > 0. There is no guarantee that the prior attempt will have written checkpoint content. `SyncCheckpoint.read()` should return `None` when src path is empty rather than raising an exception. Tasks must already handle this case, as `None` is returned on attempt 0.

## Tracking Issue
NA

## Follow-up issue
NA
