### PR TITLE
FLYTECTL_CONFIG env var should take highest precedence

### DIFF
--- a/flytekit/clis/sdk_in_container/pyflyte.py
+++ b/flytekit/clis/sdk_in_container/pyflyte.py
@@ -1,3 +1,4 @@
+import os
 import typing
 
 import grpc
@@ -17,6 +18,7 @@ from flytekit.clis.sdk_in_container.register import register
 from flytekit.clis.sdk_in_container.run import run
 from flytekit.clis.sdk_in_container.serialize import serialize
 from flytekit.clis.sdk_in_container.serve import serve
+from flytekit.configuration.file import FLYTECTL_CONFIG_ENV_VAR
 from flytekit.configuration.internal import LocalSDK
 from flytekit.exceptions.base import FlyteException
 from flytekit.exceptions.user import FlyteInvalidInputException
@@ -120,6 +122,14 @@ def main(ctx, pkgs: typing.List[str], config: str, verbose: bool):
     if config:
         ctx.obj[CTX_CONFIG_FILE] = config
         cfg = configuration.ConfigFile(config)
+        # Set here so that if someone has Config.auto() in their user code, the config here will get used.
+        if FLYTECTL_CONFIG_ENV_VAR not in os.environ:
+            os.environ[FLYTECTL_CONFIG_ENV_VAR] = config
+        else:
+            cli_logger.warning(
+                f"Config file in arg {config} will be overridden by env var {FLYTECTL_CONFIG_ENV_VAR}:"
+                f" {os.environ[FLYTECTL_CONFIG_ENV_VAR]}"
+            )
         if not pkgs:
             pkgs = LocalSDK.WORKFLOW_PACKAGES.read(cfg)
             if pkgs is None:

--- a/flytekit/clis/sdk_in_container/pyflyte.py
+++ b/flytekit/clis/sdk_in_container/pyflyte.py
@@ -18,7 +18,7 @@ from flytekit.clis.sdk_in_container.register import register
 from flytekit.clis.sdk_in_container.run import run
 from flytekit.clis.sdk_in_container.serialize import serialize
 from flytekit.clis.sdk_in_container.serve import serve
-from flytekit.configuration.file import FLYTECTL_CONFIG_ENV_VAR
+from flytekit.configuration.file import FLYTECTL_CONFIG_ENV_VAR, FLYTECTL_CONFIG_ENV_VAR_OVERRIDE
 from flytekit.configuration.internal import LocalSDK
 from flytekit.exceptions.base import FlyteException
 from flytekit.exceptions.user import FlyteInvalidInputException
@@ -124,10 +124,10 @@ def main(ctx, pkgs: typing.List[str], config: str, verbose: bool):
         cfg = configuration.ConfigFile(config)
         # Set here so that if someone has Config.auto() in their user code, the config here will get used.
         if FLYTECTL_CONFIG_ENV_VAR in os.environ:
-            print(
+            cli_logger.info(
                 f"Config file arg {config} will override env var {FLYTECTL_CONFIG_ENV_VAR}: {os.environ[FLYTECTL_CONFIG_ENV_VAR]}"
             )
-        os.environ[FLYTECTL_CONFIG_ENV_VAR] = config
+        os.environ[FLYTECTL_CONFIG_ENV_VAR_OVERRIDE] = config
         if not pkgs:
             pkgs = LocalSDK.WORKFLOW_PACKAGES.read(cfg)
             if pkgs is None:

--- a/flytekit/clis/sdk_in_container/pyflyte.py
+++ b/flytekit/clis/sdk_in_container/pyflyte.py
@@ -123,13 +123,11 @@ def main(ctx, pkgs: typing.List[str], config: str, verbose: bool):
         ctx.obj[CTX_CONFIG_FILE] = config
         cfg = configuration.ConfigFile(config)
         # Set here so that if someone has Config.auto() in their user code, the config here will get used.
-        if FLYTECTL_CONFIG_ENV_VAR not in os.environ:
-            os.environ[FLYTECTL_CONFIG_ENV_VAR] = config
-        else:
-            cli_logger.warning(
-                f"Config file in arg {config} will be overridden by env var {FLYTECTL_CONFIG_ENV_VAR}:"
-                f" {os.environ[FLYTECTL_CONFIG_ENV_VAR]}"
+        if FLYTECTL_CONFIG_ENV_VAR in os.environ:
+            print(
+                f"Config file arg {config} will override env var {FLYTECTL_CONFIG_ENV_VAR}: {os.environ[FLYTECTL_CONFIG_ENV_VAR]}"
             )
+        os.environ[FLYTECTL_CONFIG_ENV_VAR] = config
         if not pkgs:
             pkgs = LocalSDK.WORKFLOW_PACKAGES.read(cfg)
             if pkgs is None:

--- a/flytekit/configuration/file.py
+++ b/flytekit/configuration/file.py
@@ -16,6 +16,10 @@ from flytekit.loggers import logger
 
 # This is the env var that the flytectl sandbox instructions say to set
 FLYTECTL_CONFIG_ENV_VAR = "FLYTECTL_CONFIG"
+# This is an explicit override only to be used by pyflyte and takes precedence in get_config_file over the main
+# environment variable.
+# This env var should not be set by users
+FLYTECTL_CONFIG_ENV_VAR_OVERRIDE = "_FLYTECTL_CONFIG_PYFLYTE_OVERRIDE"
 
 
 def _exists(val: typing.Any) -> bool:
@@ -239,8 +243,9 @@ def get_config_file(c: typing.Union[str, ConfigFile, None]) -> typing.Optional[C
     Checks if the given argument is a file or a configFile and returns a loaded configFile else returns None
     """
     if c is None:
-        # Env var always takes the highest precedence
-        flytectl_path_from_env = getenv(FLYTECTL_CONFIG_ENV_VAR, None)
+        # Pyflyte override env var takes highest precedence
+        # Env var takes second highest precedence
+        flytectl_path_from_env = getenv(FLYTECTL_CONFIG_ENV_VAR_OVERRIDE, getenv(FLYTECTL_CONFIG_ENV_VAR, None))
         if flytectl_path_from_env:
             flytectl_path = Path(flytectl_path_from_env)
             if flytectl_path.exists():


### PR DESCRIPTION
# TL;DR
Also when running `pyflyte -c cfg.yaml package ...`, if a user has `Config.auto()` in their code, `cfg.yaml` should get used.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
