### PR TITLE
Fix handling of Optional in the DataclassTransformer

### DIFF
--- a/plugins/flytekit-dbt/tests/test_task.py
+++ b/plugins/flytekit-dbt/tests/test_task.py
@@ -58,6 +58,7 @@ class TestDBTRun:
                     project_dir=DBT_PROJECT_DIR,
                     profiles_dir=DBT_PROFILES_DIR,
                     profile=DBT_PROFILE,
+                    select=["tag:something"],
                 )
             )
 

--- a/plugins/flytekit-dbt/tests/test_task.py
+++ b/plugins/flytekit-dbt/tests/test_task.py
@@ -59,6 +59,7 @@ class TestDBTRun:
                     profiles_dir=DBT_PROFILES_DIR,
                     profile=DBT_PROFILE,
                     select=["tag:something"],
+                    exclude=["tag:something-else"],
                 )
             )
 


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Generalize the handling of Optional in DataclassTransformer

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
We catch the case of an `Optional[X]` member in a dataclass in the transformer before handing it to the List and Dictionary transformers.

I also added a test in the dbt plugins to confirm that the members in the plugin's [dbt dataclasses](https://cs.github.com/flyteorg/flytekit/blob/0bd3261c7567b0e25fa4cac88c883279b8752447/plugins/flytekit-dbt/flytekitplugins/dbt/schema.py?q=repo%3Aflyteorg%2Fflytekit+dbt#L111-L112) are handled correctly.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2953

## Follow-up issue
_NA_
