### PR TITLE
Python run multiple files

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -471,13 +471,6 @@ def load_naive_entity(module_name: str, entity_name: str, project_root: str) -> 
     return module_loader.load_object_from_module(f"{module_name}.{entity_name}")
 
 
-def get_module(module_name: str, project_root: str):
-    flyte_ctx_builder = context_manager.FlyteContextManager.current_context().new_builder()
-    with context_manager.FlyteContextManager.with_context(flyte_ctx_builder):
-        with module_loader.add_sys_path(project_root):
-            return importlib.import_module(module_name)
-
-
 def dump_flyte_remote_snippet(execution: FlyteWorkflowExecution, project: str, domain: str):
     click.secho(
         f"""

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -467,7 +467,7 @@ def load_naive_entity(module_name: str, entity_name: str, project_root: str) -> 
     flyte_ctx_builder = context_manager.FlyteContextManager.current_context().new_builder()
     with context_manager.FlyteContextManager.with_context(flyte_ctx_builder):
         with module_loader.add_sys_path(project_root):
-            m = importlib.import_module(module_name)
+            importlib.import_module(module_name)
     return module_loader.load_object_from_module(f"{module_name}.{entity_name}")
 
 

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -468,8 +468,14 @@ def load_naive_entity(module_name: str, entity_name: str, project_root: str) -> 
     with context_manager.FlyteContextManager.with_context(flyte_ctx_builder):
         with module_loader.add_sys_path(project_root):
             m = importlib.import_module(module_name)
-            print(m)
     return module_loader.load_object_from_module(f"{module_name}.{entity_name}")
+
+
+def get_module(module_name: str, project_root: str):
+    flyte_ctx_builder = context_manager.FlyteContextManager.current_context().new_builder()
+    with context_manager.FlyteContextManager.with_context(flyte_ctx_builder):
+        with module_loader.add_sys_path(project_root):
+            return importlib.import_module(module_name)
 
 
 def dump_flyte_remote_snippet(execution: FlyteWorkflowExecution, project: str, domain: str):

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -467,7 +467,8 @@ def load_naive_entity(module_name: str, entity_name: str, project_root: str) -> 
     flyte_ctx_builder = context_manager.FlyteContextManager.current_context().new_builder()
     with context_manager.FlyteContextManager.with_context(flyte_ctx_builder):
         with module_loader.add_sys_path(project_root):
-            importlib.import_module(module_name)
+            m = importlib.import_module(module_name)
+            print(m)
     return module_loader.load_object_from_module(f"{module_name}.{entity_name}")
 
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import base64
 import hashlib
-import importlib
 import os
 import pathlib
 import tempfile
@@ -34,7 +33,6 @@ from flytekit.core.data_persistence import FileAccessProvider
 from flytekit.core.launch_plan import LaunchPlan
 from flytekit.core.python_auto_container import PythonAutoContainerTask
 from flytekit.core.reference_entity import ReferenceSpec
-from flytekit.core.tracker import get_full_module_path
 from flytekit.core.type_engine import LiteralsResolver, TypeEngine
 from flytekit.core.workflow import WorkflowBase
 from flytekit.exceptions import user as user_exceptions

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -70,7 +70,7 @@ from flytekit.remote.interface import TypedInterface
 from flytekit.remote.lazy_entity import LazyEntity
 from flytekit.remote.remote_callable import RemoteEntity
 from flytekit.tools.fast_registration import fast_package
-from flytekit.tools.script_mode import compress_single_script, hash_file
+from flytekit.tools.script_mode import compress_scripts, hash_file
 from flytekit.tools.translator import (
     FlyteControlPlaneEntity,
     FlyteLocalEntity,
@@ -821,8 +821,7 @@ class FlyteRemote(object):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             archive_fname = pathlib.Path(os.path.join(tmp_dir, "script_mode.tar.gz"))
-            mod = importlib.import_module(module_name)
-            compress_single_script(source_path, str(archive_fname), get_full_module_path(mod, mod.__name__))
+            compress_scripts(source_path, str(archive_fname), module_name)
             md5_bytes, upload_native_url = self._upload_file(
                 archive_fname, project or self.default_project, domain or self.default_domain
             )

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -1,16 +1,12 @@
 import gzip
 import hashlib
 import importlib
-import inspect
 import os
 import shutil
-import sys
 import tarfile
 import tempfile
 import typing
 from pathlib import Path
-from time import sleep
-from types import ModuleType
 
 from flytekit import PythonFunctionTask
 from flytekit.core.tracker import get_full_module_path

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -58,7 +58,7 @@ def copy_module_to_destination(
     original_source_path: str, original_destination_path: str, module_name: str, visited: typing.List[str]
 ):
     """
-    Copy the module (file) to the destination directory. If the module relative import other modules, flytekit will
+    Copy the module (file) to the destination directory. If the module relative imports other modules, flytekit will
     recursively copy them as well.
     """
     mod = importlib.import_module(module_name)

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -57,6 +57,10 @@ def compress_scripts(source_path: str, destination: str, module_name: str):
 def copy_module_to_destination(
     original_source_path: str, original_destination_path: str, module_name: str, visited: typing.List[str]
 ):
+    """
+    Copy the module (file) to the destination directory. If the module relative import other modules, flytekit will
+    recursively copy them as well.
+    """
     mod = importlib.import_module(module_name)
     full_module_name = get_full_module_path(mod, mod.__name__)
     if full_module_name in visited:

--- a/tests/flytekit/unit/tools/test_script_mode.py
+++ b/tests/flytekit/unit/tools/test_script_mode.py
@@ -61,7 +61,6 @@ def test_deterministic_hash(tmp_path):
     print(workflows_dir)
     sys.path.append(str(workflows_dir.parent))
     compress_scripts(str(workflows_dir.parent), str(destination), "workflows.hello_world")
-    print(f"{os.listdir(tmp_path)}")
 
     digest, hex_digest = hash_file(destination)
 

--- a/tests/flytekit/unit/tools/test_script_mode.py
+++ b/tests/flytekit/unit/tools/test_script_mode.py
@@ -1,11 +1,36 @@
 import os
+import subprocess
+import sys
 
-from flytekit.tools.script_mode import compress_single_script, hash_file
+from flytekit.tools.script_mode import compress_scripts, hash_file
 
-WORKFLOW = """
+MAIN_WORKFLOW = """
+from flytekit import task, workflow
+from wf1.test import t1
+
 @workflow
 def my_wf() -> str:
     return "hello world"
+"""
+
+T1_TASK = """
+from flytekit import task
+from wf2.test import t2
+
+
+@task()
+def t1() -> str:
+    print("hello")
+    return "hello"
+"""
+
+T2_TASK = """
+from flytekit import task
+
+@task()
+def t2() -> str:
+    print("hello")
+    return "hello"
 """
 
 
@@ -17,19 +42,43 @@ def test_deterministic_hash(tmp_path):
     open(workflows_dir / "__init__.py", "a").close()
     # Write a dummy workflow
     workflow_file = workflows_dir / "hello_world.py"
-    workflow_file.write_text(WORKFLOW)
+    workflow_file.write_text(MAIN_WORKFLOW)
+
+    t1_dir = tmp_path / "wf1"
+    t1_dir.mkdir()
+    open(t1_dir / "__init__.py", "a").close()
+    t1_file = t1_dir / "test.py"
+    t1_file.write_text(T1_TASK)
+
+    t2_dir = tmp_path / "wf2"
+    t2_dir.mkdir()
+    open(t2_dir / "__init__.py", "a").close()
+    t2_file = t2_dir / "test.py"
+    t2_file.write_text(T2_TASK)
 
     destination = tmp_path / "destination"
 
-    compress_single_script(workflows_dir, destination, "hello_world")
+    print(workflows_dir)
+    sys.path.append(str(workflows_dir.parent))
+    compress_scripts(str(workflows_dir.parent), str(destination), "workflows.hello_world")
     print(f"{os.listdir(tmp_path)}")
 
     digest, hex_digest = hash_file(destination)
 
     # Try again to assert digest determinism
     destination2 = tmp_path / "destination2"
-    compress_single_script(workflows_dir, destination2, "hello_world")
+    compress_scripts(str(workflows_dir.parent), str(destination2), "workflows.hello_world")
     digest2, hex_digest2 = hash_file(destination)
 
     assert digest == digest2
     assert hex_digest == hex_digest2
+
+    test_dir = tmp_path / "test"
+    test_dir.mkdir()
+
+    result = subprocess.run(
+        ["tar", "-xvf", destination, "-C", test_dir],
+        stdout=subprocess.PIPE,
+    )
+    result.check_returncode()
+    assert len(next(os.walk(test_dir))[1]) == 3


### PR DESCRIPTION
# TL;DR
Add support uploading multiple files if needed when using pyflyte run.

Consider the following example, we should copy `main.py`, `t1.py`, `t2.py` to the destination. 

`compress_scripts` will do 
1. copy the script to destination.
2. import module (script).
3. Iterate all the module in this script.
4. recursively run `compress_scripts()` if import flyte entity from other file.

Source:
```
├── __init__.py
├── other.py
├── wf1
│   ├── __init__.py
│   ├── main.py # import t1
│   └── t1.py # import t2
└── wf2
    ├── __init__.py
    └── t2.py
    └── t3.py
    └── t4.py
```
Destination:
```
├── __init__.py
├── wf1
│   ├── __init__.py
│   ├── main.py
│   └── t1.py
└── wf2
    ├── __init__.py
    └── t2.py
```

All of the below commands work for me
```bash
pyflyte run --remote root/wf1/main.py wf
pyflyte run --remote wf1/main.py wf
pyflyte run --remote main.py wf
```


## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
<img width="1858" alt="image" src="https://user-images.githubusercontent.com/37936015/227075228-ff3c07ed-ac3a-4286-8466-b6481921c059.png">

## Tracking Issue
_NA_

## Follow-up issue
_NA_
