### PR TITLE
Add http_proxy to client & Fix deviceflow

### DIFF
--- a/flytekit/clients/auth/authenticator.py
+++ b/flytekit/clients/auth/authenticator.py
@@ -48,10 +48,11 @@ class Authenticator(object):
     Base authenticator for all authentication flows
     """
 
-    def __init__(self, endpoint: str, header_key: str, credentials: Credentials = None):
+    def __init__(self, endpoint: str, header_key: str, credentials: Credentials = None, http_proxy_url: typing.Optional[str] = None,):
         self._endpoint = endpoint
         self._creds = credentials
         self._header_key = header_key if header_key else "authorization"
+        self._http_proxy_url = http_proxy_url
 
     def get_credentials(self) -> Credentials:
         return self._creds
@@ -162,6 +163,7 @@ class ClientCredentialsAuthenticator(Authenticator):
         cfg_store: ClientConfigStore,
         header_key: typing.Optional[str] = None,
         scopes: typing.Optional[typing.List[str]] = None,
+        http_proxy_url: typing.Optional[str] = None
     ):
         if not client_id or not client_secret:
             raise ValueError("Client ID and Client SECRET both are required.")
@@ -171,7 +173,7 @@ class ClientCredentialsAuthenticator(Authenticator):
         self._scopes = scopes or cfg.scopes
         self._client_id = client_id
         self._client_secret = client_secret
-        super().__init__(endpoint, cfg.header_key or header_key)
+        super().__init__(endpoint, cfg.header_key or header_key, http_proxy_url=http_proxy_url)
 
     def refresh_credentials(self):
         """
@@ -187,7 +189,7 @@ class ClientCredentialsAuthenticator(Authenticator):
         # Note that unlike the Pkce flow, the client ID does not come from Admin.
         logging.debug(f"Basic authorization flow with client id {self._client_id} scope {scopes}")
         authorization_header = token_client.get_basic_authorization_header(self._client_id, self._client_secret)
-        token, expires_in = token_client.get_token(token_endpoint, scopes, authorization_header)
+        token, expires_in = token_client.get_token(token_endpoint, scopes, authorization_header, http_proxy_url=self._http_proxy_url)
         logging.info("Retrieved new token, expires in {}".format(expires_in))
         self._creds = Credentials(token)
 
@@ -207,6 +209,7 @@ class DeviceCodeAuthenticator(Authenticator):
         cfg_store: ClientConfigStore,
         header_key: typing.Optional[str] = None,
         audience: typing.Optional[str] = None,
+        http_proxy_url: typing.Optional[str] = None
     ):
         self._audience = audience
         cfg = cfg_store.get_client_config()
@@ -219,21 +222,20 @@ class DeviceCodeAuthenticator(Authenticator):
                 "Device Authentication is not available on the Flyte backend / authentication server"
             )
         super().__init__(
-            endpoint=endpoint, header_key=header_key or cfg.header_key, credentials=KeyringStore.retrieve(endpoint)
+            endpoint=endpoint, header_key=header_key or cfg.header_key, credentials=KeyringStore.retrieve(endpoint), http_proxy_url=http_proxy_url
         )
 
     def refresh_credentials(self):
-        resp = token_client.get_device_code(self._device_auth_endpoint, self._client_id, self._audience, self._scope)
+        resp = token_client.get_device_code(self._device_auth_endpoint, self._client_id, self._audience, self._scope, self._http_proxy_url)
         print(
             f"""
 To Authenticate navigate in a browser to the following URL: {resp.verification_uri} and enter code: {resp.user_code}
-OR copy paste the following URL: {resp.verification_uri_complete}
         """
         )
         try:
             # Currently the refresh token is not retreived. We may want to add support for refreshTokens so that
             # access tokens can be refreshed for once authenticated machines
-            token, expires_in = token_client.poll_token_endpoint(resp, self._token_endpoint, client_id=self._client_id)
+            token, expires_in = token_client.poll_token_endpoint(resp, self._token_endpoint, client_id=self._client_id, http_proxy_url=self._http_proxy_url)
             self._creds = Credentials(access_token=token, expires_in=expires_in, for_endpoint=self._endpoint)
             KeyringStore.store(self._creds)
         except Exception:

--- a/flytekit/clients/auth/authenticator.py
+++ b/flytekit/clients/auth/authenticator.py
@@ -48,7 +48,13 @@ class Authenticator(object):
     Base authenticator for all authentication flows
     """
 
-    def __init__(self, endpoint: str, header_key: str, credentials: Credentials = None, http_proxy_url: typing.Optional[str] = None,):
+    def __init__(
+        self,
+        endpoint: str,
+        header_key: str,
+        credentials: Credentials = None,
+        http_proxy_url: typing.Optional[str] = None,
+    ):
         self._endpoint = endpoint
         self._creds = credentials
         self._header_key = header_key if header_key else "authorization"
@@ -163,7 +169,7 @@ class ClientCredentialsAuthenticator(Authenticator):
         cfg_store: ClientConfigStore,
         header_key: typing.Optional[str] = None,
         scopes: typing.Optional[typing.List[str]] = None,
-        http_proxy_url: typing.Optional[str] = None
+        http_proxy_url: typing.Optional[str] = None,
     ):
         if not client_id or not client_secret:
             raise ValueError("Client ID and Client SECRET both are required.")
@@ -189,7 +195,9 @@ class ClientCredentialsAuthenticator(Authenticator):
         # Note that unlike the Pkce flow, the client ID does not come from Admin.
         logging.debug(f"Basic authorization flow with client id {self._client_id} scope {scopes}")
         authorization_header = token_client.get_basic_authorization_header(self._client_id, self._client_secret)
-        token, expires_in = token_client.get_token(token_endpoint, scopes, authorization_header, http_proxy_url=self._http_proxy_url)
+        token, expires_in = token_client.get_token(
+            token_endpoint, scopes, authorization_header, http_proxy_url=self._http_proxy_url
+        )
         logging.info("Retrieved new token, expires in {}".format(expires_in))
         self._creds = Credentials(token)
 
@@ -209,7 +217,7 @@ class DeviceCodeAuthenticator(Authenticator):
         cfg_store: ClientConfigStore,
         header_key: typing.Optional[str] = None,
         audience: typing.Optional[str] = None,
-        http_proxy_url: typing.Optional[str] = None
+        http_proxy_url: typing.Optional[str] = None,
     ):
         self._audience = audience
         cfg = cfg_store.get_client_config()
@@ -222,11 +230,16 @@ class DeviceCodeAuthenticator(Authenticator):
                 "Device Authentication is not available on the Flyte backend / authentication server"
             )
         super().__init__(
-            endpoint=endpoint, header_key=header_key or cfg.header_key, credentials=KeyringStore.retrieve(endpoint), http_proxy_url=http_proxy_url
+            endpoint=endpoint,
+            header_key=header_key or cfg.header_key,
+            credentials=KeyringStore.retrieve(endpoint),
+            http_proxy_url=http_proxy_url,
         )
 
     def refresh_credentials(self):
-        resp = token_client.get_device_code(self._device_auth_endpoint, self._client_id, self._audience, self._scope, self._http_proxy_url)
+        resp = token_client.get_device_code(
+            self._device_auth_endpoint, self._client_id, self._audience, self._scope, self._http_proxy_url
+        )
         print(
             f"""
 To Authenticate navigate in a browser to the following URL: {resp.verification_uri} and enter code: {resp.user_code}
@@ -235,7 +248,9 @@ To Authenticate navigate in a browser to the following URL: {resp.verification_u
         try:
             # Currently the refresh token is not retreived. We may want to add support for refreshTokens so that
             # access tokens can be refreshed for once authenticated machines
-            token, expires_in = token_client.poll_token_endpoint(resp, self._token_endpoint, client_id=self._client_id, http_proxy_url=self._http_proxy_url)
+            token, expires_in = token_client.poll_token_endpoint(
+                resp, self._token_endpoint, client_id=self._client_id, http_proxy_url=self._http_proxy_url
+            )
             self._creds = Credentials(access_token=token, expires_in=expires_in, for_endpoint=self._endpoint)
             KeyringStore.store(self._creds)
         except Exception:

--- a/flytekit/clients/auth/token_client.py
+++ b/flytekit/clients/auth/token_client.py
@@ -6,7 +6,7 @@ import typing
 import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-
+from flytekit import logger
 import requests
 
 from flytekit.clients.auth.exceptions import AuthenticationError, AuthenticationPending
@@ -150,7 +150,7 @@ def poll_token_endpoint(resp: DeviceCodeResponse, token_endpoint: str, client_id
         except AuthenticationPending:
             ...
         except Exception as e:
-            print("Authentication attempt failed: ", e)
+            logger.error("Authentication attempt failed: ", e)
             raise e
         print("Authentication Pending...")
         time.sleep(interval.total_seconds())

--- a/flytekit/clients/auth/token_client.py
+++ b/flytekit/clients/auth/token_client.py
@@ -6,9 +6,10 @@ import typing
 import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from flytekit import logger
+
 import requests
 
+from flytekit import logger
 from flytekit.clients.auth.exceptions import AuthenticationError, AuthenticationPending
 
 utf_8 = "utf-8"
@@ -132,7 +133,9 @@ def get_device_code(
     return DeviceCodeResponse.from_json_response(resp.json())
 
 
-def poll_token_endpoint(resp: DeviceCodeResponse, token_endpoint: str, client_id: str, http_proxy_url: typing.Optional[str] = None) -> typing.Tuple[str, int]:
+def poll_token_endpoint(
+    resp: DeviceCodeResponse, token_endpoint: str, client_id: str, http_proxy_url: typing.Optional[str] = None
+) -> typing.Tuple[str, int]:
     tick = datetime.now()
     interval = timedelta(seconds=resp.interval)
     end_time = tick + timedelta(seconds=resp.expires_in)
@@ -143,7 +146,7 @@ def poll_token_endpoint(resp: DeviceCodeResponse, token_endpoint: str, client_id
                 grant_type=GrantType.DEVICE_CODE,
                 client_id=client_id,
                 device_code=resp.device_code,
-                http_proxy_url=http_proxy_url
+                http_proxy_url=http_proxy_url,
             )
             print("Authentication successful!")
             return access_token, expires_in

--- a/flytekit/clients/auth_helper.py
+++ b/flytekit/clients/auth_helper.py
@@ -72,6 +72,7 @@ def get_authenticator(cfg: PlatformConfig, cfg_store: ClientConfigStore) -> Auth
             client_secret=cfg.client_credentials_secret,
             cfg_store=cfg_store,
             scopes=cfg.scopes,
+            http_proxy_url=cfg.http_proxy_url
         )
     elif cfg_auth == AuthType.EXTERNAL_PROCESS or cfg_auth == AuthType.EXTERNALCOMMAND:
         client_cfg = None
@@ -82,7 +83,7 @@ def get_authenticator(cfg: PlatformConfig, cfg_store: ClientConfigStore) -> Auth
             header_key=client_cfg.header_key if client_cfg else None,
         )
     elif cfg_auth == AuthType.DEVICEFLOW:
-        return DeviceCodeAuthenticator(endpoint=cfg.endpoint, cfg_store=cfg_store, audience=cfg.audience)
+        return DeviceCodeAuthenticator(endpoint=cfg.endpoint, cfg_store=cfg_store, audience=cfg.audience, http_proxy_url=cfg.http_proxy_url)
     else:
         raise ValueError(
             f"Invalid auth mode [{cfg_auth}] specified." f"Please update the creds config to use a valid value"

--- a/flytekit/clients/auth_helper.py
+++ b/flytekit/clients/auth_helper.py
@@ -72,7 +72,7 @@ def get_authenticator(cfg: PlatformConfig, cfg_store: ClientConfigStore) -> Auth
             client_secret=cfg.client_credentials_secret,
             cfg_store=cfg_store,
             scopes=cfg.scopes,
-            http_proxy_url=cfg.http_proxy_url
+            http_proxy_url=cfg.http_proxy_url,
         )
     elif cfg_auth == AuthType.EXTERNAL_PROCESS or cfg_auth == AuthType.EXTERNALCOMMAND:
         client_cfg = None
@@ -83,7 +83,9 @@ def get_authenticator(cfg: PlatformConfig, cfg_store: ClientConfigStore) -> Auth
             header_key=client_cfg.header_key if client_cfg else None,
         )
     elif cfg_auth == AuthType.DEVICEFLOW:
-        return DeviceCodeAuthenticator(endpoint=cfg.endpoint, cfg_store=cfg_store, audience=cfg.audience, http_proxy_url=cfg.http_proxy_url)
+        return DeviceCodeAuthenticator(
+            endpoint=cfg.endpoint, cfg_store=cfg_store, audience=cfg.audience, http_proxy_url=cfg.http_proxy_url
+        )
     else:
         raise ValueError(
             f"Invalid auth mode [{cfg_auth}] specified." f"Please update the creds config to use a valid value"

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -376,6 +376,7 @@ class PlatformConfig(object):
     :param scopes: List of scopes to request. This is only applicable to the client credentials flow
     :param auth_mode: The OAuth mode to use. Defaults to pkce flow
     :param ca_cert_file_path: [optional] str Root Cert to be loaded and used to verify admin
+    :param http_proxy_url: [optional] HTTP Proxy to be used for OAuth requests
     """
 
     endpoint: str = "localhost:30080"
@@ -390,6 +391,7 @@ class PlatformConfig(object):
     auth_mode: AuthType = AuthType.STANDARD
     audience: typing.Optional[str] = None
     rpc_retries: int = 3
+    http_proxy_url: typing.Optional[str] = None
 
     @classmethod
     def auto(cls, config_file: typing.Optional[typing.Union[str, ConfigFile]] = None) -> PlatformConfig:
@@ -426,6 +428,7 @@ class PlatformConfig(object):
         kwargs = set_if_exists(kwargs, "auth_mode", _internal.Credentials.AUTH_MODE.read(config_file))
         kwargs = set_if_exists(kwargs, "endpoint", _internal.Platform.URL.read(config_file))
         kwargs = set_if_exists(kwargs, "console_endpoint", _internal.Platform.CONSOLE_ENDPOINT.read(config_file))
+        kwargs = set_if_exists(kwargs, "http_proxy_url", _internal.Platform.HTTP_PROXY_URL.read(config_file))
         return PlatformConfig(**kwargs)
 
     @classmethod

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -111,9 +111,7 @@ class Platform(object):
     CA_CERT_FILE_PATH = ConfigEntry(
         LegacyConfigEntry(SECTION, "ca_cert_file_path"), YamlConfigEntry("admin.caCertFilePath")
     )
-    HTTP_PROXY_URL = ConfigEntry(
-        LegacyConfigEntry(SECTION, "http_proxy_url"), YamlConfigEntry("admin.httpProxyURL")
-    )
+    HTTP_PROXY_URL = ConfigEntry(LegacyConfigEntry(SECTION, "http_proxy_url"), YamlConfigEntry("admin.httpProxyURL"))
 
 
 class LocalSDK(object):

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -111,6 +111,9 @@ class Platform(object):
     CA_CERT_FILE_PATH = ConfigEntry(
         LegacyConfigEntry(SECTION, "ca_cert_file_path"), YamlConfigEntry("admin.caCertFilePath")
     )
+    HTTP_PROXY_URL = ConfigEntry(
+        LegacyConfigEntry(SECTION, "http_proxy_url"), YamlConfigEntry("admin.httpProxyURL")
+    )
 
 
 class LocalSDK(object):

--- a/tests/flytekit/unit/clients/auth/test_authenticator.py
+++ b/tests/flytekit/unit/clients/auth/test_authenticator.py
@@ -70,7 +70,11 @@ def test_command_authenticator(mock_subprocess: MagicMock):
 @patch("flytekit.clients.auth.token_client.requests")
 def test_client_creds_authenticator(mock_requests):
     authn = ClientCredentialsAuthenticator(
-        ENDPOINT, client_id="client", client_secret="secret", cfg_store=static_cfg_store, http_proxy_url="https://my-proxy:31111"
+        ENDPOINT,
+        client_id="client",
+        client_secret="secret",
+        cfg_store=static_cfg_store,
+        http_proxy_url="https://my-proxy:31111",
     )
 
     response = MagicMock()
@@ -103,12 +107,7 @@ def test_device_flow_authenticator(poll_mock: MagicMock, device_mock: MagicMock,
             device_authorization_endpoint="dev",
         )
     )
-    authn = DeviceCodeAuthenticator(
-        ENDPOINT,
-        cfg_store,
-        audience="x",
-        http_proxy_url="http://my-proxy:9000"
-    )
+    authn = DeviceCodeAuthenticator(ENDPOINT, cfg_store, audience="x", http_proxy_url="http://my-proxy:9000")
 
     device_mock.return_value = DeviceCodeResponse("x", "y", "s", 1000, 0)
     poll_mock.return_value = ("access", 100)

--- a/tests/flytekit/unit/clients/auth/test_authenticator.py
+++ b/tests/flytekit/unit/clients/auth/test_authenticator.py
@@ -70,7 +70,7 @@ def test_command_authenticator(mock_subprocess: MagicMock):
 @patch("flytekit.clients.auth.token_client.requests")
 def test_client_creds_authenticator(mock_requests):
     authn = ClientCredentialsAuthenticator(
-        ENDPOINT, client_id="client", client_secret="secret", cfg_store=static_cfg_store
+        ENDPOINT, client_id="client", client_secret="secret", cfg_store=static_cfg_store, http_proxy_url="https://my-proxy:31111"
     )
 
     response = MagicMock()
@@ -107,9 +107,10 @@ def test_device_flow_authenticator(poll_mock: MagicMock, device_mock: MagicMock,
         ENDPOINT,
         cfg_store,
         audience="x",
+        http_proxy_url="http://my-proxy:9000"
     )
 
-    device_mock.return_value = DeviceCodeResponse("x", "y", "s", "m", 1000, 0)
+    device_mock.return_value = DeviceCodeResponse("x", "y", "s", 1000, 0)
     poll_mock.return_value = ("access", 100)
     authn.refresh_credentials()
     assert authn._creds

--- a/tests/flytekit/unit/clients/auth/test_token_client.py
+++ b/tests/flytekit/unit/clients/auth/test_token_client.py
@@ -28,7 +28,9 @@ def test_get_token(mock_requests):
     response.status_code = 200
     response.json.return_value = json.loads("""{"access_token": "abc", "expires_in": 60}""")
     mock_requests.post.return_value = response
-    access, expiration = get_token("https://corp.idp.net", client_id="abc123", scopes=["my_scope"], http_proxy_url="http://proxy:3000")
+    access, expiration = get_token(
+        "https://corp.idp.net", client_id="abc123", scopes=["my_scope"], http_proxy_url="http://proxy:3000"
+    )
     assert access == "abc"
     assert expiration == 60
 
@@ -62,9 +64,7 @@ def test_poll_token_endpoint(mock_requests):
     response.json.return_value = {"error": error_auth_pending}
     mock_requests.post.return_value = response
 
-    r = DeviceCodeResponse(
-        device_code="x", user_code="y", verification_uri="v", expires_in=1, interval=1
-    )
+    r = DeviceCodeResponse(device_code="x", user_code="y", verification_uri="v", expires_in=1, interval=1)
     with pytest.raises(AuthenticationError):
         poll_token_endpoint(r, "test.com", "test", http_proxy_url="http://proxy:3000")
 
@@ -72,9 +72,7 @@ def test_poll_token_endpoint(mock_requests):
     response.ok = True
     response.json.return_value = {"access_token": "abc", "expires_in": 60}
     mock_requests.post.return_value = response
-    r = DeviceCodeResponse(
-        device_code="x", user_code="y", verification_uri="v", expires_in=1, interval=0
-    )
+    r = DeviceCodeResponse(device_code="x", user_code="y", verification_uri="v", expires_in=1, interval=0)
     t, e = poll_token_endpoint(r, "test.com", "test", http_proxy_url="http://proxy:3000")
     assert t
     assert e


### PR DESCRIPTION
# TL;DR

1. Add http_proxy to oauth2 client because in on-prem cluster use cases, the client might not have access to the external network
2. Remove `verification_url_complete` because that field not exists in [azure ad](https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-device-code#device-authorization-request) and the oauth2 standard.
3. Concat the scopes by white space per [the documentation](https://learn.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-device-code#device-authorization-request)

## Type
 - [x] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3620
