### PR TITLE
Walk inheritance hierarchy before checking `is_dataclass` in type_engine

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -651,14 +651,13 @@ class TypeEngine(typing.Generic[T]):
             find a transformer that matches the generic type of v. e.g List[int], Dict[str, int] etc
 
         Step 3:
-            if v is of type data class, use the dataclass transformer
-
-        Step 4:
             Walk the inheritance hierarchy of v and find a transformer that matches the first base class.
             This is potentially non-deterministic - will depend on the registration pattern.
 
             TODO lets make this deterministic by using an ordered dict
 
+        Step 4:
+            if v is of type data class, use the dataclass transformer
         """
 
         # Step 1
@@ -681,9 +680,6 @@ class TypeEngine(typing.Generic[T]):
             raise ValueError(f"Generic Type {python_type.__origin__} not supported currently in Flytekit.")
 
         # Step 3
-        if dataclasses.is_dataclass(python_type):
-            return cls._DATACLASS_TRANSFORMER
-
         # To facilitate cases where users may specify one transformer for multiple types that all inherit from one
         # parent.
         for base_type in cls._REGISTRY.keys():
@@ -698,6 +694,11 @@ class TypeEngine(typing.Generic[T]):
                 # As of python 3.9, calls to isinstance raise a TypeError if the base type is not a valid type, which
                 # is the case for one of the restricted types, namely NamedTuple.
                 logger.debug(f"Invalid base type {base_type} in call to isinstance", exc_info=True)
+
+        # Step 4
+        if dataclasses.is_dataclass(python_type):
+            return cls._DATACLASS_TRANSFORMER
+
         raise ValueError(f"Type {python_type} not supported currently in Flytekit. Please register a new transformer")
 
     @classmethod


### PR DESCRIPTION
# TL;DR
Swap steps 3 & 4 in `type_engine.py` to walk the inheritance hierarchy to check for a registered `TypeTransformer` before checking `is_dataclass`

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
We have internal tooling which generates dataclasses from OpenAPI specifications, which all include a `Generated` mixin and are guaranteed to have a `to_dict`/`from_dict` method. We'd like to register a singletype transformer for all classes which have the `Generated` mixin instead of taking an extra dependency on `dataclass-json`; however, this isn't possible with the present implementation since the type engine checks `is_dataclass` before walking the inheritance hierarchy to resolve the type transformer.

This PR swaps this behavior so we can successfully detect a type transformer for `Generated` rather than falling back to the default dataclass serialization.

See https://flyte-org.slack.com/archives/CREL4QVAQ/p1666049599823129 for more details/discussion

## Tracking Issue
N/A

## Follow-up issue
N/A
