### PR TITLE
Improve task decorator type hints with overload

### DIFF
--- a/flytekit/core/task.py
+++ b/flytekit/core/task.py
@@ -1,6 +1,6 @@
 import datetime as _datetime
 from functools import update_wrapper
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, overload
 
 from flytekit.core.base_task import TaskMetadata, TaskResolverMixin
 from flytekit.core.interface import transform_function_to_interface
@@ -75,9 +75,64 @@ class TaskPlugins(object):
         return PythonFunctionTask
 
 
+T = TypeVar("T")
+
+
+@overload
 def task(
-    _task_function: Optional[Callable] = None,
-    task_config: Optional[Any] = None,
+    _task_function: None = ...,
+    task_config: Optional[T] = ...,
+    cache: bool = ...,
+    cache_serialize: bool = ...,
+    cache_version: str = ...,
+    retries: int = ...,
+    interruptible: Optional[bool] = ...,
+    deprecated: str = ...,
+    timeout: Union[_datetime.timedelta, int] = ...,
+    container_image: Optional[Union[str, ImageSpec]] = ...,
+    environment: Optional[Dict[str, str]] = ...,
+    requests: Optional[Resources] = ...,
+    limits: Optional[Resources] = ...,
+    secret_requests: Optional[List[Secret]] = ...,
+    execution_mode: PythonFunctionTask.ExecutionBehavior = ...,
+    task_resolver: Optional[TaskResolverMixin] = ...,
+    docs: Optional[Documentation] = ...,
+    disable_deck: bool = ...,
+    pod_template: Optional["PodTemplate"] = ...,
+    pod_template_name: Optional[str] = ...,
+) -> Callable[[Callable[..., Any]], PythonFunctionTask[T]]:
+    ...
+
+
+@overload
+def task(
+    _task_function: Callable[..., Any],
+    task_config: Optional[T] = ...,
+    cache: bool = ...,
+    cache_serialize: bool = ...,
+    cache_version: str = ...,
+    retries: int = ...,
+    interruptible: Optional[bool] = ...,
+    deprecated: str = ...,
+    timeout: Union[_datetime.timedelta, int] = ...,
+    container_image: Optional[Union[str, ImageSpec]] = ...,
+    environment: Optional[Dict[str, str]] = ...,
+    requests: Optional[Resources] = ...,
+    limits: Optional[Resources] = ...,
+    secret_requests: Optional[List[Secret]] = ...,
+    execution_mode: PythonFunctionTask.ExecutionBehavior = ...,
+    task_resolver: Optional[TaskResolverMixin] = ...,
+    docs: Optional[Documentation] = ...,
+    disable_deck: bool = ...,
+    pod_template: Optional["PodTemplate"] = ...,
+    pod_template_name: Optional[str] = ...,
+) -> PythonFunctionTask[T]:
+    ...
+
+
+def task(
+    _task_function: Optional[Callable[..., Any]] = None,
+    task_config: Optional[T] = None,
     cache: bool = False,
     cache_serialize: bool = False,
     cache_version: str = "",
@@ -96,7 +151,7 @@ def task(
     disable_deck: bool = True,
     pod_template: Optional["PodTemplate"] = None,
     pod_template_name: Optional[str] = None,
-) -> Union[Callable, PythonFunctionTask]:
+) -> Union[Callable[[Callable[..., Any]], PythonFunctionTask[T]], PythonFunctionTask[T]]:
     """
     This is the core decorator to use for any task type in flytekit.
 
@@ -190,7 +245,7 @@ def task(
     :param pod_template_name: The name of the existing PodTemplate resource which will be used in this task.
     """
 
-    def wrapper(fn) -> PythonFunctionTask:
+    def wrapper(fn: Callable[..., Any]) -> PythonFunctionTask[T]:
         _metadata = TaskMetadata(
             cache=cache,
             cache_serialize=cache_serialize,


### PR DESCRIPTION
# TL;DR
Functions decorated by `flytekit.task` are not hinted as `PythonFunctionTask` as a result of its return typing, so there are spurious type errors when attempting to register such tasks on `FlyteRemote` objects.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

Here you can see an explanation of the problem and the fix:

```python
import flytekit
import flytekit.configuration as flyte_config
import flytekit.remote


@flytekit.task
def my_task1() -> int:
    return 0


@flytekit.task()
def my_task2() -> int:
    return 0


@flytekit.task(task_config=5)
def my_task3() -> int:
    return 0


my_task4 = flytekit.task(lambda: 0)

remote = flytekit.remote.FlyteRemote(...)  # type: ignore
serialization_settings = flyte_config.SerializationSettings(...)  # type: ignore

# before
reveal_type(my_task1)  # Type of "my_task1" is "((...) -> Any) | PythonFunctionTask"
remote.register_task(my_task1, serialization_settings)  # error: Argument of type "((...) -> Any) | PythonFunctionTask" cannot be assigned to parameter "entity" of type "PythonTask" in function "register_task"

reveal_type(my_task2)  # Type of "my_task2" is "() -> int"
remote.register_task(my_task2, serialization_settings)  # error: Argument of type "() -> int" cannot be assigned to parameter "entity" of type "PythonTask" in function "register_task"

reveal_type(my_task3)  # Type of "my_task3" is "() -> int"
remote.register_task(my_task3, serialization_settings)  # error: Argument of type "() -> int" cannot be assigned to parameter "entity" of type "PythonTask" in function "register_task"

reveal_type(my_task4)  # Type of "my_task4" is "((...) -> Any) | PythonFunctionTask"
remote.register_task(my_task4, serialization_settings)  # Argument of type "((...) -> Any) | PythonFunctionTask" cannot be assigned to parameter "entity" of type "PythonTask" in function "register_task"


# after
reveal_type(my_task1)  # Type of "my_task1" is "PythonFunctionTask"
remote.register_task(my_task1, serialization_settings)  # OK

reveal_type(my_task2)  # Type of "my_task2" is "PythonFunctionTask[T@task]"
remote.register_task(my_task2, serialization_settings)  # OK

reveal_type(my_task3)  # Type of "my_task3" is "PythonFunctionTask[int]"
remote.register_task(my_task3, serialization_settings)  # OK

reveal_type(my_task4)  # Type of "my_task4" is "PythonFunctionTask"
remote.register_task(my_task4, serialization_settings)  # OK
```

I accomplished this fix by using `typing.overload` to hint a different return type based on whether `_task_function` is passed to `flytekit.task` or not.

If nothing is passed as in the case of `my_task2` or `my_task3`, we hint the return type as `Callable[[Callable[..., Any]], PythonFunctionTask[T]]`... that is a callable that accepts a single argument that is any function and returns a `PythonFunctionTask`.

If something is passed for `_task_function` as in `my_task1` or `my_task4`, we hint the return type as `PythonFunctionTask[T]`.

## Tracking Issue
N/A

## Follow-up issue
N/A
