### PR TITLE
[Docs] SynchronousFlyteClient API reference #3095

### DIFF
--- a/docs/source/clients.rst
+++ b/docs/source/clients.rst
@@ -1,0 +1,4 @@
+.. automodule:: flytekit.clients
+    :no-members:
+    :no-inherited-members:
+    :no-special-members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -76,6 +76,7 @@ Expected output:
    flytekit
    configuration
    remote
+   clients
    testing
    extend
    deck

--- a/flytekit/clients/__init__.py
+++ b/flytekit/clients/__init__.py
@@ -1,0 +1,19 @@
+"""
+=====================
+Clients
+=====================
+
+.. currentmodule:: flytekit.clients
+
+This module provides lower level access to a Flyte backend.
+
+.. _clients_module:
+
+.. autosummary::
+   :template: custom.rst
+   :toctree: generated/
+   :nosignatures:
+
+   ~friendly.SynchronousFlyteClient
+   ~raw.RawSynchronousFlyteClient
+"""


### PR DESCRIPTION
# TL;DR
Fix [SynchronousFlyteClient API reference #3095](https://github.com/flyteorg/flyte/issues/3095)

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Docs completed
 - [x] Locally tested

## Complete description
Added new 'Clients' section in Flytekit API docs that pulls in docstring from `flytekit.clients.friendly.SynchronousFlyteClient` and `flytekit.clients.raw.RawSynchronousFlyteClient`

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3095

## Follow-up issue
_NA_
