### PR TITLE
Map over notebook task

### DIFF
--- a/flytekit/core/map_task.py
+++ b/flytekit/core/map_task.py
@@ -79,9 +79,9 @@ class MapPythonTask(PythonTask):
 
         collection_interface = transform_interface_to_list_interface(actual_task.python_interface, self._bound_inputs)
         self._run_task: PythonFunctionTask = actual_task
-        if issubclass(type(actual_task), PythonInstanceTask):
+        if isinstance(actual_task, PythonInstanceTask):
             mod = actual_task.task_type
-            f = actual_task.name
+            f = actual_task.lhs
         else:
             _, mod, f, _ = tracker.extract_task_module(actual_task.task_function)
         h = hashlib.md5(collection_interface.__str__().encode("utf-8")).hexdigest()

--- a/flytekit/core/map_task.py
+++ b/flytekit/core/map_task.py
@@ -64,7 +64,7 @@ class MapPythonTask(PythonTask):
         else:
             actual_task = python_function_task
 
-        if not isinstance(actual_task, PythonTask) or not issubclass(type(actual_task), PythonInstanceTask):
+        if not issubclass(type(actual_task), PythonTask):
             raise ValueError("Map tasks can only compose of Python Functon Tasks currently")
 
         if len(actual_task.python_interface.outputs.keys()) > 1:
@@ -76,8 +76,8 @@ class MapPythonTask(PythonTask):
 
         collection_interface = transform_interface_to_list_interface(actual_task.python_interface, self._bound_inputs)
         self._run_task: PythonFunctionTask = actual_task
-        if hasattr(actual_task, "_IMPLICIT_OP_NOTEBOOK_TYPE"):
-            mod = "papermill"
+        if issubclass(type(actual_task), PythonInstanceTask):
+            mod = actual_task.task_type
             f = actual_task.name
         else:
             _, mod, f, _ = tracker.extract_task_module(actual_task.task_function)

--- a/flytekit/core/map_task.py
+++ b/flytekit/core/map_task.py
@@ -34,7 +34,7 @@ class MapPythonTask(PythonTask):
 
     def __init__(
         self,
-        python_function_task: typing.Union[PythonFunctionTask, functools.partial],
+        python_function_task: typing.Union[PythonFunctionTask, PythonInstanceTask, functools.partial],
         concurrency: Optional[int] = None,
         min_success_ratio: Optional[float] = None,
         bound_inputs: Optional[Set[str]] = None,
@@ -65,7 +65,7 @@ class MapPythonTask(PythonTask):
             actual_task = python_function_task
 
         if not isinstance(actual_task, PythonFunctionTask):
-            if issubclass(type(actual_task), PythonInstanceTask):
+            if isinstance(actual_task, PythonInstanceTask):
                 pass
             else:
                 raise ValueError("Map tasks can only compose of PythonFuncton and PythonInstanceTasks currently")

--- a/flytekit/core/map_task.py
+++ b/flytekit/core/map_task.py
@@ -64,8 +64,11 @@ class MapPythonTask(PythonTask):
         else:
             actual_task = python_function_task
 
-        if not issubclass(type(actual_task), PythonTask):
-            raise ValueError("Map tasks can only compose of Python Functon Tasks currently")
+        if not isinstance(actual_task, PythonFunctionTask):
+            if issubclass(type(actual_task), PythonInstanceTask):
+                pass
+            else:
+                raise ValueError("Map tasks can only compose of PythonFuncton and PythonInstanceTasks currently")
 
         if len(actual_task.python_interface.outputs.keys()) > 1:
             raise ValueError("Map tasks only accept python function tasks with 0 or 1 outputs")

--- a/flytekit/core/map_task.py
+++ b/flytekit/core/map_task.py
@@ -67,12 +67,8 @@ class MapPythonTask(PythonTask):
         if not isinstance(actual_task, PythonTask) or not issubclass(type(actual_task), PythonInstanceTask):
             raise ValueError("Map tasks can only compose of Python Functon Tasks currently")
 
-        max_outputs = 1
-        if hasattr(actual_task, "_IMPLICIT_OP_NOTEBOOK_TYPE"):
-            max_outputs = 3
-
-        if len(actual_task.python_interface.outputs.keys()) > max_outputs:
-            raise ValueError(f"Map tasks only accept python function tasks with {max_outputs-1} or {max_outputs} outputs")
+        if len(actual_task.python_interface.outputs.keys()) > 1:
+            raise ValueError("Map tasks only accept python function tasks with 0 or 1 outputs")
 
         self._bound_inputs: typing.Set[str] = set(bound_inputs) if bound_inputs else set()
         if self._partial:
@@ -82,7 +78,7 @@ class MapPythonTask(PythonTask):
         self._run_task: PythonFunctionTask = actual_task
         if hasattr(actual_task, "_IMPLICIT_OP_NOTEBOOK_TYPE"):
             mod = "papermill"
-            f = "execute_notebook"
+            f = actual_task.name
         else:
             _, mod, f, _ = tracker.extract_task_module(actual_task.task_function)
         h = hashlib.md5(collection_interface.__str__().encode("utf-8")).hexdigest()

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -133,6 +133,7 @@ class NotebookTask(PythonInstanceTask[T]):
         task_config: T = None,
         inputs: typing.Optional[typing.Dict[str, typing.Type]] = None,
         outputs: typing.Optional[typing.Dict[str, typing.Type]] = None,
+        output_notebooks: typing.Optional[bool] = True,
         **kwargs,
     ):
         # Each instance of NotebookTask instantiates an underlying task with a dummy function that will only be used
@@ -164,6 +165,14 @@ class NotebookTask(PythonInstanceTask[T]):
 
         if not os.path.exists(self._notebook_path):
             raise ValueError(f"Illegal notebook path passed in {self._notebook_path}")
+
+        if outputs and output_notebooks:
+            outputs.update(
+                {
+                    self._IMPLICIT_OP_NOTEBOOK: self._IMPLICIT_OP_NOTEBOOK_TYPE,
+                    self._IMPLICIT_RENDERED_NOTEBOOK: self._IMPLICIT_RENDERED_NOTEBOOK_TYPE,
+                }
+            )
 
         super().__init__(
             name,
@@ -271,8 +280,15 @@ class NotebookTask(PythonInstanceTask[T]):
 
         for k, type_v in self.python_interface.outputs.items():
             if k in m:
-                v = TypeEngine.to_python_value(ctx=FlyteContext.current_context(), lv=m[k], expected_python_type=type_v)
-                output_list.append(v)
+                if k == self._IMPLICIT_OP_NOTEBOOK:
+                    output_list.append(self.output_notebook_path)
+                elif k == self._IMPLICIT_RENDERED_NOTEBOOK:
+                    output_list.append(self.rendered_output_path)
+                elif k in m:
+                    v = TypeEngine.to_python_value(
+                        ctx=FlyteContext.current_context(), lv=m[k], expected_python_type=type_v
+                    )
+                    output_list.append(v)
             else:
                 raise TypeError(f"Expected output {k} of type {type_v} not found in the notebook outputs")
 

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -276,6 +276,8 @@ class NotebookTask(PythonInstanceTask[T]):
             else:
                 raise TypeError(f"Expected output {k} of type {type_v} not found in the notebook outputs")
 
+        if len(output_list) == 1:
+            return output_list[0]
         return tuple(output_list)
 
     def post_execute(self, user_params: ExecutionParameters, rval: Any) -> Any:

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -284,9 +284,7 @@ class NotebookTask(PythonInstanceTask[T]):
             elif k == self._IMPLICIT_RENDERED_NOTEBOOK:
                 output_list.append(self.rendered_output_path)
             elif k in m:
-                v = TypeEngine.to_python_value(
-                    ctx=FlyteContext.current_context(), lv=m[k], expected_python_type=type_v
-                )
+                v = TypeEngine.to_python_value(ctx=FlyteContext.current_context(), lv=m[k], expected_python_type=type_v)
                 output_list.append(v)
             else:
                 raise TypeError(f"Expected output {k} of type {type_v} not found in the notebook outputs")

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -165,13 +165,6 @@ class NotebookTask(PythonInstanceTask[T]):
         if not os.path.exists(self._notebook_path):
             raise ValueError(f"Illegal notebook path passed in {self._notebook_path}")
 
-        # if outputs:
-        #     outputs.update(
-        #         {
-        #             self._IMPLICIT_OP_NOTEBOOK: self._IMPLICIT_OP_NOTEBOOK_TYPE,
-        #             self._IMPLICIT_RENDERED_NOTEBOOK: self._IMPLICIT_RENDERED_NOTEBOOK_TYPE,
-        #         }
-        #     )
         super().__init__(
             name,
             task_config,
@@ -275,22 +268,15 @@ class NotebookTask(PythonInstanceTask[T]):
         if outputs:
             m = outputs.literals
         output_list = []
-        res = None
 
         for k, type_v in self.python_interface.outputs.items():
-            if k == self._IMPLICIT_OP_NOTEBOOK:
-                ...
-                # output_list.append(self.output_notebook_path)
-            elif k == self._IMPLICIT_RENDERED_NOTEBOOK:
-                ...
-                # output_list.append(self.rendered_output_path)
-            elif k in m:
-                res = TypeEngine.to_python_value(ctx=FlyteContext.current_context(), lv=m[k], expected_python_type=type_v)
-                output_list.append(res)
+            if k in m:
+                v = TypeEngine.to_python_value(ctx=FlyteContext.current_context(), lv=m[k], expected_python_type=type_v)
+                output_list.append(v)
             else:
                 raise TypeError(f"Expected output {k} of type {type_v} not found in the notebook outputs")
 
-        return res
+        return tuple(output_list)
 
     def post_execute(self, user_params: ExecutionParameters, rval: Any) -> Any:
         if self._render_deck:

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -165,13 +165,13 @@ class NotebookTask(PythonInstanceTask[T]):
         if not os.path.exists(self._notebook_path):
             raise ValueError(f"Illegal notebook path passed in {self._notebook_path}")
 
-        if outputs:
-            outputs.update(
-                {
-                    self._IMPLICIT_OP_NOTEBOOK: self._IMPLICIT_OP_NOTEBOOK_TYPE,
-                    self._IMPLICIT_RENDERED_NOTEBOOK: self._IMPLICIT_RENDERED_NOTEBOOK_TYPE,
-                }
-            )
+        # if outputs:
+        #     outputs.update(
+        #         {
+        #             self._IMPLICIT_OP_NOTEBOOK: self._IMPLICIT_OP_NOTEBOOK_TYPE,
+        #             self._IMPLICIT_RENDERED_NOTEBOOK: self._IMPLICIT_RENDERED_NOTEBOOK_TYPE,
+        #         }
+        #     )
         super().__init__(
             name,
             task_config,
@@ -275,19 +275,22 @@ class NotebookTask(PythonInstanceTask[T]):
         if outputs:
             m = outputs.literals
         output_list = []
+        res = None
 
         for k, type_v in self.python_interface.outputs.items():
             if k == self._IMPLICIT_OP_NOTEBOOK:
-                output_list.append(self.output_notebook_path)
+                ...
+                # output_list.append(self.output_notebook_path)
             elif k == self._IMPLICIT_RENDERED_NOTEBOOK:
-                output_list.append(self.rendered_output_path)
+                ...
+                # output_list.append(self.rendered_output_path)
             elif k in m:
-                v = TypeEngine.to_python_value(ctx=FlyteContext.current_context(), lv=m[k], expected_python_type=type_v)
-                output_list.append(v)
+                res = TypeEngine.to_python_value(ctx=FlyteContext.current_context(), lv=m[k], expected_python_type=type_v)
+                output_list.append(res)
             else:
                 raise TypeError(f"Expected output {k} of type {type_v} not found in the notebook outputs")
 
-        return tuple(output_list)
+        return res
 
     def post_execute(self, user_params: ExecutionParameters, rval: Any) -> Any:
         if self._render_deck:

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -166,7 +166,9 @@ class NotebookTask(PythonInstanceTask[T]):
         if not os.path.exists(self._notebook_path):
             raise ValueError(f"Illegal notebook path passed in {self._notebook_path}")
 
-        if outputs and output_notebooks:
+        if output_notebooks:
+            if outputs is None:
+                outputs = {}
             outputs.update(
                 {
                     self._IMPLICIT_OP_NOTEBOOK: self._IMPLICIT_OP_NOTEBOOK_TYPE,

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -279,16 +279,15 @@ class NotebookTask(PythonInstanceTask[T]):
         output_list = []
 
         for k, type_v in self.python_interface.outputs.items():
-            if k in m:
-                if k == self._IMPLICIT_OP_NOTEBOOK:
-                    output_list.append(self.output_notebook_path)
-                elif k == self._IMPLICIT_RENDERED_NOTEBOOK:
-                    output_list.append(self.rendered_output_path)
-                elif k in m:
-                    v = TypeEngine.to_python_value(
-                        ctx=FlyteContext.current_context(), lv=m[k], expected_python_type=type_v
-                    )
-                    output_list.append(v)
+            if k == self._IMPLICIT_OP_NOTEBOOK:
+                output_list.append(self.output_notebook_path)
+            elif k == self._IMPLICIT_RENDERED_NOTEBOOK:
+                output_list.append(self.rendered_output_path)
+            elif k in m:
+                v = TypeEngine.to_python_value(
+                    ctx=FlyteContext.current_context(), lv=m[k], expected_python_type=type_v
+                )
+                output_list.append(v)
             else:
                 raise TypeError(f"Expected output {k} of type {type_v} not found in the notebook outputs")
 

--- a/plugins/flytekit-papermill/setup.py
+++ b/plugins/flytekit-papermill/setup.py
@@ -5,7 +5,7 @@ PLUGIN_NAME = "papermill"
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 plugin_requires = [
-    "flytekit>=1.3.0b2,<2.0.0",
+    "flytekit",
     "papermill>=1.2.0",
     "nbconvert>=6.0.7",
     "ipykernel>=5.0.0",

--- a/plugins/flytekit-papermill/tests/test_task.py
+++ b/plugins/flytekit-papermill/tests/test_task.py
@@ -34,6 +34,14 @@ nb_simple = NotebookTask(
     outputs=kwtypes(square=float),
 )
 
+nb_sub_task = NotebookTask(
+    name="test",
+    notebook_path=_get_nb_path(nb_name, abs=False),
+    inputs=kwtypes(a=float),
+    outputs=kwtypes(square=float),
+    output_notebooks=False,
+)
+
 
 def test_notebook_task_simple():
     serialization_settings = flytekit.configuration.SerializationSettings(
@@ -176,16 +184,8 @@ def test_flyte_types():
 
 
 def test_map_over_notebook_task():
-    nb_task = NotebookTask(
-        name="test",
-        notebook_path=_get_nb_path(nb_name, abs=False),
-        inputs=kwtypes(a=float),
-        outputs=kwtypes(square=float),
-        output_notebooks=False,
-    )
-
     @workflow
     def wf(a: float) -> typing.List[float]:
-        return map_task(nb_task)(a=[a, a, a])
+        return map_task(nb_sub_task)(a=[a, a])
 
-    assert wf(a=3.14) == [9.8596, 9.8596, 9.8596]
+    assert wf(a=3.14) == [9.8596, 9.8596]

--- a/plugins/flytekit-papermill/tests/test_task.py
+++ b/plugins/flytekit-papermill/tests/test_task.py
@@ -44,10 +44,12 @@ def test_notebook_task_simple():
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
     )
 
-    sqr = nb_simple.execute(pi=4)
+    sqr, out, render = nb_simple.execute(pi=4)
     assert sqr == 16.0
     assert nb_simple.python_interface.inputs == {"pi": float}
     assert nb_simple.python_interface.outputs.keys() == {"square", "out_nb", "out_rendered_nb"}
+    assert nb_simple.output_notebook_path == out == _get_nb_path(nb_name, suffix="-out")
+    assert nb_simple.rendered_output_path == render == _get_nb_path(nb_name, suffix="-out", ext=".html")
     assert (
         nb_simple.get_command(settings=serialization_settings)
         == nb_simple.get_container(settings=serialization_settings).args
@@ -62,13 +64,15 @@ def test_notebook_task_multi_values():
         inputs=kwtypes(x=int, y=int, h=str),
         outputs=kwtypes(z=int, m=int, h=str, n=datetime.datetime),
     )
-    z, m, h, n = nb.execute(x=10, y=10, h="blah")
+    z, m, h, n, out, render = nb.execute(x=10, y=10, h="blah")
     assert z == 20
     assert m == 100
     assert h == "blah world!"
     assert type(n) == datetime.datetime
     assert nb.python_interface.inputs == {"x": int, "y": int, "h": str}
     assert nb.python_interface.outputs.keys() == {"z", "m", "h", "n", "out_nb", "out_rendered_nb"}
+    assert nb.output_notebook_path == out == _get_nb_path(nb_name, suffix="-out")
+    assert nb.rendered_output_path == render == _get_nb_path(nb_name, suffix="-out", ext=".html")
 
 
 def test_notebook_task_complex():
@@ -79,12 +83,14 @@ def test_notebook_task_complex():
         inputs=kwtypes(h=str, n=int, w=str),
         outputs=kwtypes(h=str, w=PythonNotebook, x=X),
     )
-    h, w, x = nb.execute(h="blah", n=10, w=_get_nb_path("nb-multi"))
+    h, w, x, out, render = nb.execute(h="blah", n=10, w=_get_nb_path("nb-multi"))
     assert h == "blah world!"
     assert w is not None
     assert x.x == 10
     assert nb.python_interface.inputs == {"n": int, "h": str, "w": str}
     assert nb.python_interface.outputs.keys() == {"h", "w", "x", "out_nb", "out_rendered_nb"}
+    assert nb.output_notebook_path == out == _get_nb_path(nb_name, suffix="-out")
+    assert nb.rendered_output_path == render == _get_nb_path(nb_name, suffix="-out", ext=".html")
 
 
 def test_notebook_deck_local_execution_doesnt_fail():
@@ -96,7 +102,7 @@ def test_notebook_deck_local_execution_doesnt_fail():
         inputs=kwtypes(pi=float),
         outputs=kwtypes(square=float),
     )
-    sqr = nb.execute(pi=4)
+    sqr, out, render = nb.execute(pi=4)
     # This is largely a no assert test to ensure render_deck never inhibits local execution.
     assert nb._render_deck, "Passing render deck to init should result in private attribute being set"
 
@@ -165,20 +171,21 @@ def test_flyte_types():
         inputs=kwtypes(ff=FlyteFile, fd=FlyteDirectory, sd=StructuredDataset),
         outputs=kwtypes(success=bool),
     )
-    success = nb_types.execute(ff=ff, fd=fd, sd=sd)
+    success, out, render = nb_types.execute(ff=ff, fd=fd, sd=sd)
     assert success is True, "Notebook execution failed"
 
 
 def test_map_over_notebook_task():
-    nb_simple = NotebookTask(
+    nb_task = NotebookTask(
         name="test",
         notebook_path=_get_nb_path(nb_name, abs=False),
         inputs=kwtypes(a=float),
         outputs=kwtypes(square=float),
+        output_notebooks=False,
     )
 
     @workflow
     def wf(a: float) -> typing.List[float]:
-        return map_task(nb_simple)(a=[a, a, a])
+        return map_task(nb_task)(a=[a, a, a])
 
     assert wf(a=3.14) == [9.8596, 9.8596, 9.8596]


### PR DESCRIPTION
# TL;DR
This PR allows map over notebook task

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
```python
import os
import pathlib
import typing

from flytekit import kwtypes, task, workflow, ImageSpec, map_task
from flytekitplugins.papermill import NotebookTask

new_flytekit = "git+https://github.com/flyteorg/flytekit@022ade936d2fe1eb6a2d705c319cce7d2c66ade6"
new_papermill = "git+https://github.com/flyteorg/flytekit.git@022ade936d2fe1eb6a2d705c319cce7d2c66ade6#subdirectory=plugins/flytekit-papermill"
image = ImageSpec(registry="pingsutw", packages=[new_papermill, new_flytekit], apt_packages=["git"])

nb = NotebookTask(
    name="simple-nb",
    notebook_path=os.path.join(
        pathlib.Path(__file__).parent.absolute(), "nb-simple.ipynb"
    ),
    render_deck=True,
    inputs=kwtypes(a=float),
    outputs=kwtypes(square=float),
    container_image=image,
)


@workflow
def wf(a: float) -> typing.List[float]:
    return map_task(nb)(a=[a])


if __name__ == "__main__":
    print(wf(a=3.14))
```

<img width="1857" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/490d738e-1fd3-4ca1-970f-d555f6e3bbde">


## Tracking Issue
https://flyte-org.slack.com/archives/CP2HDHKE1/p1684471512753359

## Follow-up issue
_NA_
