### PR TITLE
Feat: Allow disabling rich tracebacks via env var

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -192,6 +192,7 @@ Documentation
    SourceCode
 
 """
+import os
 import sys
 from typing import Generator
 
@@ -303,4 +304,5 @@ def load_implicit_plugins():
 load_implicit_plugins()
 
 # Pretty-print exception messages
-traceback.install(width=None, extra_lines=0)
+if os.environ.get("FLYTE_SDK_RICH_TRACEBACKS") != "0":
+    traceback.install(width=None, extra_lines=0)


### PR DESCRIPTION
# TL;DR
In `flytekit==1.6.0` rich tracebacks were introduced (#1582).

Before, exceptions were shown like this:
<img width="1210" alt="Screenshot 2023-06-15 at 15 37 04" src="https://github.com/flyteorg/flytekit/assets/36511035/582373f7-d80e-43b2-9ea1-62f324090bb3">

After, they are shown like this:

<img width="1214" alt="Screenshot 2023-06-15 at 15 36 44" src="https://github.com/flyteorg/flytekit/assets/36511035/57c41990-0edc-4a85-93b1-8a086d3ac10b">

This happens as long as `import flytekit` is called somewhere in the imported code base, also when not directly working with flyte.

---

Style ultimately is a question of taste but several of our engineers have complained about this change:

> When/Why did the stacktrace get so <s>ugly</s> colorful. It takes up way too much space and pycharm cannot create crosslinks to the files anymore for me :see_no_evil: And long lines are truncated

> I feel the same, does not help me

> Can we configure this

> I wanted to complain about this too :smile:

> The tracebacks contain way more (white space) characters, meaning I can paste a lot less of them into chat gpt


Because of this, in this PR I propose to introduce an environment variable which disables rich tracebacks. I chose a naming inspired by `"FLYTE_SDK_LOGGING_LEVEL"` or `"FLYTE_SDK_LOGGING_FORMAT"` in `flytekit/loggers.py`.

Would this change be be acceptable to you @cosmicBboy @kumare3 @eapolinario ?


## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
_NA_

## Tracking Issue
_NA_

## Follow-up issue
_NA_
