### PR TITLE
Sanitize query template input in sqlite task

### DIFF
--- a/flytekit/extras/sqlite3/task.py
+++ b/flytekit/extras/sqlite3/task.py
@@ -97,6 +97,9 @@ class SQLite3Task(PythonCustomizedContainerTask[SQLite3Config], SQLTask[SQLite3C
             outputs=outputs,
             **kwargs,
         )
+        # Sanitize query by removing the newlines at the end of the query. Keep in mind
+        # that the query can be a multiline string.
+        self._query_template = query_template.replace("\n", " ")
 
     @property
     def output_columns(self) -> typing.Optional[typing.List[str]]:


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Newlines in multiline string queries should be escaped in sqlite tasks. This improves ergonomics of `SQLite3Task`

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
