### PR TITLE
pyflyte run supports pickle

### DIFF
--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -117,6 +117,8 @@ def test_pyflyte_run_cli():
             json.dumps([{"x": parquet_file}]),
             "--o",
             json.dumps({"x": [parquet_file]}),
+            "--p",
+            "Any",
         ],
         catch_exceptions=False,
     )

--- a/tests/flytekit/unit/cli/pyflyte/workflow.py
+++ b/tests/flytekit/unit/cli/pyflyte/workflow.py
@@ -58,8 +58,9 @@ def print_all(
     m: dict,
     n: typing.List[typing.Dict[str, FlyteFile]],
     o: typing.Dict[str, typing.List[FlyteFile]],
+    p: typing.Any,
 ):
-    print(f"{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}, {j}, {k}, {l}, {m}, {n}, {o}")
+    print(f"{a}, {b}, {c}, {d}, {e}, {f}, {g}, {h}, {i}, {j}, {k}, {l}, {m}, {n}, {o} , {p}")
 
 
 @task
@@ -88,6 +89,7 @@ def my_wf(
     l: dict,
     n: typing.List[typing.Dict[str, FlyteFile]],
     o: typing.Dict[str, typing.List[FlyteFile]],
+    p: typing.Any,
     remote: pd.DataFrame,
     image: StructuredDataset,
     m: dict = {"hello": "world"},
@@ -95,5 +97,5 @@ def my_wf(
     x = get_subset_df(df=remote)  # noqa: shown for demonstration; users should use the same types between tasks
     show_sd(in_sd=x)
     show_sd(in_sd=image)
-    print_all(a=a, b=b, c=c, d=d, e=e, f=f, g=g, h=h, i=i, j=j, k=k, l=l, m=m, n=n, o=o)
+    print_all(a=a, b=b, c=c, d=d, e=e, f=f, g=g, h=h, i=i, j=j, k=k, l=l, m=m, n=n, o=o, p=p)
     return x


### PR DESCRIPTION
# TL;DR
This allows pyflyte run to accept pickle file. 
```python
from typing import Dict, Any
from flytekit import task, workflow

@task
def test(config: Dict[str, Any]) -> None:
    print(config)


@workflow
def wf(config: Dict[str, Any]) -> None:
    test(config=config)
```
```bash
 pyflyte --config ~/.flyte/config-remote.yaml --verbose run --remote test.py wf --config '{"hello": "world"}'
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://flyte-org.slack.com/archives/CP2HDHKE1/p1684272325647759

## Follow-up issue
_NA_