### PR TITLE
Support URLs in API Keys

### DIFF
--- a/flytekit/clients/auth_helper.py
+++ b/flytekit/clients/auth_helper.py
@@ -68,21 +68,28 @@ def get_authenticator(cfg: PlatformConfig, cfg_store: ClientConfigStore) -> Auth
             logging.warning(f"Authentication type {cfg_auth} does not exist, defaulting to standard")
             cfg_auth = AuthType.STANDARD
 
+    verify = None
+    if cfg.insecure_skip_verify:
+        verify = False
+    elif cfg.ca_cert_file_path:
+        verify = cfg.ca_cert_file_path
+
     if cfg_auth == AuthType.APIKEY:
         api_key = decode_api_key(cfg.api_key)
+        if api_key["url"] is not None and api_key["url"] != "":
+            endpoint = api_key["url"]
+        else:
+            endpoint = cfg.endpoint
+
         return ClientCredentialsAuthenticator(
-            endpoint=cfg.endpoint,
+            endpoint=endpoint,
             client_id=api_key["client_id"],
             client_secret=api_key["client_secret"],
             cfg_store=cfg_store,
             scopes=cfg.scopes,
+            verify=verify,
         )
     elif cfg_auth == AuthType.STANDARD or cfg_auth == AuthType.PKCE:
-        verify = None
-        if cfg.insecure_skip_verify:
-            verify = False
-        elif cfg.ca_cert_file_path:
-            verify = cfg.ca_cert_file_path
         return PKCEAuthenticator(cfg.endpoint, cfg_store, verify=verify)
     elif cfg_auth == AuthType.BASIC or cfg_auth == AuthType.CLIENT_CREDENTIALS or cfg_auth == AuthType.CLIENTSECRET:
         return ClientCredentialsAuthenticator(
@@ -91,6 +98,7 @@ def get_authenticator(cfg: PlatformConfig, cfg_store: ClientConfigStore) -> Auth
             client_secret=cfg.client_credentials_secret,
             cfg_store=cfg_store,
             scopes=cfg.scopes,
+            verify=verify,
         )
     elif cfg_auth == AuthType.EXTERNAL_PROCESS or cfg_auth == AuthType.EXTERNALCOMMAND:
         client_cfg = None

--- a/flytekit/clients/auth_helper.py
+++ b/flytekit/clients/auth_helper.py
@@ -19,7 +19,7 @@ from flytekit.clients.auth.authenticator import (
 )
 from flytekit.clients.grpc_utils.auth_interceptor import AuthUnaryInterceptor
 from flytekit.clients.grpc_utils.wrap_exception_interceptor import RetryExceptionWrapperInterceptor
-from flytekit.configuration import AuthType, PlatformConfig
+from flytekit.configuration import AuthType, PlatformConfig, decode_api_key
 
 
 class RemoteClientConfigStore(ClientConfigStore):
@@ -45,15 +45,6 @@ class RemoteClientConfigStore(ClientConfigStore):
             scopes=public_client_config.scopes,
             header_key=public_client_config.authorization_metadata_key or None,
         )
-
-
-def decode_api_key(api_key: str) -> dict:
-    """
-    Decodes the api key from base64
-    """
-    decoded = base64.b64decode(api_key).decode("utf-8")
-    # json unmarshal the decoded string
-    return json.loads(decoded)
 
 
 def get_authenticator(cfg: PlatformConfig, cfg_store: ClientConfigStore) -> Authenticator:

--- a/flytekit/clis/sdk_in_container/helpers.py
+++ b/flytekit/clis/sdk_in_container/helpers.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import replace
 from typing import Optional
 
@@ -26,7 +27,8 @@ def get_and_save_remote_with_click_context(
     """
     cfg_file_location = ctx.obj.get(CTX_CONFIG_FILE)
     cfg_file = get_config_file(cfg_file_location)
-    if cfg_file is None:
+    api_key = os.environ.get("FLYTE_CREDENTIALS_API_KEY")
+    if cfg_file is None and (api_key is None or api_key == ""):
         cfg_obj = Config.for_sandbox()
         cli_logger.info("No config files found, creating remote with sandbox config")
     else:

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -427,12 +427,12 @@ class PlatformConfig(object):
         if api_key is not None:
             kwargs["auth_mode"] = AuthType.APIKEY
 
-        if "url" in api_key:
+        if api_key is not None and "url" in api_key:
             kwargs["endpoint"] = api_key["url"]
         else:
             kwargs = set_if_exists(kwargs, "endpoint", _internal.Platform.URL.read(config_file))
 
-        if "client_id" in api_key:
+        if api_key and "client_id" in api_key:
             kwargs["client_id"] = api_key["client_id"]
         else:
             kwargs = set_if_exists(kwargs, "client_id", _internal.Credentials.CLIENT_ID.read(config_file))

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -134,6 +134,7 @@ import base64
 import datetime
 import enum
 import gzip
+import json
 import os
 import pathlib
 import re
@@ -348,6 +349,15 @@ class AuthType(enum.Enum):
     APIKEY = "ApiKey"
 
 
+def decode_api_key(api_key: str) -> dict:
+    """
+    Decodes the api key from base64
+    """
+    decoded = base64.b64decode(api_key).decode("utf-8")
+    # json unmarshal the decoded string
+    return json.loads(decoded)
+
+
 @dataclass(init=True, repr=True, eq=True, frozen=True)
 class PlatformConfig(object):
     """
@@ -398,46 +408,56 @@ class PlatformConfig(object):
         kwargs = set_if_exists(kwargs, "command", _internal.Credentials.COMMAND.read(config_file))
 
         api_key_location = _internal.Credentials.API_KEY_LOCATION.read(config_file)
-        api_key_set = False
-        if _exists(api_key_location):
+        api_key_str = _internal.Credentials.API_KEY.read(config_file)
+        if _exists(api_key_str):
+            logger.info(f"Using API Key from config/env.")
+            kwargs["api_key"] = api_key_str
+        elif _exists(api_key_location):
             api_key_str = read_file_if_exists(
                 _internal.Credentials.API_KEY_LOCATION.read(config_file)
             )
 
             logger.info(f"Using API Key from file [{api_key_location}].")
             kwargs["api_key"] = api_key_str
-            api_key_set = True
 
-        api_key = _internal.Credentials.API_KEY.read(config_file)
-        if _exists(api_key):
-            logger.info(f"Using API Key from config/env.")
-            kwargs["api_key"] = api_key
-            api_key_set = True
+        api_key: dict = None
+        if api_key_str is not None and api_key_str != "":
+            api_key = decode_api_key(api_key_str)
 
-        kwargs = set_if_exists(kwargs, "client_id", _internal.Credentials.CLIENT_ID.read(config_file))
-        kwargs = set_if_exists(
-            kwargs, "client_credentials_secret", _internal.Credentials.CLIENT_CREDENTIALS_SECRET.read(config_file)
-        )
+        if api_key is not None:
+            kwargs["auth_mode"] = AuthType.APIKEY
 
-        client_credentials_secret = read_file_if_exists(
-            _internal.Credentials.CLIENT_CREDENTIALS_SECRET_LOCATION.read(config_file)
-        )
-        if client_credentials_secret and client_credentials_secret.endswith("\n"):
-            logger.info("Newline stripped from client secret")
-            client_credentials_secret = client_credentials_secret.strip()
-        kwargs = set_if_exists(
-            kwargs,
-            "client_credentials_secret",
-            client_credentials_secret,
-        )
+        if "url" in api_key:
+            kwargs["endpoint"] = api_key["url"]
+        else:
+            kwargs = set_if_exists(kwargs, "endpoint", _internal.Platform.URL.read(config_file))
+
+        if "client_id" in api_key:
+            kwargs["client_id"] = api_key["client_id"]
+        else:
+            kwargs = set_if_exists(kwargs, "client_id", _internal.Credentials.CLIENT_ID.read(config_file))
+            kwargs = set_if_exists(
+                kwargs, "client_credentials_secret", _internal.Credentials.CLIENT_CREDENTIALS_SECRET.read(config_file)
+            )
+
+            client_credentials_secret = read_file_if_exists(
+                _internal.Credentials.CLIENT_CREDENTIALS_SECRET_LOCATION.read(config_file)
+            )
+            if client_credentials_secret and client_credentials_secret.endswith("\n"):
+                logger.info("Newline stripped from client secret")
+                client_credentials_secret = client_credentials_secret.strip()
+            kwargs = set_if_exists(
+                kwargs,
+                "client_credentials_secret",
+                client_credentials_secret,
+            )
 
         kwargs = set_if_exists(kwargs, "scopes", _internal.Credentials.SCOPES.read(config_file))
         auth_mode = _internal.Credentials.AUTH_MODE.read(config_file)
         kwargs = set_if_exists(kwargs, "auth_mode", auth_mode)
         # default to APIKEY if it's set and no auth_mode is set
-        if not _exists(auth_mode) and api_key_set:
+        if not _exists(auth_mode) and api_key_str is not None and api_key_str != "":
             kwargs["auth_mode"] = AuthType.APIKEY
-        kwargs = set_if_exists(kwargs, "endpoint", _internal.Platform.URL.read(config_file))
         kwargs = set_if_exists(kwargs, "console_endpoint", _internal.Platform.CONSOLE_ENDPOINT.read(config_file))
         return PlatformConfig(**kwargs)
 


### PR DESCRIPTION
# TL;DR
Adds support for URLs within API Keys to remove the need for a config file entirely.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

This PR builds on the work in #1569. It adds another key in the encoded API Key (endpoint) to make it possible to get rid of the config file entirely for simple use-cases.

```bash
echo '{"client_id":"abc","client_secret":"def","url":"my-endpoint.com"}' | base64

FLYTE_CREDENTIALS_API_KEY=eyJjbGllbnRfaWQiOiJhYmMiLCJjbGllbnRfc2VjcmV0IjoiZGVmIiwidXJsIjoibXktZW5kcG9pbnQuY29tIn0K pyflyte run --remote my_wp.py wf
```

### Minor fixes:
- [X] Pass `verify` options (for SSL) to other authentication providers not just PKCE
- [X] If an APIKey is set as an env var and no config file exist, do not assume it's sandbox cluster

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
