### PR TITLE
Update log level for structured dataset

### DIFF
--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -483,9 +483,10 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
 
         if (default_format_for_type or default_for_type) and h.supported_format != GENERIC_FORMAT:
             if h.python_type in cls.DEFAULT_FORMATS and not override:
-                logger.debug(
-                    f"Not using handler {h} with format {h.supported_format} as default for {h.python_type}, {cls.DEFAULT_FORMATS[h.python_type]} already specified."
-                )
+                if cls.DEFAULT_FORMATS[h.python_type] != h.supported_format:
+                    logger.debug(
+                        f"Not using handler {h} with format {h.supported_format} as default for {h.python_type}, {cls.DEFAULT_FORMATS[h.python_type]} already specified."
+                    )
             else:
                 logger.debug(
                     f"Setting format {h.supported_format} for dataframes of type {h.python_type} from handler {h}"

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -483,7 +483,7 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
 
         if (default_format_for_type or default_for_type) and h.supported_format != GENERIC_FORMAT:
             if h.python_type in cls.DEFAULT_FORMATS and not override:
-                logger.warning(
+                logger.debug(
                     f"Not using handler {h} with format {h.supported_format} as default for {h.python_type}, {cls.DEFAULT_FORMATS[h.python_type]} already specified."
                 )
             else:

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -493,7 +493,7 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
                 cls.DEFAULT_FORMATS[h.python_type] = h.supported_format
         if default_storage_for_type or default_for_type:
             if h.protocol in cls.DEFAULT_PROTOCOLS and not override:
-                logger.warning(
+                logger.debug(
                     f"Not using handler {h} with storage protocol {h.protocol} as default for {h.python_type}, {cls.DEFAULT_PROTOCOLS[h.python_type]} already specified."
                 )
             else:


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Change the log level to debug. Otherwise, we will get lots of warnings about structured datasets while running the workflow 
```bash
{"asctime": "2022-12-25 22:57:07,317", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.PandasToParquetEncodingHandler object at 0x7fce624a8220> with format parquet as default for <class 'pandas.core.frame.DataFrame'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,317", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.PandasToParquetEncodingHandler object at 0x7fce624a8220> with format parquet as default for <class 'pandas.core.frame.DataFrame'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,317", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.PandasToParquetEncodingHandler object at 0x7fce624a8220> with format parquet as default for <class 'pandas.core.frame.DataFrame'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,317", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.PandasToParquetEncodingHandler object at 0x7fce624a8220> with format parquet as default for <class 'pandas.core.frame.DataFrame'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,317", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.ParquetToPandasDecodingHandler object at 0x7fce624549a0> with format parquet as default for <class 'pandas.core.frame.DataFrame'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,317", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.ParquetToPandasDecodingHandler object at 0x7fce624549a0> with format parquet as default for <class 'pandas.core.frame.DataFrame'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,317", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.ParquetToPandasDecodingHandler object at 0x7fce624549a0> with format parquet as default for <class 'pandas.core.frame.DataFrame'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,317", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.ParquetToPandasDecodingHandler object at 0x7fce624549a0> with format parquet as default for <class 'pandas.core.frame.DataFrame'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,317", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.ParquetToPandasDecodingHandler object at 0x7fce624549a0> with format parquet as default for <class 'pandas.core.frame.DataFrame'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,317", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.ArrowToParquetEncodingHandler object at 0x7fce62454940> with format parquet as default for <class 'pyarrow.lib.Table'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,318", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.ArrowToParquetEncodingHandler object at 0x7fce62454940> with format parquet as default for <class 'pyarrow.lib.Table'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,318", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.ArrowToParquetEncodingHandler object at 0x7fce62454940> with format parquet as default for <class 'pyarrow.lib.Table'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,318", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.ArrowToParquetEncodingHandler object at 0x7fce62454940> with format parquet as default for <class 'pyarrow.lib.Table'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,318", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.ParquetToArrowDecodingHandler object at 0x7fce624a82b0> with format parquet as default for <class 'pyarrow.lib.Table'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,318", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.ParquetToArrowDecodingHandler object at 0x7fce624a82b0> with format parquet as default for <class 'pyarrow.lib.Table'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,318", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.ParquetToArrowDecodingHandler object at 0x7fce624a82b0> with format parquet as default for <class 'pyarrow.lib.Table'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,318", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.ParquetToArrowDecodingHandler object at 0x7fce624a82b0> with format parquet as default for <class 'pyarrow.lib.Table'>, parquet already specified."}
{"asctime": "2022-12-25 22:57:07,318", "name": "flytekit", "levelname": "WARNING", "message": "Not using handler <flytekit.types.structured.basic_dfs.ParquetToArrowDecodingHandler object at 0x7fce624a82b0> with format parquet as default for <class 'pyarrow.lib.Table'>, parquet already specified."}
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
