### PR TITLE
Add support chain multiple tasks

### DIFF
--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -49,6 +49,7 @@ class Node(object):
 
     def __rshift__(self, other: Node):
         self.runs_before(other)
+        return self
 
     @property
     def outputs(self):

--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -49,7 +49,7 @@ class Node(object):
 
     def __rshift__(self, other: Node):
         self.runs_before(other)
-        return self
+        return other
 
     @property
     def outputs(self):

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -350,7 +350,7 @@ class Promise(object):
     def __rshift__(self, other: typing.Union[Promise, VoidPromise]):
         if not self.is_ready:
             self.ref.node.runs_before(other.ref.node)
-        return self
+        return other
 
     def with_var(self, new_var: str) -> Promise:
         if self.is_ready:
@@ -563,7 +563,7 @@ def create_task_output(
 
         def __rshift__(self, other: Any):
             # See comment for runs_before
-            return self
+            return other
 
     return Output(*promises)  # type: ignore
 
@@ -679,7 +679,7 @@ class VoidPromise(object):
     def __rshift__(self, other: typing.Union[Promise, VoidPromise]):
         if self.ref:
             self.ref.node.runs_before(other.ref.node)
-        return self
+        return other
 
     def with_overrides(self, *args, **kwargs):
         if self.ref:

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -350,6 +350,7 @@ class Promise(object):
     def __rshift__(self, other: typing.Union[Promise, VoidPromise]):
         if not self.is_ready:
             self.ref.node.runs_before(other.ref.node)
+        return self
 
     def with_var(self, new_var: str) -> Promise:
         if self.is_ready:
@@ -678,6 +679,7 @@ class VoidPromise(object):
     def __rshift__(self, other: typing.Union[Promise, VoidPromise]):
         if self.ref:
             self.ref.node.runs_before(other.ref.node)
+        return self
 
     def with_overrides(self, *args, **kwargs):
         if self.ref:

--- a/tests/flytekit/unit/core/test_node_creation.py
+++ b/tests/flytekit/unit/core/test_node_creation.py
@@ -194,7 +194,12 @@ def test_promise_chaining():
         c >> a
         return b
 
+    @workflow
+    def wf1(x: int):
+        task_a(x=x) >> task_b(x=x) >> task_c(x=x)
+
     wf(x=3)
+    wf1(x=3)
 
 
 def test_resource_request_override():


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Add support chain multiple tasks by returning `other` when calling __rshift__

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
<img width="1863" alt="image" src="https://user-images.githubusercontent.com/37936015/194171103-57f84aed-8546-4d74-936b-013b1a43a78d.png">


## Tracking Issue
https://github.com/flyteorg/flyte/issues/2955

## Follow-up issue
_NA_
