### PR TITLE
Make flytekit comply with PEP-561

### DIFF
--- a/flytekit/core/map_task.py
+++ b/flytekit/core/map_task.py
@@ -221,7 +221,12 @@ class MapPythonTask(PythonTask):
         return outputs
 
 
-def map_task(task_function: PythonFunctionTask, concurrency: int = 0, min_success_ratio: float = 1.0, **kwargs):
+def map_task(
+    task_function: typing.Union[typing.Callable, PythonFunctionTask],
+    concurrency: int = 0,
+    min_success_ratio: float = 1.0,
+    **kwargs,
+):
     """
     Use a map task for parallelizable tasks that run across a list of an input type. A map task can be composed of
     any individual :py:class:`flytekit.PythonFunctionTask`.

--- a/plugins/setup.py
+++ b/plugins/setup.py
@@ -81,5 +81,5 @@ setup(
     classifiers=["Private :: Do Not Upload to pypi server"],
     install_requires=[],
     cmdclass={"install": InstallCmd, "develop": DevelopCmd},
-    package_data={'flytekit': ['py.typed']},
+    package_data={"flytekit": ["py.typed"]},
 )

--- a/plugins/setup.py
+++ b/plugins/setup.py
@@ -81,4 +81,5 @@ setup(
     classifiers=["Private :: Do Not Upload to pypi server"],
     install_requires=[],
     cmdclass={"install": InstallCmd, "develop": DevelopCmd},
+    package_data={'flytekit': ['py.typed']},
 )


### PR DESCRIPTION
# TL;DR
To make flytekit comply with [PEP-561](https://peps.python.org/pep-0561/#packaging-type-information), Add `py.typed` to the module.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
```bash
pip install git+https://github.com/flyteorg/flytekit.git@2da8e88c7113b9b8537df520addc165c030d06cd
mypy test.py
```

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2147

## Follow-up issue
_NA_