### PR TITLE
More time info for time line deck

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -81,7 +81,6 @@ def _dispatch_execute(
     try:
         # Step1
         local_inputs_file = os.path.join(ctx.execution_state.working_dir, "inputs.pb")
-        print("inputs_path: ", inputs_path)
         ctx.file_access.get_data(inputs_path, local_inputs_file)
         input_proto = utils.load_proto_from_file(_literals_pb2.LiteralMap, local_inputs_file)
         idl_input_literals = _literal_models.LiteralMap.from_flyte_idl(input_proto)
@@ -160,8 +159,8 @@ def _dispatch_execute(
 
     ctx.file_access.put_data(ctx.execution_state.engine_dir, output_prefix, is_multipart=True)
     _output_deck(task_def.name.split(".")[-1], ctx.user_space_params)
-
     logger.info(f"Engine folder written successfully to the output prefix {output_prefix}")
+    logger.debug("Finished _dispatch_execute")
 
     if os.environ.get("FLYTE_FAIL_ON_ERROR", "").lower() == "true" and _constants.ERROR_FILE_NAME in output_file_dict:
         # This env is set by the flytepropeller

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -509,7 +509,6 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
 
         # Invoked before the task is executed
         new_user_params = self.pre_execute(ctx.user_space_params)
-        from flytekit.deck.deck import _output_deck
 
         # Create another execution context with the new user params, but let's keep the same working dir
         with FlyteContextManager.with_context(
@@ -601,8 +600,6 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 output_deck = Deck(OUTPUT)
                 for k, v in native_outputs_as_map.items():
                     output_deck.append(TypeEngine.to_html(ctx, v, self.get_type_for_output_var(k, v)))
-
-                _output_deck(self.name.split(".")[-1], new_user_params)
 
             outputs_literal_map = _literal_models.LiteralMap(literals=literals)
             # After the execute has been successfully completed

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -287,7 +287,6 @@ class FileAccessProvider(object):
         """
         return self.put_data(local_path, remote_path, is_multipart=True)
 
-    @timeit("Download data to local from remote")
     def get_data(self, remote_path: str, local_path: str, is_multipart: bool = False):
         """
         :param remote_path:
@@ -296,14 +295,14 @@ class FileAccessProvider(object):
         """
         try:
             pathlib.Path(local_path).parent.mkdir(parents=True, exist_ok=True)
-            self.get(remote_path, to_path=local_path, recursive=is_multipart)
+            with timeit(f"Download data to local from {remote_path}"):
+                self.get(remote_path, to_path=local_path, recursive=is_multipart)
         except Exception as ex:
             raise FlyteAssertion(
                 f"Failed to get data from {remote_path} to {local_path} (recursive={is_multipart}).\n\n"
                 f"Original exception: {str(ex)}"
             )
 
-    @timeit("Upload data to remote")
     def put_data(self, local_path: Union[str, os.PathLike], remote_path: str, is_multipart: bool = False, **kwargs):
         """
         The implication here is that we're always going to put data to the remote location, so we .remote to ensure
@@ -315,8 +314,8 @@ class FileAccessProvider(object):
         """
         try:
             local_path = str(local_path)
-
-            self.put(cast(str, local_path), remote_path, recursive=is_multipart, **kwargs)
+            with timeit(f"Upload data to {remote_path}"):
+                self.put(cast(str, local_path), remote_path, recursive=is_multipart, **kwargs)
         except Exception as ex:
             raise FlyteAssertion(
                 f"Failed to put data from {local_path} to {remote_path} (recursive={is_multipart}).\n\n"


### PR DESCRIPTION
# TL;DR

This PR:
-  allows users to view the remote URL for uploading and downloading in the time line deck
-  The process of "generating the timeline HTML file" has been moved to a later stage, allowing for the inclusion of more time-specific information. In the previous implementation, the user could not see the remote URL storing the 'output.pb' and 'deck.pb' files because the HTML file was generated too early. This adjustment ensures these important details are visible in the timeline.
https://github.com/flyteorg/flytekit/blob/c8433ea2d2ecf362815b1ee63554549ced9acd75/flytekit/bin/entrypoint.py#L159


## Checks
Tested in the sandbox. We are now able to see the remote url in time line deck.
<img width="882" alt="image" src="https://github.com/flyteorg/flytekit/assets/51814063/07d74f80-d133-462e-9434-98ad62c18a04">

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_


