### PR TITLE
Restrict numpy due to deprecated aliases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,9 @@ setup(
         "cloudpickle>=2.0.0",
         "cookiecutter>=1.7.3",
         "numpy<1.22.0; python_version < '3.8.0'",
+        # TODO: We should remove mentions to the deprecated numpy
+        # aliases. More details in https://github.com/flyteorg/flyte/issues/3166
+        "numpy<1.24.0",
     ],
     extras_require=extras_require,
     scripts=[


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Restrict numpy version before removing deprecated numpy aliases

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
In numpy 1.20.0 some type aliases were marked as deprecated and those were finallly removed in version 1.24.0, which was released last night and broke default installations of flytekit.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3166

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
