### PR TITLE
Pass locally defined scopes to RemoteClientConfigStore

### DIFF
--- a/flytekit/clients/auth/authenticator.py
+++ b/flytekit/clients/auth/authenticator.py
@@ -164,12 +164,14 @@ class ClientCredentialsAuthenticator(Authenticator):
         client_secret: str,
         cfg_store: ClientConfigStore,
         header_key: str = None,
+        scopes: typing.List[str] = None,
     ):
         if not client_id or not client_secret:
             raise ValueError("Client ID and Client SECRET both are required.")
         cfg = cfg_store.get_client_config()
         self._token_endpoint = cfg.token_endpoint
-        self._scopes = cfg.scopes
+        # Use scopes from `flytekit.configuration.PlatformConfig` if passed
+        self._scopes = scopes or cfg.scopes
         self._client_id = client_id
         self._client_secret = client_secret
         super().__init__(endpoint, cfg.header_key or header_key)

--- a/flytekit/clients/auth/authenticator.py
+++ b/flytekit/clients/auth/authenticator.py
@@ -164,7 +164,7 @@ class ClientCredentialsAuthenticator(Authenticator):
         client_secret: str,
         cfg_store: ClientConfigStore,
         header_key: str = None,
-        scopes: typing.List[str] = None,
+        scopes: typing.Optional[typing.List[str]] = None,
     ):
         if not client_id or not client_secret:
             raise ValueError("Client ID and Client SECRET both are required.")

--- a/flytekit/clients/auth/authenticator.py
+++ b/flytekit/clients/auth/authenticator.py
@@ -163,7 +163,7 @@ class ClientCredentialsAuthenticator(Authenticator):
         client_id: str,
         client_secret: str,
         cfg_store: ClientConfigStore,
-        header_key: str = None,
+        header_key: typing.Optional[str] = None,
         scopes: typing.Optional[typing.List[str]] = None,
     ):
         if not client_id or not client_secret:

--- a/flytekit/clients/auth_helper.py
+++ b/flytekit/clients/auth_helper.py
@@ -69,6 +69,7 @@ def get_authenticator(cfg: PlatformConfig, cfg_store: ClientConfigStore) -> Auth
             client_id=cfg.client_id,
             client_secret=cfg.client_credentials_secret,
             cfg_store=cfg_store,
+            scopes=cfg.scopes,
         )
     elif cfg_auth == AuthType.EXTERNAL_PROCESS or cfg_auth == AuthType.EXTERNALCOMMAND:
         client_cfg = None

--- a/tests/flytekit/unit/clients/auth/test_authenticator.py
+++ b/tests/flytekit/unit/clients/auth/test_authenticator.py
@@ -102,7 +102,11 @@ def test_client_creds_authenticator_without_custom_scopes(mock_requests):
 def test_client_creds_authenticator_with_custom_scopes(mock_requests):
     expected_scopes = ["foo", "baz"]
     authn = ClientCredentialsAuthenticator(
-        ENDPOINT, client_id="client", client_secret="secret", cfg_store=static_cfg_store, scopes=expected_scopes,
+        ENDPOINT,
+        client_id="client",
+        client_secret="secret",
+        cfg_store=static_cfg_store,
+        scopes=expected_scopes,
     )
     response = MagicMock()
     response.status_code = 200

--- a/tests/flytekit/unit/clients/auth/test_authenticator.py
+++ b/tests/flytekit/unit/clients/auth/test_authenticator.py
@@ -82,7 +82,7 @@ def test_get_token(mock_requests):
 
 
 @patch("flytekit.clients.auth.authenticator.requests")
-def test_client_creds_authenticator(mock_requests):
+def test_client_creds_authenticator_without_custom_scopes(mock_requests):
     authn = ClientCredentialsAuthenticator(
         ENDPOINT, client_id="client", client_secret="secret", cfg_store=static_cfg_store
     )
@@ -92,4 +92,23 @@ def test_client_creds_authenticator(mock_requests):
     response.json.return_value = json.loads("""{"access_token": "abc", "expires_in": 60}""")
     mock_requests.post.return_value = response
     authn.refresh_credentials()
+    expected_scopes = static_cfg_store.get_client_config().scopes
+
     assert authn._creds
+    assert authn._scopes == expected_scopes
+
+
+@patch("flytekit.clients.auth.authenticator.requests")
+def test_client_creds_authenticator_with_custom_scopes(mock_requests):
+    expected_scopes = ["foo", "baz"]
+    authn = ClientCredentialsAuthenticator(
+        ENDPOINT, client_id="client", client_secret="secret", cfg_store=static_cfg_store, scopes=expected_scopes,
+    )
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = json.loads("""{"access_token": "abc", "expires_in": 60}""")
+    mock_requests.post.return_value = response
+    authn.refresh_credentials()
+
+    assert authn._creds
+    assert authn._scopes == expected_scopes


### PR DESCRIPTION
# TL;DR
This PR fixes a bug in the auth mechanism where locally defined `scopes` are ignored and the ones defined in the admin are always used.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
If `scopes` are locally defined, use those for auth. This mirrors the reference implementation [here](https://github.com/flyteorg/flyteidl/blob/e1a667ef2536bbfc61331490b5417404f45ddc0b/clients/go/admin/token_source_provider.go#L67).

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3486

## Follow-up issue

