### PR TITLE
ContainerTask fix to read base env vars properly from compilation settings

### DIFF
--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -81,7 +81,8 @@ class ContainerTask(PythonTask):
         return None
 
     def get_container(self, settings: SerializationSettings) -> _task_model.Container:
-        env = {**settings.env, **self.environment} if self.environment else settings.env
+        env = settings.env or {}
+        env = {**env, **self.environment} if self.environment else env
         return _get_container_definition(
             image=self._image,
             command=self._cmd,

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -32,6 +32,7 @@ def test_serialization():
         inputs=kwtypes(val=int),
         outputs=kwtypes(out=int),
         image="alpine",
+        environment={"a": "b"},
         command=["sh", "-c", "echo $(( {{.Inputs.val}} * {{.Inputs.val}} )) | tee /var/outputs/out"],
     )
 


### PR DESCRIPTION
# TL;DR
Bug in container task that wasn't being hit unless user specifies an additional env var map in the task.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Fix npe.

## Tracking Issue
User reported issue:
https://discuss.flyte.org/t/2749411/what-s-your-gh-handle-U03KEF8H6FR