### PR TITLE
Add back attempt to use existing serialization settings when running

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -270,8 +270,8 @@ def setup_execution(
     if compressed_serialization_settings:
         ss = SerializationSettings.from_transport(compressed_serialization_settings)
         ssb = ss.new_builder()
-        ssb.project = exe_project
-        ssb.domain = exe_domain
+        ssb.project = ssb.project or exe_project
+        ssb.domain = ssb.domain or exe_domain
         ssb.version = tk_version
         if dynamic_addl_distro:
             ssb.fast_serialization_settings = FastSerializationSettings(

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -11,6 +11,7 @@ from flytekit.core import context_manager
 from flytekit.core.base_task import IgnoreOutputs
 from flytekit.core.data_persistence import DiskPersistence
 from flytekit.core.dynamic_workflow_task import dynamic
+from flytekit.configuration import Image, ImageConfig, SerializationSettings
 from flytekit.core.promise import VoidPromise
 from flytekit.core.task import task
 from flytekit.core.type_engine import TypeEngine
@@ -308,6 +309,22 @@ def test_dispatch_execute_system_error(mock_write_to_file, mock_upload_dir, mock
         assert ed.error.kind == error_models.ContainerError.Kind.RECOVERABLE
         assert "some system exception" in ed.error.message
         assert ed.error.origin == execution_models.ExecutionError.ErrorKind.SYSTEM
+
+
+def test_persist_ss():
+    default_img = Image(name="default", fqn="test", tag="tag")
+    ss = SerializationSettings(
+        project="proj1",
+        domain="dom",
+        version="version123",
+        env=None,
+        image_config=ImageConfig(default_image=default_img, images=[default_img]),
+    )
+    ss_txt = ss.serialized_context
+    os.environ["_F_SS_C"] = ss_txt
+    with setup_execution("s3://", checkpoint_path=None, prev_checkpoint=None) as ctx:
+        assert ctx.serialization_settings.project == "proj1"
+        assert ctx.serialization_settings.domain == "dom"
 
 
 def test_setup_disk_prefix():

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -7,11 +7,11 @@ import pytest
 from flyteidl.core.errors_pb2 import ErrorDocument
 
 from flytekit.bin.entrypoint import _dispatch_execute, normalize_inputs, setup_execution
+from flytekit.configuration import Image, ImageConfig, SerializationSettings
 from flytekit.core import context_manager
 from flytekit.core.base_task import IgnoreOutputs
 from flytekit.core.data_persistence import DiskPersistence
 from flytekit.core.dynamic_workflow_task import dynamic
-from flytekit.configuration import Image, ImageConfig, SerializationSettings
 from flytekit.core.promise import VoidPromise
 from flytekit.core.task import task
 from flytekit.core.type_engine import TypeEngine


### PR DESCRIPTION
# TL;DR
This PR is in response to https://github.com/flyteorg/flyte/issues/3169 which was incorrectly patched in https://github.com/flyteorg/flytekit/pull/1378 and later reverted in https://github.com/flyteorg/flytekit/pull/1460 because of 
https://github.com/flyteorg/flyte/issues/3324

This is still not the complete fix.  For that we need to enable `flytectl` to update the serialized context.  (which means we'll probably make serialization settings a protobuf object.) 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
This was tested with the test case in https://github.com/flyteorg/flyte/issues/3324 and the failure case repro'ed with [this branch](https://github.com/flyteorg/flytekit/blob/cb35b8e5518d178c5f353c20caa98282d3d44044/flytekit/bin/entrypoint.py#L273).

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3169
