### PR TITLE
Fixing Fast Registration for non root dirs

### DIFF
--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -103,10 +103,11 @@ def download_distribution(additional_distribution: str, destination: str):
     :param Text additional_distribution:
     :param os.PathLike destination:
     """
-    if not destination:
+    if not os.path.isdir(destination):
         raise ValueError("Destination path is required to download distribution and it should be a directory")
-    # NOTE the os.path.join(destitation, ''). This is to ensure that the given path is infact a directory and all
-    # downloaded data should be copied into this directory
+    # NOTE the os.path.join(destination, ''). This is to ensure that the given path is infact a directory and all
+    # downloaded data should be copied into this directory. We do this to account for a difference in behavior in 
+    # fsspec, which requires a trailing slash in case of pre-existing directory.
     FlyteContextManager.current_context().file_access.get_data(additional_distribution, os.path.join(destination, ""))
     tarfile_name = os.path.basename(additional_distribution)
     if not tarfile_name.endswith(".tar.gz"):

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -106,7 +106,7 @@ def download_distribution(additional_distribution: str, destination: str):
     if not os.path.isdir(destination):
         raise ValueError("Destination path is required to download distribution and it should be a directory")
     # NOTE the os.path.join(destination, ''). This is to ensure that the given path is infact a directory and all
-    # downloaded data should be copied into this directory. We do this to account for a difference in behavior in 
+    # downloaded data should be copied into this directory. We do this to account for a difference in behavior in
     # fsspec, which requires a trailing slash in case of pre-existing directory.
     FlyteContextManager.current_context().file_access.get_data(additional_distribution, os.path.join(destination, ""))
     tarfile_name = os.path.basename(additional_distribution)

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -18,8 +18,6 @@ from flytekit.tools.script_mode import tar_strip_file_attributes
 FAST_PREFIX = "fast"
 FAST_FILEENDING = ".tar.gz"
 
-file_access = FlyteContextManager.current_context().file_access
-
 
 def fast_package(source: os.PathLike, output_dir: os.PathLike, deref_symlinks: bool = False) -> os.PathLike:
     """
@@ -105,10 +103,14 @@ def download_distribution(additional_distribution: str, destination: str):
     :param Text additional_distribution:
     :param os.PathLike destination:
     """
-    file_access.get_data(additional_distribution, destination)
+    if not destination:
+        raise ValueError("Destination path is required to download distribution and it should be a directory")
+    # NOTE the os.path.join(destitation, ''). This is to ensure that the given path is infact a directory and all
+    # downloaded data should be copied into this directory
+    FlyteContextManager.current_context().file_access.get_data(additional_distribution, os.path.join(destination, ''))
     tarfile_name = os.path.basename(additional_distribution)
     if not tarfile_name.endswith(".tar.gz"):
-        raise ValueError("Unrecognized additional distribution format for {}".format(additional_distribution))
+        raise RuntimeError("Unrecognized additional distribution format for {}".format(additional_distribution))
 
     # This will overwrite the existing user flyte workflow code in the current working code dir.
     result = _subprocess.run(

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -107,7 +107,7 @@ def download_distribution(additional_distribution: str, destination: str):
         raise ValueError("Destination path is required to download distribution and it should be a directory")
     # NOTE the os.path.join(destitation, ''). This is to ensure that the given path is infact a directory and all
     # downloaded data should be copied into this directory
-    FlyteContextManager.current_context().file_access.get_data(additional_distribution, os.path.join(destination, ''))
+    FlyteContextManager.current_context().file_access.get_data(additional_distribution, os.path.join(destination, ""))
     tarfile_name = os.path.basename(additional_distribution)
     if not tarfile_name.endswith(".tar.gz"):
         raise RuntimeError("Unrecognized additional distribution format for {}".format(additional_distribution))


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
In the case when using a container with a non root user, the inflation dir for the code has to be specified. It is common practice to skip a trailing slash "/mypath`/`". so when the distribution is downloaded, it will instead write this to this filename
And this fails the tar logic, which loooks for a similarly named file under the destination path.

The solution simply enforces that the given destination path is actually a directory

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3022

