### PR TITLE
Do not fail if push to codecov fails

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -54,7 +54,7 @@ jobs:
         uses: codecov/codecov-action@v3.1.0
         with:
           fail_ci_if_error: false
-          
+
   build-plugins:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Codecov
         uses: codecov/codecov-action@v3.1.0
         with:
-          fail_ci_if_error: true # optional (default = false)
-
+          fail_ci_if_error: false
+          
   build-plugins:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
# TL;DR
_Please replace this text with a description of what this PR accomplishes._

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The underlying github action we use to push codecoverage data is not the most reliable and since we don't really look into the coverage data unless we're focusing on a specific area, we shouldn't fail the tests if the act of just pushing the code coverage data fails.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
