### PR TITLE
Fix ability to pass None to task with Optional kwarg, add test

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -619,7 +619,7 @@ def binding_data_from_python_std(
             f"Cannot pass output from task {t_value.task_name} that produces no outputs to a downstream task"
         )
 
-    elif expected_literal_type.union_type is not None:
+    elif t_value is not None and expected_literal_type.union_type is not None:
         for i in range(len(expected_literal_type.union_type.variants)):
             try:
                 lt_type = expected_literal_type.union_type.variants[i]

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -145,3 +145,18 @@ def test_translate_inputs_to_literals_with_wrong_types():
             t1.interface.inputs,
             t1.python_interface.inputs,
         )
+
+
+def test_optional_task_kwargs():
+    from typing import Optional
+
+    from flytekit import Workflow
+
+    @task
+    def func(foo: Optional[int] = None):
+        pass
+
+    wf = Workflow(name="test")
+    wf.add_entity(func, foo=None)
+
+    wf()


### PR DESCRIPTION
# TL;DR

```python
from flytekit import task, workflow, Workflow
from dataclasses import dataclass
from dataclasses_json import dataclass_json
from typing import Optional

@dataclass_json
@dataclass
class Config:
    lr: float = 0.1

@task
def func(cfg: Optional[Config] = None) -> None:
    print(cfg is None)

wf = Workflow(name="foo")
wf.add_entity(func, cfg=None)

wf()
```

This code snippet works up to flytekit version `1.5.0`. It does not work in `1.6.0` (change introduced in [this](https://github.com/flyteorg/flytekit/commit/4037fa0135b8faf078f0be652eb6abd486c570ce) commit), failing with this error:

```console
╭──────────────────────────────────────────────────── Traceback (most recent call last) ─────────────────────────────────────────────────────╮
│ /home/username/miniconda3/envs/debug/lib/python3.9/site-packages/flytekit/core/promise.py:1002 in create_and_link_node                   │
│                                                                                                                                            │
│ ❱ 1002 │   │   │   │   binding_from_python_std(                                                                                            │
│                                                                                                                                            │
│ /home/username/miniconda3/envs/debug/lib/python3.9/site-packages/flytekit/core/promise.py:690 in binding_from_python_std                 │
│                                                                                                                                            │
│ ❱  690 │   binding_data = binding_data_from_python_std(ctx, expected_literal_type, t_value, t_v                                            │
│                                                                                                                                            │
│ /home/username/miniconda3/envs/debug/lib/python3.9/site-packages/flytekit/core/promise.py:632 in binding_data_from_python_std            │
│                                                                                                                                            │
│ ❱  632 │   │   raise AssertionError(                                                                                                       │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
AssertionError: Failed to bind data None with literal type [<FlyteLiteral simple: STRUCT metadata { fields { key: "definitions" value { 
struct_value { fields { key: "ConfigSchema" value { struct_value { fields { key: "type" value { string_value: "object" } } fields { key: 
"properties" value { struct_value { fields { key: "lr" value { struct_value { fields { key: "type" value { string_value: "number" } } fields {
key: "title" value { string_value: "lr" } } fields { key: "format" value { string_value: "float" } } fields { key: "default" value { 
number_value: 0.1 } } } } } } } } fields { key: "additionalProperties" value { bool_value: false } } } } } } } } fields { key: "$schema" value
{ string_value: "http://json-schema.org/draft-07/schema#" } } fields { key: "$ref" value { string_value: "#/definitions/ConfigSchema" } } } 
structure { tag: "Object-Dataclass-Transformer" }>, <FlyteLiteral simple: NONE structure { tag: "none" }>].

The above exception was the direct cause of the following exception:

╭──────────────────────────────────────────────────── Traceback (most recent call last) ─────────────────────────────────────────────────────╮
│ /home/username/torch-experiments/none.py:18 in <module>                                                                                  │
│                                                                                                                                            │
│ ❱ 18 wf.add_entity(func, cfg=None)                                                                                                         │
│                                                                                                                                            │
│ /home/username/miniconda3/envs/debug/lib/python3.9/site-packages/flytekit/core/workflow.py:551 in add_entity                             │
│                                                                                                                                            │
│ ❱ 551 │   │   │   n = create_node(entity=entity, **kwargs)                                                                                 │
│                                                                                                                                            │
│ /home/username/miniconda3/envs/debug/lib/python3.9/site-packages/flytekit/core/node_creation.py:93 in create_node                        │
│                                                                                                                                            │
│ ❱  93 │   │   outputs = entity(**kwargs)                                                                                                   │
│                                                                                                                                            │
│ /home/username/miniconda3/envs/debug/lib/python3.9/site-packages/flytekit/core/base_task.py:304 in __call__                              │
│                                                                                                                                            │
│ ❱ 304 │   │   return flyte_entity_call_handler(self, *args, **kwargs)  # type: ignore                                                      │
│                                                                                                                                            │
│ /home/username/miniconda3/envs/debug/lib/python3.9/site-packages/flytekit/core/promise.py:1092 in flyte_entity_call_handler              │
│                                                                                                                                            │
│ ❱ 1092 │   │   return create_and_link_node(ctx, entity=entity, **kwargs)                                                                   │
│                                                                                                                                            │
│ /home/username/miniconda3/envs/debug/lib/python3.9/site-packages/flytekit/core/promise.py:1012 in create_and_link_node                   │
│                                                                                                                                            │
│ ❱ 1012 │   │   │   raise AssertionError(f"Failed to Bind variable {k} for function {entity.name                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
AssertionError: Failed to Bind variable cfg for function func.
```

I assume the `elif` case should not be entered if the value is `None`. Is this correct @pingsutw ?


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
