### PR TITLE
Enable envd plugin for python 3.7

### DIFF
--- a/plugins/flytekit-envd/requirements.txt
+++ b/plugins/flytekit-envd/requirements.txt
@@ -6,10 +6,41 @@
 #
 -e file:.#egg=flytekitplugins-envd
     # via -r requirements.in
+adlfs==2023.4.0
+    # via flytekit
+aiobotocore==2.5.0
+    # via s3fs
+aiohttp==3.8.4
+    # via
+    #   adlfs
+    #   aiobotocore
+    #   gcsfs
+    #   s3fs
+aioitertools==0.11.0
+    # via aiobotocore
+aiosignal==1.3.1
+    # via aiohttp
 arrow==1.2.3
     # via jinja2-time
+async-timeout==4.0.2
+    # via aiohttp
+attrs==23.1.0
+    # via aiohttp
+azure-core==1.26.4
+    # via
+    #   adlfs
+    #   azure-identity
+    #   azure-storage-blob
+azure-datalake-store==0.0.53
+    # via adlfs
+azure-identity==1.13.0
+    # via adlfs
+azure-storage-blob==12.16.0
+    # via adlfs
 binaryornot==0.4.4
     # via cookiecutter
+botocore==1.29.76
+    # via aiobotocore
 cachetools==5.3.0
     # via google-auth
 certifi==2022.12.7
@@ -17,15 +48,20 @@ certifi==2022.12.7
     #   kubernetes
     #   requests
 cffi==1.15.1
-    # via cryptography
+    # via
+    #   azure-datalake-store
+    #   cryptography
 chardet==5.1.0
     # via binaryornot
 charset-normalizer==3.1.0
-    # via requests
+    # via
+    #   aiohttp
+    #   requests
 click==8.1.3
     # via
     #   cookiecutter
     #   flytekit
+    #   rich-click
 cloudpickle==2.2.1
     # via flytekit
 cookiecutter==2.1.1
@@ -33,11 +69,16 @@ cookiecutter==2.1.1
 croniter==1.3.8
     # via flytekit
 cryptography==40.0.1
-    # via pyopenssl
+    # via
+    #   azure-identity
+    #   azure-storage-blob
+    #   msal
+    #   pyjwt
+    #   pyopenssl
 dataclasses-json==0.5.7
     # via flytekit
 decorator==5.1.1
-    # via retry
+    # via gcsfs
 deprecated==1.2.13
     # via flytekit
 diskcache==5.4.0
@@ -50,33 +91,70 @@ docstring-parser==0.15
     # via flytekit
 envd==0.3.16
     # via flytekitplugins-envd
-flyteidl==1.3.15
+flyteidl==1.2.10
     # via flytekit
-flytekit==1.5.0
+flytekit==1.2.12
     # via flytekitplugins-envd
+frozenlist==1.3.3
+    # via
+    #   aiohttp
+    #   aiosignal
+fsspec==2023.5.0
+    # via
+    #   adlfs
+    #   flytekit
+    #   gcsfs
+    #   s3fs
+gcsfs==2023.5.0
+    # via flytekit
 gitdb==4.0.10
     # via gitpython
 gitpython==3.1.31
     # via flytekit
+google-api-core==2.11.0
+    # via
+    #   google-cloud-core
+    #   google-cloud-storage
 google-auth==2.17.1
-    # via kubernetes
+    # via
+    #   gcsfs
+    #   google-api-core
+    #   google-auth-oauthlib
+    #   google-cloud-core
+    #   google-cloud-storage
+    #   kubernetes
+google-auth-oauthlib==1.0.0
+    # via gcsfs
+google-cloud-core==2.3.2
+    # via google-cloud-storage
+google-cloud-storage==2.9.0
+    # via gcsfs
+google-crc32c==1.5.0
+    # via google-resumable-media
+google-resumable-media==2.5.0
+    # via google-cloud-storage
 googleapis-common-protos==1.59.0
     # via
     #   flyteidl
     #   flytekit
+    #   google-api-core
     #   grpcio-status
-grpcio==1.53.0
+grpcio==1.48.2
     # via
     #   flytekit
     #   grpcio-status
-grpcio-status==1.53.0
+grpcio-status==1.48.2
     # via flytekit
 idna==3.4
-    # via requests
+    # via
+    #   requests
+    #   yarl
 importlib-metadata==6.1.0
     # via
     #   flytekit
     #   keyring
+isodate==0.6.1
+    # via azure-storage-blob
 jaraco-classes==3.2.3
     # via keyring
 jinja2==3.1.2
@@ -85,12 +163,16 @@ jinja2==3.1.2
     #   jinja2-time
 jinja2-time==0.2.0
     # via cookiecutter
+jmespath==1.0.1
+    # via botocore
 joblib==1.2.0
     # via flytekit
 keyring==23.13.1
     # via flytekit
 kubernetes==26.1.0
     # via flytekit
+markdown-it-py==2.2.0
+    # via rich
 markupsafe==2.1.2
     # via jinja2
 marshmallow==3.19.0
@@ -102,8 +184,21 @@ marshmallow-enum==1.5.1
     # via dataclasses-json
 marshmallow-jsonschema==0.13.0
     # via flytekit
+mdurl==0.1.2
+    # via markdown-it-py
 more-itertools==9.1.0
     # via jaraco-classes
+msal==1.22.0
+    # via
+    #   azure-datalake-store
+    #   azure-identity
+    #   msal-extensions
+msal-extensions==1.0.0
+    # via azure-identity
+multidict==6.0.4
+    # via
+    #   aiohttp
+    #   yarl
 mypy-extensions==1.0.0
     # via typing-inspect
 natsort==8.3.1
@@ -121,16 +216,18 @@ packaging==23.0
     #   marshmallow
 pandas==1.5.3
     # via flytekit
-protobuf==4.22.1
+portalocker==2.7.0
+    # via msal-extensions
+protobuf==3.20.3
     # via
     #   flyteidl
+    #   flytekit
+    #   google-api-core
     #   googleapis-common-protos
     #   grpcio-status
     #   protoc-gen-swagger
 protoc-gen-swagger==0.1.0
     # via flyteidl
-py==1.11.0
-    # via retry
 pyarrow==10.0.1
     # via flytekit
 pyasn1==0.4.8
@@ -141,11 +238,16 @@ pyasn1-modules==0.2.8
     # via google-auth
 pycparser==2.21
     # via cffi
+pygments==2.15.1
+    # via rich
+pyjwt[crypto]==2.7.0
+    # via msal
 pyopenssl==23.1.1
     # via flytekit
 python-dateutil==2.8.2
     # via
     #   arrow
+    #   botocore
     #   croniter
     #   flytekit
     #   kubernetes
@@ -170,23 +272,41 @@ regex==2023.3.23
     # via docker-image-py
 requests==2.28.2
     # via
+    #   azure-core
+    #   azure-datalake-store
     #   cookiecutter
     #   docker
     #   flytekit
+    #   gcsfs
+    #   google-api-core
+    #   google-cloud-storage
     #   kubernetes
+    #   msal
     #   requests-oauthlib
     #   responses
 requests-oauthlib==1.3.1
-    # via kubernetes
+    # via
+    #   google-auth-oauthlib
+    #   kubernetes
 responses==0.23.1
     # via flytekit
-retry==0.9.2
+rich==13.3.5
+    # via
+    #   flytekit
+    #   rich-click
+rich-click==1.6.1
     # via flytekit
 rsa==4.9
     # via google-auth
+s3fs==2023.5.0
+    # via flytekit
 six==1.16.0
     # via
+    #   azure-core
+    #   azure-identity
     #   google-auth
+    #   grpcio
+    #   isodate
     #   kubernetes
     #   python-dateutil
 smmap==5.0.0
@@ -201,12 +321,16 @@ types-pyyaml==6.0.12.9
     # via responses
 typing-extensions==4.5.0
     # via
+    #   aioitertools
+    #   azure-core
+    #   azure-storage-blob
     #   flytekit
     #   typing-inspect
 typing-inspect==0.8.0
     # via dataclasses-json
 urllib3==1.26.15
     # via
+    #   botocore
     #   docker
     #   flytekit
     #   kubernetes
@@ -220,8 +344,11 @@ wheel==0.40.0
     # via flytekit
 wrapt==1.15.0
     # via
+    #   aiobotocore
     #   deprecated
     #   flytekit
+yarl==1.9.2
+    # via aiohttp
 zipp==3.15.0
     # via importlib-metadata
 

--- a/plugins/flytekit-envd/setup.py
+++ b/plugins/flytekit-envd/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "envd"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit", "envd"]
+plugin_requires = ["flytekit<1.3.0", "envd"]
 
 __version__ = "0.0.0+develop"
 
@@ -18,15 +18,15 @@ setup(
     packages=[f"flytekitplugins.{PLUGIN_NAME}"],
     install_requires=plugin_requires,
     license="apache2",
-    python_requires=">=3.8",
+    python_requires=">=3.7",
     classifiers=[
         "Intended Audience :: Science/Research",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Software Development",


### PR DESCRIPTION
# TL;DR
envd supports python 3.7, let's make the envd flytekit plugin in the 1.2 branch also support that

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 This is preventing us from generating the default docker images for the 1.2.12 [release](https://github.com/flyteorg/flytekit/actions/runs/5007729856/jobs/8975150027#step:7:668).

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
