### PR TITLE
Add support for copying all the files in source root 

### DIFF
--- a/flytekit/clis/sdk_in_container/constants.py
+++ b/flytekit/clis/sdk_in_container/constants.py
@@ -10,6 +10,7 @@ CTX_CONFIG_FILE = "config_file"
 CTX_PROJECT_ROOT = "project_root"
 CTX_MODULE = "module"
 CTX_VERBOSE = "verbose"
+CTX_COPY_ALL = "copy_all"
 
 
 project_option = _click.option(

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -18,6 +18,7 @@ from typing_extensions import get_args
 from flytekit import BlobType, Literal, Scalar
 from flytekit.clis.sdk_in_container.constants import (
     CTX_CONFIG_FILE,
+    CTX_COPY_ALL,
     CTX_DOMAIN,
     CTX_MODULE,
     CTX_PROJECT,
@@ -513,6 +514,13 @@ def get_workflow_command_base_params() -> typing.List[click.Option]:
             help="Directory inside the image where the tar file containing the code will be copied to",
         ),
         click.Option(
+            param_decls=["--copy-all", "copy_all"],
+            required=False,
+            is_flag=True,
+            default=False,
+            help="Copy all files in the source root directory to the destination directory",
+        ),
+        click.Option(
             param_decls=["-i", "--image", "image_config"],
             required=False,
             multiple=True,
@@ -643,6 +651,7 @@ def run_command(ctx: click.Context, entity: typing.Union[PythonFunctionWorkflow,
             destination_dir=run_level_params.get("destination_dir"),
             source_path=ctx.obj[RUN_LEVEL_PARAMS_KEY].get(CTX_PROJECT_ROOT),
             module_name=ctx.obj[RUN_LEVEL_PARAMS_KEY].get(CTX_MODULE),
+            copy_all=ctx.obj[RUN_LEVEL_PARAMS_KEY].get(CTX_COPY_ALL),
         )
 
         options = None

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -825,7 +825,6 @@ class FlyteRemote(object):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             if copy_all:
-                print(source_path)
                 md5_bytes, upload_native_url = self.fast_package(pathlib.Path(source_path), False, tmp_dir)
             else:
                 archive_fname = pathlib.Path(os.path.join(tmp_dir, "script_mode.tar.gz"))

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -67,6 +67,16 @@ def test_imperative_wf():
     assert result.exit_code == 0
 
 
+def test_copy_all_files():
+    runner = CliRunner()
+    result = runner.invoke(
+        pyflyte.main,
+        ["run", "--copy-all", IMPERATIVE_WORKFLOW_FILE, "wf", "--in1", "hello", "--in2", "world"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+
 def test_pyflyte_run_cli():
     runner = CliRunner()
     parquet_file = os.path.join(DIR_NAME, "testdata/df.parquet")


### PR DESCRIPTION
# TL;DR
Fixes https://flyte-org.slack.com/archives/CP2HDHKE1/p1683114107382779

Add a new flag (--copy-all) to pyflyte run. it allows user to copy all the files in the source root directory to remote.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://flyte-org.slack.com/archives/CP2HDHKE1/p1683114107382779


## Follow-up issue
_NA_

