### PR TITLE
Real time deck support

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -159,7 +159,7 @@ def _dispatch_execute(
 
     ctx.file_access.put_data(ctx.execution_state.engine_dir, output_prefix, is_multipart=True)
     logger.info(f"Engine folder written successfully to the output prefix {output_prefix}")
-
+    print("entrypoint:", task_def.name.split(".")[-1])
     if not task_def.disable_deck:
         _output_deck(task_def.name.split(".")[-1], ctx.user_space_params)
 

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -159,7 +159,6 @@ def _dispatch_execute(
 
     ctx.file_access.put_data(ctx.execution_state.engine_dir, output_prefix, is_multipart=True)
     logger.info(f"Engine folder written successfully to the output prefix {output_prefix}")
-    print("entrypoint:", task_def.name.split(".")[-1])
     if not task_def.disable_deck:
         _output_deck(task_def.name.split(".")[-1], ctx.user_space_params)
 

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -159,6 +159,7 @@ def _dispatch_execute(
 
     ctx.file_access.put_data(ctx.execution_state.engine_dir, output_prefix, is_multipart=True)
     logger.info(f"Engine folder written successfully to the output prefix {output_prefix}")
+
     if not task_def.disable_deck:
         _output_deck(task_def.name.split(".")[-1], ctx.user_space_params)
 

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -72,6 +72,17 @@ class Deck:
     def html(self) -> str:
         return self._html
 
+    @classmethod
+    def persist(self):
+        task_name = FlyteContextManager.current_context().user_space_params.task_id.name
+        print("persist:", FlyteContextManager.current_context().user_space_params.task_id)
+        print("persist:", task_name)
+        print("persist:", task_name.split(".")[-1])
+        new_user_params = FlyteContextManager.current_context().user_space_params
+        _output_deck(task_name , new_user_params)
+
+
+
 
 class TimeLineDeck(Deck):
     """

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -75,9 +75,6 @@ class Deck:
     @classmethod
     def persist(self):
         task_name = FlyteContextManager.current_context().user_space_params.task_id.name
-        print("persist:", FlyteContextManager.current_context().user_space_params.task_id)
-        print("persist:", task_name)
-        print("persist:", task_name.split(".")[-1])
         new_user_params = FlyteContextManager.current_context().user_space_params
         _output_deck(task_name , new_user_params)
 

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -76,9 +76,7 @@ class Deck:
     def persist(self):
         task_name = FlyteContextManager.current_context().user_space_params.task_id.name
         new_user_params = FlyteContextManager.current_context().user_space_params
-        _output_deck(task_name , new_user_params)
-
-
+        _output_deck(task_name, new_user_params)
 
 
 class TimeLineDeck(Deck):


### PR DESCRIPTION
# TL;DR

This PR adds real-time deck support.

After this PR, User can use `flytekit.Deck.persist()` to generate the html based on current collected metrics/information. So that user can see the real time deck even the task is running or has already failed. See the below example:
 
```python
import flytekit
from flytekit import Resources, task, workflow
from flytekit.core.utils import timeit

@task(
    disable_deck=False,
    limits=Resources(mem="4Gi", cpu="1"),
)
def t1():
    import time

    for i in range(2):
        # timeit measure the time used in the block and shown in time line deck. See https://github.com/flyteorg/flytekit/pull/1581. 
        # Or you can add information to your own deck. See https://docs.flyte.org/projects/cookbook/en/latest/auto/core/flyte_basics/deck.html.
        with timeit(f"iteration {i}"):
            time.sleep(50)
        flytekit.Deck.persist()


@workflow
def wf():
    t1()


if __name__ == "__main__":
    wf()

```


<img width="1728" alt="截屏2023-06-23 22 39 08" src="https://github.com/flyteorg/flytekit/assets/51814063/3a934528-b067-4623-a890-1c59f69e4068">

<img width="1728" alt="截屏2023-06-23 22 39 23" src="https://github.com/flyteorg/flytekit/assets/51814063/8f8450e7-c10d-4c19-ba4b-f30808ac94be">




real time deck support includes:
- flytekit: https://github.com/flyteorg/flytekit/pull/1704
- flyteadmin: https://github.com/flyteorg/flyteadmin/pull/579
- flytepropeller: https://github.com/flyteorg/flytepropeller/pull/579
- flyteconsole: https://github.com/flyteorg/flyteconsole/pull/781

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

