### PR TITLE
 Support configuring pip index url with the image spec

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -33,6 +33,7 @@ class ImageSpec:
         apt_packages: list of apt packages to install.
         base_image: base image of the image.
         platform: Specify the target platforms for the build output (for example, windows/amd64 or linux/amd64,darwin/arm64
+        pip_index: Specify the custom pip index url
     """
 
     name: str = "flytekit"
@@ -45,6 +46,7 @@ class ImageSpec:
     apt_packages: Optional[List[str]] = None
     base_image: Optional[str] = None
     platform: str = "linux/amd64"
+    pip_index: Optional[str] = None
 
     def image_name(self) -> str:
         """

--- a/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
+++ b/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
@@ -41,6 +41,7 @@ def create_envd_config(image_spec: ImageSpec) -> str:
     env = {"PYTHONPATH": "/root", _F_IMG_ID: image_spec.image_name()}
     if image_spec.env:
         env.update(image_spec.env)
+    pip_index = "https://pypi.org/simple" if image_spec.pip_index is None else image_spec.pip_index
 
     envd_config = f"""# syntax=v1
 
@@ -49,6 +50,7 @@ def build():
     install.python_packages(name = [{', '.join(map(str, map(lambda x: f'"{x}"', packages)))}])
     install.apt_packages(name = [{', '.join(map(str, map(lambda x: f'"{x}"', apt_packages)))}])
     runtime.environ(env={env})
+    config.pip_index(url = "{pip_index}")
 """
 
     if image_spec.python_version:

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -26,6 +26,7 @@ def test_image_spec():
     assert image_spec.builder == "envd"
     assert image_spec.source_root is None
     assert image_spec.env is None
+    assert image_spec.pip_index is None
     assert image_spec.is_container() is True
     assert image_spec.image_name() == "flytekit:OLFSrRjcG5_uXuRqd0TSdQ.."
     ctx = context_manager.FlyteContext.current_context()


### PR DESCRIPTION
## Type: Bug Fix

## Complete description
Currently, we are unable to specify the pip index URL during package installation, although it is supported by envd. 
The purpose of this PR is to enable configuring the custom pip index url.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3765
