### PR TITLE
Support checkpointing in local mode from cached tasks

### DIFF
--- a/tests/flytekit/unit/core/test_checkpoint.py
+++ b/tests/flytekit/unit/core/test_checkpoint.py
@@ -123,5 +123,17 @@ def t1(n: int) -> int:
     return n + 1
 
 
+@flytekit.task(cache=True, cache_version="v0")
+def t2(n: int) -> int:
+    ctx = flytekit.current_context()
+    cp = ctx.checkpoint
+    cp.write(bytes(n + 1))
+    return n + 1
+
+
 def test_checkpoint_task():
     assert t1(n=5) == 6
+
+
+def test_checkpoint_cached_task():
+    assert t2(n=5) == 6

--- a/tests/flytekit/unit/core/test_checkpoint.py
+++ b/tests/flytekit/unit/core/test_checkpoint.py
@@ -4,6 +4,7 @@ import pytest
 
 import flytekit
 from flytekit.core.checkpointer import SyncCheckpoint
+from flytekit.core.local_cache import LocalTaskCache
 
 
 def test_sync_checkpoint_write(tmpdir):
@@ -129,6 +130,12 @@ def t2(n: int) -> int:
     cp = ctx.checkpoint
     cp.write(bytes(n + 1))
     return n + 1
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup():
+    LocalTaskCache.initialize()
+    LocalTaskCache.clear()
 
 
 def test_checkpoint_task():


### PR DESCRIPTION
# TL;DR
Support checkpointing in local mode from cached tasks

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Complete description
- There's an inconsistency in behavior for checkpoints between cached and uncached tasks
- Local non-cached tasks execute in a "sandbox" context, while cached tasks don't
- I added a simple repro case as a unit test
- I unified the two cases to a common base method in base_task
- Also added a comment to hopefully key future edits to use the shared code path

## Tracking Issue
_NA_

## Follow-up issue
_NA_
