### PR TITLE
Always a default image and streamline image handling serialize vs package

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -282,7 +282,8 @@ class ImageConfig(object):
                 images.append(img)
 
         if default_image is None:
-            default_image = Image.look_up_image_info(DEFAULT_IMAGE_NAME, DefaultImages.default_image(), False)
+            default_image_str = os.environ.get("FLYTE_INTERNAL_IMAGE", DefaultImages.default_image())
+            default_image = Image.look_up_image_info(DEFAULT_IMAGE_NAME, default_image_str, False)
         return ImageConfig.create_from(default_image=default_image, other_images=images)
 
     @classmethod

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -281,6 +281,8 @@ class ImageConfig(object):
             else:
                 images.append(img)
 
+        if default_image is None:
+            default_image = Image.look_up_image_info(DEFAULT_IMAGE_NAME, DefaultImages.default_image(), False)
         return ImageConfig.create_from(default_image=default_image, other_images=images)
 
     @classmethod

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -237,8 +237,9 @@ ic_result_1 = ImageConfig(
 )
 # test that command line args are merged with the file
 ic_result_2 = ImageConfig(
-    default_image=None,
+    default_image=Image(name="default", fqn="cr.flyte.org/flyteorg/flytekit", tag="py3.9-latest"),
     images=[
+        Image(name="default", fqn="cr.flyte.org/flyteorg/flytekit", tag="py3.9-latest"),
         Image(name="asdf", fqn="ghcr.io/asdf/asdf", tag="latest"),
         Image(name="xyz", fqn="docker.io/xyz", tag="latest"),
         Image(name="abc", fqn="docker.io/abc", tag=None),
@@ -246,8 +247,12 @@ ic_result_2 = ImageConfig(
 )
 # test that command line args override the file
 ic_result_3 = ImageConfig(
-    default_image=None,
-    images=[Image(name="xyz", fqn="ghcr.io/asdf/asdf", tag="latest"), Image(name="abc", fqn="docker.io/abc", tag=None)],
+    default_image=Image(name="default", fqn="cr.flyte.org/flyteorg/flytekit", tag="py3.9-latest"),
+    images=[
+        Image(name="default", fqn="cr.flyte.org/flyteorg/flytekit", tag="py3.9-latest"),
+        Image(name="xyz", fqn="ghcr.io/asdf/asdf", tag="latest"),
+        Image(name="abc", fqn="docker.io/abc", tag=None),
+    ],
 )
 
 ic_result_4 = ImageConfig(
@@ -262,6 +267,7 @@ ic_result_4 = ImageConfig(
 IMAGE_SPEC = os.path.join(os.path.dirname(os.path.realpath(__file__)), "imageSpec.yaml")
 
 
+@mock.patch("flytekit.configuration.default_images.DefaultImages.default_image")
 @pytest.mark.parametrize(
     "image_string, leaf_configuration_file_name, final_image_config",
     [
@@ -271,7 +277,9 @@ IMAGE_SPEC = os.path.join(os.path.dirname(os.path.realpath(__file__)), "imageSpe
         (IMAGE_SPEC, "sample.yaml", ic_result_4),
     ],
 )
-def test_pyflyte_run_run(image_string, leaf_configuration_file_name, final_image_config):
+def test_pyflyte_run_run(mock_image, image_string, leaf_configuration_file_name, final_image_config):
+    mock_image.return_value = "cr.flyte.org/flyteorg/flytekit:py3.9-latest"
+
     class TestImageSpecBuilder(ImageSpecBuilder):
         def build_image(self, img):
             ...

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
 
+import mock
 import py
 import pytest
 
@@ -64,10 +65,12 @@ def test_look_up_image_info():
     assert img.fqn == "localhost:5000/xyz"
 
 
-def test_validate_image():
+@mock.patch("flytekit.configuration.default_images.DefaultImages.default_image")
+def test_validate_image(mock_image):
+    mock_image.return_value = "cr.flyte.org/flyteorg/flytekit:py3.9-latest"
     ic = ImageConfig.validate_image(None, "image", ())
     assert ic
-    assert ic.default_image is None
+    assert ic.default_image == Image(name="default", fqn="cr.flyte.org/flyteorg/flytekit", tag="py3.9-latest")
 
     img1 = "xyz:latest"
     img2 = "docker.io/xyz:latest"


### PR DESCRIPTION
# TL;DR
If not, if i do `pyflyte register --image custom=blah:latest ...` and i have non-"custom" tasks, registration fails.

Also this PR streamlines the behavior between `pyflyte serialize --image` ... and `pyflyte package --image ...`  (see the issue below for more information)

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin


https://github.com/flyteorg/flyte/issues/3800

