### PR TITLE
Improve workflow decorator type hints with overload

### DIFF
--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -4,7 +4,7 @@ import typing
 from dataclasses import dataclass
 from enum import Enum
 from functools import update_wrapper
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast, overload
 
 from typing_extensions import get_args
 
@@ -653,7 +653,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
 
     def __init__(
         self,
-        workflow_function: Callable,
+        workflow_function: Callable[..., Any],
         metadata: WorkflowMetadata,
         default_metadata: WorkflowMetadataDefaults,
         docstring: Optional[Docstring] = None,
@@ -777,12 +777,32 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
         return exception_scopes.user_entry_point(self._workflow_function)(**kwargs)
 
 
+@overload
 def workflow(
-    _workflow_function=None,
+    _workflow_function: None = ...,
+    failure_policy: Optional[WorkflowFailurePolicy] = ...,
+    interruptible: bool = ...,
+    docs: Optional[Documentation] = ...,
+) -> Callable[[Callable[..., Any]], PythonFunctionWorkflow]:
+    ...
+
+
+@overload
+def workflow(
+    _workflow_function: Callable[..., Any],
+    failure_policy: Optional[WorkflowFailurePolicy] = ...,
+    interruptible: bool = ...,
+    docs: Optional[Documentation] = ...,
+) -> PythonFunctionWorkflow:
+    ...
+
+
+def workflow(
+    _workflow_function: Optional[Callable[..., Any]] = None,
     failure_policy: Optional[WorkflowFailurePolicy] = None,
     interruptible: bool = False,
     docs: Optional[Documentation] = None,
-) -> WorkflowBase:
+) -> Union[Callable[[Callable[..., Any]], PythonFunctionWorkflow], PythonFunctionWorkflow]:
     """
     This decorator declares a function to be a Flyte workflow. Workflows are declarative entities that construct a DAG
     of tasks using the data flow between tasks.
@@ -813,7 +833,7 @@ def workflow(
     :param docs: Description entity for the workflow
     """
 
-    def wrapper(fn):
+    def wrapper(fn: Callable[..., Any]) -> PythonFunctionWorkflow:
         workflow_metadata = WorkflowMetadata(on_failure=failure_policy or WorkflowFailurePolicy.FAIL_IMMEDIATELY)
 
         workflow_metadata_defaults = WorkflowMetadataDefaults(interruptible)
@@ -828,10 +848,10 @@ def workflow(
         update_wrapper(workflow_instance, fn)
         return workflow_instance
 
-    if _workflow_function:
+    if _workflow_function is not None:
         return wrapper(_workflow_function)
     else:
-        return wrapper  # type: ignore
+        return wrapper
 
 
 class ReferenceWorkflow(ReferenceEntity, PythonFunctionWorkflow):  # type: ignore


### PR DESCRIPTION
# TL;DR
Currently, the `workflow` decorator is hinted as always returning a `WorkflowBase`, which is not true when `_workflow_function` is `None`; this leads to a spurious type error depending on how `workflow` is called; similar to #1631, I propose using `typing.overload` to differentiate the return type of `workflow` based on the value of `_workflow_function`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

Here is an example of the typing bug this fix addresses:
```python
import flytekit
import flytekit.remote


@flytekit.workflow
def my_workflow1() -> int:
    return 0


@flytekit.workflow()
def my_workflow2() -> int:
    return 0


my_workflow3 = flytekit.workflow(lambda: 0)

remote = flytekit.remote.FlyteRemote(...)  # type: ignore

# before
reveal_type(my_workflow1)  # Type of "my_workflow1" is "WorkflowBase"
remote.register_workflow(my_workflow1)  # OK

reveal_type(my_workflow2)  # Type of "my_workflow2" is "Tuple[Promise] | Promise | VoidPromise | Tuple | None"
remote.register_workflow(my_workflow2)  # error: Argument of type "Tuple[Promise] | Promise | VoidPromise | Tuple | None" cannot be assigned to parameter "entity" of type "WorkflowBase" in function "register_workflow"

reveal_type(my_workflow3)  # Type of "my_workflow3" is "WorkflowBase"
remote.register_workflow(my_workflow3)  # OK


# after
reveal_type(my_workflow1)  # Type of "my_workflow1" is "PythonFunctionWorkflow"
remote.register_workflow(my_workflow1)  # OK

reveal_type(my_workflow2)  # Type of "my_workflow2" is "PythonFunctionWorkflow"
remote.register_workflow(my_workflow2)  # OK

reveal_type(my_workflow3)  # Type of "my_workflow3" is "PythonFunctionWorkflow"
remote.register_workflow(my_workflow3)  # OK
```

I am proposing to change the return type from `WorkflowBase` to `PythonFunctionWorkflow`. This is the class being instantiated and seems to match what is done by `task`, which returns `PythonFunctionTask` instead of the base class `PythonTask` which is expected by `FlyteRemote.register_task`.

I am also proposing we use the condition `if _workflow_function is not None:` instead of `if _workflow_function:`. This is a recommendation by the Google Python Style Guide: https://google.github.io/styleguide/pyguide.html#2144-decision

> Always use if foo is None: (or is not None) to check for a None value. E.g., when testing whether a variable or argument that defaults to None was set to some other value. The other value might be a value that’s false in a boolean context!

## Tracking Issue
N/A

## Follow-up issue
N/A
