### PR TITLE
fix: upgrade request dependency to version that does not use vulnerable py dep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -168,7 +168,7 @@ requests==2.28.1
     #   responses
 responses==0.22.0
     # via flytekit
-retry==0.9.2
+retry2==0.9.5
     # via flytekit
 secretstorage==3.3.3
     # via keyring


### PR DESCRIPTION
fix: upgrade request dependency to version that does not use vulnerable py dep

# TL;DR
This request is just to upgrade the `retry` package dependency in `requirements.txt` for flytekit. The original unmaintained package has a dependency on the `py` package, which has a CVE with no fix version available:
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-42969


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 In this PR, it is replaced with the recent release of the `retry2` package version `0.9.5`, which is a fork of the original `retry` package:
https://pypi.org/project/retry2/

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3052
