### PR TITLE
Use console endpoint config if available

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -299,6 +299,7 @@ class PlatformConfig(object):
     :param endpoint: DNS for Flyte backend
     :param insecure: Whether or not to use SSL
     :param insecure_skip_verify: Wether to skip SSL certificate verification
+    :param console_endpoint: endpoint for console if differenet than Flyte backend
     :param command: This command is executed to return a token using an external process.
     :param client_id: This is the public identifier for the app which handles authorization for a Flyte deployment.
       More details here: https://www.oauth.com/oauth2-servers/client-registration/client-id-secret/.
@@ -351,6 +352,7 @@ class PlatformConfig(object):
         kwargs = set_if_exists(kwargs, "scopes", _internal.Credentials.SCOPES.read(config_file))
         kwargs = set_if_exists(kwargs, "auth_mode", _internal.Credentials.AUTH_MODE.read(config_file))
         kwargs = set_if_exists(kwargs, "endpoint", _internal.Platform.URL.read(config_file))
+        kwargs = set_if_exists(kwargs, "console_endpoint", _internal.Platform.CONSOLE_ENDPOINT.read(config_file))
         return PlatformConfig(**kwargs)
 
     @classmethod

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -313,6 +313,7 @@ class PlatformConfig(object):
     endpoint: str = "localhost:30081"
     insecure: bool = False
     insecure_skip_verify: bool = False
+    console_endpoint: typing.Optional[str] = None
     command: typing.Optional[typing.List[str]] = None
     client_id: typing.Optional[str] = None
     client_credentials_secret: typing.Optional[str] = None

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -112,6 +112,7 @@ class Platform(object):
     INSECURE_SKIP_VERIFY = ConfigEntry(
         LegacyConfigEntry(SECTION, "insecure_skip_verify", bool), YamlConfigEntry("admin.insecureSkipVerify", bool)
     )
+    CONSOLE_ENDPOINT = ConfigEntry(LegacyConfigEntry(SECTION, "console_endpoint"), YamlConfigEntry("console.endpoint"))
 
 
 class LocalSDK(object):

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1473,13 +1473,15 @@ class FlyteRemote(object):
                 )
         return literal_models.LiteralMap({})
 
-    def generate_http_domain(self) -> str:
+    def generate_console_http_domain(self) -> str:
         """
-        This should generate the domain where the HTTP endpoints for the Flyte backend are hosted. This should be
-        the domain that console is hosted on.
+        This should generate the domain where console is hosted.
 
         :return:
         """
+        # If the console endpoint is explicitly set, return it, else derive it from the admin config
+        if self.config.platform.console_endpoint:
+            return self.config.platform.console_endpoint
         protocol = "http" if self.config.platform.insecure else "https"
         endpoint = self.config.platform.endpoint
         # N.B.: this assumes that in case we have an identical configuration as the sandbox default config we are running single binary. The intent here is
@@ -1491,4 +1493,4 @@ class FlyteRemote(object):
     def generate_console_url(
         self, execution: typing.Union[FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution]
     ):
-        return f"{self.generate_http_domain()}/console/projects/{execution.id.project}/domains/{execution.id.domain}/executions/{execution.id.name}"
+        return f"{self.generate_console_http_domain()}/console/projects/{execution.id.project}/domains/{execution.id.domain}/executions/{execution.id.name}"


### PR DESCRIPTION
Signed-off-by: Andrew Dye <andrewwdye@gmail.com>

# TL;DR
Emit explicit console endpoint from flytectl config, if available.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
https://github.com/flyteorg/flytectl/pull/361 added an optional config section for `console.endpoint`, allowing for separate endpoints between console and admin (which is the case for sandbox). This change updates the config consumption and remote helpers to use this explicit endpoint, if available, when displaying the console url after launching a remote execution. If not available, falls back to the same logic as before.

## Tracking Issue
NA

## Follow-up issue
NA