### PR TITLE
Revert "Make flytekit comply with PEP-561 (#1516)"

### DIFF
--- a/flytekit/core/map_task.py
+++ b/flytekit/core/map_task.py
@@ -221,12 +221,7 @@ class MapPythonTask(PythonTask):
         return outputs
 
 
-def map_task(
-    task_function: typing.Union[typing.Callable, PythonFunctionTask],
-    concurrency: int = 0,
-    min_success_ratio: float = 1.0,
-    **kwargs,
-):
+def map_task(task_function: PythonFunctionTask, concurrency: int = 0, min_success_ratio: float = 1.0, **kwargs):
     """
     Use a map task for parallelizable tasks that run across a list of an input type. A map task can be composed of
     any individual :py:class:`flytekit.PythonFunctionTask`.

--- a/plugins/setup.py
+++ b/plugins/setup.py
@@ -84,5 +84,4 @@ setup(
     classifiers=["Private :: Do Not Upload to pypi server"],
     install_requires=[],
     cmdclass={"install": InstallCmd, "develop": DevelopCmd},
-    package_data={"flytekit": ["py.typed"]},
 )


### PR DESCRIPTION
This reverts commit b3ad1584b210f145030b121ecbe953bb018eca4c.

# TL;DR
The public flytekit decorators are not ready yet for public consumption

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
