### PR TITLE
Relax max flytekit version constraint in Huggingface plugin

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -21,7 +21,7 @@ All the Flytekit plugins maintained by the core team are added here. It is not n
 | Great Expectations           | ```bash pip install flytekitplugins-great-expectations``` | Enforce data quality for various data types within Flyte                                                                   | [![PyPI version fury.io](https://badge.fury.io/py/flytekitplugins-great-expectations.svg)](https://pypi.python.org/pypi/flytekitplugins-great-expectations/) | Flytekit-only |
 | Snowflake                    | ```bash pip install flytekitplugins-snowflake```          | Use Snowflake as a 'data warehouse-as-a-service' within Flyte                                                              | [![PyPI version fury.io](https://badge.fury.io/py/flytekitplugins-snowflake.svg)](https://pypi.python.org/pypi/flytekitplugins-snowflake/)                   | Backend       |
 | dbt                          | ```bash pip install flytekitplugins-dbt```                | Run dbt within Flyte                                                                                                       | [![PyPI version fury.io](https://badge.fury.io/py/flytekitplugins-dbt.svg)](https://pypi.python.org/pypi/flytekitplugins-dbt/)                               | Flytekit-only |
-
+| Huggingface                  | ```bash pip install flytekitplugins-huggingface```        | Read & write Hugginface Datasets as Flyte StructuredDatasets                                                               | [![PyPI version fury.io](https://badge.fury.io/py/flytekitplugins-huggingface.svg)](https://pypi.python.org/pypi/flytekitplugins-huggingface/)               | Flytekit-only |
 
 ## Have a Plugin Idea? 💡
 Please [file an issue](https://github.com/flyteorg/flyte/issues/new?assignees=&labels=untriaged%2Cplugins&template=backend-plugin-request.md&title=%5BPlugin%5D).
@@ -72,7 +72,7 @@ microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 # microlib_name = f"flytekitplugins-data-{PLUGIN_NAME}"
 
 # TODO add additional requirements
-plugin_requires = ["flytekit>=0.21.3,<1.0.0", "<other requirements>"]
+plugin_requires = ["flytekit>=1.1.0b0,<2.0.0, "<other requirements>"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-huggingface/setup.py
+++ b/plugins/flytekit-huggingface/setup.py
@@ -5,7 +5,7 @@ PLUGIN_NAME = "huggingface"
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 plugin_requires = [
-    "flytekit>=1.1.0b0,<1.2.0",
+    "flytekit>=1.1.0b0,<2.0.0",
     "datasets>=2.4.0",
 ]
 
@@ -16,6 +16,9 @@ setup(
     version=__version__,
     author="Evan Sadler",
     description="Hugging Face plugin for flytekit",
+    url="https://github.com/flyteorg/flytekit/tree/master/plugins/flytekit-huggingface",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
     namespace_packages=["flytekitplugins"],
     packages=[f"flytekitplugins.{PLUGIN_NAME}"],
     install_requires=plugin_requires,


### PR DESCRIPTION
# TL;DR
Currently, we can't install the plugin with flytekit versions `>1.2.0` such as the current version `1.2.3`.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
