### PR TITLE
Update fg91 runtime overrides PR

### DIFF
--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -117,6 +117,7 @@ class LaunchPlan(object):
         max_parallelism: Optional[int] = None,
         security_context: Optional[security.SecurityContext] = None,
         auth_role: Optional[_common_models.AuthRole] = None,
+        task_node_overrides: Optional[_workflow_model.TaskNodeOverrides] = None,
     ) -> LaunchPlan:
         ctx = FlyteContextManager.current_context()
         default_inputs = default_inputs or {}
@@ -167,6 +168,7 @@ class LaunchPlan(object):
             raw_output_data_config=raw_output_data_config,
             max_parallelism=max_parallelism,
             security_context=security_context,
+            task_node_overrides=task_node_overrides,
         )
 
         # This is just a convenience - we'll need the fixed inputs LiteralMap for when serializing the Launch Plan out
@@ -195,7 +197,9 @@ class LaunchPlan(object):
         max_parallelism: Optional[int] = None,
         security_context: Optional[security.SecurityContext] = None,
         auth_role: Optional[_common_models.AuthRole] = None,
+        task_node_overrides: Optional[_workflow_model.TaskNodeOverrides] = None,
     ) -> LaunchPlan:
+        # FIXME: Add docstring
         """
         This function offers a friendlier interface for creating launch plans. If the name for the launch plan is not
         supplied, this assumes you are looking for the default launch plan for the workflow. If it is specified, it
@@ -232,6 +236,7 @@ class LaunchPlan(object):
             or auth_role is not None
             or max_parallelism is not None
             or security_context is not None
+            or task_node_overrides is not None
         ):
             raise ValueError(
                 "Only named launchplans can be created that have other properties. Drop the name if you want to create a default launchplan. Default launchplans cannot have any other associations"
@@ -288,6 +293,7 @@ class LaunchPlan(object):
                 max_parallelism,
                 auth_role=auth_role,
                 security_context=security_context,
+                task_node_overrides=task_node_overrides,
             )
         LaunchPlan.CACHE[name or workflow.name] = lp
         return lp
@@ -305,6 +311,7 @@ class LaunchPlan(object):
         raw_output_data_config: Optional[_common_models.RawOutputDataConfig] = None,
         max_parallelism: Optional[int] = None,
         security_context: Optional[security.SecurityContext] = None,
+        task_node_overrides: Optional[_workflow_model.TaskNodeOverrides] = None,
     ):
         self._name = name
         self._workflow = workflow
@@ -322,6 +329,7 @@ class LaunchPlan(object):
         self._raw_output_data_config = raw_output_data_config
         self._max_parallelism = max_parallelism
         self._security_context = security_context
+        self._task_node_overrides = task_node_overrides
 
         FlyteEntities.entities.append(self)
 
@@ -411,6 +419,10 @@ class LaunchPlan(object):
     @property
     def security_context(self) -> Optional[security.SecurityContext]:
         return self._security_context
+
+    @property
+    def task_node_overrides(self) -> Optional[_workflow_model.TaskNodeOverrides]:
+        return self._task_node_overrides
 
     def construct_node_metadata(self) -> _workflow_model.NodeMetadata:
         return self.workflow.construct_node_metadata()

--- a/flytekit/models/core/workflow.py
+++ b/flytekit/models/core/workflow.py
@@ -568,12 +568,8 @@ class TaskNodeOverrides(_common.FlyteIdlEntity):
         return self._task_config
 
     def to_flyte_idl(self):
-        if self._container_image is None:
-            container_image = None
-        elif isinstance(self._container_image, ImageSpec):
+        if isinstance(self._container_image, ImageSpec):
             raise NotImplementedError("TODO: runtime overrides only support str container images for now")
-        elif isinstance(self._container_image, str):
-            container_image = self._container_image
 
         return _core_workflow.TaskNodeOverrides(
             resources=self.resources.to_flyte_idl() if self.resources is not None else None,
@@ -582,7 +578,7 @@ class TaskNodeOverrides(_common.FlyteIdlEntity):
             cache_version=self.cache_version,
             retries=self.retries,
             interruptible=self.interruptible,
-            container_image=container_image,
+            container_image=self._container_image,
             environment=self.environment,
             task_config=self.task_config.to_flyte_idl()
             if self.task_config is not None

--- a/flytekit/models/core/workflow.py
+++ b/flytekit/models/core/workflow.py
@@ -611,7 +611,6 @@ class TaskNode(_common.FlyteIdlEntity):
         reference_id,
         overrides: typing.Optional[TaskNodeOverrides] = None,
         runtime_override_name: typing.Optional[str] = None,
-        runtime_override_default: typing.Optional[TaskNodeOverrides] = None,
     ):
         """
         Refers to the task that the Node is to execute.
@@ -621,13 +620,10 @@ class TaskNode(_common.FlyteIdlEntity):
         :param flytekit.models.core.identifier.Identifier reference_id: A globally unique identifier for the task.
         :param flyteidl.core.workflow_pb2.TaskNodeOverrides
         :param str runtime_override_name: [Optional] The name of the runtime override to use for this task.
-        :param flyteidl.core.workflow_pb2.TaskNodeOverrides runtime_override_default: [Optional] The default runtime
-            override to use for this task.
         """
         self._reference_id = reference_id
         self._overrides = overrides
         self._runtime_override_name = runtime_override_name
-        self._runtime_override_default = runtime_override_default  # TODO: not yet supported in flyteidl
 
     @property
     def reference_id(self):
@@ -645,10 +641,6 @@ class TaskNode(_common.FlyteIdlEntity):
     def runtime_override_name(self) -> str:
         return self._runtime_override_name
 
-    @property
-    def runtime_override_default(self) -> TaskNodeOverrides:
-        return self._runtime_override_default
-
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.core.workflow_pb2.TaskNode
@@ -657,7 +649,6 @@ class TaskNode(_common.FlyteIdlEntity):
             reference_id=self.reference_id.to_flyte_idl(),
             overrides=self.overrides.to_flyte_idl() if self.overrides is not None else None,
             runtime_override_name=self.runtime_override_name if self.runtime_override_name else None,
-            # TODO: default runtime overrides not yet supported in flyteidl
         )
 
     @classmethod
@@ -668,7 +659,6 @@ class TaskNode(_common.FlyteIdlEntity):
         """
         overrides = TaskNodeOverrides.from_flyte_idl(pb2_object.overrides)
         runtime_override_name = pb2_object.runtime_override_name
-        # TODO defaults not yet supported by flyteidl
 
         if overrides.resources is None:
             overrides = None

--- a/flytekit/models/core/workflow.py
+++ b/flytekit/models/core/workflow.py
@@ -592,11 +592,21 @@ class TaskNodeOverrides(_common.FlyteIdlEntity):
     @classmethod
     def from_flyte_idl(cls, pb2_object):
         resources = Resources.from_flyte_idl(pb2_object.resources)
-        # TODO complete
-
         if bool(resources.requests) or bool(resources.limits):
-            return cls(resources=resources)
-        return cls(resources=None)
+            resources = resources
+        else:
+            resources = None
+
+        return cls(
+            resources=resources,
+            cache=pb2_object.cache,
+            cache_serialize=pb2_object.cache_serialize,
+            cache_version=pb2_object.cache_version,
+            retries=pb2_object.retries,
+            interruptible=pb2_object.interruptible,
+            container_image=pb2_object.container_image,
+            environment=pb2_object.environment,
+        )
 
 
 class TaskNode(_common.FlyteIdlEntity):

--- a/flytekit/models/execution.py
+++ b/flytekit/models/execution.py
@@ -16,6 +16,7 @@ from flytekit.models import literals as _literals_models
 from flytekit.models import security
 from flytekit.models.core import execution as _core_execution
 from flytekit.models.core import identifier as _identifier
+from flytekit.models.core import workflow as _workflow
 from flytekit.models.node_execution import DynamicWorkflowNodeMetadata
 
 
@@ -178,6 +179,7 @@ class ExecutionSpec(_common_models.FlyteIdlEntity):
         security_context: Optional[security.SecurityContext] = None,
         overwrite_cache: Optional[bool] = None,
         envs: Optional[_common_models.Envs] = None,
+        task_node_runtime_overrides: Optional[typing.Dict[str, _workflow.TaskNodeOverrides]] = None,
     ):
         """
         :param flytekit.models.core.identifier.Identifier launch_plan: Launch plan unique identifier to execute
@@ -194,6 +196,7 @@ class ExecutionSpec(_common_models.FlyteIdlEntity):
         :param security_context: Optional security context to use for this execution.
         :param overwrite_cache: Optional flag to overwrite the cache for this execution.
         :param envs: flytekit.models.common.Envs environment variables to set for this execution.
+        :param task_node_runtime_overrides: Optional dictionary of override name to task node overrides.
         """
         self._launch_plan = launch_plan
         self._metadata = metadata
@@ -207,6 +210,7 @@ class ExecutionSpec(_common_models.FlyteIdlEntity):
         self._security_context = security_context
         self._overwrite_cache = overwrite_cache
         self._envs = envs
+        self._task_node_runtime_overrides = task_node_runtime_overrides
 
     @property
     def launch_plan(self):
@@ -281,6 +285,10 @@ class ExecutionSpec(_common_models.FlyteIdlEntity):
     def envs(self) -> Optional[_common_models.Envs]:
         return self._envs
 
+    @property
+    def task_node_runtime_overrides(self) -> Optional[typing.Dict[str, _workflow.TaskNodeOverrides]]:
+        return self._task_node_runtime_overrides
+
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.admin.execution_pb2.ExecutionSpec
@@ -300,6 +308,9 @@ class ExecutionSpec(_common_models.FlyteIdlEntity):
             security_context=self.security_context.to_flyte_idl() if self.security_context else None,
             overwrite_cache=self.overwrite_cache,
             envs=self.envs.to_flyte_idl() if self.envs else None,
+            task_node_runtime_overrides={k: v.to_flyte_idl() for k, v in self.task_node_runtime_overrides.items()}
+            if self.task_node_runtime_overrides
+            else None,
         )
 
     @classmethod
@@ -325,6 +336,11 @@ class ExecutionSpec(_common_models.FlyteIdlEntity):
             else None,
             overwrite_cache=p.overwrite_cache,
             envs=_common_models.Envs.from_flyte_idl(p.envs) if p.HasField("envs") else None,
+            task_node_runtime_overrides={
+                k: _workflow.TaskNodeOverrides.from_flyte_idl(v) for k, v in p.task_node_runtime_overrides.items()
+            }
+            if p.task_node_runtime_overrides
+            else None,
         )
 
 

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -354,6 +354,8 @@ def get_serializable_launch_plan(
         raw_output_data_config=raw_prefix_config,
         max_parallelism=options.max_parallelism or entity.max_parallelism,
         security_context=options.security_context or entity.security_context,
+        # FIXME: Add options
+        task_node_runtime_overrides=entity.task_node_overrides,
     )
 
     lp_id = _identifier_model.Identifier(

--- a/tests/flytekit/unit/core/test_node_creation.py
+++ b/tests/flytekit/unit/core/test_node_creation.py
@@ -465,3 +465,16 @@ def test_override_image():
         return "hi"
 
     assert wf.nodes[0].flyte_entity.container_image == "hello/world"
+
+
+def test_with_runtime_overrides():
+    @task
+    def bar():
+        print("hello")
+
+    @workflow
+    def wf() -> str:
+        bar().with_runtime_overrides("my_override_name")
+        return "hi"
+
+    assert wf.nodes[0]._runtime_override_name == "my_override_name"

--- a/tests/flytekit/unit/models/core/test_workflow.py
+++ b/tests/flytekit/unit/models/core/test_workflow.py
@@ -258,3 +258,15 @@ def test_task_node_with_overrides():
 
     obj = _workflow.TaskNode.from_flyte_idl(task_node.to_flyte_idl())
     assert task_node == obj
+
+
+def test_task_nodes_with_runtime_override_name():
+    runtime_override_name = "foobar"
+    task_node = _workflow.TaskNode(
+        reference_id=_generic_id,
+        runtime_override_name=runtime_override_name,
+    )
+    assert task_node.runtime_override_name == runtime_override_name
+
+    obj = _workflow.TaskNode.from_flyte_idl(task_node.to_flyte_idl())
+    assert task_node == obj

--- a/tests/flytekit/unit/models/test_execution.py
+++ b/tests/flytekit/unit/models/test_execution.py
@@ -8,6 +8,7 @@ from flytekit.models import execution as _execution
 from flytekit.models import literals as _literals
 from flytekit.models.core import execution as _core_exec
 from flytekit.models.core import identifier as _identifier
+from flytekit.models.core import workflow as _workflow
 from flytekit.models.security import Identity
 
 _INPUT_MAP = _literals.LiteralMap(
@@ -179,6 +180,7 @@ def test_execution_spec():
         security_context=SecurityContext(run_as=Identity(iam_role="role")),
         overwrite_cache=True,
         envs=_common_models.Envs({"foo": "bar"}),
+        task_node_runtime_overrides={"foo": _workflow.TaskNodeOverrides(cache=True)},
     )
     assert obj.launch_plan.resource_type == _identifier.ResourceType.LAUNCH_PLAN
     assert obj.launch_plan.domain == "domain"
@@ -203,6 +205,7 @@ def test_execution_spec():
     assert obj.security_context.run_as.iam_role == "role"
     assert obj.overwrite_cache is True
     assert obj.envs == _common_models.Envs({"foo": "bar"})
+    assert obj.task_node_runtime_overrides == {"foo": _workflow.TaskNodeOverrides(cache=True)}
 
     obj2 = _execution.ExecutionSpec.from_flyte_idl(obj.to_flyte_idl())
     assert obj == obj2

--- a/tests/flytekit/unit/models/test_launch_plan.py
+++ b/tests/flytekit/unit/models/test_launch_plan.py
@@ -76,6 +76,17 @@ def test_launch_plan_spec():
         security_context=security_context_config,
         task_node_runtime_overrides=task_node_overrides,
     )
+    assert lp_spec_raw_output_prefixed.workflow_id == identifier_model
+    assert lp_spec_raw_output_prefixed.entity_metadata == launch_plan_metadata_model
+    assert lp_spec_raw_output_prefixed.default_inputs == parameter_map
+    assert lp_spec_raw_output_prefixed.fixed_inputs == fixed_inputs
+    assert lp_spec_raw_output_prefixed.labels == labels_model
+    assert lp_spec_raw_output_prefixed.annotations == annotations_model
+    assert lp_spec_raw_output_prefixed.auth_role == auth_role_model
+    assert lp_spec_raw_output_prefixed.raw_output_data_config == raw_data_output_config
+    assert lp_spec_raw_output_prefixed.max_parallelism == max_parallelism
+    assert lp_spec_raw_output_prefixed.security_context == security_context_config
+    assert lp_spec_raw_output_prefixed.task_node_runtime_overrides == task_node_overrides
 
     obj2 = launch_plan.LaunchPlanSpec.from_flyte_idl(lp_spec_raw_output_prefixed.to_flyte_idl())
     assert obj2 == lp_spec_raw_output_prefixed

--- a/tests/flytekit/unit/models/test_launch_plan.py
+++ b/tests/flytekit/unit/models/test_launch_plan.py
@@ -1,6 +1,6 @@
 from flyteidl.admin import launch_plan_pb2 as _launch_plan_idl
 
-from flytekit.models import common, interface, launch_plan, literals, schedule, types
+from flytekit.models import common, interface, launch_plan, literals, schedule, security, types
 from flytekit.models.core import identifier
 
 
@@ -60,17 +60,19 @@ def test_launch_plan_spec():
     raw_data_output_config = common.RawOutputDataConfig("s3://bucket")
     empty_raw_data_output_config = common.RawOutputDataConfig("")
     max_parallelism = 100
+    security_context_config = security.SecurityContext(run_as=security.Identity(iam_role="role"))
 
     lp_spec_raw_output_prefixed = launch_plan.LaunchPlanSpec(
         identifier_model,
         launch_plan_metadata_model,
-        parameter_map,
-        fixed_inputs,
-        labels_model,
-        annotations_model,
-        auth_role_model,
-        raw_data_output_config,
-        max_parallelism,
+        default_inputs=parameter_map,
+        fixed_inputs=fixed_inputs,
+        labels=labels_model,
+        annotations=annotations_model,
+        auth_role=auth_role_model,
+        raw_output_data_config=raw_data_output_config,
+        max_parallelism=max_parallelism,
+        security_context=security_context_config,
     )
 
     obj2 = launch_plan.LaunchPlanSpec.from_flyte_idl(lp_spec_raw_output_prefixed.to_flyte_idl())
@@ -79,13 +81,13 @@ def test_launch_plan_spec():
     lp_spec_no_prefix = launch_plan.LaunchPlanSpec(
         identifier_model,
         launch_plan_metadata_model,
-        parameter_map,
-        fixed_inputs,
-        labels_model,
-        annotations_model,
-        auth_role_model,
-        empty_raw_data_output_config,
-        max_parallelism,
+        default_inputs=parameter_map,
+        fixed_inputs=fixed_inputs,
+        labels=labels_model,
+        annotations=annotations_model,
+        auth_role=auth_role_model,
+        raw_output_data_config=empty_raw_data_output_config,
+        max_parallelism=max_parallelism,
     )
 
     obj2 = launch_plan.LaunchPlanSpec.from_flyte_idl(lp_spec_no_prefix.to_flyte_idl())

--- a/tests/flytekit/unit/models/test_launch_plan.py
+++ b/tests/flytekit/unit/models/test_launch_plan.py
@@ -1,7 +1,7 @@
 from flyteidl.admin import launch_plan_pb2 as _launch_plan_idl
 
 from flytekit.models import common, interface, launch_plan, literals, schedule, security, types
-from flytekit.models.core import identifier
+from flytekit.models.core import identifier, workflow
 
 
 def test_metadata():
@@ -61,6 +61,7 @@ def test_launch_plan_spec():
     empty_raw_data_output_config = common.RawOutputDataConfig("")
     max_parallelism = 100
     security_context_config = security.SecurityContext(run_as=security.Identity(iam_role="role"))
+    task_node_overrides = {"n1": workflow.TaskNodeOverrides(cache=True)}
 
     lp_spec_raw_output_prefixed = launch_plan.LaunchPlanSpec(
         identifier_model,
@@ -73,6 +74,7 @@ def test_launch_plan_spec():
         raw_output_data_config=raw_data_output_config,
         max_parallelism=max_parallelism,
         security_context=security_context_config,
+        task_node_runtime_overrides=task_node_overrides,
     )
 
     obj2 = launch_plan.LaunchPlanSpec.from_flyte_idl(lp_spec_raw_output_prefixed.to_flyte_idl())


### PR DESCRIPTION
# TL;DR
- Added `ExecutionSpec.task_node_runtime_overrides`
- Added `LaunchPlanSpec.task_node_runtime_overrides`
- Added tests throughout. *Note*: Have not added any tests for `tools.translator`
- Removed the `runtime_override_default`

@fg91 This should be all we need on the model side. We will still need to add tests and functionality for high-level functions such as `LaunchPlan.get_or_create(...)` and `pyflyte run ...`. Probably it would be nice if translate the usecases we have in the RFC into unit tests
