### PR TITLE
Set reasonable defaults for pandas dataframe default renderer

### DIFF
--- a/flytekit/deck/renderer.py
+++ b/flytekit/deck/renderer.py
@@ -14,17 +14,22 @@ class Renderable(Protocol):
         raise NotImplementedError
 
 
+DEFAULT_MAX_ROWS = 10
+DEFAULT_MAX_COLS = 100
+
+
 class TopFrameRenderer:
     """
     Render a DataFrame as an HTML table.
     """
 
-    def __init__(self, max_rows: Optional[int] = None):
+    def __init__(self, max_rows: Optional[int] = DEFAULT_MAX_ROWS, max_cols: Optional[int] = DEFAULT_MAX_COLS):
         self._max_rows = max_rows
+        self._max_cols = max_cols
 
     def to_html(self, df: pandas.DataFrame) -> str:
         assert isinstance(df, pandas.DataFrame)
-        return df.to_html(max_rows=self._max_rows)
+        return df.to_html(max_rows=self._max_rows, max_cols=self._max_cols)
 
 
 class ArrowRenderer:

--- a/flytekit/deck/renderer.py
+++ b/flytekit/deck/renderer.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 import pandas
 import pyarrow
@@ -23,7 +23,7 @@ class TopFrameRenderer:
     Render a DataFrame as an HTML table.
     """
 
-    def __init__(self, max_rows: Optional[int] = DEFAULT_MAX_ROWS, max_cols: Optional[int] = DEFAULT_MAX_COLS):
+    def __init__(self, max_rows: int = DEFAULT_MAX_ROWS, max_cols: int = DEFAULT_MAX_COLS):
         self._max_rows = max_rows
         self._max_cols = max_cols
 

--- a/tests/flytekit/unit/deck/test_renderer.py
+++ b/tests/flytekit/unit/deck/test_renderer.py
@@ -1,12 +1,33 @@
 import pandas as pd
 import pyarrow as pa
+import pytest
 
-from flytekit.deck.renderer import ArrowRenderer, TopFrameRenderer
+from flytekit.deck.renderer import DEFAULT_MAX_COLS, DEFAULT_MAX_ROWS, ArrowRenderer, TopFrameRenderer
 
 
-def test_renderer():
-    df = pd.DataFrame({"Name": ["Tom", "Joseph"], "Age": [1, 22]})
+@pytest.mark.parametrize(
+    "rows, cols, max_rows, expected_max_rows, max_cols, expected_max_cols",
+    [
+        (1, 1, None, DEFAULT_MAX_ROWS, None, DEFAULT_MAX_COLS),
+        (10, 1, None, DEFAULT_MAX_ROWS, None, DEFAULT_MAX_COLS),
+        (1, 10, None, DEFAULT_MAX_ROWS, None, DEFAULT_MAX_COLS),
+        (DEFAULT_MAX_ROWS + 1, 10, None, DEFAULT_MAX_ROWS, None, DEFAULT_MAX_COLS),
+        (1, DEFAULT_MAX_COLS + 1, None, DEFAULT_MAX_ROWS, None, DEFAULT_MAX_COLS),
+        (10, DEFAULT_MAX_COLS + 1, None, DEFAULT_MAX_ROWS, None, DEFAULT_MAX_COLS),
+        (DEFAULT_MAX_ROWS + 1, DEFAULT_MAX_COLS + 1, None, DEFAULT_MAX_ROWS, None, DEFAULT_MAX_COLS),
+        (100_000, 10, 123, 123, 5, 5),
+        (10_000, 1000, DEFAULT_MAX_ROWS, DEFAULT_MAX_ROWS, DEFAULT_MAX_COLS, DEFAULT_MAX_COLS),
+    ],
+)
+def test_renderer(rows, cols, max_rows, expected_max_rows, max_cols, expected_max_cols):
+    df = pd.DataFrame({f"abc-{k}": list(range(rows)) for k in range(cols)})
     pa_df = pa.Table.from_pandas(df)
 
-    assert TopFrameRenderer().to_html(df) == df.to_html()
+    kwargs = {}
+    if max_rows is not None:
+        kwargs["max_rows"] = max_rows
+    if max_cols is not None:
+        kwargs["max_cols"] = max_cols
+
+    assert TopFrameRenderer(**kwargs).to_html(df) == df.to_html(max_rows=expected_max_rows, max_cols=expected_max_cols)
     assert ArrowRenderer().to_html(pa_df) == pa_df.to_string()


### PR DESCRIPTION
# TL;DR
pandas dataframe default renderer should be cheap to render

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The [default deck renderer for pandas dataframes](https://github.com/flyteorg/flytekit/blob/master/flytekit/deck/renderer.py#L27) relies on pandas dataframe [to_html](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.to_html.html), but big dataframes take a long time to return, so in this PR we set reasonable defaults for both the max number of rows and columns.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
