### PR TITLE
pr into #1384

### DIFF
--- a/flytekit/clis/sdk_in_container/helpers.py
+++ b/flytekit/clis/sdk_in_container/helpers.py
@@ -28,10 +28,10 @@ def get_and_save_remote_with_click_context(
     cfg_file = get_config_file(cfg_file_location)
     if cfg_file is None:
         cfg_obj = Config.for_sandbox()
-        print(f"No config files found, creating remote with sandbox config")
+        cli_logger.info(f"No config files found, creating remote with sandbox config")
     else:
         cfg_obj = Config.auto(cfg_file_location)
-        print(
+        cli_logger.info(
             f"Creating remote with config {cfg_obj}" + (f" with file {cfg_file_location}" if cfg_file_location else "")
         )
     r = FlyteRemote(cfg_obj, default_project=project, default_domain=domain)

--- a/flytekit/clis/sdk_in_container/helpers.py
+++ b/flytekit/clis/sdk_in_container/helpers.py
@@ -4,7 +4,7 @@ from typing import Optional
 import click
 
 from flytekit.clis.sdk_in_container.constants import CTX_CONFIG_FILE
-from flytekit.configuration import Config, ImageConfig
+from flytekit.configuration import Config, ImageConfig, get_config_file
 from flytekit.loggers import cli_logger
 from flytekit.remote.remote import FlyteRemote
 
@@ -25,10 +25,15 @@ def get_and_save_remote_with_click_context(
     :return: FlyteRemote instance
     """
     cfg_file_location = ctx.obj.get(CTX_CONFIG_FILE)
-    cfg_obj = Config.auto(cfg_file_location)
-    cli_logger.info(
-        f"Creating remote with config {cfg_obj}" + (f" with file {cfg_file_location}" if cfg_file_location else "")
-    )
+    cfg_file = get_config_file(cfg_file_location)
+    if cfg_file is None:
+        cfg_obj = Config.for_sandbox()
+        print(f"No config files found, creating remote with sandbox config")
+    else:
+        cfg_obj = Config.auto(cfg_file_location)
+        print(
+            f"Creating remote with config {cfg_obj}" + (f" with file {cfg_file_location}" if cfg_file_location else "")
+        )
     r = FlyteRemote(cfg_obj, default_project=project, default_domain=domain)
     if save:
         ctx.obj[FLYTE_REMOTE_INSTANCE_KEY] = r

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -529,7 +529,7 @@ class Config(object):
         )
 
     @classmethod
-    def auto(cls, config_file: typing.Union[str, ConfigFile] = None) -> Config:
+    def auto(cls, config_file: typing.Union[str, ConfigFile, None] = None) -> Config:
         """
         Automatically constructs the Config Object. The order of precedence is as follows
           1. first try to find any env vars that match the config vars specified in the FLYTE_CONFIG format.
@@ -560,7 +560,7 @@ class Config(object):
         return Config(
             platform=PlatformConfig(endpoint="localhost:30080", auth_mode="Pkce", insecure=True),
             data_config=DataConfig(
-                s3=S3Config(endpoint="http://localhost:30084", access_key_id="minio", secret_access_key="miniostorage")
+                s3=S3Config(endpoint="http://localhost:30002", access_key_id="minio", secret_access_key="miniostorage")
             ),
         )
 

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -312,7 +312,7 @@ class PlatformConfig(object):
     """
 
     endpoint: str = "localhost:30080"
-    insecure: bool = True
+    insecure: bool = False
     insecure_skip_verify: bool = False
     console_endpoint: typing.Optional[str] = None
     command: typing.Optional[typing.List[str]] = None

--- a/tests/flytekit/unit/cli/pyflyte/test_register.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_register.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 from flytekit.clients.friendly import SynchronousFlyteClient
 from flytekit.clis.sdk_in_container import pyflyte
 from flytekit.clis.sdk_in_container.helpers import get_and_save_remote_with_click_context
+from flytekit.configuration import Config
 from flytekit.core import context_manager
 from flytekit.remote.remote import FlyteRemote
 
@@ -34,6 +35,7 @@ def test_saving_remote(mock_remote):
     mock_context.obj = {}
     get_and_save_remote_with_click_context(mock_context, "p", "d")
     assert mock_context.obj["flyte_remote"] is not None
+    mock_remote.assert_called_once_with(Config.for_sandbox(), default_project="p", default_domain="d")
 
 
 def test_register_with_no_package_or_module_argument():

--- a/tests/flytekit/unit/configuration/configs/good.config
+++ b/tests/flytekit/unit/configuration/configs/good.config
@@ -7,8 +7,8 @@ assumable_iam_role=some_role
 
 
 [platform]
-
 url=fakeflyte.com
+insecure=false
 
 [madeup]
 

--- a/tests/flytekit/unit/configuration/configs/nossl.yaml
+++ b/tests/flytekit/unit/configuration/configs/nossl.yaml
@@ -1,0 +1,4 @@
+admin:
+  endpoint: dns:///flyte.mycorp.io
+  authType: Pkce
+  insecure: false

--- a/tests/flytekit/unit/configuration/test_file.py
+++ b/tests/flytekit/unit/configuration/test_file.py
@@ -8,6 +8,7 @@ from pytimeparse.timeparse import timeparse
 
 from flytekit.configuration import ConfigEntry, get_config_file, set_if_exists
 from flytekit.configuration.file import LegacyConfigEntry, _exists
+from flytekit.configuration.internal import Platform
 
 
 def test_set_if_exists():
@@ -137,3 +138,9 @@ def test_env_var_bool_transformer(mock_file_read):
 
     # The last read should've triggered the file read since now the env var is no longer set.
     assert mock_file_read.call_count == 1
+
+
+def test_nossl():
+    config_file = get_config_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/good.config"))
+    res = Platform.INSECURE.read(config_file)
+    assert res is False

--- a/tests/flytekit/unit/configuration/test_file.py
+++ b/tests/flytekit/unit/configuration/test_file.py
@@ -140,7 +140,7 @@ def test_env_var_bool_transformer(mock_file_read):
     assert mock_file_read.call_count == 1
 
 
-def test_nossl():
+def test_use_ssl():
     config_file = get_config_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/good.config"))
     res = Platform.INSECURE.read(config_file)
     assert res is False

--- a/tests/flytekit/unit/configuration/test_internal.py
+++ b/tests/flytekit/unit/configuration/test_internal.py
@@ -82,4 +82,4 @@ def test_some_int(mocked):
 def test_default_platform_config_endpoint_insecure():
     platform_config = PlatformConfig()
     assert platform_config.endpoint == "localhost:30080"
-    assert platform_config.insecure
+    assert platform_config.insecure is False

--- a/tests/flytekit/unit/configuration/test_yaml_file.py
+++ b/tests/flytekit/unit/configuration/test_yaml_file.py
@@ -72,7 +72,7 @@ def test_real_config():
     assert res == ["all"]
 
 
-def test_nossl():
+def test_use_ssl():
     config_file = get_config_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/nossl.yaml"))
     res = Platform.INSECURE.read(config_file)
     assert res is False

--- a/tests/flytekit/unit/configuration/test_yaml_file.py
+++ b/tests/flytekit/unit/configuration/test_yaml_file.py
@@ -70,3 +70,9 @@ def test_real_config():
 
     res = Credentials.SCOPES.read(config_file)
     assert res == ["all"]
+
+
+def test_nossl():
+    config_file = get_config_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/nossl.yaml"))
+    res = Platform.INSECURE.read(config_file)
+    assert res is False


### PR DESCRIPTION
Please see the other PR.

This one:
* Adds a test for false SSL for the old .ini style of config
* Adds a shortcut for the pyflyte run/register commands - if no files are detected at all, create for sandbox instead.  I think this is okay. The other option would be to fall back to checking the `~/.flyte/config-sandbox.yml` file but I think using the code option is a bit cleaner, even though it ties us closer to the flytectl demo port settings.
