### PR TITLE
Preserving Exception in the LazyEntity fetch

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -854,7 +854,8 @@ def create_and_link_node_from_remote(
     extra_inputs = used_inputs ^ set(kwargs.keys())
     if len(extra_inputs) > 0:
         raise _user_exceptions.FlyteAssertion(
-            "Too many inputs were specified for the interface.  Extra inputs were: {}".format(extra_inputs)
+            f"Too many inputs for [{entity.name}] Expected inputs: {typed_interface.inputs.keys()} "
+            f"- extra inputs: {extra_inputs}"
         )
 
     # Detect upstream nodes

--- a/flytekit/remote/lazy_entity.py
+++ b/flytekit/remote/lazy_entity.py
@@ -37,6 +37,20 @@ class LazyEntity(RemoteEntity, typing.Generic[T]):
         """
         with self._mutex:
             if self._entity is None:
+                try:
+                    self._entity = self._getter()
+                except AttributeError as e:
+                    raise RuntimeError(
+                        f"Error downloading the entity {self._name}, (check original exception...)") from e
+            return self._entity
+
+    @property
+    def entity(self) -> T:
+        """
+        If not already fetched / available, then the entity will be force fetched.
+        """
+        with self._mutex:
+            if self._entity is None:
                 self._entity = self._getter()
             return self._entity
 

--- a/flytekit/remote/lazy_entity.py
+++ b/flytekit/remote/lazy_entity.py
@@ -41,17 +41,8 @@ class LazyEntity(RemoteEntity, typing.Generic[T]):
                     self._entity = self._getter()
                 except AttributeError as e:
                     raise RuntimeError(
-                        f"Error downloading the entity {self._name}, (check original exception...)") from e
-            return self._entity
-
-    @property
-    def entity(self) -> T:
-        """
-        If not already fetched / available, then the entity will be force fetched.
-        """
-        with self._mutex:
-            if self._entity is None:
-                self._entity = self._getter()
+                        f"Error downloading the entity {self._name}, (check original exception...)"
+                    ) from e
             return self._entity
 
     def __getattr__(self, item: str) -> typing.Any:

--- a/tests/flytekit/unit/remote/test_lazy_entity.py
+++ b/tests/flytekit/unit/remote/test_lazy_entity.py
@@ -63,3 +63,16 @@ def test_lazy_loading_compile(create_and_link_node_from_remote_mock):
     e.compile(ctx)
     assert e._entity is not None
     assert e.entity == dummy_task
+
+
+def test_lazy_loading_exception():
+    def _getter():
+        raise AttributeError("Error")
+
+    e = LazyEntity("x", _getter)
+    assert e.name == "x"
+    assert e._entity is None
+    with pytest.raises(RuntimeError) as exc:
+        assert e.blah
+
+    assert isinstance(exc.value.__cause__, AttributeError)


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
In cases when the lazy fetch fails with an attribute error, the entire lazy entity will end up in a infinite recursive call. It is anyways a good practice to catch the underlying exception and bubble as a runtime error. This should not affect any users today, but this is potentially a bug waiting to be uncovered in the future.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

