### PR TITLE
Flip the settings for channel and logger

### DIFF
--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -44,10 +44,10 @@ ch.setLevel(logging.DEBUG)
 flytekit_root_env_var = f"{LOGGING_ENV_VAR}_ROOT"
 level_from_env = os.getenv(LOGGING_ENV_VAR)
 root_level_from_env = os.getenv(flytekit_root_env_var)
-if level_from_env is not None:
-    logger.setLevel(int(level_from_env))
-elif root_level_from_env is not None:
+if root_level_from_env is not None:
     logger.setLevel(int(root_level_from_env))
+elif level_from_env is not None:
+    logger.setLevel(int(level_from_env))
 else:
     logger.setLevel(logging.WARNING)
 

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -13,12 +13,6 @@ LOGGING_ENV_VAR = "FLYTE_SDK_LOGGING_LEVEL"
 
 # By default, the root flytekit logger to debug so everything is logged, but enable fine-tuning
 logger = logging.getLogger("flytekit")
-# Root logger control
-flytekit_root_env_var = f"{LOGGING_ENV_VAR}_ROOT"
-if os.getenv(flytekit_root_env_var) is not None:
-    logger.setLevel(int(os.getenv(flytekit_root_env_var)))
-else:
-    logger.setLevel(logging.DEBUG)
 
 # Stop propagation so that configuration is isolated to this file (so that it doesn't matter what the
 # global Python root logger is set to).
@@ -40,22 +34,33 @@ user_space_logger = child_loggers["user_space"]
 
 # create console handler
 ch = logging.StreamHandler()
+ch.setLevel(logging.DEBUG)
 
+# Root logger control
 # Don't want to import the configuration library since that will cause all sorts of circular imports, let's
 # just use the environment variable if it's defined. Decide in the future when we implement better controls
 # if we should control with the channel or with the logger level.
 # The handler log level controls whether log statements will actually print to the screen
+flytekit_root_env_var = f"{LOGGING_ENV_VAR}_ROOT"
 level_from_env = os.getenv(LOGGING_ENV_VAR)
+root_level_from_env = os.getenv(flytekit_root_env_var)
 if level_from_env is not None:
-    ch.setLevel(int(level_from_env))
+    logger.setLevel(int(level_from_env))
+elif root_level_from_env is not None:
+    logger.setLevel(int(root_level_from_env))
 else:
-    ch.setLevel(logging.WARNING)
+    logger.setLevel(logging.WARNING)
 
 for log_name, child_logger in child_loggers.items():
     env_var = f"{LOGGING_ENV_VAR}_{log_name.upper()}"
     level_from_env = os.getenv(env_var)
     if level_from_env is not None:
         child_logger.setLevel(int(level_from_env))
+    else:
+        if child_logger is user_space_logger:
+            child_logger.setLevel(logging.INFO)
+        else:
+            child_logger.setLevel(logging.WARNING)
 
 # create formatter
 formatter = jsonlogger.JsonFormatter(fmt="%(asctime)s %(name)s %(levelname)s %(message)s")


### PR DESCRIPTION
# TL;DR
Not sure why we didn't do this to begin with... doesn't this make more sense?  Basically

* Change the channel to be wide open, debug level.
* Make the root logger warning, unless set by `FLYTE_SDK_LOGGING_LEVEL` or `FLYTE_SDK_LOGGING_LEVEL_ROOT`.
* Make all child loggers warning, unless set by the relevant environment variable
  * Unless it's the user facing logger, in which case make it info by default.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
See above.  I think this is cleaner.  Tested locally and it seems to be more what we want.

## Tracking Issue
No issue but https://github.com/flyteorg/flyte/issues/3126 and things like it keep cropping up.
