### PR TITLE
Fix primitive decoder when evaluating Promise

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -69,7 +69,6 @@ def translate_inputs_to_literals(
         val_type: type,
         flyte_literal_type: _type_models.LiteralType,
     ) -> _literal_models.Literal:
-
         if isinstance(input_val, list):
             lt = flyte_literal_type
             python_type = val_type
@@ -142,17 +141,16 @@ def translate_inputs_to_literals(
 
 
 def get_primitive_val(prim: Primitive) -> Any:
-    if prim.integer:
-        return prim.integer
-    if prim.datetime:
-        return prim.datetime
-    if prim.boolean:
-        return prim.boolean
-    if prim.duration:
-        return prim.duration
-    if prim.string_value:
-        return prim.string_value
-    return prim.float_value
+    for value in [
+        prim.integer,
+        prim.float_value,
+        prim.string_value,
+        prim.boolean,
+        prim.datetime,
+        prim.duration,
+    ]:
+        if value is not None:
+            return value
 
 
 class ConjunctionOps(Enum):

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -71,6 +71,22 @@ def test_condition_else_fail():
         multiplier_2(my_input=10.0)
 
 
+def test_condition_else_int():
+    @workflow
+    def multiplier_3(my_input: int) -> float:
+        return (
+            conditional("fractions")
+            .if_((my_input >= 0) & (my_input < 1.0))
+            .then(double(n=my_input))
+            .elif_((my_input > 1.0) & (my_input < 10.0))
+            .then(square(n=my_input))
+            .else_()
+            .fail("The input must be between 0 and 10")
+        )
+
+    assert multiplier_3(my_input=0) == 0
+
+
 def test_condition_sub_workflows():
     @task
     def sum_div_sub(a: int, b: int) -> typing.NamedTuple("Outputs", sum=int, div=int, sub=int):


### PR DESCRIPTION
Signed-off-by: Samhita Alla <aallasamhita@gmail.com>

# TL;DR
This PR rewrites the `get_primitive_val` logic to fix condition validation when the Promise includes an integer `0`, a boolean `False` or a float `0.0`.

Slack conversation: 

> Hey all, I believe I found a small bug. LMK if there is a better channel for this. During local execution, conditionals interpret a int variable with value 0 as None.

```python
@workflow
def _impl(
    delta: int,
) -> Set[str]:
    return (
        conditional("terminal_case")
        .if_((delta != -1) & (delta <= 10))
        .then(end())
        .else_()
        .then(
            iterate()
        )
    )


def cluster_distributed() -> Set[str]:
    _impl(delta=0)
```

> Outputs an error comparing NoneType <= 10

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
When the value is validated against `None`, the function returns the correct value.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
