### PR TITLE
Allow annotated FlyteFile as task input argument

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -173,8 +173,7 @@ class SimpleTransformer(TypeTransformer[T]):
         return self._to_literal_transformer(python_val)
 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
-        if get_origin(expected_python_type) is Annotated:
-            expected_python_type = get_args(expected_python_type)[0]
+        expected_python_type = get_underlying_type(expected_python_type)
 
         if expected_python_type != self._type:
             raise TypeTransformerFailedError(
@@ -311,7 +310,7 @@ class DataclassTransformer(TypeTransformer[object]):
         Extracts the Literal type definition for a Dataclass and returns a type Struct.
         If possible also extracts the JSONSchema for the dataclass.
         """
-        if get_origin(t) is Annotated:
+        if is_annotated(t):
             raise ValueError(
                 "Flytekit does not currently have support for FlyteAnnotations applied to Dataclass."
                 f"Type {t} cannot be parsed."
@@ -368,7 +367,7 @@ class DataclassTransformer(TypeTransformer[object]):
                 self._get_origin_type_in_annotation(get_args(python_type)[0]),
                 self._get_origin_type_in_annotation(get_args(python_type)[1]),
             ]
-        elif get_origin(python_type) is Annotated:
+        elif is_annotated(python_type):
             return get_args(python_type)[0]
         elif dataclasses.is_dataclass(python_type):
             for field in dataclasses.fields(copy.deepcopy(python_type)):
@@ -734,8 +733,7 @@ class TypeEngine(typing.Generic[T]):
         """
         cls.lazy_import_transformers()
         # Step 1
-        if get_origin(python_type) is Annotated:
-            python_type = get_args(python_type)[0]
+        python_type = get_underlying_type(python_type)
 
         if python_type in cls._REGISTRY:
             return cls._REGISTRY[python_type]
@@ -744,7 +742,7 @@ class TypeEngine(typing.Generic[T]):
         if hasattr(python_type, "__origin__"):
             # Handling of annotated generics, eg:
             # Annotated[typing.List[int], 'foo']
-            if get_origin(python_type) is Annotated:
+            if is_annotated(python_type):
                 return cls.get_transformer(get_args(python_type)[0])
 
             if python_type.__origin__ in cls._REGISTRY:
@@ -815,7 +813,7 @@ class TypeEngine(typing.Generic[T]):
         transformer = cls.get_transformer(python_type)
         res = transformer.get_literal_type(python_type)
         data = None
-        if get_origin(python_type) is Annotated:
+        if is_annotated(python_type):
             for x in get_args(python_type)[1:]:
                 if not isinstance(x, FlyteAnnotation):
                     continue
@@ -843,9 +841,9 @@ class TypeEngine(typing.Generic[T]):
 
         # In case the value is an annotated type we inspect the annotations and look for hash-related annotations.
         hash = None
-        if get_origin(python_type) is Annotated:
+        if is_annotated(python_type):
             # We are now dealing with one of two cases:
-            # 1. The annotated type is a `HashMethod`, which indicates that we should we should produce the hash using
+            # 1. The annotated type is a `HashMethod`, which indicates that we should produce the hash using
             #    the method indicated in the annotation.
             # 2. The annotated type is being used for a different purpose other than calculating hash values, in which case
             #    we should just continue.
@@ -872,7 +870,7 @@ class TypeEngine(typing.Generic[T]):
     @classmethod
     def to_html(cls, ctx: FlyteContext, python_val: typing.Any, expected_python_type: Type[typing.Any]) -> str:
         transformer = cls.get_transformer(expected_python_type)
-        if get_origin(expected_python_type) is Annotated:
+        if is_annotated(expected_python_type):
             expected_python_type, *annotate_args = get_args(expected_python_type)
             from flytekit.deck.renderer import Renderable
 
@@ -996,7 +994,7 @@ class ListTransformer(TypeTransformer[T]):
         if hasattr(t, "__origin__"):
             # Handle annotation on list generic, eg:
             # Annotated[typing.List[int], 'foo']
-            if get_origin(t) is Annotated:
+            if is_annotated(t):
                 return ListTransformer.get_sub_type(get_args(t)[0])
 
             if getattr(t, "__origin__") is list and hasattr(t, "__args__"):
@@ -1022,7 +1020,7 @@ class ListTransformer(TypeTransformer[T]):
         """
         from flytekit.types.pickle import FlytePickle
 
-        if get_origin(t) is Annotated:
+        if is_annotated(t):
             return ListTransformer.is_batchable(get_args(t)[0])
         if get_origin(t) is list:
             subtype = get_args(t)[0]
@@ -1039,7 +1037,7 @@ class ListTransformer(TypeTransformer[T]):
 
             batch_size = len(python_val)  # default batch size
             # parse annotated to get the number of items saved in a pickle file.
-            if get_origin(python_type) is Annotated:
+            if is_annotated(python_type):
                 for annotation in get_args(python_type)[1:]:
                     if isinstance(annotation, BatchSize):
                         batch_size = annotation.val
@@ -1183,8 +1181,7 @@ class UnionTransformer(TypeTransformer[T]):
         return get_args(t)[0]
 
     def get_literal_type(self, t: Type[T]) -> Optional[LiteralType]:
-        if get_origin(t) is Annotated:
-            t = get_args(t)[0]
+        t = get_underlying_type(t)
 
         try:
             trans: typing.List[typing.Tuple[TypeTransformer, typing.Any]] = [
@@ -1198,8 +1195,7 @@ class UnionTransformer(TypeTransformer[T]):
             raise ValueError(f"Type of Generic Union type is not supported, {e}")
 
     def to_literal(self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:
-        if get_origin(python_type) is Annotated:
-            python_type = get_args(python_type)[0]
+        python_type = get_underlying_type(python_type)
 
         found_res = False
         res = None
@@ -1224,8 +1220,7 @@ class UnionTransformer(TypeTransformer[T]):
         raise TypeTransformerFailedError(f"Cannot convert from {python_val} to {python_type}")
 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> Optional[typing.Any]:
-        if get_origin(expected_python_type) is Annotated:
-            expected_python_type = get_args(expected_python_type)[0]
+        expected_python_type = get_underlying_type(expected_python_type)
 
         union_tag = None
         union_type = None
@@ -1460,7 +1455,7 @@ class EnumTransformer(TypeTransformer[enum.Enum]):
         super().__init__(name="DefaultEnumTransformer", t=enum.Enum)
 
     def get_literal_type(self, t: Type[T]) -> LiteralType:
-        if get_origin(t) is Annotated:
+        if is_annotated(t):
             raise ValueError(
                 f"Flytekit does not currently have support \
                     for FlyteAnnotations applied to enums. {t} cannot be \
@@ -1774,3 +1769,14 @@ class LiteralsResolver(collections.UserDict):
 
 
 _register_default_type_transformers()
+
+
+def is_annotated(t: Type) -> bool:
+    return get_origin(t) is Annotated
+
+
+def get_underlying_type(t: Type) -> Type:
+    """Return the underlying type for annotated types or the type itself"""
+    if is_annotated(t):
+        return get_args(t)[0]
+    return t

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 
 from dataclasses_json import config, dataclass_json
 from marshmallow import fields
-from typing_extensions import Annotated, get_args, get_origin
+from typing_extensions import Annotated, Type, get_args, get_origin
 
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.type_engine import TypeEngine, TypeTransformer, TypeTransformerFailedError
@@ -24,6 +24,13 @@ def noop():
 
 
 T = typing.TypeVar("T")
+
+
+def _get_origin_type(t: Type) -> Type:
+    """Return the origin type for annotated types or the type itself, such that it can be used with ``issubclass()``"""
+    if get_origin(t) is Annotated:
+        return get_args(t)[0]
+    return t
 
 
 @dataclass_json
@@ -337,8 +344,7 @@ class FlyteFilePathTransformer(TypeTransformer[FlyteFile]):
             raise TypeTransformerFailedError("None value cannot be converted to a file.")
 
         # Correctly handle `Annotated[FlyteFile, ...]` by extracting the origin type
-        if get_origin(python_type) is Annotated:
-            python_type = get_args(python_type)[0]
+        python_type = _get_origin_type(python_type)
 
         if not (python_type is os.PathLike or issubclass(python_type, FlyteFile)):
             raise ValueError(f"Incorrect type {python_type}, must be either a FlyteFile or os.PathLike")
@@ -412,6 +418,9 @@ class FlyteFilePathTransformer(TypeTransformer[FlyteFile]):
         # Using is instead of issubclass because FlyteFile does actually subclass it
         if expected_python_type is os.PathLike:
             return FlyteFile(uri)
+
+        # Correctly handle `Annotated[FlyteFile, ...]` by extracting the origin type
+        expected_python_type = _get_origin_type(expected_python_type)
 
         # The rest of the logic is only for FlyteFile types.
         if not issubclass(expected_python_type, FlyteFile):  # type: ignore

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -8,10 +8,9 @@ from dataclasses import dataclass, field
 
 from dataclasses_json import config, dataclass_json
 from marshmallow import fields
-from typing_extensions import Annotated, Type, get_args, get_origin
 
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
-from flytekit.core.type_engine import TypeEngine, TypeTransformer, TypeTransformerFailedError
+from flytekit.core.type_engine import TypeEngine, TypeTransformer, TypeTransformerFailedError, get_underlying_type
 from flytekit.loggers import logger
 from flytekit.models.core.types import BlobType
 from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
@@ -24,13 +23,6 @@ def noop():
 
 
 T = typing.TypeVar("T")
-
-
-def _get_origin_type(t: Type) -> Type:
-    """Return the origin type for annotated types or the type itself, such that it can be used with ``issubclass()``"""
-    if get_origin(t) is Annotated:
-        return get_args(t)[0]
-    return t
 
 
 @dataclass_json
@@ -344,7 +336,7 @@ class FlyteFilePathTransformer(TypeTransformer[FlyteFile]):
             raise TypeTransformerFailedError("None value cannot be converted to a file.")
 
         # Correctly handle `Annotated[FlyteFile, ...]` by extracting the origin type
-        python_type = _get_origin_type(python_type)
+        python_type = get_underlying_type(python_type)
 
         if not (python_type is os.PathLike or issubclass(python_type, FlyteFile)):
             raise ValueError(f"Incorrect type {python_type}, must be either a FlyteFile or os.PathLike")
@@ -420,7 +412,7 @@ class FlyteFilePathTransformer(TypeTransformer[FlyteFile]):
             return FlyteFile(uri)
 
         # Correctly handle `Annotated[FlyteFile, ...]` by extracting the origin type
-        expected_python_type = _get_origin_type(expected_python_type)
+        expected_python_type = get_underlying_type(expected_python_type)
 
         # The rest of the logic is only for FlyteFile types.
         if not issubclass(expected_python_type, FlyteFile):  # type: ignore

--- a/tests/flytekit/unit/core/test_flyte_file.py
+++ b/tests/flytekit/unit/core/test_flyte_file.py
@@ -439,13 +439,20 @@ def test_flyte_file_annotated_hashmethod(local_dummy_file):
     def calc_hash(ff: FlyteFile) -> str:
         return str(ff.path)
 
+    HashedFlyteFile = Annotated[FlyteFile, HashMethod(calc_hash)]
+
     @task
-    def t1(path: str) -> Annotated[FlyteFile, HashMethod(calc_hash)]:
-        return FlyteFile(path)
+    def t1(path: str) -> HashedFlyteFile:
+        return HashedFlyteFile(path)
+
+    @task
+    def t2(ff: HashedFlyteFile) -> None:
+        print(ff.path)
 
     @workflow
     def wf(path: str) -> None:
-        t1(path=path)
+        ff = t1(path=path)
+        t2(ff=ff)
 
     wf(path=local_dummy_file)
 

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1694,8 +1694,8 @@ def test_batch_pickle_list(python_val, python_type, expected_list_length):
     [
         (list, False),
         (Annotated[int, "tag"], True),
-        (Annotated[list[str], "a", "b"], True),
-        (Annotated[dict[int, str], FlyteAnnotation({"foo": "bar"})], True),
+        (Annotated[typing.List[str], "a", "b"], True),
+        (Annotated[typing.Dict[int, str], FlyteAnnotation({"foo": "bar"})], True),
     ],
 )
 def test_is_annotated(t, expected):
@@ -1703,7 +1703,12 @@ def test_is_annotated(t, expected):
 
 
 @pytest.mark.parametrize(
-    "t,expected", [(list, list), (Annotated[int, "tag"], int), (Annotated[list[str], "a", "b"], list[str])]
+    "t,expected",
+    [
+        (typing.List, typing.List),
+        (Annotated[int, "tag"], int),
+        (Annotated[typing.List[str], "a", "b"], typing.List[str]),
+    ],
 )
 def test_get_underlying_type(t, expected):
     assert get_underlying_type(t) == expected


### PR DESCRIPTION
# TL;DR

This PR allows annotated FlyteFiles to be used as input arguments of a task, e.g., when calculating a custom hash using `Annotated[FlyteFile, HashMethod(...)]`.

See the discussion on [Slack](https://flyte-org.slack.com/archives/CP2HDHKE1/p1683635974841289) for additional details.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Using an annotated FlyteFile type as an input to a task was previously impossible due to an exception being raised in `FlyteFilePathTransformer.to_python_value`.

This MR applies the fix previously used in `FlyteFilePathTransformer.to_literal` to permit using annotated FlyteFiles as either inputs or outputs of a task (see MR #1544), by unwrapping the origin type of the annotated type.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3424

## Follow-up issue
_NA_
