### PR TITLE
prefer FLYTE_ prefixed AWS creds env vars

### DIFF
--- a/plugins/flytekit-data-fsspec/flytekitplugins/fsspec/persist.py
+++ b/plugins/flytekit-data-fsspec/flytekitplugins/fsspec/persist.py
@@ -8,9 +8,6 @@ from flytekit.configuration import DataConfig, S3Config
 from flytekit.extend import DataPersistence, DataPersistencePlugins
 from flytekit.loggers import logger
 
-S3_ACCESS_KEY_ID_ENV_NAME = "AWS_ACCESS_KEY_ID"
-S3_SECRET_ACCESS_KEY_ENV_NAME = "AWS_SECRET_ACCESS_KEY"
-
 # Refer to https://github.com/fsspec/s3fs/blob/50bafe4d8766c3b2a4e1fc09669cf02fb2d71454/s3fs/core.py#L198
 # for key and secret
 _FSSPEC_S3_KEY_ID = "key"
@@ -19,13 +16,11 @@ _FSSPEC_S3_SECRET = "secret"
 
 def s3_setup_args(s3_cfg: S3Config):
     kwargs = {}
-    if S3_ACCESS_KEY_ID_ENV_NAME not in os.environ:
-        if s3_cfg.access_key_id:
-            kwargs[_FSSPEC_S3_KEY_ID] = s3_cfg.access_key_id
+    if s3_cfg.access_key_id:
+        kwargs[_FSSPEC_S3_KEY_ID] = s3_cfg.access_key_id
 
-    if S3_SECRET_ACCESS_KEY_ENV_NAME not in os.environ:
-        if s3_cfg.secret_access_key:
-            kwargs[_FSSPEC_S3_SECRET] = s3_cfg.secret_access_key
+    if s3_cfg.secret_access_key:
+        kwargs[_FSSPEC_S3_SECRET] = s3_cfg.secret_access_key
 
     # S3fs takes this as a special arg
     if s3_cfg.endpoint is not None:

--- a/plugins/flytekit-data-fsspec/tests/test_persist.py
+++ b/plugins/flytekit-data-fsspec/tests/test_persist.py
@@ -1,7 +1,7 @@
 import os
 import pathlib
 import tempfile
-from unittest import mock
+import mock
 
 from flytekitplugins.fsspec.persist import FSSpecPersistence, s3_setup_args
 from fsspec.implementations.local import LocalFileSystem

--- a/plugins/flytekit-data-fsspec/tests/test_persist.py
+++ b/plugins/flytekit-data-fsspec/tests/test_persist.py
@@ -1,8 +1,8 @@
 import os
 import pathlib
 import tempfile
-import mock
 
+import mock
 from flytekitplugins.fsspec.persist import FSSpecPersistence, s3_setup_args
 from fsspec.implementations.local import LocalFileSystem
 
@@ -20,34 +20,48 @@ def test_s3_setup_args():
     assert kwargs == {"key": "access"}
 
 
-def mockenv(**envvars):
-    return mock.patch.dict(os.environ, envvars, clear=True)
-
-
-@mockenv()
+@mock.patch.dict(os.environ, {}, clear=True)
 def test_s3_setup_args_env_empty():
     kwargs = s3_setup_args(S3Config.auto())
     assert kwargs == {}
 
 
-@mockenv(
-    AWS_ACCESS_KEY_ID="ignore-user",
-    AWS_SECRET_ACCESS_KEY="ignore-secret",
-    FLYTE_AWS_ACCESS_KEY_ID="flyte",
-    FLYTE_AWS_SECRET_ACCESS_KEY="flyte-secret",
+@mock.patch.dict(
+    os.environ,
+    {
+        "AWS_ACCESS_KEY_ID": "ignore-user",
+        "AWS_SECRET_ACCESS_KEY": "ignore-secret",
+        "FLYTE_AWS_ACCESS_KEY_ID": "flyte",
+        "FLYTE_AWS_SECRET_ACCESS_KEY": "flyte-secret",
+    },
+    clear=True,
 )
 def test_s3_setup_args_env_both():
     kwargs = s3_setup_args(S3Config.auto())
     assert kwargs == {"key": "flyte", "secret": "flyte-secret"}
 
 
-@mockenv(FLYTE_AWS_ACCESS_KEY_ID="flyte", FLYTE_AWS_SECRET_ACCESS_KEY="flyte-secret")
+@mock.patch.dict(
+    os.environ,
+    {
+        "FLYTE_AWS_ACCESS_KEY_ID": "flyte",
+        "FLYTE_AWS_SECRET_ACCESS_KEY": "flyte-secret",
+    },
+    clear=True,
+)
 def test_s3_setup_args_env_flyte():
     kwargs = s3_setup_args(S3Config.auto())
     assert kwargs == {"key": "flyte", "secret": "flyte-secret"}
 
 
-@mockenv(AWS_ACCESS_KEY_ID="ignore-user", AWS_SECRET_ACCESS_KEY="ignore-secret")
+@mock.patch.dict(
+    os.environ,
+    {
+        "AWS_ACCESS_KEY_ID": "ignore-user",
+        "AWS_SECRET_ACCESS_KEY": "ignore-secret",
+    },
+    clear=True,
+)
 def test_s3_setup_args_env_aws():
     kwargs = s3_setup_args(S3Config.auto())
     # not explicitly in kwargs, since fsspec/boto3 will use these env vars by default


### PR DESCRIPTION
# TL;DR
use FLYTE_AWS_ACCESS_KEY_ID and FLYTE_AWS_SECRET_ACCESS_KEY via config if they exist instead of AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY

so that user code can inject and use these default AWS creds env vars

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
flytekit will used the `AWS_ACCESS_KEY_ID` env var instead of the also existing `FLYTE_AWS_ACCESS_KEY_ID` env if the former exists in the container.... this made my task which needs to retrieve data from a different bucket with different creds (injected via secret) fail upon downloading/uploading flyte inputs/output.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
