### PR TITLE
Fix PyTorch transformer

### DIFF
--- a/tests/flytekit/unit/extras/pytorch/test_transformations.py
+++ b/tests/flytekit/unit/extras/pytorch/test_transformations.py
@@ -40,6 +40,7 @@ def test_get_literal_type(transformer, python_type, format):
     tf = transformer
     lt = tf.get_literal_type(python_type)
     assert lt == LiteralType(blob=BlobType(format=format, dimensionality=BlobType.BlobDimensionality.SINGLE))
+    assert tf.guess_python_type(lt) == python_type
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# TL;DR
This PR fixes type fetch for torch types.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The `guess_python_type` method has been moved to the subclasses without retaining it in the parent class. This will return the correct type when fetching the execution output via FlyteRemote.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3148

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
