### PR TITLE
Use logger instead of print statement in sqlalchemy plugin

### DIFF
--- a/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
+++ b/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
@@ -1,5 +1,5 @@
-import typing
 import logging
+import typing
 from dataclasses import dataclass
 
 import pandas as pd

--- a/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
+++ b/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
@@ -1,4 +1,3 @@
-import logging
 import typing
 from dataclasses import dataclass
 
@@ -12,6 +11,7 @@ from flytekit.configuration.default_images import DefaultImages, PythonVersion
 from flytekit.core.base_sql_task import SQLTask
 from flytekit.core.python_customized_container_task import PythonCustomizedContainerTask
 from flytekit.core.shim_task import ShimTaskExecutor
+from flytekit.loggers import logger
 from flytekit.models import task as task_models
 from flytekit.models.security import Secret
 from flytekit.types.schema import FlyteSchema
@@ -127,10 +127,10 @@ class SQLAlchemyTaskExecutor(ShimTaskExecutor[SQLAlchemyTask]):
                 tt.custom["connect_args"][key] = value
 
         engine = create_engine(tt.custom["uri"], connect_args=tt.custom["connect_args"], echo=False)
-        logging.info(f"Connecting to db {tt.custom['uri']}")
+        logger.info(f"Connecting to db {tt.custom['uri']}")
 
         interpolated_query = SQLAlchemyTask.interpolate_query(tt.custom["query_template"], **kwargs)
-        logging.info(f"Interpolated query {interpolated_query}")
+        logger.info(f"Interpolated query {interpolated_query}")
         with engine.begin() as connection:
             df = None
             if tt.interface.outputs:

--- a/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
+++ b/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
@@ -1,4 +1,5 @@
 import typing
+import logging
 from dataclasses import dataclass
 
 import pandas as pd
@@ -126,10 +127,10 @@ class SQLAlchemyTaskExecutor(ShimTaskExecutor[SQLAlchemyTask]):
                 tt.custom["connect_args"][key] = value
 
         engine = create_engine(tt.custom["uri"], connect_args=tt.custom["connect_args"], echo=False)
-        print(f"Connecting to db {tt.custom['uri']}")
+        logging.info(f"Connecting to db {tt.custom['uri']}")
 
         interpolated_query = SQLAlchemyTask.interpolate_query(tt.custom["query_template"], **kwargs)
-        print(f"Interpolated query {interpolated_query}")
+        logging.info(f"Interpolated query {interpolated_query}")
         with engine.begin() as connection:
             df = None
             if tt.interface.outputs:


### PR DESCRIPTION
# TL;DR
Use root logger instead of print statement in sqlalchemy plugin


## Type
 - [x ] Bug Fix
 - [ ] Feature
 - [ ] Plugin


## Complete description
Just replaced the print statement with the root loggers info statement as suggested in the issue

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3651