### PR TITLE
get_transformer returns pickle transformer if type is unsupported 

### DIFF
--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -346,7 +346,7 @@ def transform_variable_map(
                     original_type = getattr(v, "__args__")[0]
                 elif getattr(v, "__origin__") is dict:
                     original_type = getattr(v, "__args__")[1]
-            if res[k].type.blob.format is FlytePickleTransformer.PYTHON_PICKLE_FORMAT:
+            if res[k].type.blob and res[k].type.blob.format is FlytePickleTransformer.PYTHON_PICKLE_FORMAT:
                 if hasattr(original_type, "__name__"):
                     res[k].type.metadata = {"python_class_name": original_type.__name__}
                 elif hasattr(original_type, "_name"):

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -16,7 +16,6 @@ from flytekit.exceptions.user import FlyteValidationException
 from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
 from flytekit.models.literals import Void
-from flytekit.types.pickle.pickle import FlytePickleTransformer
 
 T = typing.TypeVar("T")
 

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -7,7 +7,7 @@ import typing
 from collections import OrderedDict
 from typing import Any, Dict, Generator, List, Optional, Tuple, Type, TypeVar, Union, cast
 
-from typing_extensions import Annotated, get_args, get_origin, get_type_hints
+from typing_extensions import get_args, get_origin, get_type_hints
 
 from flytekit.core import context_manager
 from flytekit.core.docstring import Docstring
@@ -16,7 +16,7 @@ from flytekit.exceptions.user import FlyteValidationException
 from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
 from flytekit.models.literals import Void
-from flytekit.types.pickle import FlytePickle
+from flytekit.types.pickle.pickle import FlytePickleTransformer
 
 T = typing.TypeVar("T")
 
@@ -294,31 +294,6 @@ def transform_interface_to_list_interface(interface: Interface, bound_inputs: ty
     return Interface(inputs=map_inputs, outputs=map_outputs)
 
 
-def _change_unrecognized_type_to_pickle(t: Type[T]) -> typing.Union[Tuple[Type[T]], Type[T]]:
-    try:
-        if hasattr(t, "__origin__") and hasattr(t, "__args__"):
-            ot = get_origin(t)
-            args = getattr(t, "__args__")
-            if ot is list:
-                return typing.List[_change_unrecognized_type_to_pickle(args[0])]  # type: ignore
-            elif ot is dict and args[0] == str:
-                return typing.Dict[str, _change_unrecognized_type_to_pickle(args[1])]  # type: ignore
-            elif ot is typing.Union:
-                return typing.Union[tuple(_change_unrecognized_type_to_pickle(v) for v in get_args(t))]  # type: ignore
-            elif ot is Annotated:
-                base_type, *config = get_args(t)
-                return Annotated[(_change_unrecognized_type_to_pickle(base_type), *config)]  # type: ignore
-        TypeEngine.get_transformer(t)
-    except ValueError:
-        logger.warning(
-            f"Unsupported Type {t} found, Flyte will default to use PickleFile as the transport. "
-            f"Pickle can only be used to send objects between the exact same version of Python, "
-            f"and we strongly recommend to use python type that flyte support."
-        )
-        return FlytePickle[t]
-    return t
-
-
 def transform_function_to_interface(fn: typing.Callable, docstring: Optional[Docstring] = None) -> Interface:
     """
     From the annotations on a task function that the user should have provided, and the output names they want to use
@@ -333,13 +308,13 @@ def transform_function_to_interface(fn: typing.Callable, docstring: Optional[Doc
 
     outputs = extract_return_annotation(return_annotation)
     for k, v in outputs.items():
-        outputs[k] = _change_unrecognized_type_to_pickle(v)  # type: ignore
+        outputs[k] = v  # type: ignore
     inputs: Dict[str, Tuple[Type, Any]] = OrderedDict()
     for k, v in signature.parameters.items():  # type: ignore
         annotation = type_hints.get(k, None)
         default = v.default if v.default is not inspect.Parameter.empty else None
         # Inputs with default values are currently ignored, we may want to look into that in the future
-        inputs[k] = (_change_unrecognized_type_to_pickle(annotation), default)  # type: ignore
+        inputs[k] = (annotation, default)  # type: ignore
 
     # This is just for typing.NamedTuples - in those cases, the user can select a name to call the NamedTuple. We
     # would like to preserve that name in our custom collections.namedtuple.
@@ -365,14 +340,13 @@ def transform_variable_map(
     if variable_map:
         for k, v in variable_map.items():
             res[k] = transform_type(v, descriptions.get(k, k))
-            sub_type: type = v
+            original_type: type = v
             if hasattr(v, "__origin__") and hasattr(v, "__args__"):
                 if getattr(v, "__origin__") is list:
-                    sub_type = getattr(v, "__args__")[0]
+                    original_type = getattr(v, "__args__")[0]
                 elif getattr(v, "__origin__") is dict:
-                    sub_type = getattr(v, "__args__")[1]
-            if hasattr(sub_type, "__origin__") and getattr(sub_type, "__origin__") is FlytePickle:
-                original_type = cast(FlytePickle, sub_type).python_type()
+                    original_type = getattr(v, "__args__")[1]
+            if res[k].type.blob.format is FlytePickleTransformer.PYTHON_PICKLE_FORMAT:
                 if hasattr(original_type, "__name__"):
                     res[k].type.metadata = {"python_class_name": original_type.__name__}
                 elif hasattr(original_type, "_name"):

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -340,19 +340,6 @@ def transform_variable_map(
     if variable_map:
         for k, v in variable_map.items():
             res[k] = transform_type(v, descriptions.get(k, k))
-            original_type: type = v
-            if hasattr(v, "__origin__") and hasattr(v, "__args__"):
-                if getattr(v, "__origin__") is list:
-                    original_type = getattr(v, "__args__")[0]
-                elif getattr(v, "__origin__") is dict:
-                    original_type = getattr(v, "__args__")[1]
-            if res[k].type.blob and res[k].type.blob.format is FlytePickleTransformer.PYTHON_PICKLE_FORMAT:
-                if hasattr(original_type, "__name__"):
-                    res[k].type.metadata = {"python_class_name": original_type.__name__}
-                elif hasattr(original_type, "_name"):
-                    # If the class doesn't have the __name__ attribute, like typing.Sequence, use _name instead.
-                    res[k].type.metadata = {"python_class_name": original_type._name}
-
     return res
 
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -780,7 +780,7 @@ class TypeEngine(typing.Generic[T]):
             return cls._DATACLASS_TRANSFORMER
 
         # Step 5
-        display_pickle_warning(python_type.__str__())
+        display_pickle_warning(python_type.__repr__())
         from flytekit.types.pickle.pickle import FlytePickleTransformer
 
         return FlytePickleTransformer()

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -780,7 +780,7 @@ class TypeEngine(typing.Generic[T]):
             return cls._DATACLASS_TRANSFORMER
 
         # Step 5
-        display_pickle_warning(python_type.__repr__())
+        display_pickle_warning(str(python_type))
         from flytekit.types.pickle.pickle import FlytePickleTransformer
 
         return FlytePickleTransformer()

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -102,11 +102,13 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
         raise ValueError(f"Transformer {self} cannot reverse {literal_type}")
 
     def get_literal_type(self, t: Type[T]) -> LiteralType:
-        return LiteralType(
+        lt = LiteralType(
             blob=_core_types.BlobType(
                 format=self.PYTHON_PICKLE_FORMAT, dimensionality=_core_types.BlobType.BlobDimensionality.SINGLE
             )
         )
+        lt.metadata = {"python_class_name": str(t)}
+        return lt
 
 
 TypeEngine.register(FlytePickleTransformer())

--- a/tests/flytekit/unit/core/test_flyte_pickle.py
+++ b/tests/flytekit/unit/core/test_flyte_pickle.py
@@ -48,11 +48,13 @@ def test_to_python_value_and_literal():
 def test_get_literal_type():
     tf = FlytePickleTransformer()
     lt = tf.get_literal_type(FlytePickle)
-    assert lt == LiteralType(
+    expected_lt = LiteralType(
         blob=BlobType(
             format=FlytePickleTransformer.PYTHON_PICKLE_FORMAT, dimensionality=BlobType.BlobDimensionality.SINGLE
         )
     )
+    expected_lt.metadata = {"python_class_name": str(FlytePickle)}
+    assert lt == expected_lt
 
 
 def test_batch_size():

--- a/tests/flytekit/unit/core/test_interface.py
+++ b/tests/flytekit/unit/core/test_interface.py
@@ -17,7 +17,6 @@ from flytekit.core.interface import (
 from flytekit.models.core import types as _core_types
 from flytekit.models.literals import Void
 from flytekit.types.file import FlyteFile
-from flytekit.types.pickle import FlytePickle
 
 
 def test_extract_only():
@@ -319,8 +318,8 @@ def test_parameter_change_to_pickle_type():
     params = transform_inputs_to_parameters(ctx, our_interface)
     assert params.parameters["a"].required
     assert params.parameters["a"].default is None
-    assert our_interface.outputs["o0"].__origin__ == FlytePickle
-    assert our_interface.inputs["a"].__origin__ == FlytePickle
+    assert our_interface.outputs["o0"] == Foo
+    assert our_interface.inputs["a"] == Foo
 
 
 def test_doc_string():

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -93,9 +93,7 @@ def test_type_resolution():
 
     assert type(TypeEngine.get_transformer(os.PathLike)) == FlyteFilePathTransformer
     assert type(TypeEngine.get_transformer(FlytePickle)) == FlytePickleTransformer
-
-    with pytest.raises(ValueError):
-        TypeEngine.get_transformer(typing.Any)
+    assert type(TypeEngine.get_transformer(typing.Any)) == FlytePickleTransformer
 
 
 def test_file_formats_getting_literal_type():


### PR DESCRIPTION
# TL;DR
Fixed https://flyte-org.slack.com/archives/CP2HDHKE1/p1686574457772509.
This pr also allows users to use pickle in the dataclass.

`get_transformer` returns a pickle transformer if the type is unsupported


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_