### PR TITLE
globals...

### DIFF
--- a/tests/flytekit/unit/cli/pyflyte/test_register.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_register.py
@@ -91,14 +91,15 @@ def test_non_fast_register_require_version(mock_client, mock_remote):
     mock_remote.return_value._version_from_hash.return_value = "dummy_version_from_hash"
     mock_remote.return_value._upload_file.return_value = "dummy_md5_bytes", "dummy_native_url"
     runner = CliRunner()
+    context_manager.FlyteEntities.entities.clear()
     with runner.isolated_filesystem():
         out = subprocess.run(["git", "init"], capture_output=True)
         assert out.returncode == 0
-        os.makedirs("core", exist_ok=True)
-        with open(os.path.join("core", "sample.py"), "w") as f:
+        os.makedirs("core3", exist_ok=True)
+        with open(os.path.join("core3", "sample.py"), "w") as f:
             f.write(sample_file_contents)
             f.close()
-        result = runner.invoke(pyflyte.main, ["register", "--non-fast", "core"])
+        result = runner.invoke(pyflyte.main, ["register", "--non-fast", "core3"])
         assert result.exit_code == 1
         assert str(result.exception) == "Version is a required parameter in case --non-fast is specified."
-        shutil.rmtree("core")
+        shutil.rmtree("core3")

--- a/tests/flytekit/unit/cli/pyflyte/test_register.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_register.py
@@ -54,16 +54,17 @@ def test_register_with_no_output_dir_passed(mock_client, mock_remote):
     mock_remote.return_value._version_from_hash.return_value = "dummy_version_from_hash"
     mock_remote.return_value.fast_package.return_value = "dummy_md5_bytes", "dummy_native_url"
     runner = CliRunner()
+    context_manager.FlyteEntities.entities.clear()
     with runner.isolated_filesystem():
         out = subprocess.run(["git", "init"], capture_output=True)
         assert out.returncode == 0
-        os.makedirs("core", exist_ok=True)
-        with open(os.path.join("core", "sample.py"), "w") as f:
+        os.makedirs("core1", exist_ok=True)
+        with open(os.path.join("core1", "sample.py"), "w") as f:
             f.write(sample_file_contents)
             f.close()
-        result = runner.invoke(pyflyte.main, ["register", "core"])
+        result = runner.invoke(pyflyte.main, ["register", "core1"])
         assert "Successfully registered 4 entities" in result.output
-        shutil.rmtree("core")
+        shutil.rmtree("core1")
 
 
 @mock.patch("flytekit.clis.sdk_in_container.helpers.FlyteRemote", spec=FlyteRemote)

--- a/tests/flytekit/unit/cli/pyflyte/test_register.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_register.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 from flytekit.clients.friendly import SynchronousFlyteClient
 from flytekit.clis.sdk_in_container import pyflyte
 from flytekit.clis.sdk_in_container.helpers import get_and_save_remote_with_click_context
+from flytekit.core import context_manager
 from flytekit.remote.remote import FlyteRemote
 
 sample_file_contents = """
@@ -70,16 +71,17 @@ def test_register_with_no_output_dir_passed(mock_client, mock_remote):
 def test_non_fast_register(mock_client, mock_remote):
     mock_remote._client = mock_client
     runner = CliRunner()
+    context_manager.FlyteEntities.entities.clear()
     with runner.isolated_filesystem():
         out = subprocess.run(["git", "init"], capture_output=True)
         assert out.returncode == 0
-        os.makedirs("core", exist_ok=True)
-        with open(os.path.join("core", "sample.py"), "w") as f:
+        os.makedirs("core2", exist_ok=True)
+        with open(os.path.join("core2", "sample.py"), "w") as f:
             f.write(sample_file_contents)
             f.close()
-        result = runner.invoke(pyflyte.main, ["register", "--non-fast", "--version", "a-version", "core"])
+        result = runner.invoke(pyflyte.main, ["register", "--non-fast", "--version", "a-version", "core2"])
         assert "Successfully registered 4 entities" in result.output
-        shutil.rmtree("core")
+        shutil.rmtree("core2")
 
 
 @mock.patch("flytekit.clis.sdk_in_container.helpers.FlyteRemote", spec=FlyteRemote)


### PR DESCRIPTION
This is a test PR into https://github.com/flyteorg/flytekit/pull/1237

I think there are additional changes that'll need to be made.  We should make the entities not global (maybe move it into the current compilation context).

I think the bigger issue is what's happening with the global import system.  When we call [import module](https://github.com/flyteorg/flytekit/blob/d53ebc6b8b1e59206f4fe6bdf43fd7ac60ae353f/flytekit/tools/module_loader.py#L25) we're effectively in a tmp dir that looks like
```
tmpdir
  core/
    sample.py
```
but when you call `import_module` on `core`, python is returning the `core` that was previously loaded, in a different unit test under a different temp dir (that's no longer present).  This results in this [listdir](https://github.com/flyteorg/flytekit/blob/d53ebc6b8b1e59206f4fe6bdf43fd7ac60ae353f/flytekit/core/tracker.py#L200) failing and returning an Errno 2