### PR TITLE
WIP - Detect if running on a Mac M1 and use appropriate dev-requirements file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MOCK_FLYTE_REPO=tests/flytekit/integration/remote/mock_flyte_repo/workflows
 
 # Detect if it is running on a Mac M1.
 # We need to special-case M1's because of tensorflow. More details in  https://github.com/flyteorg/flyte/issues/3264
-ifneq (,$(and $(findstring Linux, $(shell uname -s)), $(findstring x86_64, $(shell uname -p))))
+ifneq (,$(and $(findstring Darwin, $(shell uname -s)), $(findstring arm, $(shell uname -p))))
 	DEV_REQUIREMENTS_SUFFIX=-mac_arm64
 else
 	DEV_REQUIREMENTS_SUFFIX=

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ MOCK_FLYTE_REPO=tests/flytekit/integration/remote/mock_flyte_repo/workflows
 
 # Detect if it is running on a Mac M1.
 # We need to special-case M1's because of tensorflow. More details in  https://github.com/flyteorg/flyte/issues/3264
-ifneq (,$(and $(findstring Darwin, $(shell uname -s)), $(findstring arm, $(shell uname -p))))
-	DEV_REQUIREMENTS_SUFFIX="-mac_arm64"
+ifneq (,$(and $(findstring Linux, $(shell uname -s)), $(findstring x86_64, $(shell uname -p))))
+	DEV_REQUIREMENTS_SUFFIX=-mac_arm64
 else
-	DEV_REQUIREMENTS_SUFFIX=""
+	DEV_REQUIREMENTS_SUFFIX=
 endif
 
 os-platform:

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ MOCK_FLYTE_REPO=tests/flytekit/integration/remote/mock_flyte_repo/workflows
 
 # Detect if it is running on a Mac M1.
 # We need to special-case M1's because of tensorflow. More details in  https://github.com/flyteorg/flyte/issues/3264
-ifeq (0,$(and $($(shell uname -p), arm64), $($(shell uname -s), Darwin)))
+ifneq (,$(and $(findstring Darwin, $(shell uname -s)), $(findstring arm, $(shell uname -p))))
 	DEV_REQUIREMENTS_SUFFIX="-mac_arm64"
 else
 	DEV_REQUIREMENTS_SUFFIX=""
 endif
 
 os-platform:
-	echo $(DEV_REQUIREMENTS_SUFFIX)
+	@echo $(DEV_REQUIREMENTS_SUFFIX)
 
 .SILENT: help
 .PHONY: help
@@ -82,7 +82,7 @@ requirements.txt: requirements.in install-piptools
 	$(PIP_COMPILE) $<
 
 dev-requirements.txt: export CUSTOM_COMPILE_COMMAND := make dev-requirements.txt
-dev-requirements.txt: dev-requirements.in requirements.txt install-piptools
+dev-requirements.txt: dev-requirements${DEV_REQUIREMENTS_SUFFIX}.in requirements.txt install-piptools
 	$(PIP_COMPILE) $< -o dev-requirements${DEV_REQUIREMENTS_SUFFIX}.txt
 
 doc-requirements.txt: export CUSTOM_COMPILE_COMMAND := make doc-requirements.txt

--- a/dev-requirements-mac_arm64.in
+++ b/dev-requirements-mac_arm64.in
@@ -1,0 +1,22 @@
+-c requirements.txt
+
+git+https://github.com/flyteorg/pytest-flyte@main#egg=pytest-flyte
+coverage[toml]
+joblib
+mock
+pytest
+pytest-cov
+mypy
+pre-commit
+codespell
+google-cloud-bigquery
+google-cloud-bigquery-storage
+IPython
+# Newer versions of torch bring in nvidia dependencies that are not present in windows, so
+# we put this constraint while we do not have per-environment requirements files
+torch<=1.12.1
+scikit-learn
+# We maintain a separate requirements files for arm64 Macs, as per
+# https://developer.apple.com/metal/tensorflow-plugin/
+tensorflow-macos
+tensorflow-metal


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

Fixes https://github.com/flyteorg/flyte/issues/3264

# TL;DR
Special case Mac M1/2's in the case of dev environment  

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
In this PR the make targets related to the dev environment detect if the user's platform. We introduce a new dev-requirements file produced on a Mac M1.

Testing:

- [ ] need someone to run `make dev-requirements.txt` on a M1 and push a commit to this PR with the contents of the `dev-requirements-mac_arm64.txt` file.
- [ ] run `make setup` on a new venv

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3264

## Follow-up issue
_NA_
