### PR TITLE
Support configuring pip index url with the image spec

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -33,6 +33,7 @@ class ImageSpec:
         apt_packages: list of apt packages to install.
         base_image: base image of the image.
         platform: Specify the target platforms for the build output (for example, windows/amd64 or linux/amd64,darwin/arm64
+        pip_index: Specify the custom pip index url
     """
 
     name: str = "flytekit"
@@ -45,6 +46,7 @@ class ImageSpec:
     apt_packages: Optional[List[str]] = None
     base_image: Optional[str] = None
     platform: str = "linux/amd64"
+    pip_index: Optional[str] = None
 
     def image_name(self) -> str:
         """

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -153,8 +153,8 @@ def calculate_hash_from_image_spec(image_spec: ImageSpec):
     spec.source_root = hash_directory(image_spec.source_root) if image_spec.source_root else b""
     image_spec_bytes = bytes(spec.to_json(), "utf-8")
     tag = base64.urlsafe_b64encode(hashlib.md5(image_spec_bytes).digest()).decode("ascii")
-    # replace "=" with "." to make it a valid tag
-    return tag.replace("=", ".")
+    # replace "=" with "." and replace "-" with "_" to make it a valid tag
+    return tag.replace("=", ".").replace("-", "_")
 
 
 def hash_directory(path):

--- a/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
+++ b/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
@@ -41,6 +41,7 @@ def create_envd_config(image_spec: ImageSpec) -> str:
     env = {"PYTHONPATH": "/root", _F_IMG_ID: image_spec.image_name()}
     if image_spec.env:
         env.update(image_spec.env)
+    pip_index = "https://pypi.org/simple" if image_spec.pip_index is None else image_spec.pip_index
 
     envd_config = f"""# syntax=v1
 
@@ -49,6 +50,7 @@ def build():
     install.python_packages(name = [{', '.join(map(str, map(lambda x: f'"{x}"', packages)))}])
     install.apt_packages(name = [{', '.join(map(str, map(lambda x: f'"{x}"', apt_packages)))}])
     runtime.environ(env={env})
+    config.pip_index(url = "{pip_index}")
 """
 
     if image_spec.python_version:

--- a/plugins/flytekit-envd/tests/test_image_spec.py
+++ b/plugins/flytekit-envd/tests/test_image_spec.py
@@ -12,6 +12,7 @@ def test_image_spec():
         python_version="3.8",
         registry="",
         base_image="cr.flyte.org/flyteorg/flytekit:py3.8-latest",
+        pip_index="https://private-pip-index/simple",
     )
 
     EnvdImageSpecBuilder().build_image(image_spec)
@@ -28,5 +29,6 @@ def build():
     install.apt_packages(name = ["git"])
     runtime.environ(env={'PYTHONPATH': '/root', '_F_IMG_ID': 'flytekit:OLFSrRjcG5_uXuRqd0TSdQ..'})
     install.python(version="3.8")
+    config.pip_index(url = "https://private-pip-index/simple")
 """
     )

--- a/plugins/flytekit-envd/tests/test_image_spec.py
+++ b/plugins/flytekit-envd/tests/test_image_spec.py
@@ -27,8 +27,8 @@ def build():
     base(image="cr.flyte.org/flyteorg/flytekit:py3.8-latest", dev=False)
     install.python_packages(name = ["pandas"])
     install.apt_packages(name = ["git"])
-    runtime.environ(env={'PYTHONPATH': '/root', '_F_IMG_ID': 'flytekit:OLFSrRjcG5_uXuRqd0TSdQ..'})
-    install.python(version="3.8")
+    runtime.environ(env={'PYTHONPATH': '/root', '_F_IMG_ID': 'flytekit:46qVNvYHJxppEvVIYrthdA..'})
     config.pip_index(url = "https://private-pip-index/simple")
+    install.python(version="3.8")
 """
     )

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -258,9 +258,9 @@ ic_result_3 = ImageConfig(
 )
 
 ic_result_4 = ImageConfig(
-    default_image=Image(name="default", fqn="flytekit", tag="mMxGzKCqxVk8msz0yV22-g.."),
+    default_image=Image(name="default", fqn="flytekit", tag="6y6c8ofS_Pwa2FImlcm3Qg.."),
     images=[
-        Image(name="default", fqn="flytekit", tag="mMxGzKCqxVk8msz0yV22-g.."),
+        Image(name="default", fqn="flytekit", tag="6y6c8ofS_Pwa2FImlcm3Qg.."),
         Image(name="xyz", fqn="docker.io/xyz", tag="latest"),
         Image(name="abc", fqn="docker.io/abc", tag=None),
     ],

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -28,7 +28,7 @@ def test_image_spec():
     assert image_spec.env is None
     assert image_spec.pip_index is None
     assert image_spec.is_container() is True
-    assert image_spec.image_name() == "flytekit:OLFSrRjcG5_uXuRqd0TSdQ.."
+    assert image_spec.image_name() == "flytekit:_7s_KKi_73h88RBfRZ8jpQ.."
     ctx = context_manager.FlyteContext.current_context()
     with context_manager.FlyteContextManager.with_context(
         ctx.with_execution_state(ctx.execution_state.with_params(mode=ExecutionState.Mode.TASK_EXECUTION))
@@ -43,7 +43,7 @@ def test_image_spec():
     ImageBuildEngine.register("dummy", DummyImageSpecBuilder())
     ImageBuildEngine._REGISTRY["dummy"].build_image(image_spec)
     assert "dummy" in ImageBuildEngine._REGISTRY
-    assert calculate_hash_from_image_spec(image_spec) == "OLFSrRjcG5_uXuRqd0TSdQ.."
+    assert calculate_hash_from_image_spec(image_spec) == "_7s_KKi_73h88RBfRZ8jpQ.."
     assert image_spec.exist() is False
 
     with pytest.raises(Exception):

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -26,6 +26,7 @@ def test_image_spec():
     assert image_spec.builder == "envd"
     assert image_spec.source_root is None
     assert image_spec.env is None
+    assert image_spec.pip_index is None
     assert image_spec.is_container() is True
     assert image_spec.image_name() == "flytekit:OLFSrRjcG5_uXuRqd0TSdQ.."
     ctx = context_manager.FlyteContext.current_context()

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -75,7 +75,7 @@ def test_container_image_conversion():
     ImageBuildEngine.register("test", TestImageSpecBuilder())
     assert (
         get_registerable_container_image(ImageSpec(builder="test", python_version="3.7"), cfg)
-        == "flytekit:usEl-DNx_srVn7zp2vHlBw.."
+        == "flytekit:htjuk6SUglpN7CGTPPtQIA.."
     )
 
 


### PR DESCRIPTION
## Type: Bug Fix

## Complete description
Currently, we are unable to specify the pip index URL during package installation, although it is supported by envd. 
The purpose of this PR is to enable configuring the custom pip index url.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3765
