### PR TITLE
Bump requirements and restrict grpcio and grpcio-status

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -122,7 +122,7 @@ exceptiongroup==1.0.1
     # via pytest
 filelock==3.8.0
     # via virtualenv
-flyteidl==1.2.3
+flyteidl==1.2.4
     # via
     #   -c requirements.txt
     #   flytekit
@@ -131,7 +131,7 @@ google-api-core[grpc]==2.10.2
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
     #   google-cloud-core
-google-auth==2.14.0
+google-auth==2.14.1
     # via
     #   google-api-core
     #   google-cloud-core
@@ -153,14 +153,14 @@ googleapis-common-protos==1.56.4
     #   flyteidl
     #   google-api-core
     #   grpcio-status
-grpcio==1.47.0
+grpcio==1.48.2
     # via
     #   -c requirements.txt
     #   flytekit
     #   google-api-core
     #   google-cloud-bigquery
     #   grpcio-status
-grpcio-status==1.47.0
+grpcio-status==1.48.2
     # via
     #   -c requirements.txt
     #   flytekit
@@ -216,7 +216,7 @@ jsonschema==3.2.0
     # via
     #   -c requirements.txt
     #   docker-compose
-keyring==23.9.3
+keyring==23.11.0
     # via
     #   -c requirements.txt
     #   flytekit
@@ -246,7 +246,7 @@ more-itertools==9.0.0
     # via
     #   -c requirements.txt
     #   jaraco-classes
-mypy==0.982
+mypy==0.990
     # via -r dev-requirements.in
 mypy-extensions==0.4.3
     # via
@@ -265,16 +265,6 @@ numpy==1.21.6
     #   flytekit
     #   pandas
     #   pyarrow
-nvidia-cublas-cu11==11.10.3.66
-    # via
-    #   nvidia-cudnn-cu11
-    #   torch
-nvidia-cuda-nvrtc-cu11==11.7.99
-    # via torch
-nvidia-cuda-runtime-cu11==11.7.99
-    # via torch
-nvidia-cudnn-cu11==8.5.0.96
-    # via torch
 packaging==21.3
     # via
     #   -c requirements.txt
@@ -286,7 +276,7 @@ pandas==1.3.5
     # via
     #   -c requirements.txt
     #   flytekit
-paramiko==2.11.0
+paramiko==2.12.0
     # via docker
 parso==0.8.3
     # via jedi
@@ -294,7 +284,7 @@ pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-platformdirs==2.5.2
+platformdirs==2.5.3
     # via virtualenv
 pluggy==1.0.0
     # via pytest
@@ -471,7 +461,7 @@ tomli==2.0.1
     #   coverage
     #   mypy
     #   pytest
-torch==1.13.0
+torch==1.12.1
     # via -r dev-requirements.in
 traitlets==5.5.0
     # via
@@ -513,12 +503,10 @@ websocket-client==0.59.0
     #   -c requirements.txt
     #   docker
     #   docker-compose
-wheel==0.38.1
+wheel==0.38.3
     # via
     #   -c requirements.txt
     #   flytekit
-    #   nvidia-cublas-cu11
-    #   nvidia-cuda-runtime-cu11
 wrapt==1.14.1
     # via
     #   -c requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -72,7 +72,7 @@ croniter==1.3.7
     # via
     #   -c requirements.txt
     #   flytekit
-cryptography==38.0.1
+cryptography==38.0.3
     # via
     #   -c requirements.txt
     #   paramiko
@@ -99,7 +99,7 @@ distlib==0.3.6
     # via virtualenv
 distro==1.8.0
     # via docker-compose
-docker[ssh]==6.0.0
+docker[ssh]==6.0.1
     # via
     #   -c requirements.txt
     #   docker-compose
@@ -118,9 +118,11 @@ docstring-parser==0.15
     # via
     #   -c requirements.txt
     #   flytekit
+exceptiongroup==1.0.1
+    # via pytest
 filelock==3.8.0
     # via virtualenv
-flyteidl==1.2.1
+flyteidl==1.2.3
     # via
     #   -c requirements.txt
     #   flytekit
@@ -129,11 +131,11 @@ google-api-core[grpc]==2.10.2
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
     #   google-cloud-core
-google-auth==2.13.0
+google-auth==2.14.0
     # via
     #   google-api-core
     #   google-cloud-core
-google-cloud-bigquery==3.3.5
+google-cloud-bigquery==3.3.6
     # via -r dev-requirements.in
 google-cloud-bigquery-storage==2.16.2
     # via
@@ -163,7 +165,7 @@ grpcio-status==1.47.0
     #   -c requirements.txt
     #   flytekit
     #   google-api-core
-identify==2.5.6
+identify==2.5.8
     # via pre-commit
 idna==3.4
     # via
@@ -263,6 +265,16 @@ numpy==1.21.6
     #   flytekit
     #   pandas
     #   pyarrow
+nvidia-cublas-cu11==11.10.3.66
+    # via
+    #   nvidia-cudnn-cu11
+    #   torch
+nvidia-cuda-nvrtc-cu11==11.7.99
+    # via torch
+nvidia-cuda-runtime-cu11==11.7.99
+    # via torch
+nvidia-cudnn-cu11==8.5.0.96
+    # via torch
 packaging==21.3
     # via
     #   -c requirements.txt
@@ -288,7 +300,7 @@ pluggy==1.0.0
     # via pytest
 pre-commit==2.20.0
     # via -r dev-requirements.in
-prompt-toolkit==3.0.31
+prompt-toolkit==3.0.32
     # via ipython
 proto-plus==1.22.1
     # via
@@ -315,7 +327,6 @@ ptyprocess==0.7.0
 py==1.11.0
     # via
     #   -c requirements.txt
-    #   pytest
     #   retry
 pyarrow==6.0.1
     # via
@@ -344,11 +355,11 @@ pyparsing==3.0.9
     # via
     #   -c requirements.txt
     #   packaging
-pyrsistent==0.18.1
+pyrsistent==0.19.2
     # via
     #   -c requirements.txt
     #   jsonschema
-pytest==7.1.3
+pytest==7.2.0
     # via
     #   -r dev-requirements.in
     #   pytest-cov
@@ -382,7 +393,7 @@ pytimeparse==1.1.8
     # via
     #   -c requirements.txt
     #   flytekit
-pytz==2022.5
+pytz==2022.6
     # via
     #   -c requirements.txt
     #   flytekit
@@ -394,7 +405,7 @@ pyyaml==5.4.1
     #   docker-compose
     #   flytekit
     #   pre-commit
-regex==2022.9.13
+regex==2022.10.31
     # via
     #   -c requirements.txt
     #   docker-image-py
@@ -460,7 +471,7 @@ tomli==2.0.1
     #   coverage
     #   mypy
     #   pytest
-torch==1.12.1
+torch==1.13.0
     # via -r dev-requirements.in
 traitlets==5.5.0
     # via
@@ -493,7 +504,7 @@ urllib3==1.26.12
     #   flytekit
     #   requests
     #   responses
-virtualenv==20.16.5
+virtualenv==20.16.6
     # via pre-commit
 wcwidth==0.2.5
     # via prompt-toolkit
@@ -502,16 +513,18 @@ websocket-client==0.59.0
     #   -c requirements.txt
     #   docker
     #   docker-compose
-wheel==0.38.0
+wheel==0.38.1
     # via
     #   -c requirements.txt
     #   flytekit
+    #   nvidia-cublas-cu11
+    #   nvidia-cuda-runtime-cu11
 wrapt==1.14.1
     # via
     #   -c requirements.txt
     #   deprecated
     #   flytekit
-zipp==3.9.0
+zipp==3.10.0
     # via
     #   -c requirements.txt
     #   importlib-metadata

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -6,7 +6,7 @@
 #
 -e file:.#egg=flytekit
     # via -r doc-requirements.in
-absl-py==1.2.0
+absl-py==1.3.0
     # via
     #   tensorboard
     #   tensorflow
@@ -18,19 +18,20 @@ altair==4.2.0
     # via great-expectations
 ansiwrap==0.8.4
     # via papermill
-appnope==0.1.3
-    # via
-    #   ipykernel
-    #   ipython
+anyio==3.6.2
+    # via jupyter-server
 argon2-cffi==21.3.0
-    # via notebook
+    # via
+    #   jupyter-server
+    #   nbclassic
+    #   notebook
 argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 arrow==1.2.3
     # via jinja2-time
-astroid==2.12.10
+astroid==2.12.12
     # via sphinx-autoapi
-asttokens==2.0.8
+asttokens==2.1.0
     # via stack-data
 astunparse==1.6.3
     # via tensorflow
@@ -39,7 +40,7 @@ attrs==22.1.0
     #   jsonschema
     #   ray
     #   visions
-babel==2.10.3
+babel==2.11.0
     # via sphinx
 backcall==0.2.0
     # via ipython
@@ -53,7 +54,7 @@ binaryornot==0.4.4
     # via cookiecutter
 bleach==5.0.1
     # via nbconvert
-botocore==1.27.82
+botocore==1.29.3
     # via -r doc-requirements.in
 cachetools==5.2.0
     # via google-auth
@@ -78,17 +79,18 @@ click==8.0.4
     #   ray
 cloudpickle==2.2.0
     # via flytekit
-colorama==0.4.5
+colorama==0.4.6
     # via great-expectations
 cookiecutter==2.1.1
     # via flytekit
 croniter==1.3.7
     # via flytekit
-cryptography==38.0.1
+cryptography==38.0.3
     # via
     #   -r doc-requirements.in
     #   great-expectations
     #   pyopenssl
+    #   secretstorage
 css-html-js-minify==2.5.5
     # via sphinx-material
 cycler==0.11.0
@@ -111,7 +113,7 @@ diskcache==5.4.0
     # via flytekit
 distlib==0.3.6
     # via virtualenv
-docker==6.0.0
+docker==6.0.1
     # via flytekit
 docker-image-py==0.1.12
     # via flytekit
@@ -130,7 +132,7 @@ entrypoints==0.4
     #   altair
     #   jupyter-client
     #   papermill
-executing==1.1.0
+executing==1.2.0
     # via stack-data
 fastjsonschema==2.16.2
     # via nbformat
@@ -142,15 +144,15 @@ flatbuffers==1.12
     # via
     #   tensorflow
     #   tf2onnx
-flyteidl==1.2.1
+flyteidl==1.2.3
     # via flytekit
-fonttools==4.37.3
+fonttools==4.38.0
     # via matplotlib
 frozenlist==1.3.1
     # via
     #   aiosignal
     #   ray
-fsspec==2022.8.2
+fsspec==2022.10.0
     # via
     #   -r doc-requirements.in
     #   modin
@@ -164,7 +166,7 @@ google-api-core[grpc]==2.8.2
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
     #   google-cloud-core
-google-auth==2.12.0
+google-auth==2.14.0
     # via
     #   google-api-core
     #   google-auth-oauthlib
@@ -177,7 +179,7 @@ google-cloud==0.34.0
     # via -r doc-requirements.in
 google-cloud-bigquery==3.1.0
     # via -r doc-requirements.in
-google-cloud-bigquery-storage==2.16.0
+google-cloud-bigquery-storage==2.16.2
     # via google-cloud-bigquery
 google-cloud-core==2.3.2
     # via google-cloud-bigquery
@@ -185,16 +187,16 @@ google-crc32c==1.5.0
     # via google-resumable-media
 google-pasta==0.2.0
     # via tensorflow
-google-resumable-media==2.3.3
+google-resumable-media==2.4.0
     # via google-cloud-bigquery
 googleapis-common-protos==1.56.4
     # via
     #   flyteidl
     #   google-api-core
     #   grpcio-status
-great-expectations==0.15.25
+great-expectations==0.15.31
     # via -r doc-requirements.in
-greenlet==1.1.3
+greenlet==2.0.0.post0
     # via sqlalchemy
 grpcio==1.43.0
     # via
@@ -216,12 +218,14 @@ h5py==3.7.0
 htmlmin==0.1.12
     # via pandas-profiling
 idna==3.4
-    # via requests
+    # via
+    #   anyio
+    #   requests
 imagehash==4.3.1
     # via visions
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.12.0
+importlib-metadata==5.0.0
     # via
     #   flytekit
     #   great-expectations
@@ -229,14 +233,15 @@ importlib-metadata==4.12.0
     #   markdown
     #   nbconvert
     #   sphinx
-ipykernel==6.16.0
+ipykernel==6.17.0
     # via
     #   ipywidgets
     #   jupyter
     #   jupyter-console
+    #   nbclassic
     #   notebook
     #   qtconsole
-ipython==8.5.0
+ipython==8.6.0
     # via
     #   great-expectations
     #   ipykernel
@@ -244,6 +249,7 @@ ipython==8.5.0
     #   jupyter-console
 ipython-genutils==0.2.0
     # via
+    #   nbclassic
     #   notebook
     #   qtconsole
 ipywidgets==8.0.2
@@ -254,12 +260,18 @@ jaraco-classes==3.2.3
     # via keyring
 jedi==0.18.1
     # via ipython
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.2
     # via
     #   altair
     #   cookiecutter
     #   great-expectations
     #   jinja2-time
+    #   jupyter-server
+    #   nbclassic
     #   nbconvert
     #   notebook
     #   pandas-profiling
@@ -269,17 +281,16 @@ jinja2-time==0.2.0
     # via cookiecutter
 jmespath==1.0.1
     # via botocore
-joblib==1.1.0
+joblib==1.2.0
     # via
     #   flytekit
-    #   pandas-profiling
     #   phik
     #   scikit-learn
 jsonpatch==1.32
     # via great-expectations
 jsonpointer==2.3
     # via jsonpatch
-jsonschema==4.16.0
+jsonschema==4.7.2
     # via
     #   altair
     #   great-expectations
@@ -287,10 +298,12 @@ jsonschema==4.16.0
     #   ray
 jupyter==1.0.0
     # via -r doc-requirements.in
-jupyter-client==7.3.5
+jupyter-client==7.4.4
     # via
     #   ipykernel
     #   jupyter-console
+    #   jupyter-server
+    #   nbclassic
     #   nbclient
     #   notebook
     #   qtconsole
@@ -299,10 +312,16 @@ jupyter-console==6.4.4
 jupyter-core==4.11.2
     # via
     #   jupyter-client
+    #   jupyter-server
+    #   nbclassic
     #   nbconvert
     #   nbformat
     #   notebook
     #   qtconsole
+jupyter-server==1.21.0
+    # via
+    #   nbclassic
+    #   notebook-shim
 jupyterlab-pygments==0.2.2
     # via nbconvert
 jupyterlab-widgets==3.0.3
@@ -315,16 +334,14 @@ keyring==23.9.3
     # via flytekit
 kiwisolver==1.4.4
     # via matplotlib
-kubernetes==24.2.0
+kubernetes==25.3.0
     # via -r doc-requirements.in
-lazy-object-proxy==1.7.1
+lazy-object-proxy==1.8.0
     # via astroid
 libclang==14.0.6
     # via tensorflow
 lxml==4.9.1
-    # via
-    #   nbconvert
-    #   sphinx-material
+    # via sphinx-material
 makefun==1.15.0
     # via great-expectations
 markdown==3.4.1
@@ -362,13 +379,13 @@ mistune==2.0.4
     # via
     #   great-expectations
     #   nbconvert
-modin==0.15.3
+modin==0.16.2
     # via -r doc-requirements.in
-more-itertools==8.14.0
+more-itertools==9.0.0
     # via jaraco-classes
 msgpack==1.0.4
     # via ray
-multimethod==1.8
+multimethod==1.9
     # via
     #   pandas-profiling
     #   visions
@@ -376,34 +393,43 @@ mypy-extensions==0.4.3
     # via typing-inspect
 natsort==8.2.0
     # via flytekit
-nbclient==0.6.8
+nbclassic==0.4.8
+    # via notebook
+nbclient==0.7.0
     # via
     #   nbconvert
     #   papermill
-nbconvert==7.0.0
+nbconvert==7.2.3
     # via
     #   jupyter
+    #   jupyter-server
+    #   nbclassic
     #   notebook
-nbformat==5.6.1
+nbformat==5.7.0
     # via
     #   great-expectations
+    #   jupyter-server
+    #   nbclassic
     #   nbclient
     #   nbconvert
     #   notebook
     #   papermill
-nest-asyncio==1.5.5
+nest-asyncio==1.5.6
     # via
     #   ipykernel
     #   jupyter-client
+    #   nbclassic
     #   nbclient
     #   notebook
-networkx==2.8.6
+networkx==2.8.8
     # via visions
-notebook==6.4.12
+notebook==6.5.2
     # via
     #   great-expectations
     #   jupyter
-numpy==1.23.3
+notebook-shim==0.2.2
+    # via nbclassic
+numpy==1.23.4
     # via
     #   altair
     #   great-expectations
@@ -433,14 +459,24 @@ numpy==1.23.3
     #   tensorflow
     #   tf2onnx
     #   visions
-oauthlib==3.2.1
+nvidia-cublas-cu11==11.10.3.66
+    # via
+    #   nvidia-cudnn-cu11
+    #   torch
+nvidia-cuda-nvrtc-cu11==11.7.99
+    # via torch
+nvidia-cuda-runtime-cu11==11.7.99
+    # via torch
+nvidia-cudnn-cu11==8.5.0.96
+    # via torch
+oauthlib==3.2.2
     # via requests-oauthlib
 onnx==1.12.0
     # via
     #   onnxconverter-common
     #   skl2onnx
     #   tf2onnx
-onnxconverter-common==1.12.2
+onnxconverter-common==1.13.0
     # via skl2onnx
 opt-einsum==3.3.0
     # via tensorflow
@@ -450,16 +486,18 @@ packaging==21.3
     #   google-cloud-bigquery
     #   great-expectations
     #   ipykernel
+    #   jupyter-server
     #   marshmallow
     #   matplotlib
     #   modin
     #   nbconvert
+    #   onnxconverter-common
     #   pandera
     #   qtpy
     #   sphinx
     #   statsmodels
     #   tensorflow
-pandas==1.4.4
+pandas==1.5.1
     # via
     #   altair
     #   dolt-integrations
@@ -472,9 +510,9 @@ pandas==1.4.4
     #   seaborn
     #   statsmodels
     #   visions
-pandas-profiling==3.3.0
+pandas-profiling==3.4.0
     # via -r doc-requirements.in
-pandera==0.12.0
+pandera==0.13.4
     # via -r doc-requirements.in
 pandocfilters==1.5.0
     # via nbconvert
@@ -482,7 +520,7 @@ papermill==2.4.0
     # via -r doc-requirements.in
 parso==0.8.3
     # via jedi
-patsy==0.5.2
+patsy==0.5.3
     # via statsmodels
 pexpect==4.8.0
     # via ipython
@@ -490,18 +528,21 @@ phik==0.12.2
     # via pandas-profiling
 pickleshare==0.7.5
     # via ipython
-pillow==9.2.0
+pillow==9.3.0
     # via
     #   imagehash
     #   matplotlib
     #   visions
 platformdirs==2.5.2
     # via virtualenv
-plotly==5.10.0
+plotly==5.11.0
     # via -r doc-requirements.in
-prometheus-client==0.14.1
-    # via notebook
-prompt-toolkit==3.0.31
+prometheus-client==0.15.0
+    # via
+    #   jupyter-server
+    #   nbclassic
+    #   notebook
+prompt-toolkit==3.0.32
     # via
     #   ipython
     #   jupyter-console
@@ -509,7 +550,7 @@ proto-plus==1.22.1
     # via
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
-protobuf==3.19.5
+protobuf==3.19.6
     # via
     #   flyteidl
     #   flytekit
@@ -529,7 +570,7 @@ protobuf==3.19.5
     #   whylogs
 protoc-gen-swagger==0.1.0
     # via flyteidl
-psutil==5.9.2
+psutil==5.9.3
     # via
     #   ipykernel
     #   modin
@@ -547,7 +588,6 @@ pyarrow==6.0.1
     # via
     #   flytekit
     #   google-cloud-bigquery
-    #   pandera
 pyasn1==0.4.8
     # via
     #   pyasn1-modules
@@ -556,7 +596,7 @@ pyasn1-modules==0.2.8
     # via google-auth
 pycparser==2.21
     # via cffi
-pydantic==1.9.2
+pydantic==1.10.2
     # via
     #   pandas-profiling
     #   pandera
@@ -576,9 +616,9 @@ pyparsing==3.0.9
     #   great-expectations
     #   matplotlib
     #   packaging
-pyrsistent==0.18.1
+pyrsistent==0.19.2
     # via jsonschema
-pyspark==3.3.0
+pyspark==3.3.1
     # via -r doc-requirements.in
 python-dateutil==2.8.2
     # via
@@ -601,7 +641,7 @@ python-slugify[unidecode]==6.1.2
     #   sphinx-material
 pytimeparse==1.1.8
     # via flytekit
-pytz==2022.2.1
+pytz==2022.6
     # via
     #   babel
     #   flytekit
@@ -624,15 +664,17 @@ pyzmq==24.0.1
     # via
     #   ipykernel
     #   jupyter-client
+    #   jupyter-server
+    #   nbclassic
     #   notebook
     #   qtconsole
-qtconsole==5.3.2
+qtconsole==5.4.0
     # via jupyter
-qtpy==2.2.0
+qtpy==2.2.1
     # via qtconsole
-ray==2.0.0
+ray==2.0.1
     # via -r doc-requirements.in
-regex==2022.9.13
+regex==2022.10.31
     # via docker-image-py
 requests==2.28.1
     # via
@@ -655,7 +697,7 @@ requests-oauthlib==1.3.1
     # via
     #   google-auth-oauthlib
     #   kubernetes
-responses==0.21.0
+responses==0.22.0
     # via flytekit
 retry==0.9.2
     # via flytekit
@@ -663,13 +705,13 @@ rsa==4.9
     # via google-auth
 ruamel-yaml==0.17.17
     # via great-expectations
-ruamel-yaml-clib==0.2.6
+ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
 scikit-learn==1.1.1
     # via
     #   -r doc-requirements.in
     #   skl2onnx
-scipy==1.9.1
+scipy==1.9.3
     # via
     #   great-expectations
     #   imagehash
@@ -677,15 +719,19 @@ scipy==1.9.1
     #   pandas-profiling
     #   phik
     #   scikit-learn
-    #   seaborn
     #   skl2onnx
     #   statsmodels
-seaborn==0.11.2
+seaborn==0.12.1
     # via
     #   missingno
     #   pandas-profiling
+secretstorage==3.3.3
+    # via keyring
 send2trash==1.8.0
-    # via notebook
+    # via
+    #   jupyter-server
+    #   nbclassic
+    #   notebook
 six==1.16.0
     # via
     #   asttokens
@@ -703,6 +749,8 @@ six==1.16.0
     #   tf2onnx
 skl2onnx==1.13
     # via -r doc-requirements.in
+sniffio==1.3.0
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sortedcontainers==2.4.0
@@ -725,7 +773,7 @@ sphinx==4.5.0
     #   sphinxcontrib-yt
 sphinx-autoapi==2.0.0
     # via -r doc-requirements.in
-sphinx-basic-ng==0.0.1a12
+sphinx-basic-ng==1.0.0b1
     # via furo
 sphinx-code-include==1.1.1
     # via -r doc-requirements.in
@@ -755,18 +803,16 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sphinxcontrib-yt==0.2.2
     # via -r doc-requirements.in
-sqlalchemy==1.4.41
+sqlalchemy==1.4.43
     # via -r doc-requirements.in
-stack-data==0.5.1
+stack-data==0.6.0
     # via ipython
 statsd==3.3.0
     # via flytekit
-statsmodels==0.13.2
+statsmodels==0.13.5
     # via pandas-profiling
 tangled-up-in-unicode==0.2.0
-    # via
-    #   pandas-profiling
-    #   visions
+    # via visions
 tenacity==8.1.0
     # via
     #   papermill
@@ -787,8 +833,11 @@ termcolor==2.0.1
     # via
     #   great-expectations
     #   tensorflow
-terminado==0.15.0
-    # via notebook
+terminado==0.17.0
+    # via
+    #   jupyter-server
+    #   nbclassic
+    #   notebook
 text-unidecode==1.3
     # via python-slugify
 textwrap3==0.9.2
@@ -797,16 +846,20 @@ tf2onnx==1.12.1
     # via -r doc-requirements.in
 threadpoolctl==3.1.0
     # via scikit-learn
-tinycss2==1.1.1
+tinycss2==1.2.1
     # via nbconvert
+toml==0.10.2
+    # via responses
 toolz==0.12.0
     # via altair
-torch==1.12.1
+torch==1.13.0
     # via -r doc-requirements.in
 tornado==6.2
     # via
     #   ipykernel
     #   jupyter-client
+    #   jupyter-server
+    #   nbclassic
     #   notebook
     #   terminado
 tqdm==4.64.1
@@ -814,20 +867,24 @@ tqdm==4.64.1
     #   great-expectations
     #   pandas-profiling
     #   papermill
-traitlets==5.4.0
+traitlets==5.5.0
     # via
     #   ipykernel
     #   ipython
     #   ipywidgets
     #   jupyter-client
     #   jupyter-core
+    #   jupyter-server
     #   matplotlib-inline
+    #   nbclassic
     #   nbclient
     #   nbconvert
     #   nbformat
     #   notebook
     #   qtconsole
-typing-extensions==4.3.0
+types-toml==0.10.8
+    # via responses
+typing-extensions==4.4.0
     # via
     #   astroid
     #   flytekit
@@ -842,11 +899,11 @@ typing-inspect==0.8.0
     # via
     #   dataclasses-json
     #   pandera
-tzdata==2022.4
+tzdata==2022.6
     # via pytz-deprecation-shim
 tzlocal==4.2
     # via great-expectations
-unidecode==1.3.4
+unidecode==1.3.6
     # via
     #   python-slugify
     #   sphinx-autoapi
@@ -860,7 +917,7 @@ urllib3==1.26.12
     #   requests
     #   responses
     #   whylabs-client
-virtualenv==20.16.5
+virtualenv==20.16.6
     # via ray
 visions[type_image_path]==0.7.5
     # via pandas-profiling
@@ -870,20 +927,23 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
-websocket-client==1.4.1
+websocket-client==1.4.2
     # via
     #   docker
+    #   jupyter-server
     #   kubernetes
 werkzeug==2.2.2
     # via tensorboard
-wheel==0.38.0
+wheel==0.38.1
     # via
     #   astunparse
     #   flytekit
+    #   nvidia-cublas-cu11
+    #   nvidia-cuda-runtime-cu11
     #   tensorboard
-whylabs-client==0.3.0
+whylabs-client==0.4.0
     # via -r doc-requirements.in
-whylogs==1.1.4
+whylogs==1.1.10
     # via -r doc-requirements.in
 whylogs-sketching==3.4.1.dev3
     # via whylogs
@@ -896,7 +956,7 @@ wrapt==1.14.1
     #   flytekit
     #   pandera
     #   tensorflow
-zipp==3.8.1
+zipp==3.10.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-spark2.txt
+++ b/requirements-spark2.txt
@@ -52,21 +52,18 @@ docker-image-py==0.1.12
     # via flytekit
 docstring-parser==0.15
     # via flytekit
-flyteidl==1.2.3
+flyteidl==1.2.4
     # via flytekit
 googleapis-common-protos==1.56.4
     # via
     #   flyteidl
     #   grpcio-status
-grpcio==1.47.0
+grpcio==1.48.2
     # via
-    #   -r requirements.in
     #   flytekit
     #   grpcio-status
-grpcio-status==1.47.0
-    # via
-    #   -r requirements.in
-    #   flytekit
+grpcio-status==1.48.2
+    # via flytekit
 idna==3.4
     # via requests
 importlib-metadata==5.0.0
@@ -91,7 +88,7 @@ joblib==1.2.0
     # via flytekit
 jsonschema==3.2.0
     # via -r requirements.in
-keyring==23.9.3
+keyring==23.11.0
     # via flytekit
 markupsafe==2.1.1
     # via jinja2
@@ -217,7 +214,7 @@ websocket-client==0.59.0
     # via
     #   -r requirements.in
     #   docker
-wheel==0.38.1
+wheel==0.38.3
     # via flytekit
 wrapt==1.14.1
     # via

--- a/requirements-spark2.txt
+++ b/requirements-spark2.txt
@@ -34,7 +34,7 @@ cookiecutter==2.1.1
     # via flytekit
 croniter==1.3.7
     # via flytekit
-cryptography==38.0.1
+cryptography==38.0.3
     # via
     #   pyopenssl
     #   secretstorage
@@ -46,13 +46,13 @@ deprecated==1.2.13
     # via flytekit
 diskcache==5.4.0
     # via flytekit
-docker==6.0.0
+docker==6.0.1
     # via flytekit
 docker-image-py==0.1.12
     # via flytekit
 docstring-parser==0.15
     # via flytekit
-flyteidl==1.2.1
+flyteidl==1.2.3
     # via flytekit
 googleapis-common-protos==1.56.4
     # via
@@ -143,7 +143,7 @@ pyopenssl==22.1.0
     # via flytekit
 pyparsing==3.0.9
     # via packaging
-pyrsistent==0.18.1
+pyrsistent==0.19.2
     # via jsonschema
 python-dateutil==2.8.2
     # via
@@ -157,7 +157,7 @@ python-slugify==6.1.2
     # via cookiecutter
 pytimeparse==1.1.8
     # via flytekit
-pytz==2022.5
+pytz==2022.6
     # via
     #   flytekit
     #   pandas
@@ -166,7 +166,7 @@ pyyaml==5.4.1
     #   -r requirements.in
     #   cookiecutter
     #   flytekit
-regex==2022.9.13
+regex==2022.10.31
     # via docker-image-py
 requests==2.28.1
     # via
@@ -217,13 +217,13 @@ websocket-client==0.59.0
     # via
     #   -r requirements.in
     #   docker
-wheel==0.38.0
+wheel==0.38.1
     # via flytekit
 wrapt==1.14.1
     # via
     #   deprecated
     #   flytekit
-zipp==3.9.0
+zipp==3.10.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,6 @@
 .
 -e file:.#egg=flytekit
 attrs<21
-# Restrict grpcio and grpcio-status.  The 1.50.0 version pulls in a version of protobuf that is not compatible.
-# More details in https://github.com/flyteorg/flyte/issues/3006
-grpcio<=1.47.0
-grpcio-status<=1.47.0
 # We need to restrict constrain the versions of both jsonschema and pyyaml because of docker-compose (which is
 # used to run integration tests) pins those two libraries. We are in the process of removing docker-compose in
 # favor of a more generic solution that involves Flytectl to stand up the sandbox, described in

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,21 +50,18 @@ docker-image-py==0.1.12
     # via flytekit
 docstring-parser==0.15
     # via flytekit
-flyteidl==1.2.3
+flyteidl==1.2.4
     # via flytekit
 googleapis-common-protos==1.56.4
     # via
     #   flyteidl
     #   grpcio-status
-grpcio==1.47.0
+grpcio==1.48.2
     # via
-    #   -r requirements.in
     #   flytekit
     #   grpcio-status
-grpcio-status==1.47.0
-    # via
-    #   -r requirements.in
-    #   flytekit
+grpcio-status==1.48.2
+    # via flytekit
 idna==3.4
     # via requests
 importlib-metadata==5.0.0
@@ -89,7 +86,7 @@ joblib==1.2.0
     # via flytekit
 jsonschema==3.2.0
     # via -r requirements.in
-keyring==23.9.3
+keyring==23.11.0
     # via flytekit
 markupsafe==2.1.1
     # via jinja2
@@ -215,7 +212,7 @@ websocket-client==0.59.0
     # via
     #   -r requirements.in
     #   docker
-wheel==0.38.1
+wheel==0.38.3
     # via flytekit
 wrapt==1.14.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ cookiecutter==2.1.1
     # via flytekit
 croniter==1.3.7
     # via flytekit
-cryptography==38.0.1
+cryptography==38.0.3
     # via
     #   pyopenssl
     #   secretstorage
@@ -44,13 +44,13 @@ deprecated==1.2.13
     # via flytekit
 diskcache==5.4.0
     # via flytekit
-docker==6.0.0
+docker==6.0.1
     # via flytekit
 docker-image-py==0.1.12
     # via flytekit
 docstring-parser==0.15
     # via flytekit
-flyteidl==1.2.1
+flyteidl==1.2.3
     # via flytekit
 googleapis-common-protos==1.56.4
     # via
@@ -141,7 +141,7 @@ pyopenssl==22.1.0
     # via flytekit
 pyparsing==3.0.9
     # via packaging
-pyrsistent==0.18.1
+pyrsistent==0.19.2
     # via jsonschema
 python-dateutil==2.8.2
     # via
@@ -155,7 +155,7 @@ python-slugify==6.1.2
     # via cookiecutter
 pytimeparse==1.1.8
     # via flytekit
-pytz==2022.5
+pytz==2022.6
     # via
     #   flytekit
     #   pandas
@@ -164,7 +164,7 @@ pyyaml==5.4.1
     #   -r requirements.in
     #   cookiecutter
     #   flytekit
-regex==2022.9.13
+regex==2022.10.31
     # via docker-image-py
 requests==2.28.1
     # via
@@ -215,13 +215,13 @@ websocket-client==0.59.0
     # via
     #   -r requirements.in
     #   docker
-wheel==0.38.0
+wheel==0.38.1
     # via flytekit
 wrapt==1.14.1
     # via
     #   deprecated
     #   flytekit
-zipp==3.9.0
+zipp==3.10.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,10 @@ setup(
         "deprecated>=1.0,<2.0",
         "docker>=5.0.3,<7.0.0",
         "python-dateutil>=2.1",
-        "grpcio>=1.43.0,!=1.45.0,<2.0",
-        "grpcio-status>=1.43,!=1.45.0",
+        # Restrict grpcio and grpcio-status.  The 1.49.1 version pulls in a version of protobuf that is not compatible.
+        # More details in https://github.com/flyteorg/flyte/issues/3006
+        "grpcio>=1.43.0,!=1.45.0,<1.49.1,<2.0",
+        "grpcio-status>=1.43,!=1.45.0,<1.49.1",
         "importlib-metadata",
         "pyopenssl",
         "joblib",


### PR DESCRIPTION
# TL;DR
We have to restrict grpcio in setup.py otherwise we won't be able to bump requirements in plugins

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Two main changes:
1. regenerate requirements
2. move restriction to `grpcio` and `grpcio-status` to `setup.py` so that we can regenerate requirements in plugins (otherwise plugins try to pull in latest `grpcio`, which has a restriction on `protobuf>=4.21.6` (and it's incompatible with [flyteidl](https://github.com/flyteorg/flyteidl/blob/master/setup.py#L18))

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
