### PR TITLE
Remove use TypeVar to denote the extension of a Flytefile #2870

### DIFF
--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -15,6 +15,7 @@ from flytekit.models import types as _type_models
 from flytekit.models.core import types as _core_types
 from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
+from flytekit.types.file import FileExt
 
 T = typing.TypeVar("T")
 
@@ -144,7 +145,9 @@ class FlyteDirectory(os.PathLike, typing.Generic[T]):
     def __class_getitem__(cls, item: typing.Union[typing.Type, str]) -> typing.Type[FlyteDirectory]:
         if item is None:
             return cls
-        item_string = str(item)
+
+        item_string = FileExt.check_and_convert_to_str(item)
+
         item_string = item_string.strip().lstrip("~").lstrip(".")
         if item_string == "":
             return cls

--- a/flytekit/types/file/__init__.py
+++ b/flytekit/types/file/__init__.py
@@ -25,58 +25,77 @@ import typing
 
 from .file import FlyteFile
 
+
+class FileExt:
+    """Used for annotating types for file extensions for FlyteFile
+    This is usefule for extensions that have periods in them, i.e. "tar.gz"
+
+    Uses:
+    TAR_GZ = typing.Annotated[str, FileExt("tar.gz")]
+    """
+
+    def __init__(self, ext: str):
+        self._ext = ext
+
+    def __str__(self):
+        return self._ext
+
+    def __repr__(self):
+        return self._ext
+
+
 # The following section provides some predefined aliases for commonly used FlyteFile formats.
 # This makes their usage extremely simple for the users. Please keep the list sorted.
 
-hdf5 = typing.TypeVar("hdf5")
+hdf5 = typing.Annotated[str, FileExt("hdf5")]
 #: This can be used to denote that the returned file is of type hdf5 and can be received by other tasks that
 #: accept an hdf5 format. This is usually useful for serializing Tensorflow models
 HDF5EncodedFile = FlyteFile[hdf5]
 
-html = typing.TypeVar("html")
+html = typing.Annotated[str, FileExt("html")]
 #: Can be used to receive or return an HTMLPage. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 HTMLPage = FlyteFile[html]
 
-joblib = typing.TypeVar("joblib")
+joblib = typing.Annotated[str, FileExt("joblib")]
 #: This File represents a file that was serialized using `joblib.dump` method can be loaded back using `joblib.load`.
 JoblibSerializedFile = FlyteFile[joblib]
 
-jpeg = typing.TypeVar("jpeg")
+jpeg = typing.Annotated[str, FileExt("jpeg")]
 #: Can be used to receive or return an JPEGImage. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 JPEGImageFile = FlyteFile[jpeg]
 
-pdf = typing.TypeVar("pdf")
+pdf = typing.Annotated[str, FileExt("pdf")]
 #: Can be used to receive or return an PDFFile. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 PDFFile = FlyteFile[pdf]
 
-png = typing.TypeVar("png")
+png = typing.Annotated[str, FileExt("png")]
 #: Can be used to receive or return an PNGImage. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 PNGImageFile = FlyteFile[png]
 
-python_pickle = typing.TypeVar("python_pickle")
+python_pickle = typing.Annotated[str, FileExt("python_pickle")]
 #: This type can be used when a serialized Python pickled object is returned and shared between tasks. This only
 #: adds metadata to the file in Flyte, but does not really carry any object information.
 PythonPickledFile = FlyteFile[python_pickle]
 
-ipynb = typing.TypeVar("ipynb")
+ipynb = typing.Annotated[str, FileExt("ipynb")]
 #: This type is used to identify a Python notebook file.
 PythonNotebook = FlyteFile[ipynb]
 
-svg = typing.TypeVar("svg")
+svg = typing.Annotated[str, FileExt("svg")]
 #: Can be used to receive or return an SVGImage. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 SVGImageFile = FlyteFile[svg]
 
-csv = typing.TypeVar("csv")
+csv = typing.Annotated[str, FileExt("csv")]
 #: Can be used to receive or return a CSVFile. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 CSVFile = FlyteFile[csv]
 
-onnx = typing.TypeVar("onnx")
+onnx = typing.Annotated[str, FileExt("onnx")]
 #: Can be used to receive or return an ONNXFile. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 ONNXFile = FlyteFile[onnx]

--- a/flytekit/types/file/__init__.py
+++ b/flytekit/types/file/__init__.py
@@ -20,17 +20,19 @@ This list also contains a bunch of pre-formatted :py:class:`flytekit.types.file.
    PythonNotebook
    SVGImageFile
 """
+import typing
 
-from typing_extensions import Annotated
+from typing_extensions import Annotated, get_args, get_origin
 
 from .file import FlyteFile
 
 
 class FileExt:
-    """Used for annotating types for file extensions for FlyteFile
-    This is usefule for extensions that have periods in them, i.e. "tar.gz"
+    """
+    Used for annotating file extension types of FlyteFile.
+    This is useful for extensions that have periods in them, e.g., "tar.gz".
 
-    Uses:
+    Example:
     TAR_GZ = Annotated[str, FileExt("tar.gz")]
     """
 
@@ -42,6 +44,14 @@ class FileExt:
 
     def __repr__(self):
         return self._ext
+
+    @staticmethod
+    def check_and_convert_to_str(item: typing.Union[typing.Type, str]) -> str:
+        if not get_origin(item) is Annotated:
+            return str(item)
+        if get_args(item)[0] == str:
+            return str(get_args(item)[1])
+        raise ValueError("Underlying type of File Extension must be of type <str>")
 
 
 # The following section provides some predefined aliases for commonly used FlyteFile formats.

--- a/flytekit/types/file/__init__.py
+++ b/flytekit/types/file/__init__.py
@@ -21,7 +21,7 @@ This list also contains a bunch of pre-formatted :py:class:`flytekit.types.file.
    SVGImageFile
 """
 
-import typing
+from typing_extensions import Annotated
 
 from .file import FlyteFile
 
@@ -31,7 +31,7 @@ class FileExt:
     This is usefule for extensions that have periods in them, i.e. "tar.gz"
 
     Uses:
-    TAR_GZ = typing.Annotated[str, FileExt("tar.gz")]
+    TAR_GZ = Annotated[str, FileExt("tar.gz")]
     """
 
     def __init__(self, ext: str):
@@ -47,55 +47,55 @@ class FileExt:
 # The following section provides some predefined aliases for commonly used FlyteFile formats.
 # This makes their usage extremely simple for the users. Please keep the list sorted.
 
-hdf5 = typing.Annotated[str, FileExt("hdf5")]
+hdf5 = Annotated[str, FileExt("hdf5")]
 #: This can be used to denote that the returned file is of type hdf5 and can be received by other tasks that
 #: accept an hdf5 format. This is usually useful for serializing Tensorflow models
 HDF5EncodedFile = FlyteFile[hdf5]
 
-html = typing.Annotated[str, FileExt("html")]
+html = Annotated[str, FileExt("html")]
 #: Can be used to receive or return an HTMLPage. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 HTMLPage = FlyteFile[html]
 
-joblib = typing.Annotated[str, FileExt("joblib")]
+joblib = Annotated[str, FileExt("joblib")]
 #: This File represents a file that was serialized using `joblib.dump` method can be loaded back using `joblib.load`.
 JoblibSerializedFile = FlyteFile[joblib]
 
-jpeg = typing.Annotated[str, FileExt("jpeg")]
+jpeg = Annotated[str, FileExt("jpeg")]
 #: Can be used to receive or return an JPEGImage. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 JPEGImageFile = FlyteFile[jpeg]
 
-pdf = typing.Annotated[str, FileExt("pdf")]
+pdf = Annotated[str, FileExt("pdf")]
 #: Can be used to receive or return an PDFFile. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 PDFFile = FlyteFile[pdf]
 
-png = typing.Annotated[str, FileExt("png")]
+png = Annotated[str, FileExt("png")]
 #: Can be used to receive or return an PNGImage. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 PNGImageFile = FlyteFile[png]
 
-python_pickle = typing.Annotated[str, FileExt("python_pickle")]
+python_pickle = Annotated[str, FileExt("python_pickle")]
 #: This type can be used when a serialized Python pickled object is returned and shared between tasks. This only
 #: adds metadata to the file in Flyte, but does not really carry any object information.
 PythonPickledFile = FlyteFile[python_pickle]
 
-ipynb = typing.Annotated[str, FileExt("ipynb")]
+ipynb = Annotated[str, FileExt("ipynb")]
 #: This type is used to identify a Python notebook file.
 PythonNotebook = FlyteFile[ipynb]
 
-svg = typing.Annotated[str, FileExt("svg")]
+svg = Annotated[str, FileExt("svg")]
 #: Can be used to receive or return an SVGImage. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 SVGImageFile = FlyteFile[svg]
 
-csv = typing.Annotated[str, FileExt("csv")]
+csv = Annotated[str, FileExt("csv")]
 #: Can be used to receive or return a CSVFile. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 CSVFile = FlyteFile[csv]
 
-onnx = typing.Annotated[str, FileExt("onnx")]
+onnx = Annotated[str, FileExt("onnx")]
 #: Can be used to receive or return an ONNXFile. The underlying type is a FlyteFile type. This is just a
 #: decoration and useful for attaching content type information with the file and automatically documenting code.
 ONNXFile = FlyteFile[onnx]

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass, field
 
 from dataclasses_json import config, dataclass_json
 from marshmallow import fields
-from typing_extensions import Annotated
 
 from flytekit.core.context_manager import FlyteContext
 from flytekit.core.type_engine import TypeEngine, TypeTransformer, TypeTransformerFailedError
@@ -150,16 +149,13 @@ class FlyteFile(os.PathLike, typing.Generic[T]):
         return ""
 
     def __class_getitem__(cls, item: typing.Union[str, typing.Type]) -> typing.Type[FlyteFile]:
+        from . import FileExt
+
         if item is None:
             return cls
 
-        if typing.get_origin(item) is Annotated:
-            if typing.get_args(item)[0] == str:
-                item = typing.get_args(item)[1]
-            else:
-                raise ValueError("Underlying type of File Extension must be of type <str>")
+        item_string = FileExt.check_and_convert_to_str(item)
 
-        item_string = str(item)
         item_string = item_string.strip().lstrip("~").lstrip(".")
         if item == "":
             return cls

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 
 from dataclasses_json import config, dataclass_json
 from marshmallow import fields
+from typing_extensions import Annotated
 
 from flytekit.core.context_manager import FlyteContext
 from flytekit.core.type_engine import TypeEngine, TypeTransformer, TypeTransformerFailedError
@@ -152,7 +153,7 @@ class FlyteFile(os.PathLike, typing.Generic[T]):
         if item is None:
             return cls
 
-        if typing.get_origin(item) is typing.Annotated:
+        if typing.get_origin(item) is Annotated:
             if typing.get_args(item)[0] == str:
                 item = typing.get_args(item)[1]
             else:

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -151,6 +151,13 @@ class FlyteFile(os.PathLike, typing.Generic[T]):
     def __class_getitem__(cls, item: typing.Union[str, typing.Type]) -> typing.Type[FlyteFile]:
         if item is None:
             return cls
+
+        if typing.get_origin(item) is typing.Annotated:
+            if typing.get_args(item)[0] == str:
+                item = typing.get_args(item)[1]
+            else:
+                raise ValueError("Underlying type of File Extension must be of type <str>")
+
         item_string = str(item)
         item_string = item_string.strip().lstrip("~").lstrip(".")
         if item == "":

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/training.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/training.py
@@ -11,7 +11,7 @@ from flytekit.configuration import SerializationSettings
 from flytekit.extend import ExecutionState, IgnoreOutputs, Interface, PythonTask, TaskPlugins
 from flytekit.loggers import logger
 from flytekit.types.directory.types import FlyteDirectory
-from flytekit.types.file import FlyteFile
+from flytekit.types.file import FileExt, FlyteFile
 
 from .models import training_job as _training_job_models
 
@@ -48,7 +48,7 @@ class SagemakerBuiltinAlgorithmsTask(PythonTask[SagemakerTrainingJobConfig]):
 
     _SAGEMAKER_TRAINING_JOB_TASK = "sagemaker_training_job_task"
 
-    OUTPUT_TYPE = "tar.gz"
+    OUTPUT_TYPE = typing.Annotated[str, FileExt("tar.gz")]
 
     def __init__(
         self,
@@ -70,7 +70,9 @@ class SagemakerBuiltinAlgorithmsTask(PythonTask[SagemakerTrainingJobConfig]):
         ):
             raise ValueError("TaskConfig, algorithm_specification, training_job_resource_config are required")
 
-        input_type = self._content_type_to_blob_format(task_config.algorithm_specification.input_content_type)
+        input_type = typing.Annotated[
+            str, FileExt(self._content_type_to_blob_format(task_config.algorithm_specification.input_content_type))
+        ]
 
         interface = Interface(
             # TODO change train and validation to be FlyteDirectory when available

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/training.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/training.py
@@ -1,6 +1,6 @@
 import typing
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, TypeVar
+from typing import Any, Callable, Dict
 
 from flytekitplugins.awssagemaker.distributed_training import DistributedTrainingContext
 from google.protobuf.json_format import MessageToDict
@@ -48,7 +48,7 @@ class SagemakerBuiltinAlgorithmsTask(PythonTask[SagemakerTrainingJobConfig]):
 
     _SAGEMAKER_TRAINING_JOB_TASK = "sagemaker_training_job_task"
 
-    OUTPUT_TYPE = TypeVar("tar.gz")
+    OUTPUT_TYPE = "tar.gz"
 
     def __init__(
         self,
@@ -70,7 +70,7 @@ class SagemakerBuiltinAlgorithmsTask(PythonTask[SagemakerTrainingJobConfig]):
         ):
             raise ValueError("TaskConfig, algorithm_specification, training_job_resource_config are required")
 
-        input_type = TypeVar(self._content_type_to_blob_format(task_config.algorithm_specification.input_content_type))
+        input_type = self._content_type_to_blob_format(task_config.algorithm_specification.input_content_type)
 
         interface = Interface(
             # TODO change train and validation to be FlyteDirectory when available

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/training.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/training.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Dict
 
 from flytekitplugins.awssagemaker.distributed_training import DistributedTrainingContext
 from google.protobuf.json_format import MessageToDict
+from typing_extensions import Annotated
 
 import flytekit
 from flytekit import ExecutionParameters, FlyteContextManager, PythonFunctionTask, kwtypes
@@ -48,7 +49,7 @@ class SagemakerBuiltinAlgorithmsTask(PythonTask[SagemakerTrainingJobConfig]):
 
     _SAGEMAKER_TRAINING_JOB_TASK = "sagemaker_training_job_task"
 
-    OUTPUT_TYPE = typing.Annotated[str, FileExt("tar.gz")]
+    OUTPUT_TYPE = Annotated[str, FileExt("tar.gz")]
 
     def __init__(
         self,

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/training.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/training.py
@@ -71,7 +71,7 @@ class SagemakerBuiltinAlgorithmsTask(PythonTask[SagemakerTrainingJobConfig]):
         ):
             raise ValueError("TaskConfig, algorithm_specification, training_job_resource_config are required")
 
-        input_type = typing.Annotated[
+        input_type = Annotated[
             str, FileExt(self._content_type_to_blob_format(task_config.algorithm_specification.input_content_type))
         ]
 

--- a/tests/flytekit/unit/core/test_realworld_examples.py
+++ b/tests/flytekit/unit/core/test_realworld_examples.py
@@ -44,7 +44,7 @@ def test_diabetes():
     # the last column is the class
     CLASSES_COLUMNS = OrderedDict({"class": int})
 
-    MODELSER_JOBLIB = typing.TypeVar("joblib.dat")
+    MODELSER_JOBLIB = "joblib.dat"
 
     class XGBoostModelHyperparams(object):
         """
@@ -80,12 +80,7 @@ def test_diabetes():
     @task(cache_version="1.0", cache=True, limits=Resources(mem="200Mi"))
     def split_traintest_dataset(
         dataset: FlyteFile[typing.TypeVar("csv")], seed: int, test_split_ratio: float
-    ) -> (
-        FlyteSchema[FEATURE_COLUMNS],
-        FlyteSchema[FEATURE_COLUMNS],
-        FlyteSchema[CLASSES_COLUMNS],
-        FlyteSchema[CLASSES_COLUMNS],
-    ):
+    ) -> typing.Tuple[FlyteSchema[FEATURE_COLUMNS]]:
         """
         Retrieves the training dataset from the given blob location and then splits it using the split ratio and returns the result
         This splitter is only for the dataset that has the format as specified in the example csv. The last column is assumed to be

--- a/tests/flytekit/unit/core/test_realworld_examples.py
+++ b/tests/flytekit/unit/core/test_realworld_examples.py
@@ -6,7 +6,7 @@ import pandas as pd
 from flytekit import Resources
 from flytekit.core.task import task
 from flytekit.core.workflow import workflow
-from flytekit.types.file.file import FlyteFile
+from flytekit.types.file import FileExt, FlyteFile
 from flytekit.types.schema import FlyteSchema
 
 
@@ -44,7 +44,7 @@ def test_diabetes():
     # the last column is the class
     CLASSES_COLUMNS = OrderedDict({"class": int})
 
-    MODELSER_JOBLIB = "joblib.dat"
+    MODELSER_JOBLIB = typing.Annotated[str, FileExt("joblib.dat")]
 
     class XGBoostModelHyperparams(object):
         """

--- a/tests/flytekit/unit/core/test_realworld_examples.py
+++ b/tests/flytekit/unit/core/test_realworld_examples.py
@@ -2,6 +2,7 @@ import typing
 from collections import OrderedDict
 
 import pandas as pd
+from typing_extensions import Annotated
 
 from flytekit import Resources
 from flytekit.core.task import task
@@ -44,7 +45,7 @@ def test_diabetes():
     # the last column is the class
     CLASSES_COLUMNS = OrderedDict({"class": int})
 
-    MODELSER_JOBLIB = typing.Annotated[str, FileExt("joblib.dat")]
+    MODELSER_JOBLIB = Annotated[str, FileExt("joblib.dat")]
 
     class XGBoostModelHyperparams(object):
         """

--- a/tests/flytekit/unit/core/test_realworld_examples.py
+++ b/tests/flytekit/unit/core/test_realworld_examples.py
@@ -80,7 +80,12 @@ def test_diabetes():
     @task(cache_version="1.0", cache=True, limits=Resources(mem="200Mi"))
     def split_traintest_dataset(
         dataset: FlyteFile[typing.TypeVar("csv")], seed: int, test_split_ratio: float
-    ) -> typing.Tuple[FlyteSchema[FEATURE_COLUMNS]]:
+    ) -> typing.Tuple[
+        FlyteSchema[FEATURE_COLUMNS],
+        FlyteSchema[FEATURE_COLUMNS],
+        FlyteSchema[CLASSES_COLUMNS],
+        FlyteSchema[CLASSES_COLUMNS],
+    ]:
         """
         Retrieves the training dataset from the given blob location and then splits it using the split ratio and returns the result
         This splitter is only for the dataset that has the format as specified in the example csv. The last column is assumed to be

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1429,6 +1429,15 @@ def test_file_ext_with_flyte_file_existing_file():
     assert JPEGImageFile.extension() == "jpeg"
 
 
+def test_file_ext_convert_static_method():
+    TAR_GZ = Annotated[str, FileExt("tar.gz")]
+    item = FileExt.check_and_convert_to_str(TAR_GZ)
+    assert item == "tar.gz"
+
+    str_item = FileExt.check_and_convert_to_str("csv")
+    assert str_item == "csv"
+
+
 def test_file_ext_with_flyte_file_new_file():
     TAR_GZ = Annotated[str, FileExt("tar.gz")]
     flyte_file = FlyteFile[TAR_GZ]

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1430,7 +1430,7 @@ def test_file_ext_with_flyte_file_existing_file():
 
 
 def test_file_ext_with_flyte_file_new_file():
-    TAR_GZ = typing.Annotated[str, FileExt("tar.gz")]
+    TAR_GZ = Annotated[str, FileExt("tar.gz")]
     flyte_file = FlyteFile[TAR_GZ]
     assert flyte_file.extension() == "tar.gz"
 
@@ -1441,7 +1441,7 @@ class WrongType:
 
 
 def test_file_ext_with_flyte_file_wrong_type():
-    WRONG_TYPE = typing.Annotated[int, WrongType(2)]
+    WRONG_TYPE = Annotated[int, WrongType(2)]
     with pytest.raises(ValueError) as e:
         FlyteFile[WRONG_TYPE]
     assert str(e.value) == "Underlying type of File Extension must be of type <str>"

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -47,7 +47,7 @@ from flytekit.models.literals import Blob, BlobMetadata, Literal, LiteralCollect
 from flytekit.models.types import LiteralType, SimpleType, TypeStructure
 from flytekit.types.directory import TensorboardLogs
 from flytekit.types.directory.types import FlyteDirectory
-from flytekit.types.file import JPEGImageFile
+from flytekit.types.file import FileExt, JPEGImageFile
 from flytekit.types.file.file import FlyteFile, FlyteFilePathTransformer, noop
 from flytekit.types.pickle import FlytePickle
 from flytekit.types.pickle.pickle import FlytePickleTransformer
@@ -1423,3 +1423,25 @@ def test_guess_of_dataclass():
     lr = LiteralsResolver(lit_dict)
     assert lr.get("a", Foo) == foo
     assert hasattr(lr.get("a", Foo), "hello") is True
+
+
+def test_file_ext_with_flyte_file_existing_file():
+    assert JPEGImageFile.extension() == "jpeg"
+
+
+def test_file_ext_with_flyte_file_new_file():
+    TAR_GZ = typing.Annotated[str, FileExt("tar.gz")]
+    flyte_file = FlyteFile[TAR_GZ]
+    assert flyte_file.extension() == "tar.gz"
+
+
+class WrongType:
+    def __init__(self, num: int):
+        self.num = num
+
+
+def test_file_ext_with_flyte_file_wrong_type():
+    WRONG_TYPE = typing.Annotated[int, WrongType(2)]
+    with pytest.raises(ValueError) as e:
+        FlyteFile[WRONG_TYPE]
+    assert str(e.value) == "Underlying type of File Extension must be of type <str>"


### PR DESCRIPTION
# TL;DR
Do not use TypeVar to denote the extension of a Flytefile. Pylint was breaking in a couple of places. This fixes it.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Ran pylint and got the stackstrace. Fixed it and then ran again without the errors. details below.

`typing.TypeVar` requires that the name of the var it is assigned to is a match. meaning `T = TypeVar("T")` is ok but `C = TypeVar("T")` is not. So when we have a file extension like "tar.gz" there is no way to assign that as a `tar.gz` variable. So instead we are just switching it to str type.

I left the TypeVar on file extensions in https://github.com/flyteorg/flytekit/blob/master/flytekit/types/file/__init__.py#L28-L82 since they don't seem to break anything.

I searched the rest of the repo looking for any other regex matches for something like with a period in the file extesnion and didn't find any others.

I also corrected a return type for `split_traintest_dataset()` since my linter was warning me about it 

## Tracking Issue
Fixes https://github.com/flyteorg/flyte/issues/2870

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
