### PR TITLE
Set cache_regions=True in the case of s3fs

### DIFF
--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -47,7 +47,7 @@ _ANON = "anon"
 
 def s3_setup_args(s3_cfg: configuration.S3Config, anonymous: bool = False):
     kwargs = {
-      "cache_regions": True,
+        "cache_regions": True,
     }
     if s3_cfg.access_key_id:
         kwargs[_FSSPEC_S3_KEY_ID] = s3_cfg.access_key_id

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -25,7 +25,7 @@ import os
 import pathlib
 import tempfile
 import typing
-from typing import Union, cast
+from typing import Any, Dict, Union, cast
 from uuid import UUID
 
 import fsspec
@@ -46,7 +46,7 @@ _ANON = "anon"
 
 
 def s3_setup_args(s3_cfg: configuration.S3Config, anonymous: bool = False):
-    kwargs = {
+    kwargs: Dict[str, Any] = {
         "cache_regions": True,
     }
     if s3_cfg.access_key_id:

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -46,7 +46,9 @@ _ANON = "anon"
 
 
 def s3_setup_args(s3_cfg: configuration.S3Config, anonymous: bool = False):
-    kwargs = {}
+    kwargs = {
+      "cache_regions": True,
+    }
     if s3_cfg.access_key_id:
         kwargs[_FSSPEC_S3_KEY_ID] = s3_cfg.access_key_id
 

--- a/tests/flytekit/unit/core/test_data.py
+++ b/tests/flytekit/unit/core/test_data.py
@@ -176,7 +176,7 @@ def test_s3_setup_args_env_empty(mock_os, mock_get_config_file):
     mock_os.get.return_value = None
     s3c = S3Config.auto()
     kwargs = s3_setup_args(s3c)
-    assert kwargs == {}
+    assert kwargs == {"cache_regions": True}
 
 
 @mock.patch("flytekit.configuration.get_config_file")
@@ -191,7 +191,7 @@ def test_s3_setup_args_env_both(mock_os, mock_get_config_file):
     }
     mock_os.get.side_effect = lambda x, y: ee.get(x)
     kwargs = s3_setup_args(S3Config.auto())
-    assert kwargs == {"key": "flyte", "secret": "flyte-secret"}
+    assert kwargs == {"key": "flyte", "secret": "flyte-secret", "cache_regions": True}
 
 
 @mock.patch("flytekit.configuration.get_config_file")
@@ -204,7 +204,7 @@ def test_s3_setup_args_env_flyte(mock_os, mock_get_config_file):
     }
     mock_os.get.side_effect = lambda x, y: ee.get(x)
     kwargs = s3_setup_args(S3Config.auto())
-    assert kwargs == {"key": "flyte", "secret": "flyte-secret"}
+    assert kwargs == {"key": "flyte", "secret": "flyte-secret", "cache_regions": True}
 
 
 @mock.patch("flytekit.configuration.get_config_file")
@@ -218,7 +218,7 @@ def test_s3_setup_args_env_aws(mock_os, mock_get_config_file):
     mock_os.get.side_effect = lambda x, y: ee.get(x)
     kwargs = s3_setup_args(S3Config.auto())
     # not explicitly in kwargs, since fsspec/boto3 will use these env vars by default
-    assert kwargs == {}
+    assert kwargs == {"cache_regions": True}
 
 
 def test_crawl_local_nt(source_folder):


### PR DESCRIPTION
# TL;DR
Set cache_regions to circumvent an aiobotocore bug

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 According to https://github.com/fsspec/s3fs/issues/701#issuecomment-1480303225, setting `cache_regions=True` makes it so that `aiobotocore` does not hit the access denied bug.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
