### PR TITLE
Fix the failing tests when run on a system that has a GPU available.

### DIFF
--- a/tests/flytekit/unit/extras/pytorch/test_transformations.py
+++ b/tests/flytekit/unit/extras/pytorch/test_transformations.py
@@ -72,7 +72,8 @@ def test_get_literal_type(transformer, python_type, format):
 def test_to_python_value_and_literal(transformer, python_type, format, python_val):
     ctx = context_manager.FlyteContext.current_context()
     tf = transformer
-    python_val = python_val
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    python_val = python_val.to(device) if hasattr(python_val, "to") else python_val
     lt = tf.get_literal_type(python_type)
 
     lv = tf.to_literal(ctx, python_val, type(python_val), lt)  # type: ignore


### PR DESCRIPTION
This loads the `python_val` from the test to match the device logic used in `to_python_value`. A check is done to handle the case of `PyTorchCheckpoint` which does not have a to method.

# TL;DR
Fix two unit tests that fail when run on a system that has a GPU available.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 The code in `PyTorchTypeTransformer.to_python_value` will automatically load an object onto the GPU if the device is available.
```python
        # cpu <-> gpu conversion
        if torch.cuda.is_available():
            map_location = "cuda:0"
        else:
            map_location = torch.device("cpu")

        # load pytorch tensor/module from a file
        return torch.load(local_path, map_location=map_location)
```
But the objects in the unit test default to being loaded on the CPU.  This makes equality comparisons fail with a `RuntimeError`.

> RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument other in method wrapper__equal)

To address this, I added logic in the test to load the object on GPU if available.

The test includes three types of objects: `torch.Tensor`, `torch.nn.Module`, and `PyTorchCheckpoint`.  That last class is a `dataclass` defined in `flytekit/extras/pytorch/checkpoint.py` that uses a `PyTorchCheckpointTransformer`.  This class does not directly support loading onto cpu/gpu with `to`, so I added a check before the call.

## Open questions

As I am new to this project, there are some design questions I don't feel qualified to make but I can see them perhaps being an issue.

- Should there be a separate test function for the `PyTorchCheckpoint`?  Unlike `torch.Tensor` and `torch.nn.Module` which are PyTorch types, `PyTorchCheckpoint` is a `dataclass` defined in the `flytekit` project.
- Should tests disable the GPU?  I think it's good to test GPU functionality when available, so I would say no.  But I'd defer to others.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2941

## Follow-up issue
_NA_