### PR TITLE
MyPy Cleanup Incompatible Types Errors

### DIFF
--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -218,7 +218,7 @@ class Task(object):
         """
         return None
 
-    def local_execute(self, ctx: FlyteContext, **kwargs) -> Optional[Tuple[Promise], Promise, VoidPromise]:
+    def local_execute(self, ctx: FlyteContext, **kwargs) -> Union[Tuple[Promise], Promise, VoidPromise, None]:
         """
         This function is used only in the local execution path and is responsible for calling dispatch execute.
         Use this function when calling a task with native values (or Promises containing Flyte literals derived from

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -218,7 +218,7 @@ class Task(object):
         """
         return None
 
-    def local_execute(self, ctx: FlyteContext, **kwargs) -> Union[Tuple[Promise], Promise, VoidPromise]:
+    def local_execute(self, ctx: FlyteContext, **kwargs) -> Optional[Tuple[Promise], Promise, VoidPromise]:
         """
         This function is used only in the local execution path and is responsible for calling dispatch execute.
         Use this function when calling a task with native values (or Promises containing Flyte literals derived from

--- a/flytekit/core/checkpointer.py
+++ b/flytekit/core/checkpointer.py
@@ -81,7 +81,7 @@ class SyncCheckpoint(Checkpoint):
         self._checkpoint_dest = checkpoint_dest
         self._checkpoint_src = checkpoint_src if checkpoint_src and checkpoint_src != "" else None
         self._td = tempfile.TemporaryDirectory()
-        self._prev_download_path = None
+        self._prev_download_path: typing.Optional[Path] = None
 
     def __del__(self):
         self._td.cleanup()
@@ -154,6 +154,6 @@ class SyncCheckpoint(Checkpoint):
         return f.read_bytes()
 
     def write(self, b: bytes):
-        f = io.BytesIO(b)
-        f = typing.cast(io.BufferedReader, f)
+        p = io.BytesIO(b)
+        f = typing.cast(io.BufferedReader, p)
         self.save(f)

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -80,14 +80,14 @@ class ExecutionParameters(object):
     @dataclass(init=False)
     class Builder(object):
         stats: taggable.TaggableStats
-        execution_date: datetime
-        logging: _logging.Logger
+        execution_date: typing.Optional[datetime]
+        logging: Optional[_logging.Logger]
         execution_id: typing.Optional[_identifier.WorkflowExecutionIdentifier]
         attrs: typing.Dict[str, typing.Any]
-        working_dir: typing.Union[os.PathLike, utils.AutoDeletingTempDir]
+        working_dir: typing.Optional[utils.AutoDeletingTempDir]
         checkpoint: typing.Optional[Checkpoint]
         decks: List[Deck]
-        raw_output_prefix: str
+        raw_output_prefix: Optional[str]
         task_id: typing.Optional[_identifier.Identifier]
 
         def __init__(self, current: typing.Optional[ExecutionParameters] = None):

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -80,15 +80,15 @@ class ExecutionParameters(object):
     @dataclass(init=False)
     class Builder(object):
         stats: taggable.TaggableStats
-        execution_date: typing.Optional[datetime]
-        logging: Optional[_logging.Logger]
-        execution_id: typing.Optional[_identifier.WorkflowExecutionIdentifier]
         attrs: typing.Dict[str, typing.Any]
-        working_dir: typing.Optional[utils.AutoDeletingTempDir]
-        checkpoint: typing.Optional[Checkpoint]
         decks: List[Deck]
-        raw_output_prefix: Optional[str]
-        task_id: typing.Optional[_identifier.Identifier]
+        raw_output_prefix: Optional[str] = None
+        execution_id: typing.Optional[_identifier.WorkflowExecutionIdentifier] = None
+        working_dir: typing.Optional[utils.AutoDeletingTempDir] = None
+        checkpoint: typing.Optional[Checkpoint] = None
+        execution_date: typing.Optional[datetime] = None
+        logging: Optional[_logging.Logger] = None
+        task_id: typing.Optional[_identifier.Identifier] = None
 
         def __init__(self, current: typing.Optional[ExecutionParameters] = None):
             self.stats = current.stats if current else None

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -256,7 +256,7 @@ def transform_interface_to_list_interface(interface: Interface) -> Interface:
     return Interface(inputs=map_inputs, outputs=map_outputs)
 
 
-def _change_unrecognized_type_to_pickle(t: Type[T]) -> Type[T]:
+def _change_unrecognized_type_to_pickle(t: Type[T]) -> typing.Union[Tuple[Type[T]], Type[T], Annotated]:
     try:
         if hasattr(t, "__origin__") and hasattr(t, "__args__"):
             if get_origin(t) is list:
@@ -294,9 +294,9 @@ def transform_function_to_interface(fn: typing.Callable, docstring: Optional[Doc
 
     outputs = extract_return_annotation(return_annotation)
     for k, v in outputs.items():
-        outputs[k] = _change_unrecognized_type_to_pickle(v)
+        outputs[k] = _change_unrecognized_type_to_pickle(v)  # type: ignore
     inputs = OrderedDict()
-    for k, v in signature.parameters.items():
+    for k, v in signature.parameters.items():  # type: ignore
         annotation = type_hints.get(k, None)
         default = v.default if v.default is not inspect.Parameter.empty else None
         # Inputs with default values are currently ignored, we may want to look into that in the future

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -294,9 +294,9 @@ def transform_function_to_interface(fn: typing.Callable, docstring: Optional[Doc
 
     outputs = extract_return_annotation(return_annotation)
     for k, v in outputs.items():
-        outputs[k] = _change_unrecognized_type_to_pickle(v)  # type: ignore
+        outputs[k] = _change_unrecognized_type_to_pickle(v)
     inputs = OrderedDict()
-    for k, v in signature.parameters.items():  # type: ignore
+    for k, v in signature.parameters.items():
         annotation = type_hints.get(k, None)
         default = v.default if v.default is not inspect.Parameter.empty else None
         # Inputs with default values are currently ignored, we may want to look into that in the future
@@ -355,7 +355,9 @@ def output_name_generator(length: int) -> Generator[str, None, None]:
         yield default_output_name(x)
 
 
-def extract_return_annotation(return_annotation: Union[Type, Tuple, None]) -> Dict[str, Type]:
+def extract_return_annotation(
+    return_annotation: Union[Union[Tuple[Type[Any]], Type[Any], Any], Tuple, None]
+) -> Dict[str, Union[Tuple[Type[Any]], Type[Any], Any]]:
     """
     The purpose of this function is to sort out whether a function is returning one thing, or multiple things, and to
     name the outputs accordingly, either by using our default name function, or from a typing.NamedTuple.

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -294,9 +294,9 @@ def transform_function_to_interface(fn: typing.Callable, docstring: Optional[Doc
 
     outputs = extract_return_annotation(return_annotation)
     for k, v in outputs.items():
-        outputs[k] = _change_unrecognized_type_to_pickle(v)
+        outputs[k] = _change_unrecognized_type_to_pickle(v)  # type: ignore
     inputs = OrderedDict()
-    for k, v in signature.parameters.items():
+    for k, v in signature.parameters.items():  # type: ignore
         annotation = type_hints.get(k, None)
         default = v.default if v.default is not inspect.Parameter.empty else None
         # Inputs with default values are currently ignored, we may want to look into that in the future
@@ -355,9 +355,7 @@ def output_name_generator(length: int) -> Generator[str, None, None]:
         yield default_output_name(x)
 
 
-def extract_return_annotation(
-    return_annotation: Union[Union[Tuple[Type[Any]], Type[Any], Any], Tuple, None]
-) -> Dict[str, Union[Tuple[Type[Any]], Type[Any], Any]]:
+def extract_return_annotation(return_annotation: Union[Type, Tuple, None]) -> Dict[str, Type]:
     """
     The purpose of this function is to sort out whether a function is returning one thing, or multiple things, and to
     name the outputs accordingly, either by using our default name function, or from a typing.NamedTuple.

--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -303,7 +303,7 @@ class LaunchPlan(object):
         labels: _common_models.Labels = None,
         annotations: _common_models.Annotations = None,
         raw_output_data_config: _common_models.RawOutputDataConfig = None,
-        max_parallelism: int = None,
+        max_parallelism: typing.Optional[int] = None,
         security_context: typing.Optional[security.SecurityContext] = None,
     ):
         self._name = name
@@ -375,7 +375,7 @@ class LaunchPlan(object):
         return self._fixed_inputs
 
     @property
-    def workflow(self) -> _annotated_workflow.PythonFunctionWorkflow:
+    def workflow(self) -> _annotated_workflow.WorkflowBase:
         return self._workflow
 
     @property
@@ -407,7 +407,7 @@ class LaunchPlan(object):
         return self._raw_output_data_config
 
     @property
-    def max_parallelism(self) -> int:
+    def max_parallelism(self) -> typing.Optional[int]:
         return self._max_parallelism
 
     @property

--- a/flytekit/core/map_task.py
+++ b/flytekit/core/map_task.py
@@ -99,8 +99,8 @@ class MapPythonTask(PythonTask):
             return self._cmd_prefix + container_args
         return container_args
 
-    def set_command_prefix(self, cmd: typing.List[str]):
-        self._cmd_prefix = cmd
+    def set_command_prefix(self, cmd: typing.Optional[typing.List[str]]):
+        self._cmd_prefix = cmd  # type: ignore
 
     @contextmanager
     def prepare_target(self):
@@ -128,7 +128,7 @@ class MapPythonTask(PythonTask):
     def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
         return ArrayJob(parallelism=self._max_concurrency, min_success_ratio=self._min_success_ratio).to_dict()
 
-    def get_config(self, settings: SerializationSettings) -> Dict[str, str]:
+    def get_config(self, settings: SerializationSettings) -> Optional[Dict[str, str]]:
         return self._run_task.get_config(settings)
 
     @property

--- a/flytekit/core/node_creation.py
+++ b/flytekit/core/node_creation.py
@@ -164,9 +164,9 @@ def create_node(
         # The reason we return it if it's a tuple is to handle the case where the task returns a typing.NamedTuple.
         # In that case, it's already a tuple and we don't need to further tupletize.
         if isinstance(results, VoidPromise) or isinstance(results, tuple):
-            return results
+            return results  # type: ignore
 
-        output_names = entity.python_interface.output_names
+        output_names = entity.python_interface.output_names  # type: ignore
 
         if not output_names:
             raise Exception(f"Non-VoidPromise received {results} but interface for {entity.name} doesn't have outputs")

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -673,7 +673,7 @@ class VoidPromise(object):
         """
 
     @property
-    def ref(self) -> NodeOutput:
+    def ref(self) -> typing.Optional[NodeOutput]:
         return self._ref
 
     def __rshift__(self, other: typing.Union[Promise, VoidPromise]):

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -82,7 +82,7 @@ class PythonAutoContainerTask(PythonTask[T], ABC, metaclass=FlyteTrackedABC):
         self._resources = ResourceSpec(
             requests=requests if requests else Resources(), limits=limits if limits else Resources()
         )
-        self._environment = environment
+        self._environment = environment  # type: ignore
 
         compilation_state = FlyteContextManager.current_context().compilation_state
         if compilation_state and compilation_state.task_resolver:
@@ -92,7 +92,7 @@ class PythonAutoContainerTask(PythonTask[T], ABC, metaclass=FlyteTrackedABC):
                 )
             self._task_resolver = compilation_state.task_resolver
             if self._task_resolver.task_name(self) is not None:
-                self._name = self._task_resolver.task_name(self)
+                self._name = self._task_resolver.task_name(self)  # type: ignore
         else:
             self._task_resolver = task_resolver or default_task_resolver
         self._get_command_fn = self.get_default_command
@@ -190,7 +190,7 @@ class DefaultTaskResolver(TrackedInstance, TaskResolverMixin):
     def load_task(self, loader_args: List[str]) -> PythonAutoContainerTask:
         _, task_module, _, task_name, *_ = loader_args
 
-        task_module = importlib.import_module(task_module)
+        task_module = importlib.import_module(task_module)  # type: ignore
         task_def = getattr(task_module, task_name)
         return task_def
 

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -99,7 +99,7 @@ class PythonAutoContainerTask(PythonTask[T], ABC, metaclass=FlyteTrackedABC):
         self._get_command_fn = self.get_default_command
 
     @property
-    def task_resolver(self) -> TaskResolverMixin:
+    def task_resolver(self) -> Optional[TaskResolverMixin]:
         return self._task_resolver
 
     @property
@@ -140,7 +140,7 @@ class PythonAutoContainerTask(PythonTask[T], ABC, metaclass=FlyteTrackedABC):
         However, it can be useful to update the command with which the task is serialized for specific cases like
         running map tasks ("pyflyte-map-execute") or for fast-executed tasks.
         """
-        self._get_command_fn = get_command_fn
+        self._get_command_fn = get_command_fn  # type: ignore
 
     def reset_command_fn(self):
         """

--- a/flytekit/core/python_customized_container_task.py
+++ b/flytekit/core/python_customized_container_task.py
@@ -105,7 +105,7 @@ class PythonCustomizedContainerTask(ExecutableTemplateShimTask, PythonTask[TC]):
         self._resources = ResourceSpec(
             requests=requests if requests else Resources(), limits=limits if limits else Resources()
         )
-        self._environment = environment
+        self._environment = environment  # type: ignore
         self._container_image = container_image
         self._task_resolver = task_resolver or default_task_template_resolver
 

--- a/flytekit/core/python_customized_container_task.py
+++ b/flytekit/core/python_customized_container_task.py
@@ -105,7 +105,7 @@ class PythonCustomizedContainerTask(ExecutableTemplateShimTask, PythonTask[TC]):
         self._resources = ResourceSpec(
             requests=requests if requests else Resources(), limits=limits if limits else Resources()
         )
-        self._environment = environment  # type: ignore
+        self._environment = environment or {}
         self._container_image = container_image
         self._task_resolver = task_resolver or default_task_template_resolver
 

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -100,7 +100,7 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):
         task_function: Callable,
         task_type="python-task",
         ignore_input_vars: Optional[List[str]] = None,
-        execution_mode: Optional[ExecutionBehavior] = ExecutionBehavior.DEFAULT,
+        execution_mode: ExecutionBehavior = ExecutionBehavior.DEFAULT,
         task_resolver: Optional[TaskResolverMixin] = None,
         **kwargs,
     ):

--- a/flytekit/core/task.py
+++ b/flytekit/core/task.py
@@ -227,7 +227,7 @@ class ReferenceTask(ReferenceEntity, PythonFunctionTask):
         super().__init__(TaskReference(project, domain, name, version), inputs, outputs)
 
         # Reference tasks shouldn't call the parent constructor, but the parent constructor is what sets the resolver
-        self._task_resolver = None
+        self._task_resolver = None  # type: ignore
 
 
 def reference_task(

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -229,9 +229,9 @@ def extract_task_module(f: Union[Callable, TrackedInstance]) -> Tuple[str, str, 
         mod_name = mod.__name__
         name = f.lhs
         # We cannot get the sourcefile for an instance, so we replace it with the module
-        f = mod
+        f = mod  # type: ignore
     else:
-        mod = inspect.getmodule(f)
+        mod = inspect.getmodule(f)  # type: ignore
         if mod is None:
             raise AssertionError(f"Unable to determine module of {f}")
         mod_name = mod.__name__

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -229,16 +229,18 @@ def extract_task_module(f: Union[Callable, TrackedInstance]) -> Tuple[str, str, 
         mod_name = mod.__name__
         name = f.lhs
         # We cannot get the sourcefile for an instance, so we replace it with the module
-        f = mod  # type: ignore
+        g = mod
+        inspect_file = inspect.getfile(g)
     else:
         mod = inspect.getmodule(f)  # type: ignore
         if mod is None:
             raise AssertionError(f"Unable to determine module of {f}")
         mod_name = mod.__name__
         name = f.__name__.split(".")[-1]
+        inspect_file = inspect.getfile(f)
 
     if mod_name == "__main__":
-        return name, "", name, os.path.abspath(inspect.getfile(f))
+        return name, "", name, os.path.abspath(inspect_file)
 
     mod_name = get_full_module_path(mod, mod_name)
     return f"{mod_name}.{name}", mod_name, name, os.path.abspath(inspect.getfile(mod))

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -165,9 +165,7 @@ class SimpleTransformer(TypeTransformer[T]):
         return LiteralType.from_flyte_idl(self._lt.to_flyte_idl())
 
     def to_literal(self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:
-        if not isinstance(python_type, self._type) and not (
-            inspect.isclass(python_type) and issubclass(python_type, self._type)
-        ):
+        if type(python_val) != self._type:
             raise TypeTransformerFailedError(f"Expected value of type {self._type} but got type {type(python_val)}")
         return self._to_literal_transformer(python_val)
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -11,7 +11,7 @@ import textwrap
 import typing
 from abc import ABC, abstractmethod
 from functools import lru_cache
-from typing import Any, Dict, List, NamedTuple, Optional, Type, cast
+from typing import Dict, NamedTuple, Optional, Type, cast
 
 from dataclasses_json import DataClassJsonMixin, dataclass_json
 from google.protobuf import json_format as _json_format
@@ -165,7 +165,9 @@ class SimpleTransformer(TypeTransformer[T]):
         return LiteralType.from_flyte_idl(self._lt.to_flyte_idl())
 
     def to_literal(self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:
-        if type(python_val) != self._type:
+        if not isinstance(python_type, self._type) and not (
+            inspect.isclass(python_type) and issubclass(python_type, self._type)
+        ):
             raise TypeTransformerFailedError(f"Expected value of type {self._type} but got type {type(python_val)}")
         return self._to_literal_transformer(python_val)
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1122,9 +1122,9 @@ class UnionTransformer(TypeTransformer[T]):
 
         raise TypeError(f"Cannot convert from {lv} to {expected_python_type} (using tag {union_tag})")
 
-    def guess_python_type(self, literal_type: LiteralType) -> typing.Union[typing.Tuple[type], ...]:
+    def guess_python_type(self, literal_type: LiteralType) -> type:
         if literal_type.union_type is not None:
-            return typing.Union[tuple(TypeEngine.guess_python_type(v.type) for v in literal_type.union_type.variants)]
+            return typing.Union[tuple(TypeEngine.guess_python_type(v.type) for v in literal_type.union_type.variants)]  # type: ignore
 
         raise ValueError(f"Union transformer cannot reverse {literal_type}")
 
@@ -1139,7 +1139,7 @@ class DictTransformer(TypeTransformer[dict]):
         super().__init__("Typed Dict", dict)
 
     @staticmethod
-    def get_dict_types(t: Optional[Type[dict]]) -> typing.Tuple[Optional[typing.Any], ...]:
+    def get_dict_types(t: Optional[Type[dict]]) -> typing.Tuple[Optional[type], Optional[type]]:
         """
         Return the generic Type T of the Dict
         """
@@ -1153,7 +1153,7 @@ class DictTransformer(TypeTransformer[dict]):
                         parsed."
                 )
             if _origin is dict and _args is not None:
-                return _args
+                return _args  # type: ignore
         return None, None
 
     @staticmethod
@@ -1361,13 +1361,13 @@ def convert_json_schema_to_python_class(schema: dict, schema_name) -> Type[datac
     return dataclass_json(dataclasses.make_dataclass(schema_name, attribute_list))
 
 
-def _get_element_type(element_property: typing.Dict[str, str]) -> Optional[typing.Any]:
+def _get_element_type(element_property: typing.Dict[str, str]) -> type:
     element_type = element_property["type"]
     element_format = element_property["format"] if "format" in element_property else None
 
     if type(element_type) == list:
         # Element type of Optional[int] is [integer, None]
-        return typing.Optional[_get_element_type({"type": element_type[0]})]
+        return typing.Optional[_get_element_type({"type": element_type[0]})]  # type: ignore
 
     if element_type == "string":
         return str

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -134,7 +134,7 @@ def get_promise(binding_data: _literal_models.BindingData, outputs_cache: Dict[N
             val=_literal_models.Literal(collection=_literal_models.LiteralCollection(literals=literals)),
         )
     elif binding_data.map is not None:
-        literals = {}
+        literals = {}  # type: ignore
         for k, bd in binding_data.map.bindings.items():
             p = get_promise(bd, outputs_cache)
             literals[k] = p.val
@@ -178,7 +178,7 @@ class WorkflowBase(object):
         self._inputs = {}
         self._unbound_inputs = set()
         self._nodes = []
-        self._output_bindings: Optional[List[_literal_models.Binding]] = []
+        self._output_bindings: List[_literal_models.Binding] = []
         FlyteEntities.entities.append(self)
         super().__init__(**kwargs)
 
@@ -240,7 +240,7 @@ class WorkflowBase(object):
     def execute(self, **kwargs):
         raise Exception("Should not be called")
 
-    def local_execute(self, ctx: FlyteContext, **kwargs) -> Union[Tuple[Promise], Promise, VoidPromise]:
+    def local_execute(self, ctx: FlyteContext, **kwargs) -> Union[Tuple[Promise], Promise, VoidPromise, None]:
         # This is done to support the invariant that Workflow local executions always work with Promise objects
         # holding Flyte literal values. Even in a wf, a user can call a sub-workflow with a Python native value.
         for k, v in kwargs.items():
@@ -487,7 +487,7 @@ class ImperativeWorkflow(WorkflowBase):
             for input_value in filter(lambda x: isinstance(x, Promise), all_input_values):
                 if input_value in self._unbound_inputs:
                     self._unbound_inputs.remove(input_value)
-            return n
+            return n  # type: ignore
 
     def add_workflow_input(self, input_name: str, python_type: Type) -> Interface:
         """

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -17,6 +17,7 @@ from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
 
 T = typing.TypeVar("T")
+PathType = typing.Union[str, os.PathLike]
 
 
 def noop():
@@ -26,7 +27,7 @@ def noop():
 @dataclass_json
 @dataclass
 class FlyteDirectory(os.PathLike, typing.Generic[T]):
-    path: typing.Union[str, os.PathLike] = field(default=None, metadata=config(mm_field=fields.String()))
+    path: PathType = field(default=None, metadata=config(mm_field=fields.String()))  # type :ignore
     """
     .. warning::
 

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -27,7 +27,7 @@ def noop():
 @dataclass_json
 @dataclass
 class FlyteDirectory(os.PathLike, typing.Generic[T]):
-    path: PathType = field(default=None, metadata=config(mm_field=fields.String()))  # type :ignore
+    path: PathType = field(default=None, metadata=config(mm_field=fields.String()))  # type: ignore
     """
     .. warning::
 

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -27,7 +27,7 @@ T = typing.TypeVar("T")
 @dataclass_json
 @dataclass
 class FlyteFile(os.PathLike, typing.Generic[T]):
-    path: typing.Union[str, os.PathLike] = field(default=None, metadata=config(mm_field=fields.String()))
+    path: typing.Union[str, os.PathLike] = field(default=None, metadata=config(mm_field=fields.String()))  # type: ignore
     """
     Since there is no native Python implementation of files and directories for the Flyte Blob type, (like how int
     exists for Flyte's Integer type) we need to create one so that users can express that their tasks take
@@ -167,7 +167,10 @@ class FlyteFile(os.PathLike, typing.Generic[T]):
         return _SpecificFormatClass
 
     def __init__(
-        self, path: typing.Union[str, os.PathLike], downloader: typing.Callable = noop, remote_path: os.PathLike = None
+        self,
+        path: typing.Union[str, os.PathLike],
+        downloader: typing.Callable = noop,
+        remote_path: typing.Optional[os.PathLike] = None,
     ):
         """
         :param path: The source path that users are expected to call open() on
@@ -205,7 +208,7 @@ class FlyteFile(os.PathLike, typing.Generic[T]):
         return self._downloaded
 
     @property
-    def remote_path(self) -> os.PathLike:
+    def remote_path(self) -> typing.Optional[os.PathLike]:
         return self._remote_path
 
     @property

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -331,7 +331,7 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
     DEFAULT_PROTOCOLS: Dict[Type, str] = {}
     DEFAULT_FORMATS: Dict[Type, str] = {}
 
-    Handlers = typing.TypeVar["Handlers", StructuredDatasetEncoder, StructuredDatasetDecoder]
+    Handlers = Union["Handlers", StructuredDatasetEncoder, StructuredDatasetDecoder]
     Renderers: Dict[Type, Renderable] = {}
 
     @staticmethod

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -60,7 +60,7 @@ class StructuredDataset(object):
     def __init__(
         self,
         dataframe: typing.Optional[typing.Any] = None,
-        uri: Optional[str] = None,
+        uri: Optional[str, os.PathLike] = None,
         metadata: typing.Optional[literals.StructuredDatasetMetadata] = None,
         **kwargs,
     ):
@@ -73,10 +73,10 @@ class StructuredDataset(object):
         # This is not for users to set, the transformer will set this.
         self._literal_sd: Optional[literals.StructuredDataset] = None
         # Not meant for users to set, will be set by an open() call
-        self._dataframe_type = None
+        self._dataframe_type: Optional[Type[DF]] = None
 
     @property
-    def dataframe(self) -> Type[typing.Any]:
+    def dataframe(self) -> Optional[typing.Any]:
         return self._dataframe
 
     @property
@@ -363,14 +363,14 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
         if isinstance(h, StructuredDatasetEncoder):
             top_level = cls.ENCODERS
         elif isinstance(h, StructuredDatasetDecoder):
-            top_level = cls.DECODERS
+            top_level = cls.DECODERS  # type: ignore
         else:
             raise TypeError(f"We don't support this type of handler {h}")
         if h.python_type not in top_level:
             top_level[h.python_type] = {}
         if protocol not in top_level[h.python_type]:
             top_level[h.python_type][protocol] = {}
-        return top_level[h.python_type][protocol]
+        return top_level[h.python_type][protocol]  # type: ignore
 
     def __init__(self):
         super().__init__("StructuredDataset Transformer", StructuredDataset)
@@ -638,7 +638,7 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
             if issubclass(expected_python_type, StructuredDataset):
                 sd = StructuredDataset(dataframe=None, metadata=metad)
                 sd._literal_sd = sd_literal
-                return sd
+                return sd  # type: ignore
             else:
                 return self.open_as(ctx, sd_literal, expected_python_type, metad)
 
@@ -675,7 +675,7 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
             )
             sd._literal_sd = lv.scalar.structured_dataset
             sd.file_format = metad.structured_dataset_type.format
-            return sd
+            return sd  # type: ignore
 
         # If the requested type was not a StructuredDataset, then it means it was a plain dataframe type, which means
         # we should do the opening/downloading and whatever else it might entail right now. No iteration option here.
@@ -788,7 +788,7 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
         # todo: technically we should return the dataframe type specified in the constructor, but to do that,
         #   we'd have to store that, which we don't do today. See possibly #1363
         if literal_type.structured_dataset_type is not None:
-            return StructuredDataset
+            return StructuredDataset  # type: ignore
         raise ValueError(f"StructuredDatasetTransformerEngine cannot reverse {literal_type}")
 
 

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -331,7 +331,7 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
     DEFAULT_PROTOCOLS: Dict[Type, str] = {}
     DEFAULT_FORMATS: Dict[Type, str] = {}
 
-    Handlers = Union["Handlers", StructuredDatasetEncoder, StructuredDatasetDecoder]
+    Handlers = Union[StructuredDatasetEncoder, StructuredDatasetDecoder]
     Renderers: Dict[Type, Renderable] = {}
 
     @staticmethod

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -6,7 +6,7 @@ import types
 import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Dict, Generator, Optional, Type, Union
+from typing import Dict, Generator, Optional, Type, Union
 
 import _datetime
 import numpy as _np
@@ -76,7 +76,7 @@ class StructuredDataset(object):
         self._dataframe_type: Optional[Type[DF]] = None
 
     @property
-    def dataframe(self) -> Optional[typing.Any]:
+    def dataframe(self) -> Optional[Type[DF]]:
         return self._dataframe
 
     @property
@@ -360,18 +360,17 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
 
     @classmethod
     def _handler_finder(cls, h: Handlers, protocol: str) -> Dict[str, Handlers]:
-        top_level = typing.cast(Dict[Type[Any], Dict[str, Dict[str, Union[cls.DECODERS, cls.ENCODERS]]]], {})
         if isinstance(h, StructuredDatasetEncoder):
             top_level = cls.ENCODERS
         elif isinstance(h, StructuredDatasetDecoder):
-            top_level = cls.DECODERS
+            top_level = cls.DECODERS  # type: ignore
         else:
             raise TypeError(f"We don't support this type of handler {h}")
         if h.python_type not in top_level:
             top_level[h.python_type] = {}
         if protocol not in top_level[h.python_type]:
             top_level[h.python_type][protocol] = {}
-        return top_level[h.python_type][protocol]
+        return top_level[h.python_type][protocol]  # type: ignore
 
     def __init__(self):
         super().__init__("StructuredDataset Transformer", StructuredDataset)

--- a/plugins/flytekit-spark/tests/test_wf.py
+++ b/plugins/flytekit-spark/tests/test_wf.py
@@ -1,15 +1,11 @@
 import pandas as pd
 import pyspark
 from flytekitplugins.spark.task import Spark
+from typing_extensions import Annotated
 
 import flytekit
 from flytekit import kwtypes, task, workflow
 from flytekit.types.schema import FlyteSchema
-
-try:
-    from typing import Annotated
-except ImportError:
-    from typing_extensions import Annotated
 
 
 def test_wf1_with_spark():

--- a/tests/flytekit/unit/core/test_interface.py
+++ b/tests/flytekit/unit/core/test_interface.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import typing
 from typing import Dict, List

--- a/tests/flytekit/unit/core/test_interface.py
+++ b/tests/flytekit/unit/core/test_interface.py
@@ -2,6 +2,8 @@ import os
 import typing
 from typing import Dict, List
 
+from typing_extensions import Annotated  # type: ignore
+
 from flytekit.core import context_manager
 from flytekit.core.docstring import Docstring
 from flytekit.core.interface import (
@@ -15,11 +17,6 @@ from flytekit.models.core import types as _core_types
 from flytekit.models.literals import Void
 from flytekit.types.file import FlyteFile
 from flytekit.types.pickle import FlytePickle
-
-try:
-    from typing import Annotated
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 
 def test_extract_only():

--- a/tests/flytekit/unit/core/test_interface.py
+++ b/tests/flytekit/unit/core/test_interface.py
@@ -17,9 +17,9 @@ from flytekit.types.file import FlyteFile
 from flytekit.types.pickle import FlytePickle
 
 try:
-    from typing import Annotated
+    from typing import Annotated  # type: ignore
 except ImportError:
-    from typing_extensions import Annotated
+    from typing_extensions import Annotated  # type: ignore
 
 
 def test_extract_only():

--- a/tests/flytekit/unit/core/test_interface.py
+++ b/tests/flytekit/unit/core/test_interface.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import typing
 from typing import Dict, List
@@ -17,7 +19,7 @@ from flytekit.types.file import FlyteFile
 from flytekit.types.pickle import FlytePickle
 
 try:
-    from typing import Annotated  # type: ignore
+    from typing import Annotated
 except ImportError:
     from typing_extensions import Annotated  # type: ignore
 

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -27,7 +27,7 @@ def test_create_and_link_node():
     assert len(p.ref.node.bindings) == 1
 
     @task
-    def t2(a: typing.Optional[int] = None) -> typing.Union[int]:
+    def t2(a: typing.Optional[int] = None) -> typing.Optional[int]:
         return a
 
     p = create_and_link_node(ctx, t2)

--- a/tests/flytekit/unit/core/test_type_delayed.py
+++ b/tests/flytekit/unit/core/test_type_delayed.py
@@ -4,15 +4,11 @@ import typing
 from dataclasses import dataclass
 
 from dataclasses_json import dataclass_json
+from typing_extensions import Annotated  # type: ignore
 
 from flytekit.core import context_manager
 from flytekit.core.interface import transform_function_to_interface, transform_inputs_to_parameters
 from flytekit.core.type_engine import TypeEngine
-
-try:
-    from typing import Annotated
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 
 @dataclass_json

--- a/tests/flytekit/unit/core/test_type_delayed.py
+++ b/tests/flytekit/unit/core/test_type_delayed.py
@@ -10,7 +10,7 @@ from flytekit.core.interface import transform_function_to_interface, transform_i
 from flytekit.core.type_engine import TypeEngine
 
 try:
-    from typing import Annotated  # type: ignore
+    from typing import Annotated
 except ImportError:
     from typing_extensions import Annotated  # type: ignore
 

--- a/tests/flytekit/unit/core/test_type_delayed.py
+++ b/tests/flytekit/unit/core/test_type_delayed.py
@@ -10,9 +10,9 @@ from flytekit.core.interface import transform_function_to_interface, transform_i
 from flytekit.core.type_engine import TypeEngine
 
 try:
-    from typing import Annotated
+    from typing import Annotated  # type: ignore
 except ImportError:
-    from typing_extensions import Annotated
+    from typing_extensions import Annotated  # type: ignore
 
 
 @dataclass_json

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1029,11 +1029,9 @@ def test_union_custom_transformer_sanity_check():
 
             return Literal(scalar=Scalar(primitive=Primitive(integer=python_val)))
 
-        def to_python_value(
-            self, ctx: FlyteContext, lv: Literal, expected_python_type: typing.Type[T]
-        ) -> UnsignedInt[Literal]:
+        def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: typing.Type[T]) -> Literal:
             val = lv.scalar.primitive.integer
-            return UnsignedInt(0 if val < 0 else val)
+            return UnsignedInt(0 if val < 0 else val)  # type: ignore
 
     TypeEngine.register(UnsignedIntTransformer())
 

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -462,8 +462,8 @@ class TestStruct(object):
 class TestStructB(object):
     s: InnerStruct
     m: typing.Dict[int, str]
-    n: typing.List[typing.List[int]] = None
-    o: typing.Dict[int, typing.Dict[int, int]] = None
+    n: typing.Optional[typing.List[typing.List[int]]] = None
+    o: typing.Optional[typing.Dict[int, typing.Dict[int, int]]] = None
 
 
 @dataclass_json
@@ -1029,7 +1029,9 @@ def test_union_custom_transformer_sanity_check():
 
             return Literal(scalar=Scalar(primitive=Primitive(integer=python_val)))
 
-        def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: typing.Type[T]) -> T:
+        def to_python_value(
+            self, ctx: FlyteContext, lv: Literal, expected_python_type: typing.Type[T]
+        ) -> UnsignedInt[Literal]:
             val = lv.scalar.primitive.integer
             return UnsignedInt(0 if val < 0 else val)
 

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1612,7 +1612,7 @@ def test_error_messages():
         return 10, "hello"
 
     @task
-    def foo2(a: int, b: str) -> typing.Tuple[int, str]:
+    def foo2(a: int, b: str) -> typing.Tuple[str, int]:
         return "hello", 10
 
     @task

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1612,15 +1612,15 @@ def test_error_messages():
         return 10, "hello"
 
     @task
-    def foo2(a: int, b: str) -> typing.Tuple[str, int]:
-        return "hello", 10
+    def foo2(a: int, b: str) -> typing.Tuple[int, str]:
+        return "hello", 10  # type: ignore
 
     @task
     def foo3(a: typing.Dict) -> typing.Dict:
         return a
 
     with pytest.raises(TypeError, match="Type of Val 'hello' is not an instance of <class 'int'>"):
-        foo(a="hello", b=10)
+        foo(a="hello", b=10)  # type: ignore
 
     with pytest.raises(
         TypeError,
@@ -1629,7 +1629,7 @@ def test_error_messages():
         foo2(a=10, b="hello")
 
     with pytest.raises(TypeError, match="Not a collection type simple: STRUCT\n but got a list \\[{'hello': 2}\\]"):
-        foo3(a=[{"hello": 2}])
+        foo3(a=[{"hello": 2}])  # type: ignore
 
 
 def test_union_type():

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -16,7 +16,7 @@ from flytekit.tools.translator import get_serializable
 from flytekit.types.schema import FlyteSchema
 
 try:
-    from typing import Annotated  # type: ignore
+    from typing import Annotated
 except ImportError:
     from typing_extensions import Annotated  # type: ignore
 

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -16,9 +16,9 @@ from flytekit.tools.translator import get_serializable
 from flytekit.types.schema import FlyteSchema
 
 try:
-    from typing import Annotated
+    from typing import Annotated  # type: ignore
 except ImportError:
-    from typing_extensions import Annotated
+    from typing_extensions import Annotated  # type: ignore
 
 default_img = Image(name="default", fqn="test", tag="tag")
 serialization_settings = flytekit.configuration.SerializationSettings(

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
+from typing_extensions import Annotated  # type: ignore
 
 import flytekit.configuration
 from flytekit import StructuredDataset, kwtypes
@@ -14,11 +15,6 @@ from flytekit.core.workflow import WorkflowFailurePolicy, WorkflowMetadata, Work
 from flytekit.exceptions.user import FlyteValidationException, FlyteValueException
 from flytekit.tools.translator import get_serializable
 from flytekit.types.schema import FlyteSchema
-
-try:
-    from typing import Annotated
-except ImportError:
-    from typing_extensions import Annotated  # type: ignore
 
 default_img = Image(name="default", fqn="test", tag="tag")
 serialization_settings = flytekit.configuration.SerializationSettings(

--- a/tests/flytekit/unit/types/structured_dataset/test_bigquery.py
+++ b/tests/flytekit/unit/types/structured_dataset/test_bigquery.py
@@ -1,13 +1,8 @@
 import mock
 import pandas as pd
+from typing_extensions import Annotated
 
 from flytekit import StructuredDataset, kwtypes, task, workflow
-
-try:
-    from typing import Annotated
-except ImportError:
-    from typing_extensions import Annotated
-
 
 pd_df = pd.DataFrame({"Name": ["Tom", "Joseph"], "Age": [20, 22]})
 my_cols = kwtypes(Name=str, Age=int)


### PR DESCRIPTION
Signed-off-by: Ryan Nazareth <ryankarlos@gmail.com>

# TL;DR
This PR fixes all the mypy Incompatible Types errors

## Complete description

This PR fixes the following mypy errors thrown when running  `make lint | grep Incompatible`

<img width="1174" alt="Screenshot 2022-10-19 at 21 01 38" src="https://user-images.githubusercontent.com/16509490/196792229-d0a237e9-516b-4836-aaf3-41882a78260f.png">


Additonally, mypy complains that  plugins/flytekit-kf-mpi` invalid package name -  the `__init__.py` has been removed 
in this PR as this should be a directory anyway  based on other plugins structures.

## Tracking Issue

Addresses part of issue https://github.com/flyteorg/flyte/issues/1030

## Follow-up issue
_NA_
