### PR TITLE
[Issue-3617] Enables FlyteFiles, FlyteDirectors, and StructuredDatasets inputs in papermill plugin

### DIFF
--- a/plugins/flytekit-papermill/flytekitplugins/papermill/__init__.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/__init__.py
@@ -11,4 +11,4 @@ This package contains things that are useful when extending Flytekit.
    record_outputs
 """
 
-from .task import NotebookTask, read_input, record_outputs
+from .task import NotebookTask, read_flytedirectory, read_flytefile, read_structureddataset, record_outputs

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/__init__.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/__init__.py
@@ -11,4 +11,4 @@ This package contains things that are useful when extending Flytekit.
    record_outputs
 """
 
-from .task import NotebookTask, read_flytedirectory, read_flytefile, read_structureddataset, record_outputs
+from .task import NotebookTask, load_flytedirectory, load_flytefile, load_structureddataset, record_outputs

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/__init__.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/__init__.py
@@ -11,4 +11,4 @@ This package contains things that are useful when extending Flytekit.
    record_outputs
 """
 
-from .task import NotebookTask, record_outputs
+from .task import NotebookTask, read_input, record_outputs

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -4,7 +4,7 @@ import os
 import sys
 import tempfile
 import typing
-from typing import Any, Dict
+from typing import Any
 
 import nbformat
 import papermill as pm

--- a/plugins/flytekit-papermill/tests/test_task.py
+++ b/plugins/flytekit-papermill/tests/test_task.py
@@ -1,14 +1,17 @@
 import datetime
 import os
+import tempfile
 
+import pandas as pd
 from flytekitplugins.papermill import NotebookTask
 from flytekitplugins.pod import Pod
 from kubernetes.client import V1Container, V1PodSpec
 
 import flytekit
-from flytekit import kwtypes
+from flytekit import StructuredDataset, kwtypes, task, workflow
 from flytekit.configuration import Image, ImageConfig
-from flytekit.types.file import PythonNotebook
+from flytekit.types.directory import FlyteDirectory
+from flytekit.types.file import FlyteFile, PythonNotebook
 
 from .testdata.datatype import X
 
@@ -134,3 +137,36 @@ def test_notebook_pod_task():
         nb.get_command(serialization_settings)
         == nb.get_k8s_pod(serialization_settings).pod_spec["containers"][0]["args"]
     )
+
+
+def test_flyte_types():
+    @task
+    def create_file() -> FlyteFile:
+        tmp_file = tempfile.mktemp()
+        with open(tmp_file, "w") as f:
+            f.write("abc")
+        return FlyteFile(path=tmp_file)
+
+    @task
+    def create_dir() -> FlyteDirectory:
+        tmp_dir = tempfile.mkdtemp()
+        with open(os.path.join(tmp_dir, "file.txt"), "w") as f:
+            f.write("abc")
+        return FlyteDirectory(path=tmp_dir)
+
+    @task
+    def create_sd() -> StructuredDataset:
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        return StructuredDataset(dataframe=df)
+
+    ff = create_file()
+    fd = create_dir()
+    sd = create_sd()
+
+    nb_name = "nb-types"
+    nb_types = NotebookTask(
+        name="test",
+        notebook_path=_get_nb_path(nb_name, abs=False),
+        inputs=kwtypes(ff=FlyteFile, fd=FlyteDirectory, sd=StructuredDataset),
+    )
+    nb_types.execute(ff=ff, fd=fd, sd=sd)

--- a/plugins/flytekit-papermill/tests/test_task.py
+++ b/plugins/flytekit-papermill/tests/test_task.py
@@ -8,7 +8,7 @@ from flytekitplugins.pod import Pod
 from kubernetes.client import V1Container, V1PodSpec
 
 import flytekit
-from flytekit import StructuredDataset, kwtypes, task, workflow
+from flytekit import StructuredDataset, kwtypes, task
 from flytekit.configuration import Image, ImageConfig
 from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import FlyteFile, PythonNotebook
@@ -171,4 +171,4 @@ def test_flyte_types():
         outputs=kwtypes(success=bool),
     )
     success, out, render = nb_types.execute(ff=ff, fd=fd, sd=sd)
-    assert success == True, "Notebook execution failed"
+    assert success is True, "Notebook execution failed"

--- a/plugins/flytekit-papermill/tests/test_task.py
+++ b/plugins/flytekit-papermill/tests/test_task.py
@@ -168,5 +168,7 @@ def test_flyte_types():
         name="test",
         notebook_path=_get_nb_path(nb_name, abs=False),
         inputs=kwtypes(ff=FlyteFile, fd=FlyteDirectory, sd=StructuredDataset),
+        outputs=kwtypes(success=bool),
     )
-    nb_types.execute(ff=ff, fd=fd, sd=sd)
+    success, out, render = nb_types.execute(ff=ff, fd=fd, sd=sd)
+    assert success == True, "Notebook execution failed"

--- a/plugins/flytekit-papermill/tests/testdata/nb-simple.ipynb
+++ b/plugins/flytekit-papermill/tests/testdata/nb-simple.ipynb
@@ -16,6 +16,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from flytekitplugins.papermill import record_outputs, read_input\n",
+    "\n",
+    "pi = read_input(pi, float)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,8 +46,6 @@
    },
    "outputs": [],
    "source": [
-    "from flytekitplugins.papermill import record_outputs\n",
-    "\n",
     "record_outputs(square=out)"
    ]
   },
@@ -49,7 +60,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -63,9 +74,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/plugins/flytekit-papermill/tests/testdata/nb-simple.ipynb
+++ b/plugins/flytekit-papermill/tests/testdata/nb-simple.ipynb
@@ -16,19 +16,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from flytekitplugins.papermill import record_outputs, read_input\n",
-    "\n",
-    "pi = read_input(pi, float)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,6 +33,7 @@
    },
    "outputs": [],
    "source": [
+    "from flytekitplugins.papermill import record_outputs\n",
     "record_outputs(square=out)"
    ]
   },

--- a/plugins/flytekit-papermill/tests/testdata/nb-types.ipynb
+++ b/plugins/flytekit-papermill/tests/testdata/nb-types.ipynb
@@ -24,7 +24,7 @@
     "import os\n",
     "import pandas as pd\n",
     "from flytekitplugins.papermill import (\n",
-    "    read_flytefile, read_flytedirectory, read_structureddataset,\n",
+    "    load_flytefile, load_flytedirectory, load_structureddataset,\n",
     "    record_outputs\n",
     ")"
    ]
@@ -35,9 +35,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ff = read_flytefile(ff)\n",
-    "fd = read_flytedirectory(fd)\n",
-    "sd = read_structureddataset(sd)"
+    "ff = load_flytefile(ff)\n",
+    "fd = load_flytedirectory(fd)\n",
+    "sd = load_structureddataset(sd)"
    ]
   },
   {

--- a/plugins/flytekit-papermill/tests/testdata/nb-types.ipynb
+++ b/plugins/flytekit-papermill/tests/testdata/nb-types.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "ff = None\n",
+    "fd = None\n",
+    "sd = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "from flytekitplugins.papermill import (\n",
+    "    read_flytefile, read_flytedirectory, read_structureddataset,\n",
+    "    record_outputs\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ff = read_flytefile(ff)\n",
+    "fd = read_flytedirectory(fd)\n",
+    "sd = read_structureddataset(sd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# read file\n",
+    "with open(ff.download(), 'r') as f:\n",
+    "    text = f.read()\n",
+    "    assert text == \"abc\", \"Text does not match\"\n",
+    "\n",
+    "# check file inside directory\n",
+    "with open(os.path.join(fd.download(),\"file.txt\"), 'r') as f:\n",
+    "    text = f.read()\n",
+    "    assert text == \"abc\", \"Text does not match\"\n",
+    "\n",
+    "# check dataset\n",
+    "df = sd.open(pd.DataFrame).all()\n",
+    "expected = pd.DataFrame({\"a\": [1, 2], \"b\": [3, 4]})\n",
+    "assert df.equals(expected), \"Dataframes do not match\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "outputs"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "record_outputs(success=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
# TL;DR
This is a first draft for allowing the papermill plugin to access more complex inputs. 

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Right now the papermill plugin can't use `FlyteFile` or `StructuredDataset` because of a Papermill limitation that everything is json serializable.

My strategy is mostly copying `record_outputs`. These are the steps

1.  Reserializing the inputs and save to local disk
2. Add a helper function `read_input` where users must give the input type (maybe there is a smart fix)
3. `read_input` loads the protos and uses the type to convert it to the correct format

Basically I am using flyte to serialize the inputs locally (see comments), then you just need to do this. 

```python
### Params
pi = (filled in by papermill)

### In a new cell
pi = read_input(pi, float)
```
<img width="1142" alt="Screenshot 2023-05-02 at 1 42 43 PM" src="https://user-images.githubusercontent.com/106936600/235743479-d48f3cc9-4d92-4bf1-a85e-c58994e814a3.png">

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3617

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
