### PR TITLE
3006 - Added a version constraint for grpcio and grpcio-status

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,9 +8,7 @@
     # via
     #   -c requirements.txt
     #   pytest-flyte
-appnope==0.1.3
-    # via ipython
-arrow==1.2.2
+arrow==1.2.3
     # via
     #   -c requirements.txt
     #   jinja2-time
@@ -22,7 +20,7 @@ attrs==20.3.0
     #   pytest-docker
 backcall==0.2.0
     # via ipython
-bcrypt==4.0.0
+bcrypt==4.0.1
     # via paramiko
 binaryornot==0.4.4
     # via
@@ -32,7 +30,7 @@ cached-property==1.5.2
     # via docker-compose
 cachetools==5.2.0
     # via google-auth
-certifi==2022.6.15
+certifi==2022.9.24
     # via
     #   -c requirements.txt
     #   requests
@@ -56,29 +54,30 @@ click==8.1.3
     #   -c requirements.txt
     #   cookiecutter
     #   flytekit
-cloudpickle==2.1.0
+cloudpickle==2.2.0
     # via
     #   -c requirements.txt
     #   flytekit
-codespell==2.2.1
+codespell==2.2.2
     # via -r dev-requirements.in
 cookiecutter==2.1.1
     # via
     #   -c requirements.txt
     #   flytekit
-coverage[toml]==6.4.4
+coverage[toml]==6.5.0
     # via
     #   -r dev-requirements.in
     #   pytest-cov
-croniter==1.3.5
+croniter==1.3.7
     # via
     #   -c requirements.txt
     #   flytekit
-cryptography==37.0.4
+cryptography==38.0.1
     # via
     #   -c requirements.txt
     #   paramiko
     #   pyopenssl
+    #   secretstorage
 dataclasses-json==0.5.7
     # via
     #   -c requirements.txt
@@ -98,7 +97,7 @@ diskcache==5.4.0
     #   flytekit
 distlib==0.3.6
     # via virtualenv
-distro==1.7.0
+distro==1.8.0
     # via docker-compose
 docker[ssh]==6.0.0
     # via
@@ -115,36 +114,36 @@ dockerpty==0.4.1
     # via docker-compose
 docopt==0.6.2
     # via docker-compose
-docstring-parser==0.14.1
+docstring-parser==0.15
     # via
     #   -c requirements.txt
     #   flytekit
 filelock==3.8.0
     # via virtualenv
-flyteidl==1.1.12
+flyteidl==1.1.22
     # via
     #   -c requirements.txt
     #   flytekit
-google-api-core[grpc]==2.8.2
+google-api-core[grpc]==2.10.2
     # via
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
     #   google-cloud-core
-google-auth==2.11.0
+google-auth==2.13.0
     # via
     #   google-api-core
     #   google-cloud-core
-google-cloud-bigquery==3.3.2
+google-cloud-bigquery==3.3.5
     # via -r dev-requirements.in
-google-cloud-bigquery-storage==2.14.2
+google-cloud-bigquery-storage==2.16.2
     # via
     #   -r dev-requirements.in
     #   google-cloud-bigquery
 google-cloud-core==2.3.2
     # via google-cloud-bigquery
-google-crc32c==1.3.0
+google-crc32c==1.5.0
     # via google-resumable-media
-google-resumable-media==2.3.3
+google-resumable-media==2.4.0
     # via google-cloud-bigquery
 googleapis-common-protos==1.56.4
     # via
@@ -164,13 +163,13 @@ grpcio-status==1.47.0
     #   -c requirements.txt
     #   flytekit
     #   google-api-core
-identify==2.5.3
+identify==2.5.6
     # via pre-commit
-idna==3.3
+idna==3.4
     # via
     #   -c requirements.txt
     #   requests
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via
     #   -c requirements.txt
     #   click
@@ -185,8 +184,17 @@ iniconfig==1.1.1
     # via pytest
 ipython==7.34.0
     # via -r dev-requirements.in
+jaraco-classes==3.2.3
+    # via
+    #   -c requirements.txt
+    #   keyring
 jedi==0.18.1
     # via ipython
+jeepney==0.8.0
+    # via
+    #   -c requirements.txt
+    #   keyring
+    #   secretstorage
 jinja2==3.1.2
     # via
     #   -c requirements.txt
@@ -197,7 +205,7 @@ jinja2-time==0.2.0
     # via
     #   -c requirements.txt
     #   cookiecutter
-joblib==1.1.0
+joblib==1.2.0
     # via
     #   -c requirements.txt
     #   -r dev-requirements.in
@@ -206,7 +214,7 @@ jsonschema==3.2.0
     # via
     #   -c requirements.txt
     #   docker-compose
-keyring==23.8.2
+keyring==23.9.3
     # via
     #   -c requirements.txt
     #   flytekit
@@ -214,7 +222,7 @@ markupsafe==2.1.1
     # via
     #   -c requirements.txt
     #   jinja2
-marshmallow==3.17.1
+marshmallow==3.18.0
     # via
     #   -c requirements.txt
     #   dataclasses-json
@@ -232,14 +240,18 @@ matplotlib-inline==0.1.6
     # via ipython
 mock==4.0.3
     # via -r dev-requirements.in
-mypy==0.971
+more-itertools==9.0.0
+    # via
+    #   -c requirements.txt
+    #   jaraco-classes
+mypy==0.982
     # via -r dev-requirements.in
 mypy-extensions==0.4.3
     # via
     #   -c requirements.txt
     #   mypy
     #   typing-inspect
-natsort==8.1.0
+natsort==8.2.0
     # via
     #   -c requirements.txt
     #   flytekit
@@ -276,13 +288,13 @@ pluggy==1.0.0
     # via pytest
 pre-commit==2.20.0
     # via -r dev-requirements.in
-prompt-toolkit==3.0.30
+prompt-toolkit==3.0.31
     # via ipython
 proto-plus==1.22.1
     # via
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
-protobuf==3.20.2
+protobuf==3.20.3
     # via
     #   -c requirements.txt
     #   flyteidl
@@ -324,7 +336,7 @@ pygments==2.13.0
     # via ipython
 pynacl==1.5.0
     # via paramiko
-pyopenssl==22.0.0
+pyopenssl==22.1.0
     # via
     #   -c requirements.txt
     #   flytekit
@@ -336,15 +348,15 @@ pyrsistent==0.18.1
     # via
     #   -c requirements.txt
     #   jsonschema
-pytest==7.1.2
+pytest==7.1.3
     # via
     #   -r dev-requirements.in
     #   pytest-cov
     #   pytest-docker
     #   pytest-flyte
-pytest-cov==3.0.0
+pytest-cov==4.0.0
     # via -r dev-requirements.in
-pytest-docker==1.0.0
+pytest-docker==1.0.1
     # via pytest-flyte
 pytest-flyte @ git+https://github.com/flyteorg/pytest-flyte@main
     # via -r dev-requirements.in
@@ -356,7 +368,7 @@ python-dateutil==2.8.2
     #   flytekit
     #   google-cloud-bigquery
     #   pandas
-python-dotenv==0.20.0
+python-dotenv==0.21.0
     # via docker-compose
 python-json-logger==2.0.4
     # via
@@ -370,7 +382,7 @@ pytimeparse==1.1.8
     # via
     #   -c requirements.txt
     #   flytekit
-pytz==2022.2.1
+pytz==2022.5
     # via
     #   -c requirements.txt
     #   flytekit
@@ -382,7 +394,7 @@ pyyaml==5.4.1
     #   docker-compose
     #   flytekit
     #   pre-commit
-regex==2022.8.17
+regex==2022.9.13
     # via
     #   -c requirements.txt
     #   docker-image-py
@@ -396,7 +408,7 @@ requests==2.28.1
     #   google-api-core
     #   google-cloud-bigquery
     #   responses
-responses==0.21.0
+responses==0.22.0
     # via
     #   -c requirements.txt
     #   flytekit
@@ -406,6 +418,10 @@ retry==0.9.2
     #   flytekit
 rsa==4.9
     # via google-auth
+secretstorage==3.3.3
+    # via
+    #   -c requirements.txt
+    #   keyring
 singledispatchmethod==1.0
     # via
     #   -c requirements.txt
@@ -435,7 +451,10 @@ text-unidecode==1.3
 texttable==1.6.4
     # via docker-compose
 toml==0.10.2
-    # via pre-commit
+    # via
+    #   -c requirements.txt
+    #   pre-commit
+    #   responses
 tomli==2.0.1
     # via
     #   coverage
@@ -443,13 +462,17 @@ tomli==2.0.1
     #   pytest
 torch==1.12.1
     # via -r dev-requirements.in
-traitlets==5.3.0
+traitlets==5.5.0
     # via
     #   ipython
     #   matplotlib-inline
 typed-ast==1.5.4
     # via mypy
-typing-extensions==4.3.0
+types-toml==0.10.8
+    # via
+    #   -c requirements.txt
+    #   responses
+typing-extensions==4.4.0
     # via
     #   -c requirements.txt
     #   arrow
@@ -470,7 +493,7 @@ urllib3==1.26.12
     #   flytekit
     #   requests
     #   responses
-virtualenv==20.16.4
+virtualenv==20.16.5
     # via pre-commit
 wcwidth==0.2.5
     # via prompt-toolkit
@@ -488,7 +511,7 @@ wrapt==1.14.1
     #   -c requirements.txt
     #   deprecated
     #   flytekit
-zipp==3.8.1
+zipp==3.9.0
     # via
     #   -c requirements.txt
     #   importlib-metadata

--- a/requirements-spark2.txt
+++ b/requirements-spark2.txt
@@ -8,7 +8,7 @@
     # via
     #   -r requirements-spark2.in
     #   -r requirements.in
-arrow==1.2.2
+arrow==1.2.3
     # via jinja2-time
 attrs==20.3.0
     # via
@@ -16,7 +16,7 @@ attrs==20.3.0
     #   jsonschema
 binaryornot==0.4.4
     # via cookiecutter
-certifi==2022.6.15
+certifi==2022.9.24
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -28,14 +28,16 @@ click==8.1.3
     # via
     #   cookiecutter
     #   flytekit
-cloudpickle==2.1.0
+cloudpickle==2.2.0
     # via flytekit
 cookiecutter==2.1.1
     # via flytekit
-croniter==1.3.5
+croniter==1.3.7
     # via flytekit
-cryptography==37.0.4
-    # via pyopenssl
+cryptography==38.0.1
+    # via
+    #   pyopenssl
+    #   secretstorage
 dataclasses-json==0.5.7
     # via flytekit
 decorator==5.1.1
@@ -48,9 +50,9 @@ docker==6.0.0
     # via flytekit
 docker-image-py==0.1.12
     # via flytekit
-docstring-parser==0.14.1
+docstring-parser==0.15
     # via flytekit
-flyteidl==1.1.12
+flyteidl==1.1.22
     # via flytekit
 googleapis-common-protos==1.56.4
     # via
@@ -58,33 +60,42 @@ googleapis-common-protos==1.56.4
     #   grpcio-status
 grpcio==1.47.0
     # via
+    #   -r requirements.in
     #   flytekit
     #   grpcio-status
 grpcio-status==1.47.0
-    # via flytekit
-idna==3.3
+    # via
+    #   -r requirements.in
+    #   flytekit
+idna==3.4
     # via requests
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via
     #   click
     #   flytekit
     #   jsonschema
     #   keyring
+jaraco-classes==3.2.3
+    # via keyring
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.2
     # via
     #   cookiecutter
     #   jinja2-time
 jinja2-time==0.2.0
     # via cookiecutter
-joblib==1.1.0
+joblib==1.2.0
     # via flytekit
 jsonschema==3.2.0
     # via -r requirements.in
-keyring==23.8.2
+keyring==23.9.3
     # via flytekit
 markupsafe==2.1.1
     # via jinja2
-marshmallow==3.17.1
+marshmallow==3.18.0
     # via
     #   dataclasses-json
     #   marshmallow-enum
@@ -93,9 +104,11 @@ marshmallow-enum==1.5.1
     # via dataclasses-json
 marshmallow-jsonschema==0.13.0
     # via flytekit
+more-itertools==9.0.0
+    # via jaraco-classes
 mypy-extensions==0.4.3
     # via typing-inspect
-natsort==8.1.0
+natsort==8.2.0
     # via flytekit
 numpy==1.21.6
     # via
@@ -111,7 +124,7 @@ pandas==1.3.5
     # via
     #   -r requirements.in
     #   flytekit
-protobuf==3.20.2
+protobuf==3.20.3
     # via
     #   flyteidl
     #   flytekit
@@ -126,7 +139,7 @@ pyarrow==6.0.1
     # via flytekit
 pycparser==2.21
     # via cffi
-pyopenssl==22.0.0
+pyopenssl==22.1.0
     # via flytekit
 pyparsing==3.0.9
     # via packaging
@@ -144,7 +157,7 @@ python-slugify==6.1.2
     # via cookiecutter
 pytimeparse==1.1.8
     # via flytekit
-pytz==2022.2.1
+pytz==2022.5
     # via
     #   flytekit
     #   pandas
@@ -153,7 +166,7 @@ pyyaml==5.4.1
     #   -r requirements.in
     #   cookiecutter
     #   flytekit
-regex==2022.8.17
+regex==2022.9.13
     # via docker-image-py
 requests==2.28.1
     # via
@@ -161,10 +174,12 @@ requests==2.28.1
     #   docker
     #   flytekit
     #   responses
-responses==0.21.0
+responses==0.22.0
     # via flytekit
 retry==0.9.2
     # via flytekit
+secretstorage==3.3.3
+    # via keyring
 singledispatchmethod==1.0
     # via flytekit
 six==1.16.0
@@ -179,7 +194,11 @@ statsd==3.3.0
     # via flytekit
 text-unidecode==1.3
     # via python-slugify
-typing-extensions==4.3.0
+toml==0.10.2
+    # via responses
+types-toml==0.10.8
+    # via responses
+typing-extensions==4.4.0
     # via
     #   arrow
     #   flytekit
@@ -204,7 +223,7 @@ wrapt==1.14.1
     # via
     #   deprecated
     #   flytekit
-zipp==3.8.1
+zipp==3.9.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,10 @@
 .
 -e file:.#egg=flytekit
 attrs<21
+# Restrict grpcio and grpcio-status.  The 1.50.0 version pulls in a version of protobuf that is not compatible.
+# More details in https://github.com/flyteorg/flyte/issues/3006
+grpcio<=1.47.0
+grpcio-status<=1.47.0
 # We need to restrict constrain the versions of both jsonschema and pyyaml because of docker-compose (which is
 # used to run integration tests) pins those two libraries. We are in the process of removing docker-compose in
 # favor of a more generic solution that involves Flytectl to stand up the sandbox, described in

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 -e file:.#egg=flytekit
     # via -r requirements.in
-arrow==1.2.2
+arrow==1.2.3
     # via jinja2-time
 attrs==20.3.0
     # via
@@ -14,7 +14,7 @@ attrs==20.3.0
     #   jsonschema
 binaryornot==0.4.4
     # via cookiecutter
-certifi==2022.6.15
+certifi==2022.9.24
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -26,14 +26,16 @@ click==8.1.3
     # via
     #   cookiecutter
     #   flytekit
-cloudpickle==2.1.0
+cloudpickle==2.2.0
     # via flytekit
 cookiecutter==2.1.1
     # via flytekit
-croniter==1.3.5
+croniter==1.3.7
     # via flytekit
-cryptography==37.0.4
-    # via pyopenssl
+cryptography==38.0.1
+    # via
+    #   pyopenssl
+    #   secretstorage
 dataclasses-json==0.5.7
     # via flytekit
 decorator==5.1.1
@@ -46,9 +48,9 @@ docker==6.0.0
     # via flytekit
 docker-image-py==0.1.12
     # via flytekit
-docstring-parser==0.14.1
+docstring-parser==0.15
     # via flytekit
-flyteidl==1.1.12
+flyteidl==1.1.22
     # via flytekit
 googleapis-common-protos==1.56.4
     # via
@@ -56,33 +58,42 @@ googleapis-common-protos==1.56.4
     #   grpcio-status
 grpcio==1.47.0
     # via
+    #   -r requirements.in
     #   flytekit
     #   grpcio-status
 grpcio-status==1.47.0
-    # via flytekit
-idna==3.3
+    # via
+    #   -r requirements.in
+    #   flytekit
+idna==3.4
     # via requests
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via
     #   click
     #   flytekit
     #   jsonschema
     #   keyring
+jaraco-classes==3.2.3
+    # via keyring
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.2
     # via
     #   cookiecutter
     #   jinja2-time
 jinja2-time==0.2.0
     # via cookiecutter
-joblib==1.1.0
+joblib==1.2.0
     # via flytekit
 jsonschema==3.2.0
     # via -r requirements.in
-keyring==23.8.2
+keyring==23.9.3
     # via flytekit
 markupsafe==2.1.1
     # via jinja2
-marshmallow==3.17.1
+marshmallow==3.18.0
     # via
     #   dataclasses-json
     #   marshmallow-enum
@@ -91,9 +102,11 @@ marshmallow-enum==1.5.1
     # via dataclasses-json
 marshmallow-jsonschema==0.13.0
     # via flytekit
+more-itertools==9.0.0
+    # via jaraco-classes
 mypy-extensions==0.4.3
     # via typing-inspect
-natsort==8.1.0
+natsort==8.2.0
     # via flytekit
 numpy==1.21.6
     # via
@@ -109,7 +122,7 @@ pandas==1.3.5
     # via
     #   -r requirements.in
     #   flytekit
-protobuf==3.20.2
+protobuf==3.20.3
     # via
     #   flyteidl
     #   flytekit
@@ -124,7 +137,7 @@ pyarrow==6.0.1
     # via flytekit
 pycparser==2.21
     # via cffi
-pyopenssl==22.0.0
+pyopenssl==22.1.0
     # via flytekit
 pyparsing==3.0.9
     # via packaging
@@ -142,7 +155,7 @@ python-slugify==6.1.2
     # via cookiecutter
 pytimeparse==1.1.8
     # via flytekit
-pytz==2022.2.1
+pytz==2022.5
     # via
     #   flytekit
     #   pandas
@@ -151,7 +164,7 @@ pyyaml==5.4.1
     #   -r requirements.in
     #   cookiecutter
     #   flytekit
-regex==2022.8.17
+regex==2022.9.13
     # via docker-image-py
 requests==2.28.1
     # via
@@ -159,10 +172,12 @@ requests==2.28.1
     #   docker
     #   flytekit
     #   responses
-responses==0.21.0
+responses==0.22.0
     # via flytekit
 retry==0.9.2
     # via flytekit
+secretstorage==3.3.3
+    # via keyring
 singledispatchmethod==1.0
     # via flytekit
 six==1.16.0
@@ -177,7 +192,11 @@ statsd==3.3.0
     # via flytekit
 text-unidecode==1.3
     # via python-slugify
-typing-extensions==4.3.0
+toml==0.10.2
+    # via responses
+types-toml==0.10.8
+    # via responses
+typing-extensions==4.4.0
     # via
     #   arrow
     #   flytekit
@@ -202,7 +221,7 @@ wrapt==1.14.1
     # via
     #   deprecated
     #   flytekit
-zipp==3.8.1
+zipp==3.9.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
# TL;DR

Added a version constraint for `grpcio` and `grpcio-status` in order to prevent an incompatible verison of `protobuf`.

The latest version of `grpcio` (1.50.0) requires a version of `protobuf` >= 4.0 that is not compatible with this project.  This causes a failure when running `make dev-requirements.txt`.  To fix this, we add a version constraint on `grpcio` and `grpcio-status`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

This was fixed by adding version constraints for `grpcio` and `grpcio-status` in `requirements.in`.

This was originally discussed in [this slack thread](https://flyte-org.slack.com/archives/CREL4QVAQ/p1666148447450899).

This may be a temporary solution as there was mention of updating the protobuf dependency.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3006
