### PR TITLE
Updates to pyflyte init templating

### DIFF
--- a/flytekit/clis/sdk_in_container/helpers.py
+++ b/flytekit/clis/sdk_in_container/helpers.py
@@ -1,6 +1,7 @@
+import os
+import shutil
 from dataclasses import replace
 from typing import Optional
-import shutil, os
 
 import rich_click as click
 from git import Repo
@@ -78,13 +79,13 @@ def clone_and_copy_repo_dir(git_url, branch, src_dir, dest_dir):
     - dest_dir: The local directory to copy into.
     """
     # Clone the repo
-    repo = Repo.clone_from(git_url, 'temp_repo')
+    repo = Repo.clone_from(git_url, "temp_repo")
 
     # Checkout to the branch
     repo.git.checkout(branch)
 
     # Define the source directory path
-    src_path = os.path.join('temp_repo', src_dir)
+    src_path = os.path.join("temp_repo", src_dir)
 
     # Check if source directory exists
     if not os.path.exists(src_path):
@@ -95,4 +96,4 @@ def clone_and_copy_repo_dir(git_url, branch, src_dir, dest_dir):
     shutil.copytree(src_path, dest_dir)
 
     # Remove the temporary cloned repo
-    shutil.rmtree('temp_repo')
+    shutil.rmtree("temp_repo")

--- a/flytekit/clis/sdk_in_container/init.py
+++ b/flytekit/clis/sdk_in_container/init.py
@@ -1,4 +1,5 @@
 import rich_click as click
+
 from flytekit.clis.sdk_in_container.helpers import clone_and_copy_repo_dir
 
 
@@ -11,23 +12,14 @@ from flytekit.clis.sdk_in_container.helpers import clone_and_copy_repo_dir
 @click.option(
     "--repository-url",
     default="https://github.com/flyteorg/flytekit-python-template.git",
-    help="template repository url pointing to a git repository containing flytekit templates."
+    help="template repository url pointing to a git repository containing flytekit templates.",
 )
-@click.option(
-    "--repository-branch",
-    default="main",
-    help="template repository branch to be used."
-)
+@click.option("--repository-branch", default="main", help="template repository branch to be used.")
 @click.argument("project-name")
 def init(template, repository_url, repository_branch, project_name):
     """
     Create flyte-ready projects.
     """
-    config = {
-        "project_name": project_name,
-        "app": "flyte",
-        "workflow": "my_wf",
-    }
 
     clone_and_copy_repo_dir(repository_url, repository_branch, template, project_name)
 

--- a/flytekit/clis/sdk_in_container/init.py
+++ b/flytekit/clis/sdk_in_container/init.py
@@ -1,5 +1,5 @@
 import rich_click as click
-from cookiecutter.main import cookiecutter
+from flytekit.clis.sdk_in_container.helpers import clone_and_copy_repo_dir
 
 
 @click.command("init")
@@ -8,8 +8,18 @@ from cookiecutter.main import cookiecutter
     default="simple-example",
     help="cookiecutter template folder name to be used in the repo - https://github.com/flyteorg/flytekit-python-template.git",
 )
+@click.option(
+    "--repository-url",
+    default="https://github.com/flyteorg/flytekit-python-template.git",
+    help="template repository url pointing to a git repository containing flytekit templates."
+)
+@click.option(
+    "--repository-branch",
+    default="main",
+    help="template repository branch to be used."
+)
 @click.argument("project-name")
-def init(template, project_name):
+def init(template, repository_url, repository_branch, project_name):
     """
     Create flyte-ready projects.
     """
@@ -18,19 +28,8 @@ def init(template, project_name):
         "app": "flyte",
         "workflow": "my_wf",
     }
-    cookiecutter(
-        "https://github.com/flyteorg/flytekit-python-template.git",
-        checkout="main",
-        no_input=True,
-        # We do not want to clobber existing files/directories.
-        overwrite_if_exists=False,
-        extra_context=config,
-        # By specifying directory we can have multiple templates in the same repository,
-        # as described in https://cookiecutter.readthedocs.io/en/1.7.2/advanced/directories.html.
-        # The idea is to extend the number of templates, each in their own subdirectory, for example
-        # a tensorflow-based example.
-        directory=template,
-    )
+
+    clone_and_copy_repo_dir(repository_url, repository_branch, template, project_name)
 
     click.echo(
         f"Visit the {project_name} directory and follow the next steps in the Getting started guide (https://docs.flyte.org/en/latest/getting_started.html) to proceed."

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setup(
         "docstring-parser>=0.9.0",
         "diskcache>=5.2.1",
         "cloudpickle>=2.0.0",
-        "cookiecutter>=1.7.3",
         "numpy",
         "gitpython",
         "kubernetes>=12.0.1",


### PR DESCRIPTION
# TL;DR
This PR removes the cookiecutter templating system for `pyflyte init`, and instead uses gitpython, without templating.
This is part of a wider effort to replace our Dockerfile / docker_build.sh systems with the much simpler `ImageSpec`.

This PR depends on https://github.com/flyteorg/flytekit-python-template/pull/40

**This is a breaking change**
All templates are now imagespec based, and cookiecutter is no longer used to generate custom readme titles or directory names.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
As discussed as part of the larger Flyte example improvement with newly introduced imagespec.

