### PR TITLE
fix: pass gpu resource request and limit in ContainerTask

### DIFF
--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -101,4 +101,6 @@ class ContainerTask(PythonTask):
             memory_limit=self.resources.limits.mem,
             ephemeral_storage_request=self.resources.requests.ephemeral_storage,
             ephemeral_storage_limit=self.resources.limits.ephemeral_storage,
+            gpu_request=self.resources.requests.gpu,
+            gpu_limit=self.resources.limits.gpu,
         )

--- a/tests/flytekit/unit/test_translator.py
+++ b/tests/flytekit/unit/test_translator.py
@@ -10,6 +10,7 @@ from flytekit.core.reference_entity import ReferenceSpec, ReferenceTemplate
 from flytekit.core.task import ReferenceTask, task
 from flytekit.core.workflow import ReferenceWorkflow, workflow
 from flytekit.models.core import identifier as identifier_models
+from flytekit.models.task import Resources as resource_model
 from flytekit.tools.translator import get_serializable
 
 default_img = Image(name="default", fqn="test", tag="tag")
@@ -114,7 +115,7 @@ def test_container():
         output_data_dir="/tmp",
         command=["cat"],
         arguments=["/tmp/a"],
-        requests=Resources(mem="400Mi", cpu="1", gpu="1"),
+        requests=Resources(mem="400Mi", cpu="1", gpu="2"),
     )
 
     ssettings = (
@@ -124,8 +125,12 @@ def test_container():
     )
     task_spec = get_serializable(OrderedDict(), ssettings, t2)
     assert "pyflyte" not in task_spec.template.container.args
-    assert t2.get_container(ssettings).resources.requests[0].name == "gpu"
+    assert t2.get_container(ssettings).resources.requests[0].name == resource_model.ResourceName.CPU
     assert t2.get_container(ssettings).resources.requests[0].value == "1"
+    assert t2.get_container(ssettings).resources.requests[1].name == resource_model.ResourceName.GPU
+    assert t2.get_container(ssettings).resources.requests[1].value == "2"
+    assert t2.get_container(ssettings).resources.requests[2].name == resource_model.ResourceName.MEMORY
+    assert t2.get_container(ssettings).resources.requests[2].value == "400Mi"
 
 
 def test_launch_plan_with_fixed_input():

--- a/tests/flytekit/unit/test_translator.py
+++ b/tests/flytekit/unit/test_translator.py
@@ -114,7 +114,7 @@ def test_container():
         output_data_dir="/tmp",
         command=["cat"],
         arguments=["/tmp/a"],
-        requests=Resources(mem="400Mi", cpu="1"),
+        requests=Resources(mem="400Mi", cpu="1", gpu="1"),
     )
 
     ssettings = (
@@ -124,6 +124,8 @@ def test_container():
     )
     task_spec = get_serializable(OrderedDict(), ssettings, t2)
     assert "pyflyte" not in task_spec.template.container.args
+    assert t2.get_container(ssettings).resources.requests[0].name == "gpu"
+    assert t2.get_container(ssettings).resources.requests[0].value == "1"
 
 
 def test_launch_plan_with_fixed_input():


### PR DESCRIPTION
Signed-off-by: Felix Ruess <felix.ruess@roboception.de>

# TL;DR
GPU resource request and limit were not passed on to container for `ContainerTask`. 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Actually pass gpu request/limit like for the other Python container tasks...

## Tracking Issue
_NA_

## Follow-up issue
_NA_
