### PR TITLE
Handle special characters in snowflake query

### DIFF
--- a/flytekit/core/base_sql_task.py
+++ b/flytekit/core/base_sql_task.py
@@ -41,7 +41,7 @@ class SQLTask(PythonTask[T]):
             task_config=task_config,
             **kwargs,
         )
-        self._query_template = query_template
+        self._query_template = query_template.replace("\n", "\\n").replace("\t", "\\t")
 
     @property
     def query_template(self) -> str:

--- a/plugins/flytekit-snowflake/tests/test_snowflake.py
+++ b/plugins/flytekit-snowflake/tests/test_snowflake.py
@@ -10,7 +10,7 @@ from flytekit.types.schema import FlyteSchema
 
 query_template = """
             insert overwrite directory '{{ .rawOutputDataPrefix }}' stored as parquet
-            select *
+            select * 
             from my_table
             where ds = '{{ .Inputs.ds }}'
         """
@@ -64,14 +64,27 @@ def test_local_exec():
     snowflake_task = SnowflakeTask(
         name="flytekit.demo.snowflake_task.query2",
         inputs=kwtypes(ds=str),
-        query_template=query_template,
+        query_template="select 1\n",
         # the schema literal's backend uri will be equal to the value of .raw_output_data
         output_schema_type=FlyteSchema,
     )
 
     assert len(snowflake_task.interface.inputs) == 1
+    assert snowflake_task.query_template == "select 1\\n"
     assert len(snowflake_task.interface.outputs) == 1
 
     # will not run locally
     with pytest.raises(Exception):
         snowflake_task()
+
+
+def test_sql_template():
+    snowflake_task = SnowflakeTask(
+        name="flytekit.demo.snowflake_task.query2",
+        inputs=kwtypes(ds=str),
+        query_template="""select 1 from\t
+         custom where column = 1""",
+        # the schema literal's backend uri will be equal to the value of .raw_output_data
+        output_schema_type=FlyteSchema,
+    )
+    assert snowflake_task.query_template == "select 1 from\\t\\n         custom where column = 1"

--- a/plugins/flytekit-snowflake/tests/test_snowflake.py
+++ b/plugins/flytekit-snowflake/tests/test_snowflake.py
@@ -84,7 +84,6 @@ def test_sql_template():
         inputs=kwtypes(ds=str),
         query_template="""select 1 from\t
          custom where column = 1""",
-        # the schema literal's backend uri will be equal to the value of .raw_output_data
         output_schema_type=FlyteSchema,
     )
     assert snowflake_task.query_template == "select 1 from\\t\\n         custom where column = 1"

--- a/plugins/flytekit-snowflake/tests/test_snowflake.py
+++ b/plugins/flytekit-snowflake/tests/test_snowflake.py
@@ -10,7 +10,7 @@ from flytekit.types.schema import FlyteSchema
 
 query_template = """
             insert overwrite directory '{{ .rawOutputDataPrefix }}' stored as parquet
-            select * 
+            select *
             from my_table
             where ds = '{{ .Inputs.ds }}'
         """


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Related to https://flyte-org.slack.com/archives/CP2HDHKE1/p1664792800827789?thread_ts=1663843915.889099&cid=CP2HDHKE1.

[snowflake docs](https://docs.snowflake.com/en/sql-reference/data-types-text.html#dollar-quoted-string-constants)

Replace "\n" to "\\n" to fix the 400 error.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
