### PR TITLE
Allow for environment variables to be defined in the pod spec

### DIFF
--- a/plugins/flytekit-k8s-pod/flytekitplugins/pod/task.py
+++ b/plugins/flytekit-k8s-pod/flytekitplugins/pod/task.py
@@ -109,7 +109,7 @@ class PodFunctionTask(PythonFunctionTask[Pod]):
                     container.resources = resource_requirements
 
                 container.env = [V1EnvVar(name=key, value=val) for key, val in sdk_default_container.env.items()] + (
-                    container.env if container.env else []
+                    container.env or []
                 )
 
             final_containers.append(container)

--- a/plugins/flytekit-k8s-pod/flytekitplugins/pod/task.py
+++ b/plugins/flytekit-k8s-pod/flytekitplugins/pod/task.py
@@ -108,7 +108,9 @@ class PodFunctionTask(PythonFunctionTask[Pod]):
                     # Important! Only copy over resource requirements if they are non-empty.
                     container.resources = resource_requirements
 
-                container.env = [V1EnvVar(name=key, value=val) for key, val in sdk_default_container.env.items()]
+                container.env = [V1EnvVar(name=key, value=val) for key, val in sdk_default_container.env.items()] + (
+                    container.env if container.env else []
+                )
 
             final_containers.append(container)
 


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Let environment variables be defined in the pod spec

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Up to now we only let environment variables to be defined at the task level (via setting the `environment` field in the call to @task). In other words, if users wanted to control the env vars via env vars, they would have to define them using this method, which is not very ergonomic. This PR lets users define env vars in pod specs.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3059

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
