### PR TITLE
Remove project/domain from being overridden with execution values in serialized context

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -264,8 +264,6 @@ def setup_execution(
     if compressed_serialization_settings:
         ss = SerializationSettings.from_transport(compressed_serialization_settings)
         ssb = ss.new_builder()
-        ssb.project = exe_project
-        ssb.domain = exe_domain
         ssb.version = tk_version
         if dynamic_addl_distro:
             ssb.fast_serialization_settings = FastSerializationSettings(

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -292,7 +292,7 @@ def test_setup_cloud_prefix():
         assert isinstance(ctx.file_access._default_remote, GCSPersistence)
 
 
-def test_perkjlzxujoi():
+def test_persist_ss():
     default_img = Image(name="default", fqn="test", tag="tag")
     ss = SerializationSettings(
         project="proj1",

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -1,3 +1,4 @@
+import os
 import typing
 from collections import OrderedDict
 
@@ -5,6 +6,7 @@ import mock
 from flyteidl.core.errors_pb2 import ErrorDocument
 
 from flytekit.bin.entrypoint import _dispatch_execute, normalize_inputs, setup_execution
+from flytekit.configuration import Image, ImageConfig, SerializationSettings
 from flytekit.core import context_manager
 from flytekit.core.base_task import IgnoreOutputs
 from flytekit.core.data_persistence import DiskPersistence
@@ -288,6 +290,22 @@ def test_setup_cloud_prefix():
 
     with setup_execution("gs://", checkpoint_path=None, prev_checkpoint=None) as ctx:
         assert isinstance(ctx.file_access._default_remote, GCSPersistence)
+
+
+def test_perkjlzxujoi():
+    default_img = Image(name="default", fqn="test", tag="tag")
+    ss = SerializationSettings(
+        project="proj1",
+        domain="dom",
+        version="version123",
+        env=None,
+        image_config=ImageConfig(default_image=default_img, images=[default_img]),
+    )
+    ss_txt = ss.serialized_context
+    os.environ["_F_SS_C"] = ss_txt
+    with setup_execution("s3://", checkpoint_path=None, prev_checkpoint=None) as ctx:
+        assert ctx.serialization_settings.project == "proj1"
+        assert ctx.serialization_settings.domain == "dom"
 
 
 def test_normalize_inputs():


### PR DESCRIPTION
# TL;DR
The serialized context that's stored in the environment variable `_F_SS_C` is present for dynamic tasks and contains the values detected at serialization time.  We should not be overriding the project and domain here.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue

