### PR TITLE
Fix config of user facing execution parameters in spawning elastic tasks

### DIFF
--- a/plugins/flytekit-kf-pytorch/tests/test_elastic_task.py
+++ b/plugins/flytekit-kf-pytorch/tests/test_elastic_task.py
@@ -8,6 +8,7 @@ import torch.distributed as dist
 from dataclasses_json import dataclass_json
 from flytekitplugins.kfpytorch.task import Elastic
 
+import flytekit
 from flytekit import task, workflow
 
 
@@ -65,3 +66,32 @@ def test_end_to_end(start_method: str) -> None:
     only be obtained if the distributed process group is initialized correctly.
     """
     assert distributed_result == sum([5 + 2 * rank + world_size for rank in range(world_size)])
+
+
+@pytest.mark.parametrize(
+    "start_method,target_exec_id,monkeypatch_exec_id_env_var",
+    [
+        ("spawn", "", False),
+        ("spawn", "f12345678", True),
+        ("fork", "local", False),
+    ],
+)
+def test_execution_params(
+    start_method: str, target_exec_id: str, monkeypatch_exec_id_env_var: bool, monkeypatch
+) -> None:
+    """Test that execution parameters are set in the worker processes."""
+    if monkeypatch_exec_id_env_var:
+        monkeypatch.setenv("FLYTE_INTERNAL_EXECUTION_ID", target_exec_id)
+
+    @task(task_config=Elastic(nnodes=1, nproc_per_node=1, start_method=start_method))
+    def test_task(n: int):
+        ctx = flytekit.current_context()
+
+        assert ctx.execution_id.name == target_exec_id
+        cp = ctx.checkpoint
+        assert cp is not None
+
+        cp.write(bytes(n + 1))
+        return n + 1
+
+    test_task(n=1)


### PR DESCRIPTION
# TL;DR

When using `@task(task_config=flytekitplugins.kfpytorch.Elastic())`, the task function is started in a number of worker processes using torch `elastic_launch` (`torchrun`). The processes can be created using fork or spawn which is controlled by the arg `Elastic(start_method=...)`.

When using `fork`, the child process inherits a copy of the parent process' stack including the flyte context and the user facing execution parameters `ctx = flytekit.current_context()`.

When spawning, however, fresh processes are started and the flyte context and the execution parameters are not transferred to the child process currently. This means that within a task with ``@task(task_config=Elastic(start_method="spawn"))` the execution id and the checkpoint cannot be accessed from the execution parameters.

This PR fixes this by setting up the flyte context in the spawned worker processes.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description

In the spawned worker processes I call `flytekit.bin.entrypoint.setup_execution` which sets up the flyte context the same way as when a normal python task is started. Raw data prefix and checkpoint pathes are transferred from the parent process.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
