### PR TITLE
Fetch task executions in dynamic 

### DIFF
--- a/flytekit/remote/entities.py
+++ b/flytekit/remote/entities.py
@@ -362,6 +362,7 @@ class FlyteNode(_hash_mixin.HashOnReferenceMixin, _workflow_model.Node):
             )
         # TODO: Revisit flyte_branch_node and flyte_gate_node, should they be another type like Condition instead
         #       of a node?
+        self._flyte_task_node = task_node
         if task_node:
             self._flyte_entity = task_node.flyte_task
         elif workflow_node:
@@ -381,6 +382,10 @@ class FlyteNode(_hash_mixin.HashOnReferenceMixin, _workflow_model.Node):
             gate_node=gate_node,
         )
         self._upstream = upstream_nodes
+
+    @property
+    def task_node(self) -> Optional[FlyteTaskNode]:
+        return self._flyte_task_node
 
     @property
     def flyte_entity(self) -> Union[FlyteTask, FlyteWorkflow, FlyteLaunchPlan, FlyteBranchNode]:
@@ -707,7 +712,7 @@ class FlyteWorkflow(_hash_mixin.HashOnReferenceMixin, RemoteEntity, WorkflowSpec
 
         :param closure: This is the closure returned by Admin
         :param node_launch_plans: The reason this exists is because the compiled closure doesn't have launch plans.
-          It only has subworkflows and tasks. Why this is is unclear. If supplied, this map of launch plans will be
+          It only has subworkflows and tasks. Why this is unclear. If supplied, this map of launch plans will be
         :return:
         """
         sub_workflows = {sw.template.id: sw.template for sw in closure.sub_workflows}

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -30,7 +30,6 @@ from flytekit.core import constants, utils
 from flytekit.core.base_task import PythonTask
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.data_persistence import FileAccessProvider
-from flytekit.core.interface import Interface
 from flytekit.core.launch_plan import LaunchPlan
 from flytekit.core.python_auto_container import PythonAutoContainerTask
 from flytekit.core.reference_entity import ReferenceSpec

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1513,7 +1513,6 @@ class FlyteRemote(object):
         self,
         execution: FlyteNodeExecution,
         node_mapping: typing.Dict[str, FlyteNode],
-        node_interface: typing.Optional[Interface] = None,
     ) -> FlyteNodeExecution:
         """
         Get data backing a node execution. These FlyteNodeExecution objects should've come from Admin with the model

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -30,6 +30,7 @@ from flytekit.core import constants, utils
 from flytekit.core.base_task import PythonTask
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.data_persistence import FileAccessProvider
+from flytekit.core.interface import Interface
 from flytekit.core.launch_plan import LaunchPlan
 from flytekit.core.python_auto_container import PythonAutoContainerTask
 from flytekit.core.reference_entity import ReferenceSpec
@@ -1512,6 +1513,7 @@ class FlyteRemote(object):
         self,
         execution: FlyteNodeExecution,
         node_mapping: typing.Dict[str, FlyteNode],
+        node_interface: typing.Optional[Interface] = None,
     ) -> FlyteNodeExecution:
         """
         Get data backing a node execution. These FlyteNodeExecution objects should've come from Admin with the model
@@ -1610,13 +1612,10 @@ class FlyteRemote(object):
                     self.sync_node_execution(FlyteNodeExecution.promote_from_model(cne), dynamic_flyte_wf._node_map)
                     for cne in child_node_executions
                 ]
-                # This is copied from below - dynamic tasks have both task executions (executions of the parent
-                # task) as well as underlying node executions (of the generated subworkflow). Feel free to refactor
-                # if you can think of a better way.
                 execution._task_executions = [
-                    self.sync_task_execution(FlyteTaskExecution.promote_from_model(t))
-                    for t in iterate_task_executions(self.client, execution.id)
+                    node_exes.task_executions for node_exes in execution.subworkflow_node_executions.values()
                 ]
+
                 execution._interface = dynamic_flyte_wf.interface
 
             # Handle the case where it's a static subworkflow
@@ -1643,7 +1642,9 @@ class FlyteRemote(object):
         # This is the plain ol' task execution case
         else:
             execution._task_executions = [
-                self.sync_task_execution(FlyteTaskExecution.promote_from_model(t))
+                self.sync_task_execution(
+                    FlyteTaskExecution.promote_from_model(t), node_mapping[node_id].task_node.flyte_task
+                )
                 for t in iterate_task_executions(self.client, execution.id)
             ]
             execution._interface = execution._node.flyte_entity.interface
@@ -1657,17 +1658,15 @@ class FlyteRemote(object):
         return execution
 
     def sync_task_execution(
-        self, execution: FlyteTaskExecution, entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None
+        self, execution: FlyteTaskExecution, entity_definition: typing.Optional[FlyteTask] = None
     ) -> FlyteTaskExecution:
         """Sync a FlyteTaskExecution object with its corresponding remote state."""
-        if entity_definition is not None:
-            raise ValueError("Entity definition arguments aren't supported when syncing task executions")
-
         execution._closure = self.client.get_task_execution(execution.id).closure
         execution_data = self.client.get_task_execution_data(execution.id)
         task_id = execution.id.task_id
-        task = self.fetch_task(task_id.project, task_id.domain, task_id.name, task_id.version)
-        return self._assign_inputs_and_outputs(execution, execution_data, task.interface)
+        if entity_definition is None:
+            entity_definition = self.fetch_task(task_id.project, task_id.domain, task_id.name, task_id.version)
+        return self._assign_inputs_and_outputs(execution, execution_data, entity_definition.interface)
 
     #############################
     # Terminate Execution State #


### PR DESCRIPTION
# TL;DR
Fixes https://github.com/flyteorg/flyte/issues/3639
Instead of fetching flyte task entity from admin, we should get task interface from [DynamicWorkflowNodeMetadata](https://github.com/flyteorg/flyteidl/blob/5e89823156a3dd616f57d8c9ac7495bf15b8ede6/protos/flyteidl/admin/node_execution.proto#LL229C5-L229C32).
btw, the sub node data in the dynamic has been add into the `node_mapping`. we can directly get task interface from the node_mapping

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
```python
from typing import Dict

from flytekit import task, workflow, dynamic
from flytekit.configuration import Config, SerializationSettings, ImageConfig
from flytekit.remote import FlyteRemote


@task
def t1(a: int) -> int:
    print(a)
    return a


@task
def t2(b: int) -> int:
    print(b)
    return b


@dynamic
def bayesopt(n_iter: int, concurrency: int) -> Dict:
    t1(a=n_iter)
    t2(b=concurrency)
    return {"a": n_iter, "b": concurrency}


@workflow
def wf(n_iter: int = 10, concurrency: int = 10) -> Dict:
    t1(a=n_iter)
    return bayesopt(n_iter=n_iter, concurrency=concurrency)


if __name__ == "__main__":
    remote = FlyteRemote(
        config=Config.auto("/Users/kevin/.flyte/config-remote.yaml"),
        default_project="flytesnacks",
        default_domain="development",
    )
    exe = remote.fetch_execution(project="flytesnacks", domain="development", name="fe8101d409e9b45c9b88")
    remote.wait(exe)
    print(exe.node_executions["n1"].task_executions)

```

## Tracking Issue
^^^

## Follow-up issue
_NA_