### PR TITLE
Support for ArrayNode

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -394,7 +394,7 @@ def _execute_map_task(
         map_task = mtr.load_task(loader_args=resolver_args, max_concurrency=max_concurrency)
 
         task_index = _compute_array_job_index()
-        output_prefix = os.path.join(output_prefix, str(task_index))
+        #output_prefix = os.path.join(output_prefix, str(task_index)) # TODO @hamersaw remove
 
         if test:
             logger.info(


### PR DESCRIPTION
# TL;DR
Removed `task_index` `output_prefix` append when executing map tasks. `ArrayNode` is updating maptasks execution entrypoint to the node executor (rather than flyteplugins). This introduces issues updating the maptask subnode execution data directories to support cache lookups / population and starting flytekit maptask execution.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1131

## Follow-up issue
_NA_
