### PR TITLE
Include traceback in errors from admin

### DIFF
--- a/flytekit/clis/sdk_in_container/pyflyte.py
+++ b/flytekit/clis/sdk_in_container/pyflyte.py
@@ -56,6 +56,18 @@ def pretty_print_exception(e: Exception):
         if isinstance(e, FlyteInvalidInputException):
             click.secho("Request rejected by the API, due to Invalid input.", fg="red")
             click.secho(f"\tReason: {str(e)}", dim=True)
+            import traceback
+
+            def get_traceback(ee):
+                lines = traceback.format_exception(type(ee), ee, ee.__traceback__)
+                return "".join(lines)
+
+            print("get traceback:")
+            print(get_traceback(e))
+            print("Formatted:")
+            tb_str = "".join(traceback.format_exception(None, e, e.__traceback__))
+            print(tb_str)
+
             click.secho(f"\tInput Request: {MessageToJson(e.request)}", dim=True)
             return
         click.secho(f"Failed with Exception: Reason: {e._ERROR_CODE}", fg="red")  # noqa

--- a/flytekit/clis/sdk_in_container/pyflyte.py
+++ b/flytekit/clis/sdk_in_container/pyflyte.py
@@ -1,4 +1,3 @@
-import traceback
 import typing
 
 import grpc
@@ -39,8 +38,8 @@ def validate_package(ctx, param, values):
 
 def pretty_print_grpc_error(e: grpc.RpcError):
     if isinstance(e, grpc._channel._InactiveRpcError):  # noqa
-        click.secho(f"RPC Failed, with Status: {e.code()}", fg="red")
-        click.secho(f"\tdetails: {e.details()}", fg="magenta")
+        click.secho(f"RPC Failed, with Status: {e.code()}", fg="red", bold=True)
+        click.secho(f"\tdetails: {e.details()}", fg="magenta", bold=True)
         click.secho(f"\tDebug string {e.debug_error_string()}", dim=True)
     return
 
@@ -54,13 +53,11 @@ def pretty_print_exception(e: Exception):
         raise e
 
     if isinstance(e, FlyteException):
+        click.secho(f"Failed with Exception Code: {e._ERROR_CODE}", fg="red")  # noqa
         if isinstance(e, FlyteInvalidInputException):
             click.secho("Request rejected by the API, due to Invalid input.", fg="red")
-            lines = traceback.format_exception(type(e), e, e.__traceback__, limit=1)
-            click.secho(f"Reason:\n" + "".join(lines), dim=True)
             click.secho(f"\tInput Request: {MessageToJson(e.request)}", dim=True)
-            return
-        click.secho(f"Failed with Exception: Reason: {e._ERROR_CODE}", fg="red")  # noqa
+
         cause = e.__cause__
         if cause:
             if isinstance(cause, grpc.RpcError):

--- a/flytekit/clis/sdk_in_container/pyflyte.py
+++ b/flytekit/clis/sdk_in_container/pyflyte.py
@@ -1,3 +1,4 @@
+import traceback
 import typing
 
 import grpc
@@ -55,19 +56,8 @@ def pretty_print_exception(e: Exception):
     if isinstance(e, FlyteException):
         if isinstance(e, FlyteInvalidInputException):
             click.secho("Request rejected by the API, due to Invalid input.", fg="red")
-            click.secho(f"\tReason: {str(e)}", dim=True)
-            import traceback
-
-            def get_traceback(ee):
-                lines = traceback.format_exception(type(ee), ee, ee.__traceback__)
-                return "".join(lines)
-
-            print("get traceback:")
-            print(get_traceback(e))
-            print("Formatted:")
-            tb_str = "".join(traceback.format_exception(None, e, e.__traceback__))
-            print(tb_str)
-
+            lines = traceback.format_exception(type(e), e, e.__traceback__, limit=1)
+            click.secho(f"Reason:\n" + "".join(lines), dim=True)
             click.secho(f"\tInput Request: {MessageToJson(e.request)}", dim=True)
             return
         click.secho(f"Failed with Exception: Reason: {e._ERROR_CODE}", fg="red")  # noqa


### PR DESCRIPTION
# TL;DR
We were returning too early and not printing the actual error.  Now we do.

![image](https://user-images.githubusercontent.com/2896568/236583658-5a48bb72-733b-4efc-9fba-a69eaa491287.png)

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Also make things bold.
