### PR TITLE
Override node name

### DIFF
--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -108,6 +108,8 @@ class Node(object):
             )
         if "interruptible" in kwargs:
             self._metadata._interruptible = kwargs["interruptible"]
+        if "name" in kwargs and kwargs["name"] is not None:
+            self._metadata._name = kwargs["name"]
         return self
 
 
@@ -134,7 +136,9 @@ def _convert_resource_overrides(
         )
     if resources.ephemeral_storage is not None:
         resource_entries.append(
-            _resources_model.ResourceEntry(_resources_model.ResourceName.EPHEMERAL_STORAGE, resources.ephemeral_storage)
+            _resources_model.ResourceEntry(
+                _resources_model.ResourceName.EPHEMERAL_STORAGE, resources.ephemeral_storage,
+            )
         )
 
     return resource_entries

--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -137,7 +137,8 @@ def _convert_resource_overrides(
     if resources.ephemeral_storage is not None:
         resource_entries.append(
             _resources_model.ResourceEntry(
-                _resources_model.ResourceName.EPHEMERAL_STORAGE, resources.ephemeral_storage,
+                _resources_model.ResourceName.EPHEMERAL_STORAGE,
+                resources.ephemeral_storage,
             )
         )
 

--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -108,7 +108,7 @@ class Node(object):
             )
         if "interruptible" in kwargs:
             self._metadata._interruptible = kwargs["interruptible"]
-        if kwargs.get("name") is not None:
+        if "name" in kwargs:
             self._metadata._name = kwargs["name"]
         return self
 

--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -108,7 +108,7 @@ class Node(object):
             )
         if "interruptible" in kwargs:
             self._metadata._interruptible = kwargs["interruptible"]
-        if "name" in kwargs and kwargs["name"] is not None:
+        if kwargs.get("name") is not None:
             self._metadata._name = kwargs["name"]
         return self
 

--- a/tests/flytekit/unit/core/test_node_creation.py
+++ b/tests/flytekit/unit/core/test_node_creation.py
@@ -102,7 +102,9 @@ def test_more_normal_task():
     @task
     def t1(a: int) -> nt:
         # This one returns a regular tuple
-        return nt(f"{a + 2}",)
+        return nt(
+            f"{a + 2}",
+        )
 
     @task
     def t1_nt(a: int) -> nt:
@@ -130,7 +132,9 @@ def test_reserved_keyword():
     @task
     def t1(a: int) -> nt:
         # This one returns a regular tuple
-        return nt(f"{a + 2}",)
+        return nt(
+            f"{a + 2}",
+        )
 
     # Test that you can't name an output "outputs"
     with pytest.raises(FlyteAssertion):
@@ -294,7 +298,8 @@ def test_resources_override():
 
 
 @pytest.mark.parametrize(
-    "timeout,expected", [(None, datetime.timedelta()), (10, datetime.timedelta(seconds=10))],
+    "timeout,expected",
+    [(None, datetime.timedelta()), (10, datetime.timedelta(seconds=10))],
 )
 def test_timeout_override(timeout, expected):
     @task
@@ -330,7 +335,8 @@ def test_timeout_override_invalid_value():
 
 
 @pytest.mark.parametrize(
-    "retries,expected", [(None, _literal_models.RetryStrategy(0)), (3, _literal_models.RetryStrategy(3))],
+    "retries,expected",
+    [(None, _literal_models.RetryStrategy(0)), (3, _literal_models.RetryStrategy(3))],
 )
 def test_retries_override(retries, expected):
     @task

--- a/tests/flytekit/unit/core/test_node_creation.py
+++ b/tests/flytekit/unit/core/test_node_creation.py
@@ -87,6 +87,7 @@ def test_normal_task():
     wf_spec = get_serializable(OrderedDict(), serialization_settings, empty_wf2)
     assert wf_spec.template.nodes[0].upstream_node_ids[0] == "n1"
     assert wf_spec.template.nodes[0].id == "n0"
+    assert wf_spec.template.nodes[0].metadata.name == "t2"
 
     with pytest.raises(FlyteAssertion):
 
@@ -398,17 +399,14 @@ def test_void_promise_override():
     ]
 
 
-@pytest.mark.parametrize(
-    "name,expected", [(None, "t1"), ("foo", "foo")],
-)
-def test_name_override(name, expected):
+def test_name_override():
     @task
     def t1(a: str) -> str:
         return f"*~*~*~{a}*~*~*~"
 
     @workflow
     def my_wf(a: str) -> str:
-        return t1(a=a).with_overrides(name=name)
+        return t1(a=a).with_overrides(name="foo")
 
     serialization_settings = flytekit.configuration.SerializationSettings(
         project="test_proj",
@@ -419,4 +417,4 @@ def test_name_override(name, expected):
     )
     wf_spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
     assert len(wf_spec.template.nodes) == 1
-    assert wf_spec.template.nodes[0].metadata.name == expected
+    assert wf_spec.template.nodes[0].metadata.name == "foo"


### PR DESCRIPTION
Signed-off-by: Hongxin Liang <honnix@users.noreply.github.com>

# TL;DR
Override node name.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
More details are captured in #3092.

I tested this on our setup. Everything seems to work fine, except the `Nodes` tab of the execution detail view. While `Graph` and `Timeline` both show the overridden node name, `Nodes` tab still shows the original task name.

Also note that many changes were made by `black`.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3092

## Follow-up issue
_NA_