### PR TITLE
Remove flytekit-fsspec plugin from default dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,6 @@ RUN apt-get update && apt-get install build-essential -y
 RUN pip install -U flytekit==$VERSION \
 	flytekitplugins-pod==$VERSION \
 	flytekitplugins-deck-standard==$VERSION \
-	flytekitplugins-data-fsspec[aws]==$VERSION \
-	flytekitplugins-data-fsspec[gcp]==$VERSION \
 	scikit-learn
 
 RUN useradd -u 1000 flytekit


### PR DESCRIPTION
# TL;DR
This plugin is no longer needed as the functionality has been moved into flytekit core.

