### PR TITLE
move FlyteSchema deprecation warning to initialization method

### DIFF
--- a/flytekit/types/schema/types.py
+++ b/flytekit/types/schema/types.py
@@ -186,7 +186,6 @@ class FlyteSchema(object):
     """
     This is the main schema class that users should use.
     """
-    logger.warning("FlyteSchema is deprecated, use Structured Dataset instead.")
 
     @classmethod
     def columns(cls) -> typing.Dict[str, typing.Type]:
@@ -240,6 +239,7 @@ class FlyteSchema(object):
         supported_mode: SchemaOpenMode = SchemaOpenMode.WRITE,
         downloader: typing.Optional[typing.Callable] = None,
     ):
+        logger.warning("FlyteSchema is deprecated, use Structured Dataset instead.")
         if supported_mode == SchemaOpenMode.READ and remote_path is None:
             raise ValueError("To create a FlyteSchema in read mode, remote_path is required")
         if (

--- a/flytekit/types/schema/types.py
+++ b/flytekit/types/schema/types.py
@@ -202,6 +202,7 @@ class FlyteSchema(object):
     def __class_getitem__(
         cls, columns: typing.Dict[str, typing.Type], fmt: SchemaFormat = SchemaFormat.PARQUET
     ) -> Type[FlyteSchema]:
+        logger.warning("FlyteSchema is deprecated, use Structured Dataset instead.")
         if columns is None:
             return FlyteSchema
 


### PR DESCRIPTION
# TL;DR

This moves the FlyteSchema deprcation message from a global warning to only get logged when a user initializes the FlyteSchema class or uses `FlyteSchema[TYPE]` in their code.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

The global warning throws new users off, especially since they are (probably) not even using or aware of FlyteSchema.

## Tracking Issue
NA

## Follow-up issue
_NA_
