### PR TITLE
Update papermill container's command

### DIFF
--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -168,6 +168,12 @@ class NotebookTask(PythonInstanceTask[T]):
         return self._notebook_path.split(".ipynb")[0] + "-out.html"
 
     def get_container(self, settings: SerializationSettings) -> task_models.Container:
+        # The task name in the original command is incorrect because we use _dummy_task_func to construct the _config_task_instance.
+        # Therefore, Here we replace the original command with NotebookTask's command.
+        def fn(settings: SerializationSettings) -> typing.List[str]:
+            return self.get_command(settings)
+
+        self._config_task_instance.set_command_fn(fn)
         return self._config_task_instance.get_container(settings)
 
     def get_k8s_pod(self, settings: SerializationSettings) -> task_models.K8sPod:

--- a/plugins/flytekit-papermill/tests/test_task.py
+++ b/plugins/flytekit-papermill/tests/test_task.py
@@ -22,20 +22,34 @@ def _get_nb_path(name: str, suffix: str = "", abs: bool = True, ext: str = ".ipy
     return os.path.abspath(path) if abs else path
 
 
+nb_name = "nb-simple"
+nb_simple = NotebookTask(
+    name="test",
+    notebook_path=_get_nb_path(nb_name, abs=False),
+    inputs=kwtypes(pi=float),
+    outputs=kwtypes(square=float),
+)
+
+
 def test_notebook_task_simple():
-    nb_name = "nb-simple"
-    nb = NotebookTask(
-        name="test",
-        notebook_path=_get_nb_path(nb_name, abs=False),
-        inputs=kwtypes(pi=float),
-        outputs=kwtypes(square=float),
+    serialization_settings = flytekit.configuration.SerializationSettings(
+        project="project",
+        domain="domain",
+        version="version",
+        env=None,
+        image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
     )
-    sqr, out, render = nb.execute(pi=4)
+
+    sqr, out, render = nb_simple.execute(pi=4)
     assert sqr == 16.0
-    assert nb.python_interface.inputs == {"pi": float}
-    assert nb.python_interface.outputs.keys() == {"square", "out_nb", "out_rendered_nb"}
-    assert nb.output_notebook_path == out == _get_nb_path(nb_name, suffix="-out")
-    assert nb.rendered_output_path == render == _get_nb_path(nb_name, suffix="-out", ext=".html")
+    assert nb_simple.python_interface.inputs == {"pi": float}
+    assert nb_simple.python_interface.outputs.keys() == {"square", "out_nb", "out_rendered_nb"}
+    assert nb_simple.output_notebook_path == out == _get_nb_path(nb_name, suffix="-out")
+    assert nb_simple.rendered_output_path == render == _get_nb_path(nb_name, suffix="-out", ext=".html")
+    assert (
+        nb_simple.get_command(settings=serialization_settings)
+        == nb_simple.get_container(settings=serialization_settings).args
+    )
 
 
 def test_notebook_task_multi_values():


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
https://flyte-org.slack.com/archives/CP2HDHKE1/p1664357806566249
The command in the papermill task is incorrect because we use `_dummy_task_func` to construct the `_config_task_instance` and set the task name to `_dummy_task_func` instead of `nb`.

Update the papermill container's command in this pr, so we properly run the task.

```python
nb = NotebookTask(
    name="simple-nb",
    task_config=Pod(pod_spec=generate_por_spec_for_task(), primary_container_name="primary"),
    notebook_path=os.path.join(pathlib.Path(__file__).parent.absolute(), "nb-simple.ipynb"),
    render_deck=True,
    inputs=kwtypes(v=float),
    outputs=kwtypes(square=float),
)
```

Before
<img width="329" alt="Screen Shot 2022-09-29 at 11 42 56 PM" src="https://user-images.githubusercontent.com/37936015/198246884-04aa2fde-ec2a-4081-b87f-90f27a86e4ab.png">
After
<img width="327" alt="Screen Shot 2022-09-29 at 11 42 35 PM" src="https://user-images.githubusercontent.com/37936015/198246878-909d1529-544a-47a8-93f5-5d9d3730d6d1.png">


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
