### PR TITLE
Automatically remove unused import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ setup: install-piptools ## Install requirements
 
 .PHONY: fmt
 fmt: ## Format code with black and isort
-	autoflake --remove-all-unused-imports --ignore-init-module-imports --ignore-pass-after-docstring --in-place -r flytekit/ plugins tests
+	autoflake --remove-all-unused-imports --ignore-init-module-imports --ignore-pass-after-docstring --in-place -r flytekit plugins tests
 	pre-commit run black --all-files || true
 	pre-commit run isort --all-files || true
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ setup: install-piptools ## Install requirements
 
 .PHONY: fmt
 fmt: ## Format code with black and isort
+	autoflake --remove-all-unused-imports --ignore-init-module-imports --ignore-pass-after-docstring --in-place -r flytekit/ plugins tests
 	pre-commit run black --all-files || true
 	pre-commit run isort --all-files || true
 

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -29,3 +29,4 @@ scikit-learn
 types-protobuf
 types-croniter
 types-mock
+autoflake

--- a/flytekit/clis/flyte_cli/main.py
+++ b/flytekit/clis/flyte_cli/main.py
@@ -1167,7 +1167,6 @@ def terminate_execution(host, insecure, cause, urn=None):
                 raise _click.UsageError('Missing option "-u" / "--urn" or missing pipe inputs.')
         except KeyboardInterrupt:
             _sys.stdout.flush()
-            pass
     else:
         _terminate_one_execution(client, urn, cause)
 

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -91,7 +91,6 @@ class TrackedInstance(metaclass=InstanceTrackingMeta):
                 # Since dataframes aren't registrable entities to begin with we swallow any errors they raise and
                 # continue looping through m.
                 logger.warning("Caught ValueError {} while attempting to auto-assign name".format(err))
-                pass
 
         logger.error(f"Could not find LHS for {self} in {self._instantiated_in}")
         raise _system_exceptions.FlyteSystemException(f"Error looking for LHS in {self._instantiated_in}")


### PR DESCRIPTION
# TL;DR
Add `autoflake` to `make fmt`, it can remove unused import. 
https://pypi.org/project/autoflake/

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_

