### PR TITLE
Explicitly set the content type for flyte deck

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -183,6 +183,7 @@ def get_one_of(*args) -> str:
 @contextlib.contextmanager
 def setup_execution(
     raw_output_data_prefix: str,
+    output_prefix: Optional[str] = None,
     checkpoint_path: Optional[str] = None,
     prev_checkpoint: Optional[str] = None,
     dynamic_addl_distro: Optional[str] = None,
@@ -190,7 +191,8 @@ def setup_execution(
 ):
     """
 
-    :param raw_output_data_prefix:
+    :param raw_output_data_prefix: Where to write primitive outputs
+    :param output_prefix:  Where to write offloaded data (files, directories, dataframes).
     :param checkpoint_path:
     :param prev_checkpoint:
     :param dynamic_addl_distro: Works in concert with the other dynamic arg. If present, indicates that if a dynamic
@@ -247,6 +249,7 @@ def setup_execution(
         logging=user_space_logger,
         tmp_dir=user_workspace_dir,
         raw_output_prefix=raw_output_data_prefix,
+        output_prefix=output_prefix,
         checkpoint=checkpointer,
         task_id=_identifier.Identifier(_identifier.ResourceType.TASK, tk_project, tk_domain, tk_name, tk_version),
     )
@@ -337,6 +340,7 @@ def _execute_task(
 
     with setup_execution(
         raw_output_data_prefix,
+        output_prefix,
         checkpoint_path,
         prev_checkpoint,
         dynamic_addl_distro,

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -151,6 +151,7 @@ class ExecutionParameters(object):
         execution_id: typing.Optional[_identifier.WorkflowExecutionIdentifier],
         logging,
         raw_output_prefix,
+        output_prefix=None,
         checkpoint=None,
         decks=None,
         task_id: typing.Optional[_identifier.Identifier] = None,
@@ -173,6 +174,7 @@ class ExecutionParameters(object):
         self._execution_id = execution_id
         self._logging = logging
         self._raw_output_prefix = raw_output_prefix
+        self._output_prefix = output_prefix
         # AutoDeletingTempDir's should be used with a with block, which creates upon entry
         self._attrs = kwargs
         # It is safe to recreate the Secrets Manager
@@ -200,6 +202,10 @@ class ExecutionParameters(object):
     @property
     def raw_output_prefix(self) -> str:
         return self._raw_output_prefix
+
+    @property
+    def output_prefix(self) -> str:
+        return self._output_prefix
 
     @property
     def working_directory(self) -> str:

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -217,7 +217,7 @@ class FileAccessProvider(object):
                     self.strip_file_header(from_path), self.strip_file_header(to_path), dirs_exist_ok=True
                 )
             from_path, to_path = self.recursive_paths(from_path, to_path)
-        return file_system.put(from_path, to_path, recursive=recursive, **kwargs)
+        return file_system.put(from_path, to_path, recursive=recursive)
 
     def get_random_remote_path(self, file_path_or_file_name: typing.Optional[str] = None) -> str:
         """

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -203,7 +203,7 @@ class FileAccessProvider(object):
                 return file_system.get(from_path, to_path, recursive=recursive)
             raise oe
 
-    def put(self, from_path: str, to_path: str, recursive: bool = False):
+    def put(self, from_path: str, to_path: str, recursive: bool = False, **kwargs):
         file_system = self.get_filesystem_for_path(to_path)
         from_path = self.strip_file_header(from_path)
         if recursive:
@@ -217,7 +217,7 @@ class FileAccessProvider(object):
                     self.strip_file_header(from_path), self.strip_file_header(to_path), dirs_exist_ok=True
                 )
             from_path, to_path = self.recursive_paths(from_path, to_path)
-        return file_system.put(from_path, to_path, recursive=recursive)
+        return file_system.put(from_path, to_path, recursive=recursive, **kwargs)
 
     def get_random_remote_path(self, file_path_or_file_name: typing.Optional[str] = None) -> str:
         """
@@ -304,7 +304,7 @@ class FileAccessProvider(object):
             )
 
     @timeit("Upload data to remote")
-    def put_data(self, local_path: Union[str, os.PathLike], remote_path: str, is_multipart: bool = False):
+    def put_data(self, local_path: Union[str, os.PathLike], remote_path: str, is_multipart: bool = False, **kwargs):
         """
         The implication here is that we're always going to put data to the remote location, so we .remote to ensure
         we don't use the true local proxy if the remote path is a file://
@@ -316,7 +316,7 @@ class FileAccessProvider(object):
         try:
             local_path = str(local_path)
 
-            self.put(cast(str, local_path), remote_path, recursive=is_multipart)
+            self.put(cast(str, local_path), remote_path, recursive=is_multipart, **kwargs)
         except Exception as ex:
             raise FlyteAssertion(
                 f"Failed to put data from {local_path} to {remote_path} (recursive={is_multipart}).\n\n"

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -217,7 +217,7 @@ class FileAccessProvider(object):
                     self.strip_file_header(from_path), self.strip_file_header(to_path), dirs_exist_ok=True
                 )
             from_path, to_path = self.recursive_paths(from_path, to_path)
-        return file_system.put(from_path, to_path, recursive=recursive)
+        return file_system.put(from_path, to_path, recursive=recursive, **kwargs)
 
     def get_random_remote_path(self, file_path_or_file_name: typing.Optional[str] = None) -> str:
         """

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -145,7 +145,7 @@ def _get_deck(
 
 def _output_deck(task_name: str, new_user_params: ExecutionParameters):
     ctx = FlyteContext.current_context()
-    local_path = ctx.file_access.get_random_local_path()
+    local_path = ctx.file_access.get_random_local_path(DECK_FILE_NAME)
     with open(local_path, "w") as f:
         f.write(_get_deck(new_user_params, ignore_jupyter=True))
     logger.info(f"{task_name} task creates flyte deck html to file://{local_path}")
@@ -153,7 +153,7 @@ def _output_deck(task_name: str, new_user_params: ExecutionParameters):
     if ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
         remote_path = ctx.execution_state.user_space_params.output_prefix
         kwargs: typing.Dict[str, str] = {
-            "ContentType": "text/html",
+            "ContentType": "text/htm",
         }
         ctx.file_access.put_data(local_path, remote_path, **kwargs)
 

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -152,7 +152,7 @@ def _output_deck(task_name: str, new_user_params: ExecutionParameters):
     logger.info(f"{task_name} task creates flyte deck html to file://{local_path}")
     print(local_path)
     if ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
-        remote_path = ctx.execution_state.user_space_params.output_prefix
+        remote_path = new_user_params.output_prefix
         kwargs: typing.Dict[str, str] = {
             "ContentType": "text/htm",
         }

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -154,7 +154,7 @@ def _output_deck(task_name: str, new_user_params: ExecutionParameters):
     if ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
         remote_path = os.path.join(new_user_params.output_prefix, DECK_FILE_NAME)
         kwargs: typing.Dict[str, str] = {
-            "ContentType": "text/htm",
+            "ContentType": "application/octet-stream",
         }
         print(remote_path)
         ctx.file_access.put_data(local_path, remote_path, **kwargs)

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -153,7 +153,7 @@ def _output_deck(task_name: str, new_user_params: ExecutionParameters):
     if ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
         remote_path = os.path.join(new_user_params.output_prefix, DECK_FILE_NAME)
         kwargs: typing.Dict[str, str] = {
-            "ContentType": "text/htm",
+            "ContentType": "text/html",
         }
         ctx.file_access.put_data(local_path, remote_path, **kwargs)
 

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -145,7 +145,8 @@ def _get_deck(
 
 def _output_deck(task_name: str, new_user_params: ExecutionParameters):
     ctx = FlyteContext.current_context()
-    local_path = ctx.file_access.get_random_local_path(DECK_FILE_NAME)
+    local_dir = ctx.file_access.get_random_local_directory()
+    local_path = os.path.join(local_dir, DECK_FILE_NAME)
     with open(local_path, "w") as f:
         f.write(_get_deck(new_user_params, ignore_jupyter=True))
     logger.info(f"{task_name} task creates flyte deck html to file://{local_path}")

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -150,13 +150,14 @@ def _output_deck(task_name: str, new_user_params: ExecutionParameters):
     with open(local_path, "w") as f:
         f.write(_get_deck(new_user_params, ignore_jupyter=True))
     logger.info(f"{task_name} task creates flyte deck html to file://{local_path}")
-
+    print(local_path)
     if ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
         remote_path = ctx.execution_state.user_space_params.output_prefix
         kwargs: typing.Dict[str, str] = {
             "ContentType": "text/htm",
         }
         ctx.file_access.put_data(local_path, remote_path, **kwargs)
+        print(remote_path)
 
 
 def get_deck_template() -> "Template":

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -157,7 +157,7 @@ def _output_deck(task_name: str, new_user_params: ExecutionParameters):
             "ContentType": "text/htm",
         }
         print(remote_path)
-        ctx.file_access.put_data(local_path, remote_path)
+        ctx.file_access.put_data(local_path, remote_path, **kwargs)
 
 
 def get_deck_template() -> "Template":

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -150,13 +150,11 @@ def _output_deck(task_name: str, new_user_params: ExecutionParameters):
     with open(local_path, "w") as f:
         f.write(_get_deck(new_user_params, ignore_jupyter=True))
     logger.info(f"{task_name} task creates flyte deck html to file://{local_path}")
-    print(local_path)
     if ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
         remote_path = os.path.join(new_user_params.output_prefix, DECK_FILE_NAME)
         kwargs: typing.Dict[str, str] = {
-            "ContentType": "application/octet-stream",
+            "ContentType": "text/htm",
         }
-        print(remote_path)
         ctx.file_access.put_data(local_path, remote_path, **kwargs)
 
 

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -152,12 +152,12 @@ def _output_deck(task_name: str, new_user_params: ExecutionParameters):
     logger.info(f"{task_name} task creates flyte deck html to file://{local_path}")
     print(local_path)
     if ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
-        remote_path = new_user_params.output_prefix
+        remote_path = os.path.join(new_user_params.output_prefix, DECK_FILE_NAME)
         kwargs: typing.Dict[str, str] = {
             "ContentType": "text/htm",
         }
-        ctx.file_access.put_data(local_path, remote_path)
         print(remote_path)
+        ctx.file_access.put_data(local_path, remote_path)
 
 
 def get_deck_template() -> "Template":

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -156,7 +156,7 @@ def _output_deck(task_name: str, new_user_params: ExecutionParameters):
         kwargs: typing.Dict[str, str] = {
             "ContentType": "text/htm",
         }
-        ctx.file_access.put_data(local_path, remote_path, **kwargs)
+        ctx.file_access.put_data(local_path, remote_path)
         print(remote_path)
 
 


### PR DESCRIPTION
# TL;DR
Sometimes s3 or gcs will set the content type to `application/octet-stream`. In this pr, we explicitly set the type, so flyteconsole can render flyte deck properly.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
```python
from flytekit import task, workflow
from flytekit.image_spec import ImageSpec


new_flytekit = "git+https://github.com/flyteorg/flytekit@e199d01b44042a19a6f18b7942150b02dac24e01"

python_image = ImageSpec(
    registry="pingsutw",
    apt_packages=["git"],
    packages=[new_flytekit],
)


@task(container_image=python_image, disable_deck=False)
def t1():
    print("t1")


@workflow()
def wf():
    t1()


if __name__ == '__main__':
    wf()

```

## Tracking Issue
https://unionai.slack.com/archives/C02CMUNT4PQ/p1684943237121539

## Follow-up issue
_NA_