### PR TITLE
Add PydanticRemote plugin for creating pythonic interfaces to remote workflows

### DIFF
--- a/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/pydantic_remote.py
+++ b/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/pydantic_remote.py
@@ -15,6 +15,22 @@ from flytekit.remote import FlyteRemote
 
 
 class PydanticFlyteRemote(FlyteRemote):
+    """Extension of FlyteRemote to convert Flyte objects into Pydantic interfaces.
+
+    Pydantic interfaces for workflows are created by:
+        - Querying Flyte for workflows and their associated input/output interface
+        - Converting the interface to a Pydantic model and populating the docstring
+        - Returning the Pydantic model with a execute method that enables launching
+            the workflow on a remote cluster
+
+    All of the existing methods and functionality of FlyteRemote are included. The
+    following methods have been added:
+        - fetch_pydantic_workflow: Fetch a specific workflow and return a Pydantic
+            interface
+        - fetch_pydantic_workflows: Fetch all workflows under a given project and domain
+            and return a dictionary with keys as workflow names and values as interfaces
+    """
+
     def _list_all_workflows(
         self,
         project: Optional[str] = None,

--- a/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/pydantic_remote.py
+++ b/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/pydantic_remote.py
@@ -1,0 +1,119 @@
+from collections import defaultdict
+from typing import Optional
+
+from flytekitplugins.pydantic_remote.pydantic_workflow_interface import (
+    PydanticWorkflowInterface,
+    create_pydantic_workflow_interface,
+)
+
+from flytekit.exceptions import user as user_exceptions
+from flytekit.models import filters as flyte_filters
+from flytekit.models.admin import common as admin_common_models
+from flytekit.models.admin.workflow import Workflow
+from flytekit.models.common import NamedEntityIdentifier
+from flytekit.remote import FlyteRemote
+
+
+class PydanticFlyteRemote(FlyteRemote):
+    def list_all_workflows(
+        self,
+        project: Optional[str] = None,
+        domain: Optional[str] = None,
+        filters: Optional[list[flyte_filters.Filter]] = None,
+        sort_by: Optional[admin_common_models.Sort] = None,
+        max_workflows_to_fetch: Optional[int] = None,
+    ) -> list[Workflow]:
+        """Return all workflows give project, domain, and filters."""
+        project = project or self.default_project
+        domain = domain or self.default_domain
+        client = self.client
+        all_workflows = []
+        token = None
+        sort_by = sort_by or admin_common_models.Sort(
+            "created_at", admin_common_models.Sort.Direction.DESCENDING
+        )
+        while token != "":
+            wfs, token = client.list_workflows_paginated(
+                identifier=NamedEntityIdentifier(project, domain),
+                token=token,
+                filters=filters,
+                sort_by=sort_by,
+            )
+            all_workflows.extend(wfs)
+            if max_workflows_to_fetch and len(all_workflows) >= max_workflows_to_fetch:
+                break
+        return all_workflows
+
+    def fetch_pydantic_workflow(
+        self,
+        project: str = None,
+        domain: str = None,
+        name: str = None,
+        version: str = None,
+    ) -> PydanticWorkflowInterface:
+        """Fetch PydanticWorkflowInterface from FlyteRemote.
+
+        Args:
+            project: Name of Flyte project. If None, uses the default_project attribute.
+            domain: Domain of Flyte project. If None, uses the default_project attribute.
+            name: Name of Flyte workflow.
+            version: Version of Flyte workflow. If None, gets the latest version of the entity.
+
+        Returns:
+            Instantiated PydanticWorkflowInterface
+        """
+        if name is None:
+            raise user_exceptions.FlyteAssertion(
+                "the 'name' argument must be specified."
+            )
+        model = create_pydantic_workflow_interface(
+            project, domain, name, version, remote=self
+        )
+        return model
+
+    def fetch_pydantic_workflows(
+        self,
+        project: Optional[str] = None,
+        domain: Optional[str] = None,
+        filters: Optional[list[flyte_filters.Filter]] = None,
+        sort_by: Optional[admin_common_models.Sort] = None,
+        max_workflows_to_fetch: Optional[int] = 200,
+    ) -> dict[str, PydanticWorkflowInterface]:
+        """Get registered workflows from a given Flyte project and domain.
+
+        Args:
+            project: Name of Flyte project. If None, uses the default_project attribute.
+            domain: Domain of Flyte project. If None, uses the default_project attribute.
+            filters: Optional filters to use when fetching. Defaults to None.
+            sort_by: Optional alternative sorting. Defaults to sorting by most recent.
+            max_workflows_to_fetch: Maximum number of workflows to fetch from remote.
+                Defaults to 200, but can be increased if you need to fetch and old version,
+                or set to `None` to fetch all workflows.
+
+        Returns:
+            Dict with key=name, value=PydanticWorkflowInterface objects
+        """
+        fetched_workflows = self.list_all_workflows(
+            project,
+            domain,
+            filters=filters or [],
+            sort_by=sort_by,
+            max_workflows_to_fetch=max_workflows_to_fetch,
+        )
+        workflow_versions = defaultdict(list)
+        for wf in fetched_workflows:
+            workflow_versions[wf.id.name].append(wf)
+        pydantic_models = {}
+        for wf_versions in workflow_versions.values():
+            first, *others = wf_versions
+            other_versions = [x.id.version for x in others]
+            model = create_pydantic_workflow_interface(
+                first.id.project,
+                first.id.domain,
+                first.id.name,
+                first.id.version,
+                remote=self,
+                other_versions=other_versions,
+            )
+            pydantic_models[first.id.name] = model
+        return pydantic_models

--- a/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/pydantic_workflow_interface.py
+++ b/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/pydantic_workflow_interface.py
@@ -135,7 +135,9 @@ def create_pydantic_interface_docstring(
         f"{output_docs}\n\n"
         "Example usage of `PydanticWorkflowInterface`:\n\n"
         "Provide keyword arguments to model and call execute:\n"
-        "wf(value=1).execute()"
+        "wf(value=1).execute()\n\n"
+        "Other versions of this workflow can be accessed using `get_other_versions()` "
+        "and `load_version()` class methods."
     )
     wrapped_lines = [textwrap.fill(line, width=80) for line in model_docs.splitlines()]
     wrapped_text = "\n".join(wrapped_lines)

--- a/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/pydantic_workflow_interface.py
+++ b/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/pydantic_workflow_interface.py
@@ -52,13 +52,14 @@ class PydanticWorkflowInterface(BaseModel):
         cls._other_versions = other_versions
         cls._remote = remote
 
-    @property
-    def other_versions(self) -> list[str]:
-        return self._other_versions
+    @classmethod
+    def get_other_versions(cls) -> list[str]:
+        return cls._other_versions
 
-    def load_version(self, version: str) -> PydanticWorkflowInterface:
+    @classmethod
+    def load_version(cls, version: str) -> PydanticWorkflowInterface:
         return create_pydantic_workflow_interface(
-            self._project, self._domain, self._name, version, self._remote
+            cls._project, cls._domain, cls._name, version, cls._remote
         )
 
     def execute(

--- a/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/pydantic_workflow_interface.py
+++ b/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/pydantic_workflow_interface.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import pathlib
+import textwrap
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
+
+from flytekitplugins.pydantic_remote.remote_utils import (
+    get_execution_url,
+    get_flyte_workflow_execution_outputs,
+)
+from pydantic import BaseModel, Field, create_model
+from pydantic.fields import FieldInfo, Undefined
+from rich.console import Console
+
+from flytekit.core.type_engine import LiteralsResolver, TypeEngine
+from flytekit.models.interface import Parameter
+from flytekit.remote.entities import FlyteLaunchPlan
+from flytekit.types.file import FlyteFile
+
+if TYPE_CHECKING:
+    from flytekit.remote import FlyteRemote
+
+
+console = Console()
+
+
+class PydanticWorkflowInterface(BaseModel):
+    _project: str = Field(default=None)
+    _domain: str = Field(default=None)
+    _name: str = Field(default=None)
+    _version: str = Field(default=None)
+    _other_versions: list[str] = Field(default=None)
+    _remote: FlyteRemote = Field(default=None)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    @classmethod
+    def _set_workflow_info(
+        cls,
+        project: str,
+        domain: str,
+        name: str,
+        version: str,
+        other_versions: list[str],
+        remote: FlyteRemote,
+    ) -> None:
+        cls._project = project
+        cls._domain = domain
+        cls._name = name
+        cls._version = version
+        cls._other_versions = other_versions
+        cls._remote = remote
+
+    @property
+    def other_versions(self) -> list[str]:
+        return self._other_versions
+
+    def load_version(self, version: str) -> PydanticWorkflowInterface:
+        return create_pydantic_workflow_interface(
+            self._project, self._domain, self._name, version, self._remote
+        )
+
+    def execute(
+        self,
+        wait_for_outputs: bool = True,
+        **execution_kwargs: Any,
+    ) -> Any:
+        """Execute Flyte workflow on remote.
+
+        Args:
+            wait_for_outputs: If True, wait for Flyte workflow outputs, otherwise
+                return FlyteWorkflowExecution
+
+        Kwargs:
+            All arguments supported by FlyteRemote.execute can be passed as keyword
+            arguments to this function.
+
+        """
+        lp = self._remote.fetch_launch_plan(
+            project=self._project,
+            domain=self._domain,
+            name=self._name,
+            version=self._version,
+        )
+        name_info = f"[deep_sky_blue4]Workflow name:[/deep_sky_blue4] [italic]{self._name}[/italic]"
+        version_info = f"[deep_sky_blue4]Workflow version:[/deep_sky_blue4] [italic]{self._version}[/italic]"
+        console.print(
+            f"[bold]🛫 Launching Flyte Workflow 🛬[/bold]\n\n{name_info}\n{version_info}",
+        )
+        execution = self._remote.execute(lp, inputs=self.dict(), **execution_kwargs)
+        execution_url = get_execution_url(execution)
+        console.print(
+            f"Track progress at the [link={execution_url}]Flyte Console[/link]"
+        )
+        if wait_for_outputs:
+            outputs = get_flyte_workflow_execution_outputs(
+                execution, log_interval=10, remote=self._remote
+            )
+            return outputs
+        return execution
+
+
+def create_parameter_docs(params: dict[str, Any]) -> str:
+    return "\n".join(
+        textwrap.fill(
+            f"{k}: {v.description}",
+            width=80,
+            initial_indent=" " * 4,
+            subsequent_indent=" " * 8,
+        )
+        for k, v in params.items()
+    )
+
+
+def create_pydantic_interface_docstring(
+    lp: FlyteLaunchPlan, lp_inputs: dict[str, Any], lp_outputs: dict[str, Any]
+) -> str:
+    simple_name = lp.id.name.split(".")[-1]
+    parameter_docs = create_parameter_docs(lp_inputs)
+    output_docs = create_parameter_docs(lp_outputs)
+    model_docs = (
+        f"PydanticWorkflowInterface ({simple_name})\n\n"
+        f"Project: {lp.id.project!r}\n"
+        f"Domain: {lp.id.domain!r}\n"
+        f"Name: {lp.id.name!r}\n"
+        f"Version: {lp.id.version!r}\n\n"
+        "To execute this workflow on Flyte, provide the required "
+        "arguments and call `execute()`, which takes all parameters of "
+        "`FlyteRemote.execute`.\n\n"
+        "Workflow parameters:\n"
+        f"{parameter_docs}\n\n"
+        "Workflow outputs:\n"
+        f"{output_docs}\n\n"
+        "Example usage of `PydanticWorkflowInterface`:\n\n"
+        "Provide keyword arguments to model and call execute:\n"
+        "wf(value=1).execute()"
+    )
+    wrapped_lines = [textwrap.fill(line, width=80) for line in model_docs.splitlines()]
+    wrapped_text = "\n".join(wrapped_lines)
+    return wrapped_text
+
+
+def get_default_parameter(parameter: Parameter) -> Any:
+    if not parameter.default:
+        raise ValueError("No default for parameter.")
+    k = "param"
+    default = LiteralsResolver({k: parameter.default}, {k: parameter.var}).get(k)
+    if isinstance(default, FlyteFile):
+        default = default.remote_source
+    return default
+
+
+def create_pydantic_workflow_interface(
+    project: str,
+    domain: str,
+    name: str,
+    version: str,
+    remote: FlyteRemote,
+    other_versions: Optional[list[str]] = None,
+) -> PydanticWorkflowInterface:
+    """Creates a Pydantic model based on workflow's interface from remote."""
+    lp = remote.fetch_launch_plan(project, domain, name, version)
+    assert lp.interface
+
+    # Iterate through LaunchPlan, extract parameters with defaults which will be used
+    # to sort parameters when creating the Pydantic model.
+    model_parameters = {}
+    keys_with_defaults = []
+    for k, parameter in lp.default_inputs.parameters.items():
+        default: Any = Undefined
+        if parameter.default:
+            keys_with_defaults.append(k)
+            default = get_default_parameter(parameter)
+        python_type = TypeEngine.guess_python_type(parameter.var.type)
+        if python_type is FlyteFile:
+            python_type = Union[python_type, str, pathlib.Path]  # type: ignore
+        model_parameters[k] = (
+            python_type,
+            FieldInfo(default, description=parameter.var.description),
+        )
+    model_parameters = dict(
+        sorted(model_parameters.items(), key=lambda x: x[0] in keys_with_defaults)
+    )
+
+    sorted_lp_inputs = {k: lp.interface.inputs[k] for k in model_parameters}
+    model_docstring = create_pydantic_interface_docstring(
+        lp=lp,
+        lp_inputs=sorted_lp_inputs,
+        lp_outputs=lp.interface.outputs,
+    )
+    repr_name = model_docstring.splitlines()[0]
+    model = create_model(  # type: ignore
+        repr_name, __base__=PydanticWorkflowInterface, **model_parameters
+    )
+    model.__doc__ = model_docstring
+    model._set_workflow_info(
+        project,
+        domain,
+        name,
+        version,
+        remote=remote,
+        other_versions=other_versions or [],
+    )
+    return cast(PydanticWorkflowInterface, model)

--- a/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/remote_utils.py
+++ b/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/remote_utils.py
@@ -2,20 +2,12 @@ import datetime
 import logging
 import os
 import time
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from flytekit.configuration import Config
 from flytekit.remote import FlyteRemote
 from flytekit.remote.executions import FlyteWorkflowExecution
 
-if TYPE_CHECKING:
-    from flytekit.remote import FlyteRemote
-
 logger = logging.getLogger(__name__)
-
-
-def get_default_flyte_remote() -> FlyteRemote:
-    return FlyteRemote(config=Config.auto())
 
 
 def get_platform_url() -> str:

--- a/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/remote_utils.py
+++ b/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/remote_utils.py
@@ -1,0 +1,98 @@
+import datetime
+import logging
+import os
+import time
+from typing import TYPE_CHECKING, Any
+
+from flytekit.configuration import Config
+from flytekit.remote import FlyteRemote
+from flytekit.remote.executions import FlyteWorkflowExecution
+
+if TYPE_CHECKING:
+    from flytekit.remote import FlyteRemote
+
+logger = logging.getLogger(__name__)
+
+
+def get_default_flyte_remote() -> FlyteRemote:
+    return FlyteRemote(config=Config.auto())
+
+
+def get_platform_url() -> str:
+    return os.getenv("FLYTE_PLATFORM_URL", "localhost:30080")
+
+
+def get_flyte_base_console_url() -> str:
+    platform_url = get_platform_url()
+    return os.environ.get("FLYTE_CONSOLE_BASE_URL", f"http://{platform_url}/console")
+
+
+def get_execution_url(execution: FlyteWorkflowExecution) -> str:
+    """Return execution URL if user previously called execute, raise otherwise."""
+    base_url = get_flyte_base_console_url()
+    return (
+        f"{base_url}/projects/{execution.id.project}/domains/"
+        f"{execution.id.domain}/executions/{execution.id.name}"
+    )
+
+
+def get_flyte_workflow_execution_outputs(
+    execution: FlyteWorkflowExecution,
+    remote: FlyteRemote,
+    log_interval: int | None = None,
+) -> Any:
+    """Return outputs after workflow has completed."""
+    finished_execution = wait_for_workflow_execution_to_finish(
+        execution,
+        log_interval=log_interval,
+        remote=remote,
+    )
+    if finished_execution.outputs:
+        output_keys = list(finished_execution.outputs.literals.keys())
+        if len(output_keys) == 1:
+            return finished_execution.outputs.get(output_keys[0])
+        else:
+            return tuple(finished_execution.outputs.get(key) for key in output_keys)
+    else:
+        raise ValueError("Workflow aborted.")
+
+
+def wait_for_workflow_execution_to_finish(
+    execution: FlyteWorkflowExecution,
+    remote: FlyteRemote,
+    log_interval: int | None = None,
+) -> FlyteWorkflowExecution:
+    """Wait for workflow to complete and return execution.
+
+    Args:
+        execution: FlyteWorkflowExecution object
+        log_interval: Interval for logging (in seconds). Defaults to 60.
+
+    Raises:
+        ValueError: If workflow execution failed
+
+    Returns:
+        Synced workflow execution
+    """
+    log_interval = log_interval or 60
+    start_time = time.time()
+    log_idx = 0
+    if execution.is_done:
+        execution = remote.sync_execution(execution)
+        return execution
+
+    logger.info("Waiting for workflow to complete before returning output.")
+    while not execution.is_done:
+        current_time = time.time()
+        seconds_elapsed = current_time - start_time
+        if seconds_elapsed >= log_interval * log_idx:
+            elapsed = datetime.timedelta(seconds=seconds_elapsed)
+            logger.info(f"Syncing execution. Total time elapsed: {elapsed}.")
+            log_idx += 1
+        execution = remote.sync_execution(execution)
+        time.sleep(5)
+    if execution.error:
+        raise ValueError(execution.closure.error.message)
+    elapsed = datetime.timedelta(seconds=time.time() - start_time)
+    logger.info(f"Workflow completed. Total time elapsed: {elapsed}")
+    return execution

--- a/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/setup.py
+++ b/plugins/flytekit-pydantic-remote/flytekitplugins/pydantic_remote/setup.py
@@ -1,0 +1,35 @@
+from setuptools import setup
+
+PLUGIN_NAME = "pydantic_remote"
+
+microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
+
+plugin_requires = ["pydantic", "flytekit>=1.3.0b2,<2.0.0", "flyteidl>=1.1.10"]
+
+__version__ = "0.0.0+develop"
+
+setup(
+    name=microlib_name,
+    version=__version__,
+    author="flyteorg",
+    author_email="admin@flyte.org",
+    description="This package contains a Pydantic FlyteRemote interface for flytekit",
+    namespace_packages=["flytekitplugins"],
+    packages=[f"flytekitplugins.{PLUGIN_NAME}"],
+    install_requires=plugin_requires,
+    license="apache2",
+    python_requires=">=3.8",
+    classifiers=[
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Software Development",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+)

--- a/plugins/flytekit-pydantic-remote/tests/test_pydantic_remote.py
+++ b/plugins/flytekit-pydantic-remote/tests/test_pydantic_remote.py
@@ -1,0 +1,37 @@
+import pytest
+from flytekitplugins.pydantic_remote.pydantic_remote import PydanticFlyteRemote
+from mock import patch
+
+from flytekit.configuration import Config
+from flytekit.models.admin.workflow import Workflow, WorkflowClosure
+from flytekit.models.core.identifier import Identifier, ResourceType
+from flytekit.models.task import Task
+from tests.flytekit.common.parameterizers import LIST_OF_TASK_CLOSURES
+from tests.flytekit.unit.remote.test_remote import get_compiled_workflow_closure
+
+
+@pytest.fixture
+def remote():
+    with patch("flytekit.clients.friendly.SynchronousFlyteClient") as mock_client:
+        flyte_remote = PydanticFlyteRemote(
+            config=Config.auto(), default_project="p", default_domain="d"
+        )
+        flyte_remote._client_initialized = True
+        flyte_remote._client = mock_client
+        return flyte_remote
+
+
+def test_fetch_pydantic_workflow(remote: PydanticFlyteRemote) -> None:
+    mock_client = remote._client
+    mock_client.get_task.return_value = Task(
+        id=Identifier(ResourceType.TASK, "p", "d", "n", "v"),
+        closure=LIST_OF_TASK_CLOSURES[0],
+    )
+
+    mock_client.get_workflow.return_value = Workflow(
+        id=Identifier(ResourceType.TASK, "p", "d", "n", "v"),
+        closure=WorkflowClosure(compiled_workflow=get_compiled_workflow_closure()),
+    )
+    wf = remote.fetch_pydantic_workflow(name="n", version="v")
+    assert wf.__name__ == "PydanticWorkflowInterface (n)"
+    assert (wf._project, wf._domain, wf._name, wf._version) == ("p", "d", "n", "v")


### PR DESCRIPTION
# TL;DR
Adds a PydanticRemote plugin that provides a simpler UX for retrieving and launching workflows from FlyteRemote. See [YouTube](https://www.youtube.com/watch?v=PMMYhFrHKu8&t=746s&ab_channel=Flyte) demo for more information.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Most of the users of Flyte that I interact with are launching tasks and workflows from Python or Jupyter notebooks. Currently with `FlyteRemote.execute`, the user must know the workflow interface and provide workflow inputs as a Python dictionary when launching a workflow. This works, but often involves the user going back and forth between the FlyteConsole and their Jupyter Notebook to ensure all inputs are provided and are of the correct type. 

To address this, I created a version of FlyteRemote that leverages Pydantic to dynamically create workflow interfaces. This works by:
1. Querying Flyte for workflows and their input/output interface
2. Converting the interface to a Pydantic model and populating the docstring
3. Returning this model with a `execute` method that enables launching the workflow on a remote cluster
