### PR TITLE
Wait for the pod plugin instead of flytekit

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -57,7 +57,7 @@ jobs:
             echo "No tagged version found, exiting"
             exit 1
           fi
-          LINK="https://pypi.org/project/flytekit/${VERSION}"
+          LINK="https://pypi.org/project/flytekitplugins-pod/${VERSION}"
           for i in {1..60}; do
             if curl -L -I -s -f ${LINK} >/dev/null; then
               echo "Found pypi"


### PR DESCRIPTION
# TL;DR
Wait for one the plugins to show up in PyPI instead of the main package

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 We introduced an explicit wait in https://github.com/flyteorg/flytekit/pull/1554, but it turns out that most of the failures (e.g. https://github.com/flyteorg/flytekit/actions/runs/5007729856/jobs/8974742807#step:7:659) we're seeing during releases are for the plugins (which are published in order). So, let's wait for the pod plugin instead of the main package.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
