### PR TITLE
Generate decks at local execution

### DIFF
--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -602,9 +602,9 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 for k, v in native_outputs_as_map.items():
                     output_deck.append(TypeEngine.to_html(ctx, v, self.get_type_for_output_var(k, v)))
 
-                # if ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION:
+                if ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION:
                     # When we run the workflow remotely, flytekit outputs decks at the end of _dispatch_execute
-                    # _output_deck(self.name.split(".")[-1], new_user_params)
+                    _output_deck(self.name.split(".")[-1], new_user_params)
 
             outputs_literal_map = _literal_models.LiteralMap(literals=literals)
             # After the execute has been successfully completed

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -509,6 +509,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
 
         # Invoked before the task is executed
         new_user_params = self.pre_execute(ctx.user_space_params)
+        from flytekit.deck.deck import _output_deck
 
         # Create another execution context with the new user params, but let's keep the same working dir
         with FlyteContextManager.with_context(
@@ -600,6 +601,10 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 output_deck = Deck(OUTPUT)
                 for k, v in native_outputs_as_map.items():
                     output_deck.append(TypeEngine.to_html(ctx, v, self.get_type_for_output_var(k, v)))
+
+                if ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION:
+                    # When we run the workflow remotely, flytekit outputs decks at the end of _dispatch_execute
+                    _output_deck(self.name.split(".")[-1], new_user_params)
 
             outputs_literal_map = _literal_models.LiteralMap(literals=literals)
             # After the execute has been successfully completed

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -602,7 +602,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 for k, v in native_outputs_as_map.items():
                     output_deck.append(TypeEngine.to_html(ctx, v, self.get_type_for_output_var(k, v)))
 
-                if ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION:
+                if ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION:
                     # When we run the workflow remotely, flytekit outputs decks at the end of _dispatch_execute
                     _output_deck(self.name.split(".")[-1], new_user_params)
 

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -602,9 +602,9 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 for k, v in native_outputs_as_map.items():
                     output_deck.append(TypeEngine.to_html(ctx, v, self.get_type_for_output_var(k, v)))
 
-                if ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION:
+                # if ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION:
                     # When we run the workflow remotely, flytekit outputs decks at the end of _dispatch_execute
-                    _output_deck(self.name.split(".")[-1], new_user_params)
+                    # _output_deck(self.name.split(".")[-1], new_user_params)
 
             outputs_literal_map = _literal_models.LiteralMap(literals=literals)
             # After the execute has been successfully completed


### PR DESCRIPTION
# TL;DR
this [PR](https://github.com/flyteorg/flytekit/commit/06d95b805d36998b58cce93f3837f0bd0ec0b945) breaks it, because it moves `_outpu_deck` to `entrypoint.py` . we use `entrypoint.py` only when we run the workflow remotely.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://unionai.slack.com/archives/C02CMUNT4PQ/p1687268923664029

## Follow-up issue
_NA_