### PR TITLE
Root cert should be byte string when loading from caCertFilePath

### DIFF
--- a/flytekit/clients/auth_helper.py
+++ b/flytekit/clients/auth_helper.py
@@ -176,7 +176,8 @@ def get_channel(cfg: PlatformConfig, **kwargs) -> grpc.Channel:
         if cfg.insecure_skip_verify:
             credentials = bootstrap_creds_from_server(cfg.endpoint)
         elif cfg.ca_cert_file_path:
-            credentials = grpc.ssl_channel_credentials(load_cert(cfg.ca_cert_file_path))
+            credentials = grpc.ssl_channel_credentials(
+                crypto.dump_certificate(crypto.FILETYPE_PEM, load_cert(cfg.ca_cert_file_path)))
         else:
             credentials = grpc.ssl_channel_credentials(
                 root_certificates=kwargs.get("root_certificates", None),

--- a/flytekit/clients/auth_helper.py
+++ b/flytekit/clients/auth_helper.py
@@ -177,7 +177,8 @@ def get_channel(cfg: PlatformConfig, **kwargs) -> grpc.Channel:
             credentials = bootstrap_creds_from_server(cfg.endpoint)
         elif cfg.ca_cert_file_path:
             credentials = grpc.ssl_channel_credentials(
-                crypto.dump_certificate(crypto.FILETYPE_PEM, load_cert(cfg.ca_cert_file_path)))
+                crypto.dump_certificate(crypto.FILETYPE_PEM, load_cert(cfg.ca_cert_file_path))
+            )
         else:
             credentials = grpc.ssl_channel_credentials(
                 root_certificates=kwargs.get("root_certificates", None),


### PR DESCRIPTION
# TL;DR
Please see issue for a detailed explanation.

Tested with a user, got past the error in the issue, but still timing out.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description


## Tracking Issue
https://github.com/flyteorg/flyte/issues/3715
