### PR TITLE
Remove plugins from flytekit core packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@
 # include folders
 recursive-include flytekit *
 recursive-include flytekit_scripts *
-recursive-include plugins *
 
 # include specific files
 include README.md
@@ -25,6 +24,7 @@ recursive-exclude tests *
 recursive-exclude docs *
 recursive-exclude boilerplate *
 recursive-exclude .github *
+recursive-exclude plugins *
 
 # exclude dist folder:
 #  - contains the generated *.tar.gz and .whl files.

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
     maintainer="Flyte Contributors",
     maintainer_email="admin@flyte.org",
     packages=find_packages(
-        include=["flytekit", "flytekit_scripts", "plugins"],
-        exclude=["boilerplate", "docs", "tests*"],
+        include=["flytekit", "flytekit_scripts"],
+        exclude=["boilerplate", "docs", "plugins", "tests*"],
     ),
     include_package_data=True,
     url="https://github.com/flyteorg/flytekit",


### PR DESCRIPTION
Missed this when https://github.com/flyteorg/flytekit/pull/1088 went in.

We don't need to package plugins.  Those are packaged separately.