### PR TITLE
Update ray plugin dependency

### DIFF
--- a/plugins/flytekit-ray/requirements.txt
+++ b/plugins/flytekit-ray/requirements.txt
@@ -6,16 +6,31 @@
 #
 -e file:.#egg=flytekitplugins-ray
     # via -r requirements.in
-aiosignal==1.2.0
+aiohttp==3.8.3
+    # via
+    #   aiohttp-cors
+    #   ray
+aiohttp-cors==0.7.0
     # via ray
+aiosignal==1.2.0
+    # via
+    #   aiohttp
+    #   ray
 arrow==1.2.2
     # via jinja2-time
+async-timeout==4.0.2
+    # via aiohttp
 attrs==21.4.0
     # via
+    #   aiohttp
     #   jsonschema
     #   ray
 binaryornot==0.4.4
     # via cookiecutter
+blessed==1.19.1
+    # via gpustat
+cachetools==5.2.0
+    # via google-auth
 certifi==2022.5.18.1
     # via requests
 cffi==1.15.0
@@ -23,7 +38,9 @@ cffi==1.15.0
 chardet==4.0.0
     # via binaryornot
 charset-normalizer==2.0.12
-    # via requests
+    # via
+    #   aiohttp
+    #   requests
 click==8.0.4
     # via
     #   cookiecutter
@@ -31,6 +48,8 @@ click==8.0.4
     #   ray
 cloudpickle==2.1.0
     # via flytekit
+colorful==0.5.5
+    # via ray
 cookiecutter==1.7.3
     # via flytekit
 croniter==1.3.5
@@ -65,12 +84,20 @@ flytekit==1.1.0
     # via flytekitplugins-ray
 frozenlist==1.3.0
     # via
+    #   aiohttp
     #   aiosignal
     #   ray
-googleapis-common-protos==1.56.1
+google-api-core==2.11.0
+    # via opencensus
+google-auth==2.15.0
+    # via google-api-core
+googleapis-common-protos==1.57.0
     # via
     #   flyteidl
+    #   google-api-core
     #   grpcio-status
+gpustat==1.0.0
+    # via ray
 grpcio==1.43.0
     # via
     #   flytekit
@@ -79,7 +106,9 @@ grpcio==1.43.0
 grpcio-status==1.43.0
     # via flytekit
 idna==3.3
-    # via requests
+    # via
+    #   requests
+    #   yarl
 importlib-metadata==4.11.3
     # via
     #   flytekit
@@ -107,6 +136,10 @@ marshmallow-jsonschema==0.13.0
     # via flytekit
 msgpack==1.0.4
     # via ray
+multidict==6.0.3
+    # via
+    #   aiohttp
+    #   yarl
 mypy-extensions==0.4.3
     # via typing-inspect
 natsort==8.1.0
@@ -116,6 +149,12 @@ numpy==1.21.6
     #   pandas
     #   pyarrow
     #   ray
+nvidia-ml-py==11.495.46
+    # via gpustat
+opencensus==0.11.0
+    # via ray
+opencensus-context==0.1.3
+    # via opencensus
 packaging==21.3
     # via marshmallow
 pandas==1.3.5
@@ -124,20 +163,33 @@ platformdirs==2.5.2
     # via virtualenv
 poyo==0.5.0
     # via cookiecutter
+prometheus-client==0.13.1
+    # via ray
 protobuf==3.20.2
     # via
     #   flyteidl
     #   flytekit
+    #   google-api-core
     #   googleapis-common-protos
     #   grpcio-status
     #   protoc-gen-swagger
     #   ray
 protoc-gen-swagger==0.1.0
     # via flyteidl
+psutil==5.9.4
+    # via gpustat
 py==1.11.0
     # via retry
+py-spy==0.3.14
+    # via ray
 pyarrow==6.0.1
     # via flytekit
+pyasn1==0.4.8
+    # via
+    #   pyasn1-modules
+    #   rsa
+pyasn1-modules==0.2.8
+    # via google-auth
 pycparser==2.21
     # via cffi
 pyopenssl==22.0.0
@@ -166,7 +218,7 @@ pyyaml==6.0
     # via
     #   flytekit
     #   ray
-ray==1.13.0
+ray[default]==1.13.0
     # via flytekitplugins-ray
 regex==2022.4.24
     # via docker-image-py
@@ -175,18 +227,26 @@ requests==2.27.1
     #   cookiecutter
     #   docker
     #   flytekit
+    #   google-api-core
     #   ray
     #   responses
 responses==0.20.0
     # via flytekit
 retry==0.9.2
     # via flytekit
+rsa==4.9
+    # via google-auth
 six==1.16.0
     # via
+    #   blessed
     #   cookiecutter
+    #   google-auth
+    #   gpustat
     #   grpcio
     #   python-dateutil
     #   virtualenv
+smart-open==6.2.0
+    # via ray
 sortedcontainers==2.4.0
     # via flytekit
 statsd==3.3.0
@@ -206,6 +266,8 @@ urllib3==1.26.9
     #   responses
 virtualenv==20.15.1
     # via ray
+wcwidth==0.2.5
+    # via blessed
 websocket-client==1.3.2
     # via docker
 wheel==0.38.0
@@ -214,5 +276,10 @@ wrapt==1.14.1
     # via
     #   deprecated
     #   flytekit
+yarl==1.8.2
+    # via aiohttp
 zipp==3.8.0
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/plugins/flytekit-ray/setup.py
+++ b/plugins/flytekit-ray/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "ray"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["ray", "flytekit>=1.1.0b0,<2.0.0", "flyteidl>=1.1.10"]
+plugin_requires = ["ray[default]", "flytekit>=1.1.0b0,<2.0.0", "flyteidl>=1.1.10"]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
We should install `ray[default]` instead of `ray`. `ray[default]` contains ray dashboard dependency, which will be used when we creating ray cluster. If we don't install it, ray operator will failed to submit the job to ray cluster because it can't find the dashboard IP address.

https://docs.ray.io/en/latest/ray-core/ray-dashboard.html#getting-started

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
Might related to https://flyte-org.slack.com/archives/CP2HDHKE1/p1669843950108329

## Follow-up issue
_NA_
