### PR TITLE
Improve error message for pyflyte-fast-execute

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -511,7 +511,8 @@ def fast_execute_task_cmd(additional_distribution: str, dest_dir: str, task_exec
 
     # Use the commandline to run the task execute command rather than calling it directly in python code
     # since the current runtime bytecode references the older user code, rather than the downloaded distribution.
-    p = subprocess.run(cmd, check=False)
+    p = subprocess.Popen(cmd)
+    p.communicate()
     if p.returncode != 0:
         raise Exception(f"Failed to run the task.")
 

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -511,7 +511,9 @@ def fast_execute_task_cmd(additional_distribution: str, dest_dir: str, task_exec
 
     # Use the commandline to run the task execute command rather than calling it directly in python code
     # since the current runtime bytecode references the older user code, rather than the downloaded distribution.
-    subprocess.run(cmd, check=True)
+    p = subprocess.run(cmd, check=False, capture_output=True)
+    if p.returncode != 0:
+        raise Exception(f"Failed to run task with error: {p.stderr.decode('utf-8')}")
 
 
 @_pass_through.command("pyflyte-map-execute")

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -511,9 +511,9 @@ def fast_execute_task_cmd(additional_distribution: str, dest_dir: str, task_exec
 
     # Use the commandline to run the task execute command rather than calling it directly in python code
     # since the current runtime bytecode references the older user code, rather than the downloaded distribution.
-    p = subprocess.run(cmd, check=False, capture_output=True)
+    p = subprocess.run(cmd, check=False)
     if p.returncode != 0:
-        raise Exception(f"Failed to run the task with error: {p.stderr.decode('utf-8')}")
+        raise Exception(f"Failed to run the task.")
 
 
 @_pass_through.command("pyflyte-map-execute")

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -511,10 +511,8 @@ def fast_execute_task_cmd(additional_distribution: str, dest_dir: str, task_exec
 
     # Use the commandline to run the task execute command rather than calling it directly in python code
     # since the current runtime bytecode references the older user code, rather than the downloaded distribution.
-    p = subprocess.Popen(cmd)
-    p.communicate()
-    if p.returncode != 0:
-        raise Exception(f"Failed to run the task.")
+    p = subprocess.run(cmd, check=False)
+    exit(p.returncode)
 
 
 @_pass_through.command("pyflyte-map-execute")

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -513,7 +513,7 @@ def fast_execute_task_cmd(additional_distribution: str, dest_dir: str, task_exec
     # since the current runtime bytecode references the older user code, rather than the downloaded distribution.
     p = subprocess.run(cmd, check=False, capture_output=True)
     if p.returncode != 0:
-        raise Exception(f"Failed to run task with error: {p.stderr.decode('utf-8')}")
+        raise Exception(f"Failed to run the task with error: {p.stderr.decode('utf-8')}")
 
 
 @_pass_through.command("pyflyte-map-execute")


### PR DESCRIPTION
# TL;DR
Remove CalledProocessError, and only show user error

Before:
<img width="1598" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/ea0cdcd4-b6f0-4ba3-ad0b-b77ffe1d5a54">
After:
<img width="1588" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/77890563-ff1d-4a07-ad77-227871744158">



## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Here is an example to reproduce it.

```python
from flytekit import task, workflow
import torch

@task
def t1():
    print("helloee")


@workflow
def wf():
    t1()


if __name__ == '__main__':
    wf()
```

## Tracking Issue
_NA_

## Follow-up issue
_NA_