### PR TITLE
Enable use of image stanza in `pyflyte register` and other small changes

### DIFF
--- a/flytekit/clis/sdk_in_container/helpers.py
+++ b/flytekit/clis/sdk_in_container/helpers.py
@@ -1,7 +1,10 @@
+from dataclasses import replace
+from typing import Optional
+
 import click
 
 from flytekit.clis.sdk_in_container.constants import CTX_CONFIG_FILE
-from flytekit.configuration import Config
+from flytekit.configuration import Config, ImageConfig
 from flytekit.loggers import cli_logger
 from flytekit.remote.remote import FlyteRemote
 
@@ -30,3 +33,28 @@ def get_and_save_remote_with_click_context(
     if save:
         ctx.obj[FLYTE_REMOTE_INSTANCE_KEY] = r
     return r
+
+
+def patch_image_config(config_file: Optional[str], image_config: ImageConfig) -> ImageConfig:
+    """
+    Merge ImageConfig object with images defined in config file
+    """
+    # Images come from three places:
+    # * The default flytekit images, which are already supplied by the base run_level_params.
+    # * The images provided by the user on the command line.
+    # * The images provided by the user via the config file, if there is one. (Images on the command line should
+    #   override all).
+    #
+    # However, the run_level_params already contains both the default flytekit images (lowest priority), as well
+    # as the images from the command line (highest priority). So when we read from the config file, we only
+    # want to add in the images that are missing, including the default, if that's also missing.
+    additional_image_names = set([v.name for v in image_config.images])
+    new_additional_images = [v for v in image_config.images]
+    new_default = image_config.default_image
+    if config_file:
+        cfg_ic = ImageConfig.auto(config_file=config_file)
+        new_default = new_default or cfg_ic.default_image
+        for addl in cfg_ic.images:
+            if addl.name not in additional_image_names:
+                new_additional_images.append(addl)
+    return replace(image_config, default_image=new_default, images=new_additional_images)

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -202,7 +202,7 @@ def register(
         version = remote._version_from_hash(md5_bytes, serialization_settings, service_account, raw_data_prefix)  # noqa
         cli_logger.info(f"Computed version is {version}")
 
-    cli_logger.warn(
+    click.echo(
         f"Registering entities under version {version} using the following serialization settings = {serialization_settings}"
     )
 

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -6,7 +6,7 @@ import click
 
 from flytekit.clis.helpers import display_help_with_error
 from flytekit.clis.sdk_in_container import constants
-from flytekit.clis.sdk_in_container.helpers import get_and_save_remote_with_click_context
+from flytekit.clis.sdk_in_container.helpers import get_and_save_remote_with_click_context, patch_image_config
 from flytekit.configuration import FastSerializationSettings, ImageConfig, SerializationSettings
 from flytekit.configuration.default_images import DefaultImages
 from flytekit.loggers import cli_logger
@@ -145,6 +145,11 @@ def register(
             ctx,
             "Missing argument 'PACKAGE_OR_MODULE...', at least one PACKAGE_OR_MODULE is required but multiple can be passed",
         )
+
+    # Use extra images in the config file if that file exists
+    config_file = ctx.obj.get(constants.CTX_CONFIG_FILE)
+    if config_file:
+        image_config = patch_image_config(config_file, image_config)
 
     cli_logger.debug(
         f"Running pyflyte register from {os.getcwd()} "

--- a/tests/flytekit/unit/cli/pyflyte/test_register.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_register.py
@@ -79,6 +79,26 @@ def test_non_fast_register(mock_client, mock_remote):
         with open(os.path.join("core", "sample.py"), "w") as f:
             f.write(sample_file_contents)
             f.close()
-        result = runner.invoke(pyflyte.main, ["register", "--non-fast", "core"])
+        result = runner.invoke(pyflyte.main, ["register", "--non-fast", "--version", "a-version", "core"])
         assert "Output given as None, using a temporary directory at" in result.output
+        shutil.rmtree("core")
+
+
+@mock.patch("flytekit.clis.sdk_in_container.helpers.FlyteRemote", spec=FlyteRemote)
+@mock.patch("flytekit.clients.friendly.SynchronousFlyteClient", spec=SynchronousFlyteClient)
+def test_non_fast_register_require_version(mock_client, mock_remote):
+    mock_remote._client = mock_client
+    mock_remote.return_value._version_from_hash.return_value = "dummy_version_from_hash"
+    mock_remote.return_value._upload_file.return_value = "dummy_md5_bytes", "dummy_native_url"
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        out = subprocess.run(["git", "init"], capture_output=True)
+        assert out.returncode == 0
+        os.makedirs("core", exist_ok=True)
+        with open(os.path.join("core", "sample.py"), "w") as f:
+            f.write(sample_file_contents)
+            f.close()
+        result = runner.invoke(pyflyte.main, ["register", "--non-fast", "core"])
+        assert result.exit_code == 1
+        assert str(result.exception) == "Version is a required parameter in case --non-fast is specified."
         shutil.rmtree("core")

--- a/tests/flytekit/unit/cli/pyflyte/test_register.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_register.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 import shutil
 import subprocess
 
@@ -45,30 +44,6 @@ def test_register_with_no_package_or_module_argument():
             "Missing argument 'PACKAGE_OR_MODULE...', at least one PACKAGE_OR_MODULE is required but multiple can be passed"
             in result.output
         )
-
-
-@mock.patch("flytekit.clis.sdk_in_container.register.repo_register")
-@mock.patch("flytekit.clis.sdk_in_container.helpers.FlyteRemote", spec=FlyteRemote)
-@mock.patch("flytekit.clients.friendly.SynchronousFlyteClient", spec=SynchronousFlyteClient)
-def test_image_config(mock_client, mock_remote, mock_repo_register):
-    mock_remote._client = mock_client
-    mock_remote.return_value._version_from_hash.return_value = "dummy_version_from_hash"
-    mock_remote.return_value._upload_file.return_value = "dummy_md5_bytes", "dummy_native_url"
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        out = subprocess.run(["git", "init"], capture_output=True)
-        assert out.returncode == 0
-        os.makedirs("core2", exist_ok=True)
-        with open(os.path.join("core2", "sample.py"), "w") as f:
-            f.write(sample_file_contents)
-            f.close()
-
-        pp = pathlib.Path.joinpath(pathlib.Path(__file__).parent.parent.parent, "configuration/configs/", "sample.yaml")
-        result = runner.invoke(
-            pyflyte.main, ["--config", str(pp), "register", "--non-fast", "--version", "v42", "core2"]
-        )
-        assert result.exit_code == 0
-        shutil.rmtree("core2")
 
 
 @mock.patch("flytekit.clis.sdk_in_container.helpers.FlyteRemote", spec=FlyteRemote)

--- a/tests/flytekit/unit/cli/pyflyte/test_register.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_register.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import shutil
 import subprocess
 
@@ -101,4 +102,28 @@ def test_non_fast_register_require_version(mock_client, mock_remote):
         result = runner.invoke(pyflyte.main, ["register", "--non-fast", "core"])
         assert result.exit_code == 1
         assert str(result.exception) == "Version is a required parameter in case --non-fast is specified."
+        shutil.rmtree("core")
+
+
+@mock.patch("flytekit.clis.sdk_in_container.register.repo_register")
+@mock.patch("flytekit.clis.sdk_in_container.helpers.FlyteRemote", spec=FlyteRemote)
+@mock.patch("flytekit.clients.friendly.SynchronousFlyteClient", spec=SynchronousFlyteClient)
+def test_image_config(mock_client, mock_remote, mock_repo_register):
+    mock_remote._client = mock_client
+    mock_remote.return_value._version_from_hash.return_value = "dummy_version_from_hash"
+    mock_remote.return_value._upload_file.return_value = "dummy_md5_bytes", "dummy_native_url"
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        out = subprocess.run(["git", "init"], capture_output=True)
+        assert out.returncode == 0
+        os.makedirs("core", exist_ok=True)
+        with open(os.path.join("core", "sample.py"), "w") as f:
+            f.write(sample_file_contents)
+            f.close()
+
+        pp = pathlib.Path.joinpath(pathlib.Path(__file__).parent.parent.parent, "configuration/configs/", "sample.yaml")
+        result = runner.invoke(
+            pyflyte.main, ["--config", str(pp), "register", "--non-fast", "--version", "v42", "core"]
+        )
+        assert result.exit_code == 0
         shutil.rmtree("core")

--- a/tests/flytekit/unit/cli/pyflyte/test_register.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_register.py
@@ -47,6 +47,30 @@ def test_register_with_no_package_or_module_argument():
         )
 
 
+@mock.patch("flytekit.clis.sdk_in_container.register.repo_register")
+@mock.patch("flytekit.clis.sdk_in_container.helpers.FlyteRemote", spec=FlyteRemote)
+@mock.patch("flytekit.clients.friendly.SynchronousFlyteClient", spec=SynchronousFlyteClient)
+def test_image_config(mock_client, mock_remote, mock_repo_register):
+    mock_remote._client = mock_client
+    mock_remote.return_value._version_from_hash.return_value = "dummy_version_from_hash"
+    mock_remote.return_value._upload_file.return_value = "dummy_md5_bytes", "dummy_native_url"
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        out = subprocess.run(["git", "init"], capture_output=True)
+        assert out.returncode == 0
+        os.makedirs("core2", exist_ok=True)
+        with open(os.path.join("core2", "sample.py"), "w") as f:
+            f.write(sample_file_contents)
+            f.close()
+
+        pp = pathlib.Path.joinpath(pathlib.Path(__file__).parent.parent.parent, "configuration/configs/", "sample.yaml")
+        result = runner.invoke(
+            pyflyte.main, ["--config", str(pp), "register", "--non-fast", "--version", "v42", "core2"]
+        )
+        assert result.exit_code == 0
+        shutil.rmtree("core2")
+
+
 @mock.patch("flytekit.clis.sdk_in_container.helpers.FlyteRemote", spec=FlyteRemote)
 @mock.patch("flytekit.clients.friendly.SynchronousFlyteClient", spec=SynchronousFlyteClient)
 def test_register_with_no_output_dir_passed(mock_client, mock_remote):
@@ -102,28 +126,4 @@ def test_non_fast_register_require_version(mock_client, mock_remote):
         result = runner.invoke(pyflyte.main, ["register", "--non-fast", "core"])
         assert result.exit_code == 1
         assert str(result.exception) == "Version is a required parameter in case --non-fast is specified."
-        shutil.rmtree("core")
-
-
-@mock.patch("flytekit.clis.sdk_in_container.register.repo_register")
-@mock.patch("flytekit.clis.sdk_in_container.helpers.FlyteRemote", spec=FlyteRemote)
-@mock.patch("flytekit.clients.friendly.SynchronousFlyteClient", spec=SynchronousFlyteClient)
-def test_image_config(mock_client, mock_remote, mock_repo_register):
-    mock_remote._client = mock_client
-    mock_remote.return_value._version_from_hash.return_value = "dummy_version_from_hash"
-    mock_remote.return_value._upload_file.return_value = "dummy_md5_bytes", "dummy_native_url"
-    runner = CliRunner()
-    with runner.isolated_filesystem():
-        out = subprocess.run(["git", "init"], capture_output=True)
-        assert out.returncode == 0
-        os.makedirs("core", exist_ok=True)
-        with open(os.path.join("core", "sample.py"), "w") as f:
-            f.write(sample_file_contents)
-            f.close()
-
-        pp = pathlib.Path.joinpath(pathlib.Path(__file__).parent.parent.parent, "configuration/configs/", "sample.yaml")
-        result = runner.invoke(
-            pyflyte.main, ["--config", str(pp), "register", "--non-fast", "--version", "v42", "core"]
-        )
-        assert result.exit_code == 0
         shutil.rmtree("core")


### PR DESCRIPTION
# TL;DR
`pyflyte register` is now able to load images present in the config file. That sub-command also requires a version in non-fast case.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Changes to `pyflyte register`:
1. The output of the command now is more explicit about which serialization settings are used, which include the images allowed to be used.
2. Force version in non fast. The idea is to make it clear that this option requires the user to be deliberate about versions when registering entities using the non-fast option.
3. Allow for images present in a config file to be used during registration

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
