### PR TITLE
Handle Optional[FlyteFile] in Dataclass type transformer

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -361,6 +361,12 @@ class DataclassTransformer(TypeTransformer[object]):
         from flytekit.types.schema.types import FlyteSchema
         from flytekit.types.structured.structured_dataset import StructuredDataset
 
+        # Handle Optional
+        if get_origin(python_type) is typing.Union and type(None) in get_args(python_type):
+            if python_val is None:
+                return None
+            return self._serialize_flyte_type(python_val, get_args(python_type)[0])
+
         if hasattr(python_type, "__origin__") and python_type.__origin__ is list:
             return [self._serialize_flyte_type(v, python_type.__args__[0]) for v in python_val]
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -400,11 +400,17 @@ class DataclassTransformer(TypeTransformer[object]):
                 python_val.__setattr__(v.name, self._serialize_flyte_type(val, field_type))
             return python_val
 
-    def _deserialize_flyte_type(self, python_val: T, expected_python_type: Type) -> T:
+    def _deserialize_flyte_type(self, python_val: T, expected_python_type: Type) -> Optional[T]:
         from flytekit.types.directory.types import FlyteDirectory, FlyteDirToMultipartBlobTransformer
         from flytekit.types.file.file import FlyteFile, FlyteFilePathTransformer
         from flytekit.types.schema.types import FlyteSchema, FlyteSchemaTransformer
         from flytekit.types.structured.structured_dataset import StructuredDataset, StructuredDatasetTransformerEngine
+
+        # Handle Optional
+        if get_origin(expected_python_type) is typing.Union and type(None) in get_args(expected_python_type):
+            if python_val is None:
+                return None
+            return self._deserialize_flyte_type(python_val, get_args(expected_python_type)[0])
 
         if hasattr(expected_python_type, "__origin__") and expected_python_type.__origin__ is list:
             return [self._deserialize_flyte_type(v, expected_python_type.__args__[0]) for v in python_val]  # type: ignore

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -572,6 +572,11 @@ def test_dataclass_int_preserving():
 def test_optional_flytefile_in_dataclass():
     @dataclass_json
     @dataclass
+    class A(object):
+        a: int
+
+    @dataclass_json
+    @dataclass
     class TestFileStruct(object):
         a: FlyteFile
         b: typing.Optional[FlyteFile]
@@ -585,6 +590,8 @@ def test_optional_flytefile_in_dataclass():
         g_prime: typing.Dict[str, typing.Optional[FlyteFile]]
         h: typing.Optional[FlyteFile] = None
         h_prime: typing.Optional[FlyteFile] = None
+        i: typing.Optional[A] = None
+        i_prime: typing.Optional[A] = A(a=99)
 
     remote_path = "s3://tmp/file"
     f1 = FlyteFile(remote_path)
@@ -600,6 +607,7 @@ def test_optional_flytefile_in_dataclass():
         g={"a": f1},
         g_prime={"a": None},
         h=f1,
+        i=A(a=42),
     )
 
     ctx = FlyteContext.current_context()
@@ -620,6 +628,8 @@ def test_optional_flytefile_in_dataclass():
     assert o.g_prime == {"a": None}
     assert o.h.path == ot.h.remote_source
     assert ot.h_prime is None
+    assert o.i == ot.i
+    assert o.i_prime == A(a=99)
 
 
 def test_flyte_file_in_dataclass():

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -584,6 +584,7 @@ def test_optional_flytefile_in_dataclass():
         g: typing.Dict[str, typing.Optional[FlyteFile]]
         g_prime: typing.Dict[str, typing.Optional[FlyteFile]]
         h: typing.Optional[FlyteFile] = None
+        h_prime: typing.Optional[FlyteFile] = None
 
     remote_path = "s3://tmp/file"
     f1 = FlyteFile(remote_path)
@@ -598,6 +599,7 @@ def test_optional_flytefile_in_dataclass():
         f={"a": f1},
         g={"a": f1},
         g_prime={"a": None},
+        h=f1,
     )
 
     ctx = FlyteContext.current_context()
@@ -616,7 +618,8 @@ def test_optional_flytefile_in_dataclass():
     assert o.f["a"].path == ot.f["a"].remote_source
     assert o.g["a"].path == ot.g["a"].remote_source
     assert o.g_prime == {"a": None}
-    assert ot.h is None
+    assert o.h.path == ot.h.remote_source
+    assert ot.h_prime is None
 
 
 def test_flyte_file_in_dataclass():


### PR DESCRIPTION
# TL;DR
Add support for optional fields in the dataclass type transformer

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Handle `Optional` in the dataclass transformer explicitly, both in serialization and deserialization of dataclasses. This affects any type that includes a non-trivial transformation (e.g. `FlyteFile`).

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3187

## Follow-up issue
_NA_
