### PR TITLE
feat: Add audience token for Auth0 ClientCredentials Auth Flow

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -23,4 +23,4 @@ jobs:
         run: |
           sudo apt-get install python3-sphinx
           pip install -r doc-requirements.txt
-          SPHINXOPTS="-W" cd docs && make html
+          cd docs && SPHINXOPTS="-W" make html

--- a/Dockerfile.external-plugin-service
+++ b/Dockerfile.external-plugin-service
@@ -4,7 +4,6 @@ MAINTAINER Flyte Team <users@flyte.org>
 LABEL org.opencontainers.image.source=https://github.com/flyteorg/flytekit
 
 ARG VERSION
-RUN pip install -U flytekit==$VERSION \
-	flytekitplugins-bigquery==$VERSION \
+RUN pip install -U flytekit==$VERSION flytekitplugins-bigquery==$VERSION
 
 CMD pyflyte serve --port 8000

--- a/flytekit/clients/auth/authenticator.py
+++ b/flytekit/clients/auth/authenticator.py
@@ -208,8 +208,6 @@ class ClientCredentialsAuthenticator(Authenticator):
                 scopes=scopes, 
                 authorization_header=authorization_header,
             )
-        logging.warning(token)
-        logging.warning(expires_in)
         logging.info("Retrieved new token, expires in {}".format(expires_in))
         self._creds = Credentials(token)
 

--- a/flytekit/clients/auth/authenticator.py
+++ b/flytekit/clients/auth/authenticator.py
@@ -23,7 +23,7 @@ class ClientConfig:
     device_authorization_endpoint: typing.Optional[str] = None
     scopes: typing.List[str] = None
     header_key: str = "authorization"
-
+    audience: typing.Optional[str] = None
 
 class ClientConfigStore(object):
     """
@@ -162,6 +162,7 @@ class ClientCredentialsAuthenticator(Authenticator):
         cfg_store: ClientConfigStore,
         header_key: typing.Optional[str] = None,
         scopes: typing.Optional[typing.List[str]] = None,
+        audience: typing.Optional[str] = None,
     ):
         if not client_id or not client_secret:
             raise ValueError("Client ID and Client SECRET both are required.")
@@ -171,6 +172,7 @@ class ClientCredentialsAuthenticator(Authenticator):
         self._scopes = scopes or cfg.scopes
         self._client_id = client_id
         self._client_secret = client_secret
+        self._audience = cfg.audience 
         super().__init__(endpoint, cfg.header_key or header_key)
 
     def refresh_credentials(self):
@@ -183,11 +185,31 @@ class ClientCredentialsAuthenticator(Authenticator):
         """
         token_endpoint = self._token_endpoint
         scopes = self._scopes
+        audience = self._audience
+        client_id = self._client_id
+        client_secret = self._client_secret
 
         # Note that unlike the Pkce flow, the client ID does not come from Admin.
         logging.debug(f"Basic authorization flow with client id {self._client_id} scope {scopes}")
         authorization_header = token_client.get_basic_authorization_header(self._client_id, self._client_secret)
-        token, expires_in = token_client.get_token(token_endpoint, scopes, authorization_header)
+
+        if audience is not None:
+            token, expires_in = token_client.get_token(
+                token_endpoint=token_endpoint, 
+                authorization_header=authorization_header,
+                client_id=client_id,
+                client_secret=client_secret,
+                audience=audience,
+                # scopes=scopes
+            )
+        else:
+            token, expires_in = token_client.get_token(
+                token_endpoint=token_endpoint, 
+                scopes=scopes, 
+                authorization_header=authorization_header,
+            )
+        logging.warning(token)
+        logging.warning(expires_in)
         logging.info("Retrieved new token, expires in {}".format(expires_in))
         self._creds = Credentials(token)
 

--- a/flytekit/clients/auth/token_client.py
+++ b/flytekit/clients/auth/token_client.py
@@ -105,7 +105,6 @@ def get_token(
     if scopes is not None:
         body["scope"] = ",".join(scopes)
 
-    logging.warning(body)
     response = requests.post(token_endpoint, data=body, headers=headers)
 
     if not response.ok:

--- a/flytekit/clients/auth/token_client.py
+++ b/flytekit/clients/auth/token_client.py
@@ -75,6 +75,8 @@ def get_token(
     scopes: typing.Optional[typing.List[str]] = None,
     authorization_header: typing.Optional[str] = None,
     client_id: typing.Optional[str] = None,
+    client_secret: typing.Optional[str] = None,
+    audience: typing.Optional[str] = None,
     device_code: typing.Optional[str] = None,
     grant_type: GrantType = GrantType.CLIENT_CREDS,
 ) -> typing.Tuple[str, int]:
@@ -94,12 +96,18 @@ def get_token(
     }
     if client_id:
         body["client_id"] = client_id
+    if client_secret:
+        body["client_secret"] = client_secret
     if device_code:
         body["device_code"] = device_code
+    if audience is not None:
+        body["audience"] = audience
     if scopes is not None:
         body["scope"] = ",".join(scopes)
 
+    logging.warning(body)
     response = requests.post(token_endpoint, data=body, headers=headers)
+
     if not response.ok:
         j = response.json()
         if "error" in j:

--- a/flytekit/clients/auth_helper.py
+++ b/flytekit/clients/auth_helper.py
@@ -43,6 +43,7 @@ class RemoteClientConfigStore(ClientConfigStore):
             scopes=public_client_config.scopes,
             header_key=public_client_config.authorization_metadata_key or None,
             device_authorization_endpoint=oauth2_metadata.device_authorization_endpoint,
+            audience=public_client_config.audience,
         )
 
 
@@ -66,13 +67,23 @@ def get_authenticator(cfg: PlatformConfig, cfg_store: ClientConfigStore) -> Auth
             verify = cfg.ca_cert_file_path
         return PKCEAuthenticator(cfg.endpoint, cfg_store, verify=verify)
     elif cfg_auth == AuthType.BASIC or cfg_auth == AuthType.CLIENT_CREDENTIALS or cfg_auth == AuthType.CLIENTSECRET:
-        return ClientCredentialsAuthenticator(
-            endpoint=cfg.endpoint,
-            client_id=cfg.client_id,
-            client_secret=cfg.client_credentials_secret,
-            cfg_store=cfg_store,
-            scopes=cfg.scopes,
-        )
+        if cfg.audience is not None:
+            return ClientCredentialsAuthenticator(
+                endpoint=cfg.endpoint,
+                client_id=cfg.client_id,
+                client_secret=cfg.client_credentials_secret,
+                cfg_store=cfg_store,
+                scopes=cfg.scopes,
+                audience=cfg.audience,
+            )
+        else:
+            return ClientCredentialsAuthenticator(
+                endpoint=cfg.endpoint,
+                client_id=cfg.client_id,
+                client_secret=cfg.client_credentials_secret,
+                cfg_store=cfg_store,
+                scopes=cfg.scopes,
+            )
     elif cfg_auth == AuthType.EXTERNAL_PROCESS or cfg_auth == AuthType.EXTERNALCOMMAND:
         client_cfg = None
         if cfg_store:

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -15,6 +15,7 @@ from flytekit.clients.auth_helper import get_channel, upgrade_channel_to_authent
 from flytekit.configuration import PlatformConfig
 from flytekit.loggers import cli_logger
 
+import logging
 
 class RawSynchronousFlyteClient(object):
     """

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -375,7 +375,8 @@ class PlatformConfig(object):
       less secure! Please only use this if mounting the secret as a file is impossible
     :param scopes: List of scopes to request. This is only applicable to the client credentials flow
     :param auth_mode: The OAuth mode to use. Defaults to pkce flow
-    :param ca_cert_file_path: [optional] str Root Cert to be loaded and used to verify admin
+    :param ca_cert_file_path: [optional] str: Root Cert to be loaded and used to verify admin
+    :parmam audience: [optional] str: The audience to pass into the token request for OAuth flow
     """
 
     endpoint: str = "localhost:30080"
@@ -426,6 +427,9 @@ class PlatformConfig(object):
         kwargs = set_if_exists(kwargs, "auth_mode", _internal.Credentials.AUTH_MODE.read(config_file))
         kwargs = set_if_exists(kwargs, "endpoint", _internal.Platform.URL.read(config_file))
         kwargs = set_if_exists(kwargs, "console_endpoint", _internal.Platform.CONSOLE_ENDPOINT.read(config_file))
+        
+        kwargs = set_if_exists(kwargs, "audience", _internal.Credentials.AUDIENCE.read(config_file))
+        
         return PlatformConfig(**kwargs)
 
     @classmethod

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -85,6 +85,10 @@ class Credentials(object):
     password from a mounted file.
     """
 
+    AUDIENCE = ConfigEntry(
+        LegacyConfigEntry(SECTION, "audience"), YamlConfigEntry("admin.audience")
+    )
+
     SCOPES = ConfigEntry(LegacyConfigEntry(SECTION, "scopes", list), YamlConfigEntry("admin.scopes", list))
 
     AUTH_MODE = ConfigEntry(LegacyConfigEntry(SECTION, "auth_mode"), YamlConfigEntry("admin.authType"))

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -14,11 +14,7 @@ simple implementation that ships with the core.
    :template: custom.rst
    :nosignatures:
 
-   DataPersistence
-   DataPersistencePlugins
-   DiskPersistence
    FileAccessProvider
-   UnsupportedPersistenceOp
 
 """
 import os

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -21,6 +21,7 @@ from flytekit.core.interface import Interface
 from flytekit.core.node import Node
 from flytekit.core.type_engine import DictTransformer, ListTransformer, TypeEngine, TypeTransformerFailedError
 from flytekit.exceptions import user as _user_exceptions
+from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
 from flytekit.models import literals as _literal_models
 from flytekit.models import literals as _literals_models
@@ -618,10 +619,21 @@ def binding_data_from_python_std(
             f"Cannot pass output from task {t_value.task_name} that produces no outputs to a downstream task"
         )
 
-    elif isinstance(t_value, list):
-        if expected_literal_type.collection_type is None:
-            raise AssertionError(f"this should be a list and it is not: {type(t_value)} vs {expected_literal_type}")
+    elif expected_literal_type.union_type is not None:
+        for i in range(len(expected_literal_type.union_type.variants)):
+            try:
+                lt_type = expected_literal_type.union_type.variants[i]
+                python_type = get_args(t_value_type)[i] if t_value_type else None
+                return binding_data_from_python_std(ctx, lt_type, t_value, python_type)
+            except Exception:
+                logger.debug(
+                    f"failed to bind data {t_value} with literal type {expected_literal_type.union_type.variants[i]}."
+                )
+        raise AssertionError(
+            f"Failed to bind data {t_value} with literal type {expected_literal_type.union_type.variants}."
+        )
 
+    elif isinstance(t_value, list):
         sub_type: Optional[type] = ListTransformer.get_sub_type(t_value_type) if t_value_type else None
         collection = _literals_models.BindingDataCollection(
             bindings=[

--- a/flytekit/core/task.py
+++ b/flytekit/core/task.py
@@ -1,6 +1,6 @@
 import datetime as _datetime
 from functools import update_wrapper
-from typing import Any, Callable, Dict, List, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union, overload
 
 from flytekit.core.base_task import TaskMetadata, TaskResolverMixin
 from flytekit.core.interface import transform_function_to_interface
@@ -75,9 +75,64 @@ class TaskPlugins(object):
         return PythonFunctionTask
 
 
+T = TypeVar("T")
+
+
+@overload
 def task(
-    _task_function: Optional[Callable] = None,
-    task_config: Optional[Any] = None,
+    _task_function: None = ...,
+    task_config: Optional[T] = ...,
+    cache: bool = ...,
+    cache_serialize: bool = ...,
+    cache_version: str = ...,
+    retries: int = ...,
+    interruptible: Optional[bool] = ...,
+    deprecated: str = ...,
+    timeout: Union[_datetime.timedelta, int] = ...,
+    container_image: Optional[Union[str, ImageSpec]] = ...,
+    environment: Optional[Dict[str, str]] = ...,
+    requests: Optional[Resources] = ...,
+    limits: Optional[Resources] = ...,
+    secret_requests: Optional[List[Secret]] = ...,
+    execution_mode: PythonFunctionTask.ExecutionBehavior = ...,
+    task_resolver: Optional[TaskResolverMixin] = ...,
+    docs: Optional[Documentation] = ...,
+    disable_deck: bool = ...,
+    pod_template: Optional["PodTemplate"] = ...,
+    pod_template_name: Optional[str] = ...,
+) -> Callable[[Callable[..., Any]], PythonFunctionTask[T]]:
+    ...
+
+
+@overload
+def task(
+    _task_function: Callable[..., Any],
+    task_config: Optional[T] = ...,
+    cache: bool = ...,
+    cache_serialize: bool = ...,
+    cache_version: str = ...,
+    retries: int = ...,
+    interruptible: Optional[bool] = ...,
+    deprecated: str = ...,
+    timeout: Union[_datetime.timedelta, int] = ...,
+    container_image: Optional[Union[str, ImageSpec]] = ...,
+    environment: Optional[Dict[str, str]] = ...,
+    requests: Optional[Resources] = ...,
+    limits: Optional[Resources] = ...,
+    secret_requests: Optional[List[Secret]] = ...,
+    execution_mode: PythonFunctionTask.ExecutionBehavior = ...,
+    task_resolver: Optional[TaskResolverMixin] = ...,
+    docs: Optional[Documentation] = ...,
+    disable_deck: bool = ...,
+    pod_template: Optional["PodTemplate"] = ...,
+    pod_template_name: Optional[str] = ...,
+) -> PythonFunctionTask[T]:
+    ...
+
+
+def task(
+    _task_function: Optional[Callable[..., Any]] = None,
+    task_config: Optional[T] = None,
     cache: bool = False,
     cache_serialize: bool = False,
     cache_version: str = "",
@@ -96,7 +151,7 @@ def task(
     disable_deck: bool = True,
     pod_template: Optional["PodTemplate"] = None,
     pod_template_name: Optional[str] = None,
-) -> Union[Callable, PythonFunctionTask]:
+) -> Union[Callable[[Callable[..., Any]], PythonFunctionTask[T]], PythonFunctionTask[T]]:
     """
     This is the core decorator to use for any task type in flytekit.
 
@@ -190,7 +245,7 @@ def task(
     :param pod_template_name: The name of the existing PodTemplate resource which will be used in this task.
     """
 
-    def wrapper(fn) -> PythonFunctionTask:
+    def wrapper(fn: Callable[..., Any]) -> PythonFunctionTask[T]:
         _metadata = TaskMetadata(
             cache=cache,
             cache_serialize=cache_serialize,

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -718,24 +718,32 @@ class TypeEngine(typing.Generic[T]):
           d = dictionary of registered transformers, where is a python `type`
           v = lookup type
         Step 1:
-            find a transformer that matches v exactly
+            If the type is annotated with a TypeTransformer instance, use that.
 
         Step 2:
-            find a transformer that matches the generic type of v. e.g List[int], Dict[str, int] etc
+            find a transformer that matches v exactly
 
         Step 3:
+            find a transformer that matches the generic type of v. e.g List[int], Dict[str, int] etc
+
+        Step 4:
             Walk the inheritance hierarchy of v and find a transformer that matches the first base class.
             This is potentially non-deterministic - will depend on the registration pattern.
 
             TODO lets make this deterministic by using an ordered dict
 
-        Step 4:
+        Step 5:
             if v is of type data class, use the dataclass transformer
         """
         cls.lazy_import_transformers()
         # Step 1
         if get_origin(python_type) is Annotated:
-            python_type = get_args(python_type)[0]
+            args = get_args(python_type)
+            for annotation in args:
+                if isinstance(annotation, TypeTransformer):
+                    return annotation
+
+            python_type = args[0]
 
         if python_type in cls._REGISTRY:
             return cls._REGISTRY[python_type]

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -4,7 +4,7 @@ import typing
 from dataclasses import dataclass
 from enum import Enum
 from functools import update_wrapper
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast, overload
 
 from typing_extensions import get_args
 
@@ -653,7 +653,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
 
     def __init__(
         self,
-        workflow_function: Callable,
+        workflow_function: Callable[..., Any],
         metadata: WorkflowMetadata,
         default_metadata: WorkflowMetadataDefaults,
         docstring: Optional[Docstring] = None,
@@ -777,12 +777,32 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
         return exception_scopes.user_entry_point(self._workflow_function)(**kwargs)
 
 
+@overload
 def workflow(
-    _workflow_function=None,
+    _workflow_function: None = ...,
+    failure_policy: Optional[WorkflowFailurePolicy] = ...,
+    interruptible: bool = ...,
+    docs: Optional[Documentation] = ...,
+) -> Callable[[Callable[..., Any]], PythonFunctionWorkflow]:
+    ...
+
+
+@overload
+def workflow(
+    _workflow_function: Callable[..., Any],
+    failure_policy: Optional[WorkflowFailurePolicy] = ...,
+    interruptible: bool = ...,
+    docs: Optional[Documentation] = ...,
+) -> PythonFunctionWorkflow:
+    ...
+
+
+def workflow(
+    _workflow_function: Optional[Callable[..., Any]] = None,
     failure_policy: Optional[WorkflowFailurePolicy] = None,
     interruptible: bool = False,
     docs: Optional[Documentation] = None,
-) -> WorkflowBase:
+) -> Union[Callable[[Callable[..., Any]], PythonFunctionWorkflow], PythonFunctionWorkflow]:
     """
     This decorator declares a function to be a Flyte workflow. Workflows are declarative entities that construct a DAG
     of tasks using the data flow between tasks.
@@ -813,7 +833,7 @@ def workflow(
     :param docs: Description entity for the workflow
     """
 
-    def wrapper(fn):
+    def wrapper(fn: Callable[..., Any]) -> PythonFunctionWorkflow:
         workflow_metadata = WorkflowMetadata(on_failure=failure_policy or WorkflowFailurePolicy.FAIL_IMMEDIATELY)
 
         workflow_metadata_defaults = WorkflowMetadataDefaults(interruptible)
@@ -828,10 +848,10 @@ def workflow(
         update_wrapper(workflow_instance, fn)
         return workflow_instance
 
-    if _workflow_function:
+    if _workflow_function is not None:
         return wrapper(_workflow_function)
     else:
-        return wrapper  # type: ignore
+        return wrapper
 
 
 class ReferenceWorkflow(ReferenceEntity, PythonFunctionWorkflow):  # type: ignore

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import typing
 from dataclasses import dataclass
 from enum import Enum
 from functools import update_wrapper
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
+
+from typing_extensions import get_args
 
 from flytekit.core import constants as _common_constants
 from flytekit.core.base_task import PythonTask
@@ -32,14 +35,16 @@ from flytekit.core.promise import (
 from flytekit.core.python_auto_container import PythonAutoContainerTask
 from flytekit.core.reference_entity import ReferenceEntity, WorkflowReference
 from flytekit.core.tracker import extract_task_module
-from flytekit.core.type_engine import TypeEngine, TypeTransformerFailedError
+from flytekit.core.type_engine import TypeEngine, TypeTransformerFailedError, UnionTransformer
 from flytekit.exceptions import scopes as exception_scopes
 from flytekit.exceptions.user import FlyteValidationException, FlyteValueException
 from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
 from flytekit.models import literals as _literal_models
+from flytekit.models import types as type_models
 from flytekit.models.core import workflow as _workflow_model
 from flytekit.models.documentation import Description, Documentation
+from flytekit.models.types import TypeStructure
 
 GLOBAL_START_NODE = Node(
     id=_common_constants.GLOBAL_INPUT_NODE_ID,
@@ -48,6 +53,8 @@ GLOBAL_START_NODE = Node(
     upstream_nodes=[],
     flyte_entity=None,
 )
+
+T = typing.TypeVar("T")
 
 
 class WorkflowFailurePolicy(Enum):
@@ -272,24 +279,63 @@ class WorkflowBase(object):
     def compile(self, **kwargs):
         pass
 
+    def ensure_literal(
+        self, ctx, py_type: Type[T], input_type: type_models.LiteralType, python_value: Any
+    ) -> _literal_models.Literal:
+        """
+        This function will attempt to convert a python value to a literal. If the python value is a promise, it will
+        return the promise's value.
+        """
+        if input_type.union_type is not None:
+            if python_value is None and UnionTransformer.is_optional_type(py_type):
+                return _literal_models.Literal(scalar=_literal_models.Scalar(none_type=_literal_models.Void()))
+            for i in range(len(input_type.union_type.variants)):
+                lt_type = input_type.union_type.variants[i]
+                python_type = get_args(py_type)[i]
+                try:
+                    final_lt = self.ensure_literal(ctx, python_type, lt_type, python_value)
+                    lt_type._structure = TypeStructure(tag=TypeEngine.get_transformer(python_type).name)
+                    return _literal_models.Literal(
+                        scalar=_literal_models.Scalar(union=_literal_models.Union(value=final_lt, stored_type=lt_type))
+                    )
+                except Exception as e:
+                    logger.debug(f"Failed to convert {python_value} to {lt_type} with error {e}")
+            raise TypeError(f"Failed to convert {python_value} to {input_type}")
+        if isinstance(python_value, list) and input_type.collection_type:
+            collection_lit_type = input_type.collection_type
+            collection_py_type = get_args(py_type)[0]
+            xx = [self.ensure_literal(ctx, collection_py_type, collection_lit_type, pv) for pv in python_value]
+            return _literal_models.Literal(collection=_literal_models.LiteralCollection(literals=xx))
+        elif isinstance(python_value, dict) and input_type.map_value_type:
+            mapped_lit_type = input_type.map_value_type
+            mapped_py_type = get_args(py_type)[1]
+            xx = {k: self.ensure_literal(ctx, mapped_py_type, mapped_lit_type, v) for k, v in python_value.items()}  # type: ignore
+            return _literal_models.Literal(map=_literal_models.LiteralMap(literals=xx))
+        # It is a scalar, convert to Promise if necessary.
+        else:
+            if isinstance(python_value, Promise):
+                return python_value.val
+            if not isinstance(python_value, Promise):
+                try:
+                    res = TypeEngine.to_literal(ctx, python_value, py_type, input_type)
+                    return res
+                except TypeTransformerFailedError as exc:
+                    raise TypeError(
+                        f"Failed to convert input '{python_value}' of workflow '{self.name}':\n  {exc}"
+                    ) from exc
+
     def local_execute(self, ctx: FlyteContext, **kwargs) -> Union[Tuple[Promise], Promise, VoidPromise, None]:
         # This is done to support the invariant that Workflow local executions always work with Promise objects
         # holding Flyte literal values. Even in a wf, a user can call a sub-workflow with a Python native value.
         for k, v in kwargs.items():
-            if not isinstance(v, Promise):
-                t = self.python_interface.inputs[k]
-                try:
-                    kwargs[k] = Promise(var=k, val=TypeEngine.to_literal(ctx, v, t, self.interface.inputs[k].type))
-                except TypeTransformerFailedError as exc:
-                    raise TypeError(
-                        f"Failed to convert input argument '{k}' of workflow '{self.name}':\n  {exc}"
-                    ) from exc
+            py_type = self.python_interface.inputs[k]
+            lit_type = self.interface.inputs[k].type
+            kwargs[k] = Promise(var=k, val=self.ensure_literal(ctx, py_type, lit_type, v))
 
-        # The output of this will always be a combination of Python native values and Promises containing Flyte
-        # Literals.
+            # The output of this will always be a combination of Python native values and Promises containing Flyte
+            # Literals.
         self.compile()
         function_outputs = self.execute(**kwargs)
-
         # First handle the empty return case.
         # A workflow function may return a task that doesn't return anything
         #   def wf():

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -32,6 +32,7 @@ class ImageSpec:
         packages: list of python packages to install.
         apt_packages: list of apt packages to install.
         base_image: base image of the image.
+        platform: Specify the target platforms for the build output (for example, windows/amd64 or linux/amd64,darwin/arm64
     """
 
     name: str = "flytekit"
@@ -43,6 +44,7 @@ class ImageSpec:
     packages: Optional[List[str]] = None
     apt_packages: Optional[List[str]] = None
     base_image: Optional[str] = None
+    platform: str = "linux/amd64"
 
     def image_name(self) -> str:
         """
@@ -147,7 +149,7 @@ def calculate_hash_from_image_spec(image_spec: ImageSpec):
     # copy the image spec to avoid modifying the original image spec. otherwise, the hash will be different.
     spec = copy(image_spec)
     spec.source_root = hash_directory(image_spec.source_root) if image_spec.source_root else b""
-    image_spec_bytes = bytes(image_spec.to_json(), "utf-8")
+    image_spec_bytes = bytes(spec.to_json(), "utf-8")
     tag = base64.urlsafe_b64encode(hashlib.md5(image_spec_bytes).digest()).decode("ascii")
     # replace "=" with "." to make it a valid tag
     return tag.replace("=", ".")

--- a/flytekit/models/types.py
+++ b/flytekit/models/types.py
@@ -259,7 +259,7 @@ class LiteralType(_common.FlyteIdlEntity):
         :param flytekit.models.core.types.StructuredDatasetType structured_dataset_type: structured dataset
         :param dict[Text, T] metadata: Additional data describing the type
         :param flytekit.models.annotation.TypeAnnotation annotation: Additional data
-            describing the type _intended to be saturated by the client_
+            describing the type intended to be saturated by the client
         """
         self._simple = simple
         self._schema = schema

--- a/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
+++ b/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
@@ -16,7 +16,7 @@ class EnvdImageSpecBuilder(ImageSpecBuilder):
 
     def build_image(self, image_spec: ImageSpec):
         cfg_path = create_envd_config(image_spec)
-        command = f"envd build --path {pathlib.Path(cfg_path).parent}"
+        command = f"envd build --path {pathlib.Path(cfg_path).parent}  --platform {image_spec.platform}"
         if image_spec.registry:
             command += f" --output type=image,name={image_spec.image_name()},push=true"
         click.secho(f"Run command: {command} ", fg="blue")

--- a/plugins/flytekit-envd/requirements.txt
+++ b/plugins/flytekit-envd/requirements.txt
@@ -6,10 +6,41 @@
 #
 -e file:.#egg=flytekitplugins-envd
     # via -r requirements.in
+adlfs==2023.4.0
+    # via flytekit
+aiobotocore==2.5.0
+    # via s3fs
+aiohttp==3.8.4
+    # via
+    #   adlfs
+    #   aiobotocore
+    #   gcsfs
+    #   s3fs
+aioitertools==0.11.0
+    # via aiobotocore
+aiosignal==1.3.1
+    # via aiohttp
 arrow==1.2.3
     # via jinja2-time
+async-timeout==4.0.2
+    # via aiohttp
+attrs==23.1.0
+    # via aiohttp
+azure-core==1.26.4
+    # via
+    #   adlfs
+    #   azure-identity
+    #   azure-storage-blob
+azure-datalake-store==0.0.53
+    # via adlfs
+azure-identity==1.13.0
+    # via adlfs
+azure-storage-blob==12.16.0
+    # via adlfs
 binaryornot==0.4.4
     # via cookiecutter
+botocore==1.29.76
+    # via aiobotocore
 cachetools==5.3.0
     # via google-auth
 certifi==2022.12.7
@@ -17,11 +48,15 @@ certifi==2022.12.7
     #   kubernetes
     #   requests
 cffi==1.15.1
-    # via cryptography
+    # via
+    #   azure-datalake-store
+    #   cryptography
 chardet==5.1.0
     # via binaryornot
 charset-normalizer==3.1.0
-    # via requests
+    # via
+    #   aiohttp
+    #   requests
 click==8.1.3
     # via
     #   cookiecutter
@@ -33,11 +68,16 @@ cookiecutter==2.1.1
 croniter==1.3.8
     # via flytekit
 cryptography==40.0.1
-    # via pyopenssl
+    # via
+    #   azure-identity
+    #   azure-storage-blob
+    #   msal
+    #   pyjwt
+    #   pyopenssl
 dataclasses-json==0.5.7
     # via flytekit
 decorator==5.1.1
-    # via retry
+    # via gcsfs
 deprecated==1.2.13
     # via flytekit
 diskcache==5.4.0
@@ -48,22 +88,55 @@ docker-image-py==0.1.12
     # via flytekit
 docstring-parser==0.15
     # via flytekit
-envd==0.3.16
+envd==0.3.22
     # via flytekitplugins-envd
 flyteidl==1.3.15
     # via flytekit
 flytekit==1.5.0
     # via flytekitplugins-envd
+frozenlist==1.3.3
+    # via
+    #   aiohttp
+    #   aiosignal
+fsspec==2023.5.0
+    # via
+    #   adlfs
+    #   flytekit
+    #   gcsfs
+    #   s3fs
+gcsfs==2023.5.0
+    # via flytekit
 gitdb==4.0.10
     # via gitpython
 gitpython==3.1.31
     # via flytekit
+google-api-core==2.11.0
+    # via
+    #   google-cloud-core
+    #   google-cloud-storage
 google-auth==2.17.1
-    # via kubernetes
+    # via
+    #   gcsfs
+    #   google-api-core
+    #   google-auth-oauthlib
+    #   google-cloud-core
+    #   google-cloud-storage
+    #   kubernetes
+google-auth-oauthlib==1.0.0
+    # via gcsfs
+google-cloud-core==2.3.2
+    # via google-cloud-storage
+google-cloud-storage==2.9.0
+    # via gcsfs
+google-crc32c==1.5.0
+    # via google-resumable-media
+google-resumable-media==2.5.0
+    # via google-cloud-storage
 googleapis-common-protos==1.59.0
     # via
     #   flyteidl
     #   flytekit
+    #   google-api-core
     #   grpcio-status
 grpcio==1.53.0
     # via
@@ -72,11 +145,15 @@ grpcio==1.53.0
 grpcio-status==1.53.0
     # via flytekit
 idna==3.4
-    # via requests
+    # via
+    #   requests
+    #   yarl
 importlib-metadata==6.1.0
     # via
     #   flytekit
     #   keyring
+isodate==0.6.1
+    # via azure-storage-blob
 jaraco-classes==3.2.3
     # via keyring
 jinja2==3.1.2
@@ -85,6 +162,8 @@ jinja2==3.1.2
     #   jinja2-time
 jinja2-time==0.2.0
     # via cookiecutter
+jmespath==1.0.1
+    # via botocore
 joblib==1.2.0
     # via flytekit
 keyring==23.13.1
@@ -104,6 +183,17 @@ marshmallow-jsonschema==0.13.0
     # via flytekit
 more-itertools==9.1.0
     # via jaraco-classes
+msal==1.22.0
+    # via
+    #   azure-datalake-store
+    #   azure-identity
+    #   msal-extensions
+msal-extensions==1.0.0
+    # via azure-identity
+multidict==6.0.4
+    # via
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via typing-inspect
 natsort==8.3.1
@@ -121,16 +211,17 @@ packaging==23.0
     #   marshmallow
 pandas==1.5.3
     # via flytekit
+portalocker==2.7.0
+    # via msal-extensions
 protobuf==4.22.1
     # via
     #   flyteidl
+    #   google-api-core
     #   googleapis-common-protos
     #   grpcio-status
     #   protoc-gen-swagger
 protoc-gen-swagger==0.1.0
     # via flyteidl
-py==1.11.0
-    # via retry
 pyarrow==10.0.1
     # via flytekit
 pyasn1==0.4.8
@@ -141,11 +232,14 @@ pyasn1-modules==0.2.8
     # via google-auth
 pycparser==2.21
     # via cffi
+pyjwt[crypto]==2.7.0
+    # via msal
 pyopenssl==23.1.1
     # via flytekit
 python-dateutil==2.8.2
     # via
     #   arrow
+    #   botocore
     #   croniter
     #   flytekit
     #   kubernetes
@@ -170,23 +264,34 @@ regex==2023.3.23
     # via docker-image-py
 requests==2.28.2
     # via
+    #   azure-core
+    #   azure-datalake-store
     #   cookiecutter
     #   docker
     #   flytekit
+    #   gcsfs
+    #   google-api-core
+    #   google-cloud-storage
     #   kubernetes
+    #   msal
     #   requests-oauthlib
     #   responses
 requests-oauthlib==1.3.1
-    # via kubernetes
+    # via
+    #   google-auth-oauthlib
+    #   kubernetes
 responses==0.23.1
-    # via flytekit
-retry==0.9.2
     # via flytekit
 rsa==4.9
     # via google-auth
+s3fs==2023.5.0
+    # via flytekit
 six==1.16.0
     # via
+    #   azure-core
+    #   azure-identity
     #   google-auth
+    #   isodate
     #   kubernetes
     #   python-dateutil
 smmap==5.0.0
@@ -201,12 +306,16 @@ types-pyyaml==6.0.12.9
     # via responses
 typing-extensions==4.5.0
     # via
+    #   aioitertools
+    #   azure-core
+    #   azure-storage-blob
     #   flytekit
     #   typing-inspect
 typing-inspect==0.8.0
     # via dataclasses-json
 urllib3==1.26.15
     # via
+    #   botocore
     #   docker
     #   flytekit
     #   kubernetes
@@ -220,8 +329,11 @@ wheel==0.40.0
     # via flytekit
 wrapt==1.15.0
     # via
+    #   aiobotocore
     #   deprecated
     #   flytekit
+yarl==1.9.2
+    # via aiohttp
 zipp==3.15.0
     # via importlib-metadata
 

--- a/plugins/flytekit-envd/setup.py
+++ b/plugins/flytekit-envd/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "envd"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit", "envd"]
+plugin_requires = ["flytekit", "envd>=0.3.22"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-envd/tests/test_image_spec.py
+++ b/plugins/flytekit-envd/tests/test_image_spec.py
@@ -16,6 +16,7 @@ def test_image_spec():
 
     EnvdImageSpecBuilder().build_image(image_spec)
     config_path = create_envd_config(image_spec)
+    assert image_spec.platform == "linux/amd64"
     contents = Path(config_path).read_text()
     assert (
         contents
@@ -25,7 +26,7 @@ def build():
     base(image="cr.flyte.org/flyteorg/flytekit:py3.8-latest", dev=False)
     install.python_packages(name = ["pandas"])
     install.apt_packages(name = ["git"])
-    runtime.environ(env={'PYTHONPATH': '/root', '_F_IMG_ID': 'flytekit:yZ8jICcDTLoDArmNHbWNwg..'})
+    runtime.environ(env={'PYTHONPATH': '/root', '_F_IMG_ID': 'flytekit:OLFSrRjcG5_uXuRqd0TSdQ..'})
     install.python(version="3.8")
 """
     )

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/__init__.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/__init__.py
@@ -8,6 +8,7 @@ This package contains things that are useful when extending Flytekit.
    :toctree: generated/
 
    PyTorch
+   Elastic
 """
 
 from .task import Elastic, PyTorch

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Union
 
 import cloudpickle
-from flyteidl.plugins.pytorch_pb2 import DistributedPyTorchTrainingTask, ElasticConfig
+from flyteidl.plugins.pytorch_pb2 import DistributedPyTorchTrainingTask
 from google.protobuf.json_format import MessageToDict
 
 import flytekit
@@ -227,6 +227,8 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
             """
             return super().get_custom(settings)
         else:
+            from flyteidl.plugins.pytorch_pb2 import ElasticConfig
+
             elastic_config = ElasticConfig(
                 rdzv_backend=self.rdzv_backend,
                 min_replicas=self.min_nodes,

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/__init__.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/__init__.py
@@ -11,4 +11,4 @@ This package contains things that are useful when extending Flytekit.
    record_outputs
 """
 
-from .task import NotebookTask, record_outputs
+from .task import NotebookTask, load_flytedirectory, load_flytefile, load_structureddataset, record_outputs

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -2,24 +2,28 @@ import json
 import logging
 import os
 import sys
+import tempfile
 import typing
 from typing import Any
 
 import nbformat
 import papermill as pm
+from flyteidl.core.literals_pb2 import Literal as _pb2_Literal
 from flyteidl.core.literals_pb2 import LiteralMap as _pb2_LiteralMap
 from google.protobuf import text_format as _text_format
 from nbconvert import HTMLExporter
 
-from flytekit import FlyteContext, PythonInstanceTask
+from flytekit import FlyteContext, PythonInstanceTask, StructuredDataset
 from flytekit.configuration import SerializationSettings
+from flytekit.core import utils
 from flytekit.core.context_manager import ExecutionParameters
 from flytekit.deck.deck import Deck
 from flytekit.extend import Interface, TaskPlugins, TypeEngine
 from flytekit.loggers import logger
 from flytekit.models import task as task_models
-from flytekit.models.literals import LiteralMap
-from flytekit.types.file import HTMLPage, PythonNotebook
+from flytekit.models.literals import Literal, LiteralMap
+from flytekit.types.directory import FlyteDirectory
+from flytekit.types.file import FlyteFile, HTMLPage, PythonNotebook
 
 T = typing.TypeVar("T")
 
@@ -27,6 +31,8 @@ T = typing.TypeVar("T")
 def _dummy_task_func():
     return None
 
+
+SAVE_AS_LITERAL = (FlyteFile, FlyteDirectory, StructuredDataset)
 
 PAPERMILL_TASK_PREFIX = "pm.nb"
 
@@ -255,6 +261,10 @@ class NotebookTask(PythonInstanceTask[T]):
         singleton
         """
         logger.info(f"Hijacking the call for task-type {self.task_type}, to call notebook.")
+        for k, v in kwargs.items():
+            if isinstance(v, SAVE_AS_LITERAL):
+                kwargs[k] = save_python_val_to_file(v)
+
         # Execute Notebook via Papermill.
         pm.execute_notebook(self._notebook_path, self.output_notebook_path, parameters=kwargs, log_output=self._stream_logs)  # type: ignore
 
@@ -265,6 +275,7 @@ class NotebookTask(PythonInstanceTask[T]):
         if outputs:
             m = outputs.literals
         output_list = []
+
         for k, type_v in self.python_interface.outputs.items():
             if k == self._IMPLICIT_OP_NOTEBOOK:
                 output_list.append(self.output_notebook_path)
@@ -274,7 +285,7 @@ class NotebookTask(PythonInstanceTask[T]):
                 v = TypeEngine.to_python_value(ctx=FlyteContext.current_context(), lv=m[k], expected_python_type=type_v)
                 output_list.append(v)
             else:
-                raise RuntimeError(f"Expected output {k} of type {v} not found in the notebook outputs")
+                raise TypeError(f"Expected output {k} of type {type_v} not found in the notebook outputs")
 
         return tuple(output_list)
 
@@ -307,3 +318,80 @@ def record_outputs(**kwargs) -> str:
         lit = TypeEngine.to_literal(ctx, python_type=type(v), python_val=v, expected=expected)
         m[k] = lit
     return LiteralMap(literals=m).to_flyte_idl()
+
+
+def save_python_val_to_file(input: Any) -> str:
+    """Save a python value to a local file as a Flyte literal.
+
+    Args:
+        input (Any): the python value
+
+    Returns:
+        str: the path to the file
+    """
+    ctx = FlyteContext.current_context()
+    expected = TypeEngine.to_literal_type(type(input))
+    lit = TypeEngine.to_literal(ctx, python_type=type(input), python_val=input, expected=expected)
+
+    tmp_file = tempfile.mktemp(suffix="bin")
+    utils.write_proto_to_file(lit.to_flyte_idl(), tmp_file)
+    return tmp_file
+
+
+def load_python_val_from_file(path: str, dtype: T) -> T:
+    """Loads a python value from a Flyte literal saved to a local file.
+
+    If the path matches the type, it is returned as is. This enables
+    reusing the parameters cell for local development.
+
+    Args:
+        path (str): path to the file
+        dtype (T): the type of the literal
+
+    Returns:
+        T: the python value of the literal
+    """
+    if isinstance(path, dtype):
+        return path
+
+    proto = utils.load_proto_from_file(_pb2_Literal, path)
+    lit = Literal.from_flyte_idl(proto)
+    ctx = FlyteContext.current_context()
+    python_value = TypeEngine.to_python_value(ctx, lit, dtype)
+    return python_value
+
+
+def load_flytefile(path: str) -> T:
+    """Loads a FlyteFile from a file.
+
+    Args:
+        path (str): path to the file
+
+    Returns:
+        T: the python value of the literal
+    """
+    return load_python_val_from_file(path=path, dtype=FlyteFile)
+
+
+def load_flytedirectory(path: str) -> T:
+    """Loads a FlyteDirectory from a file.
+
+    Args:
+        path (str): path to the file
+
+    Returns:
+        T: the python value of the literal
+    """
+    return load_python_val_from_file(path=path, dtype=FlyteDirectory)
+
+
+def load_structureddataset(path: str) -> T:
+    """Loads a StructuredDataset from a file.
+
+    Args:
+        path (str): path to the file
+
+    Returns:
+        T: the python value of the literal
+    """
+    return load_python_val_from_file(path=path, dtype=StructuredDataset)

--- a/plugins/flytekit-papermill/tests/test_task.py
+++ b/plugins/flytekit-papermill/tests/test_task.py
@@ -1,14 +1,17 @@
 import datetime
 import os
+import tempfile
 
+import pandas as pd
 from flytekitplugins.papermill import NotebookTask
 from flytekitplugins.pod import Pod
 from kubernetes.client import V1Container, V1PodSpec
 
 import flytekit
-from flytekit import kwtypes
+from flytekit import StructuredDataset, kwtypes, task
 from flytekit.configuration import Image, ImageConfig
-from flytekit.types.file import PythonNotebook
+from flytekit.types.directory import FlyteDirectory
+from flytekit.types.file import FlyteFile, PythonNotebook
 
 from .testdata.datatype import X
 
@@ -134,3 +137,38 @@ def test_notebook_pod_task():
         nb.get_command(serialization_settings)
         == nb.get_k8s_pod(serialization_settings).pod_spec["containers"][0]["args"]
     )
+
+
+def test_flyte_types():
+    @task
+    def create_file() -> FlyteFile:
+        tmp_file = tempfile.mktemp()
+        with open(tmp_file, "w") as f:
+            f.write("abc")
+        return FlyteFile(path=tmp_file)
+
+    @task
+    def create_dir() -> FlyteDirectory:
+        tmp_dir = tempfile.mkdtemp()
+        with open(os.path.join(tmp_dir, "file.txt"), "w") as f:
+            f.write("abc")
+        return FlyteDirectory(path=tmp_dir)
+
+    @task
+    def create_sd() -> StructuredDataset:
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        return StructuredDataset(dataframe=df)
+
+    ff = create_file()
+    fd = create_dir()
+    sd = create_sd()
+
+    nb_name = "nb-types"
+    nb_types = NotebookTask(
+        name="test",
+        notebook_path=_get_nb_path(nb_name, abs=False),
+        inputs=kwtypes(ff=FlyteFile, fd=FlyteDirectory, sd=StructuredDataset),
+        outputs=kwtypes(success=bool),
+    )
+    success, out, render = nb_types.execute(ff=ff, fd=fd, sd=sd)
+    assert success is True, "Notebook execution failed"

--- a/plugins/flytekit-papermill/tests/testdata/nb-simple.ipynb
+++ b/plugins/flytekit-papermill/tests/testdata/nb-simple.ipynb
@@ -34,7 +34,6 @@
    "outputs": [],
    "source": [
     "from flytekitplugins.papermill import record_outputs\n",
-    "\n",
     "record_outputs(square=out)"
    ]
   },
@@ -49,7 +48,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -63,9 +62,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/plugins/flytekit-papermill/tests/testdata/nb-types.ipynb
+++ b/plugins/flytekit-papermill/tests/testdata/nb-types.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "ff = None\n",
+    "fd = None\n",
+    "sd = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "from flytekitplugins.papermill import (\n",
+    "    load_flytefile, load_flytedirectory, load_structureddataset,\n",
+    "    record_outputs\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ff = load_flytefile(ff)\n",
+    "fd = load_flytedirectory(fd)\n",
+    "sd = load_structureddataset(sd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# read file\n",
+    "with open(ff.download(), 'r') as f:\n",
+    "    text = f.read()\n",
+    "    assert text == \"abc\", \"Text does not match\"\n",
+    "\n",
+    "# check file inside directory\n",
+    "with open(os.path.join(fd.download(),\"file.txt\"), 'r') as f:\n",
+    "    text = f.read()\n",
+    "    assert text == \"abc\", \"Text does not match\"\n",
+    "\n",
+    "# check dataset\n",
+    "df = sd.open(pd.DataFrame).all()\n",
+    "expected = pd.DataFrame({\"a\": [1, 2], \"b\": [3, 4]})\n",
+    "assert df.equals(expected), \"Dataframes do not match\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "outputs"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "record_outputs(success=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -23,10 +23,14 @@ class Spark(object):
     Args:
         spark_conf: Dictionary of spark config. The variables should match what spark expects
         hadoop_conf: Dictionary of hadoop conf. The variables should match a typical hadoop configuration for spark
+        executor_path: Python binary executable to use for PySpark in driver and executor.
+        applications_path: MainFile is the path to a bundled JAR, Python, or R file of the application to execute.
     """
 
     spark_conf: Optional[Dict[str, str]] = None
     hadoop_conf: Optional[Dict[str, str]] = None
+    executor_path: Optional[str] = None
+    applications_path: Optional[str] = None
 
     def __post_init__(self):
         if self.spark_conf is None:
@@ -107,8 +111,8 @@ class PysparkFunctionTask(PythonFunctionTask[Spark]):
         **kwargs,
     ):
         self.sess: Optional[SparkSession] = None
-        self._default_executor_path: Optional[str] = None
-        self._default_applications_path: Optional[str] = None
+        self._default_executor_path: Optional[str] = task_config.executor_path
+        self._default_applications_path: Optional[str] = task_config.applications_path
 
         if isinstance(container_image, ImageSpec):
             if container_image.base_image is None:

--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -36,7 +36,13 @@ def test_spark_task(reset_spark_session):
         },
     }
 
-    @task(task_config=Spark(spark_conf={"spark": "1"}))
+    @task(
+        task_config=Spark(
+            spark_conf={"spark": "1"},
+            executor_path="/usr/bin/python3",
+            applications_path="local:///usr/local/bin/entrypoint.py",
+        )
+    )
     def my_spark(a: str) -> int:
         session = flytekit.current_context().spark_session
         assert session.sparkContext.appName == "FlyteSpark: ex:local:local:local"
@@ -56,6 +62,8 @@ def test_spark_task(reset_spark_session):
 
     retrieved_settings = my_spark.get_custom(settings)
     assert retrieved_settings["sparkConf"] == {"spark": "1"}
+    assert retrieved_settings["executorPath"] == "/usr/bin/python3"
+    assert retrieved_settings["mainApplicationFile"] == "local:///usr/local/bin/entrypoint.py"
 
     pb = ExecutionParameters.new_builder()
     pb.working_dir = "/tmp"

--- a/plugins/setup.py
+++ b/plugins/setup.py
@@ -36,6 +36,7 @@ SOURCES = {
     "flytekitplugins-onnxpytorch": "flytekit-onnx-pytorch",
     "flytekitplugins-pandera": "flytekit-pandera",
     "flytekitplugins-papermill": "flytekit-papermill",
+    "flytekitplugins-polars": "flytekit-polars",
     "flytekitplugins-ray": "flytekit-ray",
     "flytekitplugins-snowflake": "flytekit-snowflake",
     "flytekitplugins-spark": "flytekit-spark",

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -261,9 +261,9 @@ ic_result_3 = ImageConfig(
 )
 
 ic_result_4 = ImageConfig(
-    default_image=Image(name="default", fqn="flytekit", tag="4VC-c-UDrUvfySJ0aS3qCw.."),
+    default_image=Image(name="default", fqn="flytekit", tag="mMxGzKCqxVk8msz0yV22-g.."),
     images=[
-        Image(name="default", fqn="flytekit", tag="4VC-c-UDrUvfySJ0aS3qCw.."),
+        Image(name="default", fqn="flytekit", tag="mMxGzKCqxVk8msz0yV22-g.."),
         Image(name="xyz", fqn="docker.io/xyz", tag="latest"),
         Image(name="abc", fqn="docker.io/abc", tag=None),
     ],

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -27,7 +27,7 @@ def test_image_spec():
     assert image_spec.source_root is None
     assert image_spec.env is None
     assert image_spec.is_container() is True
-    assert image_spec.image_name() == "flytekit:yZ8jICcDTLoDArmNHbWNwg.."
+    assert image_spec.image_name() == "flytekit:OLFSrRjcG5_uXuRqd0TSdQ.."
     ctx = context_manager.FlyteContext.current_context()
     with context_manager.FlyteContextManager.with_context(
         ctx.with_execution_state(ctx.execution_state.with_params(mode=ExecutionState.Mode.TASK_EXECUTION))
@@ -42,7 +42,7 @@ def test_image_spec():
     ImageBuildEngine.register("dummy", DummyImageSpecBuilder())
     ImageBuildEngine._REGISTRY["dummy"].build_image(image_spec)
     assert "dummy" in ImageBuildEngine._REGISTRY
-    assert calculate_hash_from_image_spec(image_spec) == "yZ8jICcDTLoDArmNHbWNwg.."
+    assert calculate_hash_from_image_spec(image_spec) == "OLFSrRjcG5_uXuRqd0TSdQ.."
     assert image_spec.exist() is False
 
     with pytest.raises(Exception):

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -75,7 +75,7 @@ def test_container_image_conversion():
     ImageBuildEngine.register("test", TestImageSpecBuilder())
     assert (
         get_registerable_container_image(ImageSpec(builder="test", python_version="3.7"), cfg)
-        == "flytekit:0N8X-XowtpEkDYWDlb8Abg.."
+        == "flytekit:usEl-DNx_srVn7zp2vHlBw.."
     )
 
 

--- a/tests/flytekit/unit/core/test_type_conversion_errors.py
+++ b/tests/flytekit/unit/core/test_type_conversion_errors.py
@@ -91,11 +91,9 @@ def test_workflow_with_task_error(correct_input):
 def test_workflow_with_input_error(incorrect_input):
     with pytest.raises(
         TypeError,
-        match=(
-            r"Encountered error while executing workflow '{}':\n"
-            r"  Failed to convert input argument 'a' of workflow '.+':\n"
-            r"  Expected value of type \<class 'int'\> but got .+ of type"
-        ).format(wf_with_output_error.name),
+        match=(r"Encountered error while executing workflow '{}':\n" r"  Failed to convert input").format(
+            wf_with_output_error.name
+        ),
     ):
         wf_with_output_error(a=incorrect_input)
 

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -136,6 +136,89 @@ def test_sub_wf_multi_named_tuple():
     assert x == (7, 7)
 
 
+def test_sub_wf_varying_types():
+    @task
+    def t1l(
+        a: typing.List[typing.Dict[str, typing.List[int]]],
+        b: typing.Dict[str, typing.List[int]],
+        c: typing.Union[typing.List[typing.Dict[str, typing.List[int]]], typing.Dict[str, typing.List[int]], int],
+        d: int,
+    ) -> str:
+        xx = ",".join([f"{k}:{v}" for d in a for k, v in d.items()])
+        yy = ",".join([f"{k}: {i}" for k, v in b.items() for i in v])
+        if isinstance(c, list):
+            zz = ",".join([f"{k}:{v}" for d in c for k, v in d.items()])
+        elif isinstance(c, dict):
+            zz = ",".join([f"{k}: {i}" for k, v in c.items() for i in v])
+        else:
+            zz = str(c)
+        return f"First: {xx} Second: {yy} Third: {zz} Int: {d}"
+
+    @task
+    def get_int() -> int:
+        return 1
+
+    @workflow
+    def subwf(
+        a: typing.List[typing.Dict[str, typing.List[int]]],
+        b: typing.Dict[str, typing.List[int]],
+        c: typing.Union[typing.List[typing.Dict[str, typing.List[int]]], typing.Dict[str, typing.List[int]]],
+        d: int,
+    ) -> str:
+        return t1l(a=a, b=b, c=c, d=d)
+
+    @workflow
+    def wf() -> str:
+        ds = [
+            {"first_map_a": [42], "first_map_b": [get_int(), 2]},
+            {
+                "second_map_c": [33],
+                "second_map_d": [9, 99],
+            },
+        ]
+        ll = {
+            "ll_1": [get_int(), get_int(), get_int()],
+            "ll_2": [4, 5, 6],
+        }
+        out = subwf(a=ds, b=ll, c=ds, d=get_int())
+        return out
+
+    wf.compile()
+    x = wf()
+    expected = (
+        "First: first_map_a:[42],first_map_b:[1, 2],second_map_c:[33],second_map_d:[9, 99] "
+        "Second: ll_1: 1,ll_1: 1,ll_1: 1,ll_2: 4,ll_2: 5,ll_2: 6 "
+        "Third: first_map_a:[42],first_map_b:[1, 2],second_map_c:[33],second_map_d:[9, 99] "
+        "Int: 1"
+    )
+    assert x == expected
+
+    @workflow
+    def wf() -> str:
+        ds = [
+            {"first_map_a": [42], "first_map_b": [get_int(), 2]},
+            {
+                "second_map_c": [33],
+                "second_map_d": [9, 99],
+            },
+        ]
+        ll = {
+            "ll_1": [get_int(), get_int(), get_int()],
+            "ll_2": [4, 5, 6],
+        }
+        out = subwf(a=ds, b=ll, c=ll, d=get_int())
+        return out
+
+    x = wf()
+    expected = (
+        "First: first_map_a:[42],first_map_b:[1, 2],second_map_c:[33],second_map_d:[9, 99] "
+        "Second: ll_1: 1,ll_1: 1,ll_1: 1,ll_2: 4,ll_2: 5,ll_2: 6 "
+        "Third: ll_1: 1,ll_1: 1,ll_1: 1,ll_2: 4,ll_2: 5,ll_2: 6 "
+        "Int: 1"
+    )
+    assert x == expected
+
+
 def test_unexpected_outputs():
     @task
     def t1(a: int) -> int:


### PR DESCRIPTION
# TL;DR
This PR enables passing in the `audience` parameter into the `get_token` method - via the ClientCredentials flow and the ClientConfig object. Also adds in the ability for Pyflyte/Flytekit to read in the audience from the config.yaml file, but it is not linked to the get_token method  (only ClientConfig object params are used at the moment).

## Type
 - [ x ] Bug Fix
 - [ x ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ x ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ x ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_
 
 Auth0 requires an audience parameter for its various requests. This was previously not enabled in the Flytekit source code. This PR adds support for that by piping in the `audience` parameter as input from FlyteAdmin's audience field, and then into the various functions/methods/classes that handle the auth request.
 
The ability to pipe in "audience" from the config.yaml file is also enabled so set up is there for enabling this method of defining the parameter, but it's fine if it gets deleted as the ClientConfig inferring audience from Admin works.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3661

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
