### PR TITLE
Dep: Use protos of new `kubeflow.pytorch` plugin instead of legacy `pytorch` plugin

### DIFF
--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -338,7 +338,7 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
             """
             return super().get_custom(settings)
         else:
-            from flyteidl.plugins.pytorch_pb2 import ElasticConfig
+            from flyteidl.plugins.kubeflow.pytorch_pb2 import ElasticConfig
 
             elastic_config = ElasticConfig(
                 rdzv_backend=self.rdzv_backend,

--- a/plugins/flytekit-kf-pytorch/setup.py
+++ b/plugins/flytekit-kf-pytorch/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "kfpytorch"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["cloudpickle", "flytekit>=1.6.1"]
+plugin_requires = ["cloudpickle", "flyteidl>=1.5.1", "flytekit>=1.6.1"]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
# TL;DR
In https://github.com/flyteorg/flyteidl/commit/5a3a44f13415bf5ed8ac57cc5814b7277a85825f the kubeflow training operator plugins' protos where refactored.

In this PR I update the task to use the new `flyteidl.plugins.kubeflow.pytorch_pb2.ElasticConfig` instead of the legacy `from flyteidl.plugins.pytorch_pb2.ElasticConfig` (notice the addional `kubeflow`).

Without this fix, registration fails with this error:

```
│ /home/fabiogratz/miniconda3/envs/dev/lib/python3.9/site-packages/flytekitplugins/kfpytorch/task.py:371 in get_custom                               │
│                                                                                                                                                    │
│ ❱ 371 │   │   │   job = pytorch_task.DistributedPyTorchTrainingTask(                                                                               │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: Parameter to MergeFrom() must be instance of same class: expected <class 'flyteidl.plugins.kubeflow.pytorch_pb2.ElasticConfig'> got <class 
'flyteidl.plugins.pytorch_pb2.ElasticConfig'>.
```

Here, I used `flytekit==1.6.2` and `flyteidl==1.5.8` and the cluster was running images of version `1.6.0`.

I pin `flyteidl` to at least version `1.5.1` which introduced the new `flyteidl.plugins.kubeflow` module.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
_NA_
## Tracking Issue
_NA_

## Follow-up issue
_NA_
