### PR TITLE
set maximum python version to 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,5 @@
-import sys
-
 from setuptools import find_packages, setup  # noqa
 
-MIN_PYTHON_VERSION = (3, 7)
-CURRENT_PYTHON = sys.version_info[:2]
-if CURRENT_PYTHON < MIN_PYTHON_VERSION:
-    print(
-        f"Flytekit API is only supported for Python version is {MIN_PYTHON_VERSION}+. Detected you are on"
-        f" version {CURRENT_PYTHON}, installation will not proceed!"
-    )
-    sys.exit(-1)
 
 extras_require = {}
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import find_packages, setup  # noqa
 
-
 extras_require = {}
 
 __version__ = "0.0.0+develop"

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         "flytekit/bin/entrypoint.py",
     ],
     license="apache2",
-    python_requires=">=3.7",
+    python_requires=">=3.7,<3.11",
     classifiers=[
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

# TL;DR
Fixes https://github.com/flyteorg/flyte/issues/3313, which allows users to install flytekit on python 3.11 but then come up against errors on import.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - ~~[ ] Unit tests added~~
 - ~~[ ] Code documentation added~~
 - ~~[ ] Any pending items have an associated Issue~~

## Complete description

This restriction was expressed softly in the `classifiers` tags but not programmatically enforced.

## Test Plan

- Create a python virtual environment on python 3.11 (either with `pyenv` or `miniconda`)
- Go to the `flytekit` root repo
- `pip install -e .` to do an editable install
- Expected outcome: you should see an error:
```
ERROR: Package 'flytekit' requires a different Python: 3.11.0 not in '<3.11,>=3.7'
```

## Tracking Issue
[https://github.com/flyteorg/flyte/issues/<number>](https://github.com/flyteorg/flyte/issues/3313)

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
