### PR TITLE
Add support to choose docker build target architecture

### DIFF
--- a/flytekit_scripts/flytekit_build_image.sh
+++ b/flytekit_scripts/flytekit_build_image.sh
@@ -73,7 +73,7 @@ fi
 echo "Building: $FLYTE_INTERNAL_IMAGE using $TARGET_PLATFORM_BUILD architecture"
 
 # This build command is the raison d'etre of this script, it ensures that the version is injected into the image itself
-eval "$(docker build ${DOCKER_PLATFORM_OPT} . --build-arg tag=${FLYTE_INTERNAL_IMAGE} -t ${FLYTE_INTERNAL_IMAGE} -f ${DOCKERFILE_PATH})"
+docker build ${DOCKER_PLATFORM_OPT} . --build-arg tag=${FLYTE_INTERNAL_IMAGE} -t ${FLYTE_INTERNAL_IMAGE} -f ${DOCKERFILE_PATH}
 
 echo "$IMAGE_NAME built locally."
 

--- a/flytekit_scripts/flytekit_build_image.sh
+++ b/flytekit_scripts/flytekit_build_image.sh
@@ -61,10 +61,17 @@ if [ -n "$REGISTRY" ]; then
 else
   FLYTE_INTERNAL_IMAGE=${IMAGE_NAME}:${PREFIX}${TAG}
 fi
-echo "Building: $FLYTE_INTERNAL_IMAGE"
+
+# Check if the user set the target build architecture, if not use the default instead.
+if [ -z "$TARGET_PLATFORM_BUILD" ]; then
+  TARGET_PLATFORM_BUILD=$(docker system info --format '{{.OSType}}/{{.Architecture}}')
+fi
+
+echo "Building: $FLYTE_INTERNAL_IMAGE using $TARGET_PLATFORM_BUILD as target architecture"
 
 # This build command is the raison d'etre of this script, it ensures that the version is injected into the image itself
-docker build . --build-arg tag="$FLYTE_INTERNAL_IMAGE" -t "$FLYTE_INTERNAL_IMAGE" -f "${DOCKERFILE_PATH}"
+docker build --platform $TARGET_PLATFORM_BUILD . --build-arg tag="$FLYTE_INTERNAL_IMAGE" -t "$FLYTE_INTERNAL_IMAGE" -f "${DOCKERFILE_PATH}"
+
 echo "$IMAGE_NAME built locally."
 
 # Create the appropriate tags

--- a/flytekit_scripts/flytekit_build_image.sh
+++ b/flytekit_scripts/flytekit_build_image.sh
@@ -73,7 +73,7 @@ fi
 echo "Building: $FLYTE_INTERNAL_IMAGE using $TARGET_PLATFORM_BUILD architecture"
 
 # This build command is the raison d'etre of this script, it ensures that the version is injected into the image itself
-$(docker build $DOCKER_PLATFORM_OPT . --build-arg tag="$FLYTE_INTERNAL_IMAGE" -t "$FLYTE_INTERNAL_IMAGE" -f "${DOCKERFILE_PATH}")
+eval "$(docker build ${DOCKER_PLATFORM_OPT} . --build-arg tag=${FLYTE_INTERNAL_IMAGE} -t ${FLYTE_INTERNAL_IMAGE} -f ${DOCKERFILE_PATH})"
 
 echo "$IMAGE_NAME built locally."
 

--- a/flytekit_scripts/flytekit_build_image.sh
+++ b/flytekit_scripts/flytekit_build_image.sh
@@ -18,6 +18,7 @@ echo ""
 
 DIRPATH=""
 DOCKERFILE_PATH=""
+DOCKER_PLATFORM_OPT=""
 if [ -d "$1" ]; then
   DIRPATH=$(cd "$1" && pwd)
   DOCKERFILE_PATH=${DIRPATH}/"Dockerfile"
@@ -63,14 +64,16 @@ else
 fi
 
 # Check if the user set the target build architecture, if not use the default instead.
-if [ -z "$TARGET_PLATFORM_BUILD" ]; then
-  TARGET_PLATFORM_BUILD=$(docker system info --format '{{.OSType}}/{{.Architecture}}')
+if [ -n "$TARGET_PLATFORM_BUILD" ]; then
+  DOCKER_PLATFORM_OPT="--platform $TARGET_PLATFORM_BUILD"
+else
+  TARGET_PLATFORM_BUILD="default"
 fi
 
-echo "Building: $FLYTE_INTERNAL_IMAGE using $TARGET_PLATFORM_BUILD as target architecture"
+echo "Building: $FLYTE_INTERNAL_IMAGE using $TARGET_PLATFORM_BUILD architecture"
 
 # This build command is the raison d'etre of this script, it ensures that the version is injected into the image itself
-docker build --platform $TARGET_PLATFORM_BUILD . --build-arg tag="$FLYTE_INTERNAL_IMAGE" -t "$FLYTE_INTERNAL_IMAGE" -f "${DOCKERFILE_PATH}"
+$(docker build $DOCKER_PLATFORM_OPT . --build-arg tag="$FLYTE_INTERNAL_IMAGE" -t "$FLYTE_INTERNAL_IMAGE" -f "${DOCKERFILE_PATH}")
 
 echo "$IMAGE_NAME built locally."
 

--- a/flytekit_scripts/flytekit_build_image.sh
+++ b/flytekit_scripts/flytekit_build_image.sh
@@ -65,7 +65,7 @@ fi
 DOCKER_PLATFORM_OPT=()
 # Check if the user set the target build architecture, if not use the default instead.
 if [ -n "$TARGET_PLATFORM_BUILD" ]; then
-  DOCKER_PLATFORM_OPT=(--platform $TARGET_PLATFORM_BUILD)
+  DOCKER_PLATFORM_OPT=(--platform "$TARGET_PLATFORM_BUILD")
 else
   TARGET_PLATFORM_BUILD="default"
 fi

--- a/flytekit_scripts/flytekit_build_image.sh
+++ b/flytekit_scripts/flytekit_build_image.sh
@@ -18,7 +18,6 @@ echo ""
 
 DIRPATH=""
 DOCKERFILE_PATH=""
-DOCKER_PLATFORM_OPT=""
 if [ -d "$1" ]; then
   DIRPATH=$(cd "$1" && pwd)
   DOCKERFILE_PATH=${DIRPATH}/"Dockerfile"
@@ -63,17 +62,18 @@ else
   FLYTE_INTERNAL_IMAGE=${IMAGE_NAME}:${PREFIX}${TAG}
 fi
 
+DOCKER_PLATFORM_OPT=()
 # Check if the user set the target build architecture, if not use the default instead.
 if [ -n "$TARGET_PLATFORM_BUILD" ]; then
-  DOCKER_PLATFORM_OPT="--platform $TARGET_PLATFORM_BUILD"
+  DOCKER_PLATFORM_OPT=(--platform $TARGET_PLATFORM_BUILD)
 else
   TARGET_PLATFORM_BUILD="default"
 fi
 
-echo "Building: $FLYTE_INTERNAL_IMAGE using $TARGET_PLATFORM_BUILD architecture"
+echo "Building: $FLYTE_INTERNAL_IMAGE for $TARGET_PLATFORM_BUILD architecture"
 
 # This build command is the raison d'etre of this script, it ensures that the version is injected into the image itself
-docker build ${DOCKER_PLATFORM_OPT} . --build-arg tag=${FLYTE_INTERNAL_IMAGE} -t ${FLYTE_INTERNAL_IMAGE} -f ${DOCKERFILE_PATH}
+docker build . "${DOCKER_PLATFORM_OPT[@]}" --build-arg tag="${FLYTE_INTERNAL_IMAGE}" -t "${FLYTE_INTERNAL_IMAGE}" -f "${DOCKERFILE_PATH}"
 
 echo "$IMAGE_NAME built locally."
 


### PR DESCRIPTION
# TL;DR
Add new `TARGET_PLATFORM_BUILD` ENV var to set the target platform architecture to allow to build docker image on a machine with a different architecture than the docker image will be executed. 

## Type
 - [x] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
_NA_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3097

## Follow-up issue
_NA_
