### PR TITLE
Remove duplicate reporting logic

### DIFF
--- a/flytekit/tools/serialize_helpers.py
+++ b/flytekit/tools/serialize_helpers.py
@@ -48,14 +48,18 @@ def _find_duplicate_tasks(tasks: typing.List[task_models.TaskSpec]) -> typing.Se
     """
     Given a list of `TaskSpec`, this function returns a set containing the duplicated `TaskSpec` if any exists.
     """
-    seen: typing.Set[_identifier.Identifier] = set()
-    duplicate_tasks: typing.Set[task_models.TaskSpec] = set()
+    seen: typing.Dict[_identifier. Identifier, task_models.TaskSpec] = {}
+    duplicate_tasks: typing.Dict[_identifier. Identifier, task_models.TaskSpec] = {}
     for task in tasks:
         if task.template.id not in seen:
-            seen.add(task.template.id)
+            seen[task.template.id] = task
         else:
-            duplicate_tasks.add(task)
-    return duplicate_tasks
+            existing = seen[task.template.id]
+            if existing != task:
+                duplicate_tasks[task.template.id] = task
+            else:
+                print("duplicate but same")
+    return set(list(duplicate_tasks.values()))
 
 
 def get_registrable_entities(

--- a/flytekit/tools/serialize_helpers.py
+++ b/flytekit/tools/serialize_helpers.py
@@ -44,24 +44,6 @@ def _should_register_with_admin(entity) -> bool:
     ) and not isinstance(entity, RemoteEntity)
 
 
-def _find_duplicate_tasks(tasks: typing.List[task_models.TaskSpec]) -> typing.Set[task_models.TaskSpec]:
-    """
-    Given a list of `TaskSpec`, this function returns a set containing the duplicated `TaskSpec` if any exists.
-    """
-    seen: typing.Dict[_identifier. Identifier, task_models.TaskSpec] = {}
-    duplicate_tasks: typing.Dict[_identifier. Identifier, task_models.TaskSpec] = {}
-    for task in tasks:
-        if task.template.id not in seen:
-            seen[task.template.id] = task
-        else:
-            existing = seen[task.template.id]
-            if existing != task:
-                duplicate_tasks[task.template.id] = task
-            else:
-                print("duplicate but same")
-    return set(list(duplicate_tasks.values()))
-
-
 def get_registrable_entities(
     ctx: flyte_context.FlyteContext, options: typing.Optional[Options] = None
 ) -> typing.List[FlyteControlPlaneEntity]:
@@ -85,16 +67,6 @@ def get_registrable_entities(
     serializable_tasks: typing.List[task_models.TaskSpec] = [
         entity for entity in entities_to_be_serialized if isinstance(entity, task_models.TaskSpec)
     ]
-    # Detect if any of the tasks is duplicated. Duplicate tasks are defined as having the same
-    # metadata identifiers (see :py:class:`flytekit.common.core.identifier.Identifier`). Duplicate
-    # tasks are considered invalid at registration
-    # time and usually indicate user error, so we catch this common mistake at serialization time.
-    duplicate_tasks = _find_duplicate_tasks(serializable_tasks)
-    if len(duplicate_tasks) > 0:
-        duplicate_task_names = [task.template.id.name for task in duplicate_tasks]
-        raise FlyteValidationException(
-            f"Multiple definitions of the following tasks were found: {duplicate_task_names}"
-        )
 
     return entities_to_be_serialized
 

--- a/flytekit/tools/serialize_helpers.py
+++ b/flytekit/tools/serialize_helpers.py
@@ -10,12 +10,10 @@ from flytekit import LaunchPlan
 from flytekit.core import context_manager as flyte_context
 from flytekit.core.base_task import PythonTask
 from flytekit.core.workflow import WorkflowBase
-from flytekit.exceptions.user import FlyteValidationException
 from flytekit.models import launch_plan as _launch_plan_models
 from flytekit.models import task as task_models
 from flytekit.models.admin import workflow as admin_workflow_models
 from flytekit.models.admin.workflow import WorkflowSpec
-from flytekit.models.core import identifier as _identifier
 from flytekit.models.task import TaskSpec
 from flytekit.remote.remote_callable import RemoteEntity
 from flytekit.tools.translator import FlyteControlPlaneEntity, Options, get_serializable
@@ -64,9 +62,6 @@ def get_registrable_entities(
 
     new_api_model_values = list(new_api_serializable_entities.values())
     entities_to_be_serialized = list(filter(_should_register_with_admin, new_api_model_values))
-    serializable_tasks: typing.List[task_models.TaskSpec] = [
-        entity for entity in entities_to_be_serialized if isinstance(entity, task_models.TaskSpec)
-    ]
 
     return entities_to_be_serialized
 

--- a/tests/flytekit/unit/cli/pyflyte/test_package.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_package.py
@@ -104,56 +104,6 @@ def test_package_with_fast_registration():
         shutil.rmtree("core")
 
 
-def test_duplicate_registrable_entities():
-    @flytekit.task
-    def t_1():
-        pass
-
-    # Keep a reference to a task named `t_1` that's going to be duplicated below
-    reference_1 = t_1
-
-    @flytekit.workflow
-    def wf_1():
-        return t_1()
-
-    # Duplicate definition of `t_1`
-    @flytekit.task
-    def t_1() -> str:
-        pass
-
-    # Keep a second reference to the duplicate task named `t_1` so that we can use it later
-    reference_2 = t_1
-
-    @flytekit.task
-    def non_duplicate_task():
-        pass
-
-    @flytekit.workflow
-    def wf_2():
-        non_duplicate_task()
-        # refers to the second definition of `t_1`
-        return t_1()
-
-    ctx = context_manager.FlyteContextManager.current_context().with_serialization_settings(
-        flytekit.configuration.SerializationSettings(
-            project="p",
-            domain="d",
-            version="v",
-            image_config=flytekit.configuration.ImageConfig(
-                default_image=flytekit.configuration.Image("def", "docker.io/def", "latest")
-            ),
-        )
-    )
-
-    context_manager.FlyteEntities.entities = [reference_1, wf_1, "str", reference_2, non_duplicate_task, wf_2, "str"]
-
-    with pytest.raises(
-        FlyteValidationException,
-        match=r"Multiple definitions of the following tasks were found: \['pyflyte.test_package.t_1'\]",
-    ):
-        flytekit.tools.serialize_helpers.get_registrable_entities(ctx)
-
-
 def test_package():
     runner = CliRunner()
     with runner.isolated_filesystem():

--- a/tests/flytekit/unit/cli/pyflyte/test_package.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_package.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 
-import pytest
 from click.testing import CliRunner
 
 import flytekit
@@ -10,7 +9,6 @@ import flytekit.tools.serialize_helpers
 from flytekit import TaskMetadata
 from flytekit.clis.sdk_in_container import pyflyte
 from flytekit.core import context_manager
-from flytekit.exceptions.user import FlyteValidationException
 from flytekit.models.admin.workflow import WorkflowSpec
 from flytekit.models.core.identifier import Identifier, ResourceType
 from flytekit.models.launch_plan import LaunchPlan


### PR DESCRIPTION
# TL;DR
This used to be a problem but is now less so.  In early iterations of flytekit, we would run into issues with multiple definitions of flyte entities.  They tended to have different definitions and so would trigger a 'duplicate entity with different definition' error in flyte admin.  This occurs much less frequently now and this check is causing an issue with map tasks.

We will investigate post 1.5 release how to cache map task definitions so that multiple map_task() declarations on the same underlying task do not result in a new object being created.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
