### PR TITLE
Download chinook.zip only once in the tests

### DIFF
--- a/tests/flytekit/unit/extras/sqlite3/test_task.py
+++ b/tests/flytekit/unit/extras/sqlite3/test_task.py
@@ -2,12 +2,15 @@ import pandas
 
 from flytekit import kwtypes, task, workflow
 from flytekit.configuration import DefaultImages
+from flytekit.core import context_manager
 from flytekit.extras.sqlite3.task import SQLite3Config, SQLite3Task
 
 # https://www.sqlitetutorial.net/sqlite-sample-database/
 from flytekit.types.schema import FlyteSchema
 
-EXAMPLE_DB = "https://www.sqlitetutorial.net/wp-content/uploads/2018/03/chinook.zip"
+ctx = context_manager.FlyteContextManager.current_context()
+EXAMPLE_DB = ctx.file_access.get_random_local_path("chinook.zip")
+ctx.file_access.get_data("https://www.sqlitetutorial.net/wp-content/uploads/2018/03/chinook.zip", EXAMPLE_DB)
 
 # This task belongs to test_task_static but is intentionally here to help test tracking
 tk = SQLite3Task(
@@ -29,7 +32,6 @@ def test_task_static():
 
 def test_task_schema():
     # sqlite3_start
-    DB_LOCATION = "https://www.sqlitetutorial.net/wp-content/uploads/2018/03/chinook.zip"
 
     sql_task = SQLite3Task(
         "test",
@@ -37,7 +39,7 @@ def test_task_schema():
         inputs=kwtypes(limit=int),
         output_schema_type=FlyteSchema[kwtypes(TrackId=int, Name=str)],
         task_config=SQLite3Config(
-            uri=DB_LOCATION,
+            uri=EXAMPLE_DB,
             compressed=True,
         ),
     )


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Download quota was exceeded in the unit test, and caused the test to fail. 

To reduce downloads, we could download the file to local first, and then run the tests

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_

