### PR TITLE
Failed to initialize FlyteInvalidInputException

### DIFF
--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -93,4 +93,4 @@ class FlyteInvalidInputException(FlyteUserException):
 
     def __init__(self, request: typing.Any):
         self.request = request
-        super(self).__init__()
+        super().__init__()


### PR DESCRIPTION
# TL;DR
Failed to initialize FlyteInvalidInputException. should not use `self` in `super()`
```bash
Failed with Unknown Exception <class 'TypeError'> Reason: super() argument 1 must be type, not FlyteInvalidInputException
super() argument 1 must be type, not FlyteInvalidInputException
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
NA

## Follow-up issue
_NA_