### PR TITLE
fix(pyflyte register): change -d to -D for --destination-dir as -d is already used for --domain

### DIFF
--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -67,7 +67,7 @@ Note: This command only works on regular Python packages, not namespace packages
     help="Directory to write the output zip file containing the protobuf definitions",
 )
 @click.option(
-    "-d",
+    "-D",
     "--destination-dir",
     required=False,
     type=str,


### PR DESCRIPTION
# TL;DR

`pyflyte register` currently lists `-d` as the short option for both `--domain` and `--destination-dir`, which can result in unexpected behavior (e.g., causing executions of workflows to crash because it's pointing at the `development` directory, which does not exist). 

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
Changed `-d` flag for `--destination-dir` to `-D`, left `-d` flag as valid short flag for `--domain`.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3178

## Follow-up issue
_NA_