### PR TITLE
Remove ensure literal

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -75,96 +75,6 @@ def translate_inputs_to_literals(
     :param native_types: Map to native Python type.
     """
 
-    def extract_value(
-        ctx: FlyteContext,
-        input_val: Any,
-        val_type: type,
-        flyte_literal_type: _type_models.LiteralType,
-    ) -> _literals_models.Literal:
-        # Handle base case and simple errors
-        if isinstance(input_val, Promise):
-            # In the example above, this handles the "in2=a" type of argument
-            return input_val.val
-        elif isinstance(input_val, VoidPromise):
-            raise AssertionError(
-                f"Outputs of a non-output producing task {input_val.task_name} cannot be passed to another task."
-            )
-        elif isinstance(input_val, tuple):
-            raise AssertionError(
-                "Tuples are not a supported type for individual values in Flyte - got a tuple -"
-                f" {input_val}. If using named tuple in an inner task, please, de-reference the"
-                "actual attribute that you want to use. For example, in NamedTuple('OP', x=int) then"
-                "return v.x, instead of v, even if this has a single element"
-            )
-        # Handle Unions
-        if flyte_literal_type.union_type is not None:
-            if input_val is None and UnionTransformer.is_optional_type(val_type):
-                return _literals_models.Literal(scalar=_literals_models.Scalar(none_type=_literals_models.Void()))
-            for i in range(len(flyte_literal_type.union_type.variants)):
-                lt_type = flyte_literal_type.union_type.variants[i]
-                python_type = get_args(val_type)[i]
-                try:
-                    final_lt = extract_value(ctx, input_val, python_type, lt_type)
-                    lt_type._structure = TypeStructure(tag=TypeEngine.get_transformer(python_type).name)
-                    return _literals_models.Literal(
-                        scalar=_literals_models.Scalar(
-                            union=_literals_models.Union(value=final_lt, stored_type=lt_type)
-                        )
-                    )
-                except Exception as e:
-                    logger.debug(f"Failed to convert {input_val} to {lt_type} with error {e}")
-            raise TypeError(f"Failed to convert {input_val} to {flyte_literal_type}")
-
-        # Handle container types
-        if isinstance(input_val, list):
-            lt = flyte_literal_type
-            python_type = val_type
-            if flyte_literal_type.union_type:
-                for i in range(len(flyte_literal_type.union_type.variants)):
-                    variant = flyte_literal_type.union_type.variants[i]
-                    if variant.collection_type:
-                        lt = variant
-                        python_type = get_args(val_type)[i]
-            if lt.collection_type is None:
-                raise TypeError(f"Not a collection type {flyte_literal_type} but got a list {input_val}")
-            try:
-                sub_type: type = ListTransformer.get_sub_type(python_type)
-            except ValueError:
-                if len(input_val) == 0:
-                    raise
-                sub_type = type(input_val[0])
-            # To maintain consistency between translate_inputs_to_literals and ListTransformer.to_literal for batchable types,
-            # directly call ListTransformer.to_literal to batch process the list items. This is necessary because processing
-            # each list item separately could lead to errors since ListTransformer.to_python_value may treat the literal
-            # as it is batched for batchable types.
-            if ListTransformer.is_batchable(python_type):
-                return TypeEngine.to_literal(ctx, input_val, python_type, lt)
-            literal_list = [extract_value(ctx, v, sub_type, lt.collection_type) for v in input_val]
-            return _literals_models.Literal(collection=_literals_models.LiteralCollection(literals=literal_list))
-        elif isinstance(input_val, dict):
-            lt = flyte_literal_type
-            python_type = val_type
-            if flyte_literal_type.union_type:
-                for i in range(len(flyte_literal_type.union_type.variants)):
-                    variant = flyte_literal_type.union_type.variants[i]
-                    if variant.map_value_type:
-                        lt = variant
-                        python_type = get_args(val_type)[i]
-                    if variant.simple == _type_models.SimpleType.STRUCT:
-                        lt = variant
-                        python_type = get_args(val_type)[i]
-            if lt.map_value_type is None and lt.simple != _type_models.SimpleType.STRUCT:
-                raise TypeError(f"Not a map type {lt} but got a map {input_val}")
-            if lt.simple == _type_models.SimpleType.STRUCT:
-                return TypeEngine.to_literal(ctx, input_val, type(input_val), lt)
-            else:
-                k_type, sub_type = DictTransformer.get_dict_types(python_type)  # type: ignore
-                literal_map = {k: extract_value(ctx, v, sub_type, lt.map_value_type) for k, v in input_val.items()}
-                return _literals_models.Literal(map=_literals_models.LiteralMap(literals=literal_map))
-
-        # Handle everything else - native values, the 5 example
-        return TypeEngine.to_literal(ctx, input_val, val_type, flyte_literal_type)
-
     if incoming_values is None:
         raise ValueError("Incoming values cannot be None, must be a dict")
 
@@ -175,7 +85,7 @@ def translate_inputs_to_literals(
         var = flyte_interface_types[k]
         t = native_types[k]
         try:
-            result[k] = extract_value(ctx, v, t, var.type)
+            result[k] = TypeEngine.to_literal(ctx, v, t, var.type)
         except TypeTransformerFailedError as exc:
             raise TypeTransformerFailedError(f"Failed argument '{k}': {exc}") from exc
 

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -75,6 +75,96 @@ def translate_inputs_to_literals(
     :param native_types: Map to native Python type.
     """
 
+    def extract_value(
+        ctx: FlyteContext,
+        input_val: Any,
+        val_type: type,
+        flyte_literal_type: _type_models.LiteralType,
+    ) -> _literals_models.Literal:
+        # Handle base case and simple errors
+        if isinstance(input_val, Promise):
+            # In the example above, this handles the "in2=a" type of argument
+            return input_val.val
+        elif isinstance(input_val, VoidPromise):
+            raise AssertionError(
+                f"Outputs of a non-output producing task {input_val.task_name} cannot be passed to another task."
+            )
+        elif isinstance(input_val, tuple):
+            raise AssertionError(
+                "Tuples are not a supported type for individual values in Flyte - got a tuple -"
+                f" {input_val}. If using named tuple in an inner task, please, de-reference the"
+                "actual attribute that you want to use. For example, in NamedTuple('OP', x=int) then"
+                "return v.x, instead of v, even if this has a single element"
+            )
+        # Handle Unions
+        if flyte_literal_type.union_type is not None:
+            if input_val is None and UnionTransformer.is_optional_type(val_type):
+                return _literals_models.Literal(scalar=_literals_models.Scalar(none_type=_literals_models.Void()))
+            for i in range(len(flyte_literal_type.union_type.variants)):
+                lt_type = flyte_literal_type.union_type.variants[i]
+                python_type = get_args(val_type)[i]
+                try:
+                    final_lt = extract_value(ctx, input_val, python_type, lt_type)
+                    lt_type._structure = TypeStructure(tag=TypeEngine.get_transformer(python_type).name)
+                    return _literals_models.Literal(
+                        scalar=_literals_models.Scalar(
+                            union=_literals_models.Union(value=final_lt, stored_type=lt_type)
+                        )
+                    )
+                except Exception as e:
+                    logger.debug(f"Failed to convert {input_val} to {lt_type} with error {e}")
+            raise TypeError(f"Failed to convert {input_val} to {flyte_literal_type}")
+
+        # Handle container types
+        if isinstance(input_val, list):
+            lt = flyte_literal_type
+            python_type = val_type
+            if flyte_literal_type.union_type:
+                for i in range(len(flyte_literal_type.union_type.variants)):
+                    variant = flyte_literal_type.union_type.variants[i]
+                    if variant.collection_type:
+                        lt = variant
+                        python_type = get_args(val_type)[i]
+            if lt.collection_type is None:
+                raise TypeError(f"Not a collection type {flyte_literal_type} but got a list {input_val}")
+            try:
+                sub_type: type = ListTransformer.get_sub_type(python_type)
+            except ValueError:
+                if len(input_val) == 0:
+                    raise
+                sub_type = type(input_val[0])
+            # To maintain consistency between translate_inputs_to_literals and ListTransformer.to_literal for batchable types,
+            # directly call ListTransformer.to_literal to batch process the list items. This is necessary because processing
+            # each list item separately could lead to errors since ListTransformer.to_python_value may treat the literal
+            # as it is batched for batchable types.
+            if ListTransformer.is_batchable(python_type):
+                return TypeEngine.to_literal(ctx, input_val, python_type, lt)
+            literal_list = [extract_value(ctx, v, sub_type, lt.collection_type) for v in input_val]
+            return _literals_models.Literal(collection=_literals_models.LiteralCollection(literals=literal_list))
+        elif isinstance(input_val, dict):
+            lt = flyte_literal_type
+            python_type = val_type
+            if flyte_literal_type.union_type:
+                for i in range(len(flyte_literal_type.union_type.variants)):
+                    variant = flyte_literal_type.union_type.variants[i]
+                    if variant.map_value_type:
+                        lt = variant
+                        python_type = get_args(val_type)[i]
+                    if variant.simple == _type_models.SimpleType.STRUCT:
+                        lt = variant
+                        python_type = get_args(val_type)[i]
+            if lt.map_value_type is None and lt.simple != _type_models.SimpleType.STRUCT:
+                raise TypeError(f"Not a map type {lt} but got a map {input_val}")
+            if lt.simple == _type_models.SimpleType.STRUCT:
+                return TypeEngine.to_literal(ctx, input_val, type(input_val), lt)
+            else:
+                k_type, sub_type = DictTransformer.get_dict_types(python_type)  # type: ignore
+                literal_map = {k: extract_value(ctx, v, sub_type, lt.map_value_type) for k, v in input_val.items()}
+                return _literals_models.Literal(map=_literals_models.LiteralMap(literals=literal_map))
+
+        # Handle everything else - native values, the 5 example
+        return TypeEngine.to_literal(ctx, input_val, val_type, flyte_literal_type)
+
     if incoming_values is None:
         raise ValueError("Incoming values cannot be None, must be a dict")
 
@@ -85,7 +175,7 @@ def translate_inputs_to_literals(
         var = flyte_interface_types[k]
         t = native_types[k]
         try:
-            result[k] = TypeEngine.to_literal(ctx, v, t, var.type)
+            result[k] = extract_value(ctx, v, t, var.type)
         except TypeTransformerFailedError as exc:
             raise TypeTransformerFailedError(f"Failed argument '{k}': {exc}") from exc
 

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -19,13 +19,7 @@ from flytekit.core.context_manager import (
 )
 from flytekit.core.interface import Interface
 from flytekit.core.node import Node
-from flytekit.core.type_engine import (
-    DictTransformer,
-    ListTransformer,
-    TypeEngine,
-    TypeTransformerFailedError,
-    UnionTransformer,
-)
+from flytekit.core.type_engine import DictTransformer, ListTransformer, TypeEngine, TypeTransformerFailedError
 from flytekit.exceptions import user as _user_exceptions
 from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
@@ -34,7 +28,7 @@ from flytekit.models import types as _type_models
 from flytekit.models import types as type_models
 from flytekit.models.core import workflow as _workflow_model
 from flytekit.models.literals import Primitive
-from flytekit.models.types import SimpleType, TypeStructure
+from flytekit.models.types import SimpleType
 
 
 def translate_inputs_to_literals(
@@ -74,97 +68,6 @@ def translate_inputs_to_literals(
     :param flyte_interface_types: One side of an :py:class:`flytekit.models.interface.TypedInterface` basically.
     :param native_types: Map to native Python type.
     """
-
-    def extract_value(
-        ctx: FlyteContext,
-        input_val: Any,
-        val_type: type,
-        flyte_literal_type: _type_models.LiteralType,
-    ) -> _literals_models.Literal:
-        # Handle base case and simple errors
-        if isinstance(input_val, Promise):
-            # In the example above, this handles the "in2=a" type of argument
-            return input_val.val
-        elif isinstance(input_val, VoidPromise):
-            raise AssertionError(
-                f"Outputs of a non-output producing task {input_val.task_name} cannot be passed to another task."
-            )
-        elif isinstance(input_val, tuple):
-            raise AssertionError(
-                "Tuples are not a supported type for individual values in Flyte - got a tuple -"
-                f" {input_val}. If using named tuple in an inner task, please, de-reference the"
-                "actual attribute that you want to use. For example, in NamedTuple('OP', x=int) then"
-                "return v.x, instead of v, even if this has a single element"
-            )
-        # Handle Unions
-        if flyte_literal_type.union_type is not None:
-            if input_val is None and UnionTransformer.is_optional_type(val_type):
-                return _literals_models.Literal(scalar=_literals_models.Scalar(none_type=_literals_models.Void()))
-            for i in range(len(flyte_literal_type.union_type.variants)):
-                lt_type = flyte_literal_type.union_type.variants[i]
-                python_type = get_args(val_type)[i]
-                try:
-                    final_lt = extract_value(ctx, input_val, python_type, lt_type)
-                    lt_type._structure = TypeStructure(tag=TypeEngine.get_transformer(python_type).name)
-                    return _literals_models.Literal(
-                        scalar=_literals_models.Scalar(
-                            union=_literals_models.Union(value=final_lt, stored_type=lt_type)
-                        )
-                    )
-                except Exception as e:
-                    logger.debug(f"Failed to convert {input_val} to {lt_type} with error {e}")
-            raise TypeError(f"Failed to convert {input_val} to {flyte_literal_type}")
-
-        # Handle container types
-        if isinstance(input_val, list):
-            lt = flyte_literal_type
-            python_type = val_type
-            if flyte_literal_type.union_type:
-                for i in range(len(flyte_literal_type.union_type.variants)):
-                    variant = flyte_literal_type.union_type.variants[i]
-                    if variant.collection_type:
-                        lt = variant
-                        python_type = get_args(val_type)[i]
-            if lt.collection_type is None:
-                raise TypeError(f"Not a collection type {flyte_literal_type} but got a list {input_val}")
-            try:
-                sub_type: type = ListTransformer.get_sub_type(python_type)
-            except ValueError:
-                if len(input_val) == 0:
-                    raise
-                sub_type = type(input_val[0])
-            # To maintain consistency between translate_inputs_to_literals and ListTransformer.to_literal for batchable types,
-            # directly call ListTransformer.to_literal to batch process the list items. This is necessary because processing
-            # each list item separately could lead to errors since ListTransformer.to_python_value may treat the literal
-            # as it is batched for batchable types.
-            if ListTransformer.is_batchable(python_type):
-                return TypeEngine.to_literal(ctx, input_val, python_type, lt)
-            literal_list = [extract_value(ctx, v, sub_type, lt.collection_type) for v in input_val]
-            return _literals_models.Literal(collection=_literals_models.LiteralCollection(literals=literal_list))
-        elif isinstance(input_val, dict):
-            lt = flyte_literal_type
-            python_type = val_type
-            if flyte_literal_type.union_type:
-                for i in range(len(flyte_literal_type.union_type.variants)):
-                    variant = flyte_literal_type.union_type.variants[i]
-                    if variant.map_value_type:
-                        lt = variant
-                        python_type = get_args(val_type)[i]
-                    if variant.simple == _type_models.SimpleType.STRUCT:
-                        lt = variant
-                        python_type = get_args(val_type)[i]
-            if lt.map_value_type is None and lt.simple != _type_models.SimpleType.STRUCT:
-                raise TypeError(f"Not a map type {lt} but got a map {input_val}")
-            if lt.simple == _type_models.SimpleType.STRUCT:
-                return TypeEngine.to_literal(ctx, input_val, type(input_val), lt)
-            else:
-                k_type, sub_type = DictTransformer.get_dict_types(python_type)  # type: ignore
-                literal_map = {k: extract_value(ctx, v, sub_type, lt.map_value_type) for k, v in input_val.items()}
-                return _literals_models.Literal(map=_literals_models.LiteralMap(literals=literal_map))
-
-        # Handle everything else - native values, the 5 example
-        return TypeEngine.to_literal(ctx, input_val, val_type, flyte_literal_type)
-
     if incoming_values is None:
         raise ValueError("Incoming values cannot be None, must be a dict")
 
@@ -175,7 +78,7 @@ def translate_inputs_to_literals(
         var = flyte_interface_types[k]
         t = native_types[k]
         try:
-            result[k] = extract_value(ctx, v, t, var.type)
+            result[k] = TypeEngine.to_literal(ctx, v, t, var.type)
         except TypeTransformerFailedError as exc:
             raise TypeTransformerFailedError(f"Failed argument '{k}': {exc}") from exc
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -846,6 +846,22 @@ class TypeEngine(typing.Generic[T]):
         """
         Converts a python value of a given type and expected ``LiteralType`` into a resolved ``Literal`` value.
         """
+        from flytekit.core.promise import Promise, VoidPromise
+
+        if isinstance(python_val, Promise):
+            # In the example above, this handles the "in2=a" type of argument
+            return python_val.val
+        if isinstance(python_val, VoidPromise):
+            raise AssertionError(
+                f"Outputs of a non-output producing task {python_val.task_name} cannot be passed to another task."
+            )
+        if isinstance(python_val, tuple):
+            raise AssertionError(
+                "Tuples are not a supported type for individual values in Flyte - got a tuple -"
+                f" {python_val}. If using named tuple in an inner task, please, de-reference the"
+                "actual attribute that you want to use. For example, in NamedTuple('OP', x=int) then"
+                "return v.x, instead of v, even if this has a single element"
+            )
         if python_val is None and expected.union_type is None:
             raise TypeTransformerFailedError(f"Python value cannot be None, expected {python_type}/{expected}")
         transformer = cls.get_transformer(python_type)

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -846,6 +846,21 @@ class TypeEngine(typing.Generic[T]):
         """
         Converts a python value of a given type and expected ``LiteralType`` into a resolved ``Literal`` value.
         """
+        from flytekit.core.promise import Promise, VoidPromise
+        if isinstance(python_val, Promise):
+            # In the example above, this handles the "in2=a" type of argument
+            return python_val.val
+        if isinstance(python_val, VoidPromise):
+            raise AssertionError(
+                f"Outputs of a non-output producing task {python_val.task_name} cannot be passed to another task."
+            )
+        if isinstance(python_val, tuple):
+            raise AssertionError(
+                "Tuples are not a supported type for individual values in Flyte - got a tuple -"
+                f" {python_val}. If using named tuple in an inner task, please, de-reference the"
+                "actual attribute that you want to use. For example, in NamedTuple('OP', x=int) then"
+                "return v.x, instead of v, even if this has a single element"
+            )
         if python_val is None and expected.union_type is None:
             raise TypeTransformerFailedError(f"Python value cannot be None, expected {python_type}/{expected}")
         transformer = cls.get_transformer(python_type)
@@ -1502,6 +1517,28 @@ class EnumTransformer(TypeTransformer[enum.Enum]):
 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
         return expected_python_type(lv.scalar.primitive.string_value)  # type: ignore
+
+
+# class PromiseTransformer(TypeTransformer["Promise"]):
+#     def __init__(self):
+#         from flytekit.core.promise import Promise
+#         super().__init__(name="PromiseTransformer", t=Promise)
+#
+#     def get_literal_type(self, t: Type[T]) -> LiteralType:
+#         raise NotImplementedError("PromiseTransformer.get_literal_type")
+#
+#     def to_literal(
+#         self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType
+#     ) -> Literal:
+#         from flytekit.core.promise import Promise, VoidPromise
+#         if isinstance(python_val, VoidPromise):
+#             raise AssertionError(
+#                 f"Outputs of a non-output producing task {python_val.task_name} cannot be passed to another task."
+#             )
+#         return python_val.val
+#
+#     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
+#         raise NotImplementedError("PromiseTransformer.to_python_value")
 
 
 def convert_json_schema_to_python_class(schema: dict, schema_name) -> Type[dataclasses.dataclass()]:  # type: ignore

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1239,11 +1239,11 @@ class UnionTransformer(TypeTransformer[T]):
         found_res = False
         res = None
         res_type = None
-        for t in get_args(python_type):
+        for i in range(len(get_args(python_type))):
             try:
+                t = get_args(python_type)[i]
                 trans: TypeTransformer[T] = TypeEngine.get_transformer(t)
-
-                res = trans.to_literal(ctx, python_val, t, expected)
+                res = trans.to_literal(ctx, python_val, t, expected.union_type.variants[i])
                 res_type = _add_tag_to_type(trans.get_literal_type(t), trans.name)
                 if found_res:
                     # Should really never happen, sanity check

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -6,8 +6,6 @@ from enum import Enum
 from functools import update_wrapper
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast, overload
 
-from typing_extensions import get_args
-
 from flytekit.core import constants as _common_constants
 from flytekit.core.base_task import PythonTask
 from flytekit.core.class_based_resolver import ClassStorageTaskResolver
@@ -35,16 +33,14 @@ from flytekit.core.promise import (
 from flytekit.core.python_auto_container import PythonAutoContainerTask
 from flytekit.core.reference_entity import ReferenceEntity, WorkflowReference
 from flytekit.core.tracker import extract_task_module
-from flytekit.core.type_engine import TypeEngine, TypeTransformerFailedError, UnionTransformer
+from flytekit.core.type_engine import TypeEngine
 from flytekit.exceptions import scopes as exception_scopes
 from flytekit.exceptions.user import FlyteValidationException, FlyteValueException
 from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
 from flytekit.models import literals as _literal_models
-from flytekit.models import types as type_models
 from flytekit.models.core import workflow as _workflow_model
 from flytekit.models.documentation import Description, Documentation
-from flytekit.models.types import TypeStructure
 
 GLOBAL_START_NODE = Node(
     id=_common_constants.GLOBAL_INPUT_NODE_ID,
@@ -279,63 +275,63 @@ class WorkflowBase(object):
     def compile(self, **kwargs):
         pass
 
-    def ensure_literal(
-        self, ctx, py_type: Type[T], input_type: type_models.LiteralType, python_value: Any
-    ) -> _literal_models.Literal:
-        """
-        This function will attempt to convert a python value to a literal. If the python value is a promise, it will
-        return the promise's value.
-        """
-        if input_type.union_type is not None:
-            if python_value is None and UnionTransformer.is_optional_type(py_type):
-                return _literal_models.Literal(scalar=_literal_models.Scalar(none_type=_literal_models.Void()))
-            for i in range(len(input_type.union_type.variants)):
-                lt_type = input_type.union_type.variants[i]
-                python_type = get_args(py_type)[i]
-                try:
-                    final_lt = self.ensure_literal(ctx, python_type, lt_type, python_value)
-                    lt_type._structure = TypeStructure(tag=TypeEngine.get_transformer(python_type).name)
-                    return _literal_models.Literal(
-                        scalar=_literal_models.Scalar(union=_literal_models.Union(value=final_lt, stored_type=lt_type))
-                    )
-                except Exception as e:
-                    logger.debug(f"Failed to convert {python_value} to {lt_type} with error {e}")
-            raise TypeError(f"Failed to convert {python_value} to {input_type}")
-        if isinstance(python_value, list) and input_type.collection_type:
-            collection_lit_type = input_type.collection_type
-            collection_py_type = get_args(py_type)[0]
-            xx = [self.ensure_literal(ctx, collection_py_type, collection_lit_type, pv) for pv in python_value]
-            return _literal_models.Literal(collection=_literal_models.LiteralCollection(literals=xx))
-        elif isinstance(python_value, dict) and input_type.map_value_type:
-            mapped_lit_type = input_type.map_value_type
-            mapped_py_type = get_args(py_type)[1]
-            xx = {k: self.ensure_literal(ctx, mapped_py_type, mapped_lit_type, v) for k, v in python_value.items()}  # type: ignore
-            return _literal_models.Literal(map=_literal_models.LiteralMap(literals=xx))
-        # It is a scalar, convert to Promise if necessary.
-        else:
-            if isinstance(python_value, Promise):
-                return python_value.val
-            if not isinstance(python_value, Promise):
-                try:
-                    res = TypeEngine.to_literal(ctx, python_value, py_type, input_type)
-                    return res
-                except TypeTransformerFailedError as exc:
-                    raise TypeError(
-                        f"Failed to convert input '{python_value}' of workflow '{self.name}':\n  {exc}"
-                    ) from exc
+    # def ensure_literal(
+    #     self, ctx, py_type: Type[T], input_type: type_models.LiteralType, python_value: Any
+    # ) -> _literal_models.Literal:
+    #     """
+    #     This function will attempt to convert a python value to a literal. If the python value is a promise, it will
+    #     return the promise's value.
+    #     """
+    #     if input_type.union_type is not None:
+    #         if python_value is None and UnionTransformer.is_optional_type(py_type):
+    #             return _literal_models.Literal(scalar=_literal_models.Scalar(none_type=_literal_models.Void()))
+    #         for i in range(len(input_type.union_type.variants)):
+    #             lt_type = input_type.union_type.variants[i]
+    #             python_type = get_args(py_type)[i]
+    #             try:
+    #                 final_lt = self.ensure_literal(ctx, python_type, lt_type, python_value)
+    #                 lt_type._structure = TypeStructure(tag=TypeEngine.get_transformer(python_type).name)
+    #                 return _literal_models.Literal(
+    #                     scalar=_literal_models.Scalar(union=_literal_models.Union(value=final_lt, stored_type=lt_type))
+    #                 )
+    #             except Exception as e:
+    #                 logger.debug(f"Failed to convert {python_value} to {lt_type} with error {e}")
+    #         raise TypeError(f"Failed to convert {python_value} to {input_type}")
+    #     if isinstance(python_value, list) and input_type.collection_type:
+    #         collection_lit_type = input_type.collection_type
+    #         collection_py_type = get_args(py_type)[0]
+    #         xx = [self.ensure_literal(ctx, collection_py_type, collection_lit_type, pv) for pv in python_value]
+    #         return _literal_models.Literal(collection=_literal_models.LiteralCollection(literals=xx))
+    #     elif isinstance(python_value, dict) and input_type.map_value_type:
+    #         mapped_lit_type = input_type.map_value_type
+    #         mapped_py_type = get_args(py_type)[1]
+    #         xx = {k: self.ensure_literal(ctx, mapped_py_type, mapped_lit_type, v) for k, v in python_value.items()}  # type: ignore
+    #         return _literal_models.Literal(map=_literal_models.LiteralMap(literals=xx))
+    #     # It is a scalar, convert to Promise if necessary.
+    #     else:
+    #         if isinstance(python_value, Promise):
+    #             return python_value.val
+    #         if not isinstance(python_value, Promise):
+    #             try:
+    #                 res = TypeEngine.to_literal(ctx, python_value, py_type, input_type)
+    #                 return res
+    #             except TypeTransformerFailedError as exc:
+    #                 raise TypeError(
+    #                     f"Failed to convert input '{python_value}' of workflow '{self.name}':\n  {exc}"
+    #                 ) from exc
 
     def local_execute(self, ctx: FlyteContext, **kwargs) -> Union[Tuple[Promise], Promise, VoidPromise, None]:
         # This is done to support the invariant that Workflow local executions always work with Promise objects
         # holding Flyte literal values. Even in a wf, a user can call a sub-workflow with a Python native value.
-        for k, v in kwargs.items():
-            py_type = self.python_interface.inputs[k]
-            lit_type = self.interface.inputs[k].type
-            kwargs[k] = Promise(var=k, val=self.ensure_literal(ctx, py_type, lit_type, v))
-
-            # The output of this will always be a combination of Python native values and Promises containing Flyte
-            # Literals.
+        literal_map = translate_inputs_to_literals(
+            ctx,
+            incoming_values=kwargs,
+            flyte_interface_types=self.interface.inputs,
+            native_types=self.python_interface.inputs,
+        )
+        kwargs_literals = {k: Promise(var=k, val=v) for k, v in literal_map.items()}
         self.compile()
-        function_outputs = self.execute(**kwargs)
+        function_outputs = self.execute(**kwargs_literals)
         # First handle the empty return case.
         # A workflow function may return a task that doesn't return anything
         #   def wf():

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -275,51 +275,6 @@ class WorkflowBase(object):
     def compile(self, **kwargs):
         pass
 
-    # def ensure_literal(
-    #     self, ctx, py_type: Type[T], input_type: type_models.LiteralType, python_value: Any
-    # ) -> _literal_models.Literal:
-    #     """
-    #     This function will attempt to convert a python value to a literal. If the python value is a promise, it will
-    #     return the promise's value.
-    #     """
-    #     if input_type.union_type is not None:
-    #         if python_value is None and UnionTransformer.is_optional_type(py_type):
-    #             return _literal_models.Literal(scalar=_literal_models.Scalar(none_type=_literal_models.Void()))
-    #         for i in range(len(input_type.union_type.variants)):
-    #             lt_type = input_type.union_type.variants[i]
-    #             python_type = get_args(py_type)[i]
-    #             try:
-    #                 final_lt = self.ensure_literal(ctx, python_type, lt_type, python_value)
-    #                 lt_type._structure = TypeStructure(tag=TypeEngine.get_transformer(python_type).name)
-    #                 return _literal_models.Literal(
-    #                     scalar=_literal_models.Scalar(union=_literal_models.Union(value=final_lt, stored_type=lt_type))
-    #                 )
-    #             except Exception as e:
-    #                 logger.debug(f"Failed to convert {python_value} to {lt_type} with error {e}")
-    #         raise TypeError(f"Failed to convert {python_value} to {input_type}")
-    #     if isinstance(python_value, list) and input_type.collection_type:
-    #         collection_lit_type = input_type.collection_type
-    #         collection_py_type = get_args(py_type)[0]
-    #         xx = [self.ensure_literal(ctx, collection_py_type, collection_lit_type, pv) for pv in python_value]
-    #         return _literal_models.Literal(collection=_literal_models.LiteralCollection(literals=xx))
-    #     elif isinstance(python_value, dict) and input_type.map_value_type:
-    #         mapped_lit_type = input_type.map_value_type
-    #         mapped_py_type = get_args(py_type)[1]
-    #         xx = {k: self.ensure_literal(ctx, mapped_py_type, mapped_lit_type, v) for k, v in python_value.items()}  # type: ignore
-    #         return _literal_models.Literal(map=_literal_models.LiteralMap(literals=xx))
-    #     # It is a scalar, convert to Promise if necessary.
-    #     else:
-    #         if isinstance(python_value, Promise):
-    #             return python_value.val
-    #         if not isinstance(python_value, Promise):
-    #             try:
-    #                 res = TypeEngine.to_literal(ctx, python_value, py_type, input_type)
-    #                 return res
-    #             except TypeTransformerFailedError as exc:
-    #                 raise TypeError(
-    #                     f"Failed to convert input '{python_value}' of workflow '{self.name}':\n  {exc}"
-    #                 ) from exc
-
     def local_execute(self, ctx: FlyteContext, **kwargs) -> Union[Tuple[Promise], Promise, VoidPromise, None]:
         # This is done to support the invariant that Workflow local executions always work with Promise objects
         # holding Flyte literal values. Even in a wf, a user can call a sub-workflow with a Python native value.

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -105,7 +105,7 @@ def test_translate_inputs_to_literals(input):
         a: typing.List[str]
 
     @task
-    def t1(a: typing.Union[float, MyDataclass, Annotated[typing.List[typing.Any], BatchSize(2)]]):
+    def t1(a: typing.Union[float, typing.List[int], MyDataclass, Annotated[typing.List[FlytePickle], BatchSize(2)]]):
         print(a)
 
     ctx = context_manager.FlyteContext.current_context()
@@ -114,7 +114,7 @@ def test_translate_inputs_to_literals(input):
 
 def test_translate_inputs_to_literals_with_wrong_types():
     ctx = context_manager.FlyteContext.current_context()
-    with pytest.raises(TypeError, match="Cannot convert"):
+    with pytest.raises(TypeError, match="Failed to convert"):
 
         @task
         def t1(a: typing.Union[float, typing.List[int]]):
@@ -122,7 +122,7 @@ def test_translate_inputs_to_literals_with_wrong_types():
 
         translate_inputs_to_literals(ctx, {"a": {"a": 3}}, t1.interface.inputs, t1.python_interface.inputs)
 
-    with pytest.raises(TypeError, match="Cannot convert"):
+    with pytest.raises(TypeError, match="Failed to convert"):
 
         @task
         def t1(a: typing.Union[float, typing.Dict[str, int]]):

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -105,7 +105,7 @@ def test_translate_inputs_to_literals(input):
         a: typing.List[str]
 
     @task
-    def t1(a: typing.Union[float, typing.List[int], MyDataclass, Annotated[typing.List[FlytePickle], BatchSize(2)]]):
+    def t1(a: typing.Union[float, MyDataclass, Annotated[typing.List[typing.Any], BatchSize(2)]]):
         print(a)
 
     ctx = context_manager.FlyteContext.current_context()
@@ -114,7 +114,7 @@ def test_translate_inputs_to_literals(input):
 
 def test_translate_inputs_to_literals_with_wrong_types():
     ctx = context_manager.FlyteContext.current_context()
-    with pytest.raises(TypeError, match="Failed to convert"):
+    with pytest.raises(TypeError, match="Cannot convert"):
 
         @task
         def t1(a: typing.Union[float, typing.List[int]]):
@@ -122,7 +122,7 @@ def test_translate_inputs_to_literals_with_wrong_types():
 
         translate_inputs_to_literals(ctx, {"a": {"a": 3}}, t1.interface.inputs, t1.python_interface.inputs)
 
-    with pytest.raises(TypeError, match="Failed to convert"):
+    with pytest.raises(TypeError, match="Cannot convert"):
 
         @task
         def t1(a: typing.Union[float, typing.Dict[str, int]]):

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -114,7 +114,7 @@ def test_translate_inputs_to_literals(input):
 
 def test_translate_inputs_to_literals_with_wrong_types():
     ctx = context_manager.FlyteContext.current_context()
-    with pytest.raises(TypeError, match="Not a map type <FlyteLiteral union_type"):
+    with pytest.raises(TypeError, match="Failed to convert"):
 
         @task
         def t1(a: typing.Union[float, typing.List[int]]):
@@ -122,7 +122,7 @@ def test_translate_inputs_to_literals_with_wrong_types():
 
         translate_inputs_to_literals(ctx, {"a": {"a": 3}}, t1.interface.inputs, t1.python_interface.inputs)
 
-    with pytest.raises(TypeError, match="Not a collection type <FlyteLiteral union_type"):
+    with pytest.raises(TypeError, match="Failed to convert"):
 
         @task
         def t1(a: typing.Union[float, typing.Dict[str, int]]):

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -15,7 +15,6 @@ from flytekit.core.promise import (
     translate_inputs_to_literals,
 )
 from flytekit.exceptions.user import FlyteAssertion
-from flytekit.types.pickle import FlytePickle
 from flytekit.types.pickle.pickle import BatchSize
 
 
@@ -93,19 +92,20 @@ def test_create_and_link_node_from_remote_ignore():
     create_and_link_node_from_remote(ctx, lp, _inputs_not_allowed={"i"}, _ignorable_inputs={"j"}, j=15)
 
 
+@dataclass_json
+@dataclass
+class MyDataclass(object):
+    i: int
+    a: typing.List[str]
+
+
 @pytest.mark.parametrize(
     "input",
-    [2.0, {"i": 1, "a": ["h", "e"]}, [1, 2, 3], ["foo"] * 5],
+    [2.0, MyDataclass(i=1, a=["h", "e"]), [1, 2, 3], ["foo"] * 5],
 )
 def test_translate_inputs_to_literals(input):
-    @dataclass_json
-    @dataclass
-    class MyDataclass(object):
-        i: int
-        a: typing.List[str]
-
     @task
-    def t1(a: typing.Union[float, typing.List[int], MyDataclass, Annotated[typing.List[FlytePickle], BatchSize(2)]]):
+    def t1(a: typing.Union[float, MyDataclass, Annotated[typing.List[typing.Any], BatchSize(2)]]):
         print(a)
 
     ctx = context_manager.FlyteContext.current_context()
@@ -114,7 +114,7 @@ def test_translate_inputs_to_literals(input):
 
 def test_translate_inputs_to_literals_with_wrong_types():
     ctx = context_manager.FlyteContext.current_context()
-    with pytest.raises(TypeError, match="Failed to convert"):
+    with pytest.raises(TypeError, match="Cannot convert"):
 
         @task
         def t1(a: typing.Union[float, typing.List[int]]):
@@ -122,7 +122,7 @@ def test_translate_inputs_to_literals_with_wrong_types():
 
         translate_inputs_to_literals(ctx, {"a": {"a": 3}}, t1.interface.inputs, t1.python_interface.inputs)
 
-    with pytest.raises(TypeError, match="Failed to convert"):
+    with pytest.raises(TypeError, match="Cannot convert"):
 
         @task
         def t1(a: typing.Union[float, typing.Dict[str, int]]):

--- a/tests/flytekit/unit/core/test_type_conversion_errors.py
+++ b/tests/flytekit/unit/core/test_type_conversion_errors.py
@@ -96,7 +96,7 @@ def test_workflow_with_task_error(correct_input):
 def test_workflow_with_input_error(incorrect_input):
     with pytest.raises(
         TypeError,
-        match=(r"Encountered error while executing workflow '{}':\n" r"  Failed to convert input").format(
+        match=(r"Encountered error while executing workflow '{}':\n" r"  Failed argument").format(
             wf_with_output_error.name
         ),
     ):

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1647,7 +1647,7 @@ def test_error_messages():
 
     with pytest.raises(
         TypeError,
-        match="Not a collection type <FlyteLiteral simple: STRUCT> but got a list \\[{'hello': 2}\\]",
+        match="Failed to convert inputs of task 'tests.flytekit.unit.core.test_type_hints.foo3':\n  Failed argument 'a': Expected a dict",
     ):
         foo3(a=[{"hello": 2}])  # type: ignore
 

--- a/tests/flytekit/unit/extras/sklearn/test_transformations.py
+++ b/tests/flytekit/unit/extras/sklearn/test_transformations.py
@@ -35,7 +35,6 @@ def get_model(model_type: str) -> BaseEstimator:
     x = np.random.normal(size=(10, 2))
     y = np.random.randint(2, size=(10,))
     model = models_map[model_type]()
-    print(f"Training123 {x} {y}")
     model.fit(x, y)
     return model
 

--- a/tests/flytekit/unit/extras/sklearn/test_transformations.py
+++ b/tests/flytekit/unit/extras/sklearn/test_transformations.py
@@ -35,6 +35,7 @@ def get_model(model_type: str) -> BaseEstimator:
     x = np.random.normal(size=(10, 2))
     y = np.random.randint(2, size=(10,))
     model = models_map[model_type]()
+    print(f"Training123 {x} {y}")
     model.fit(x, y)
     return model
 


### PR DESCRIPTION
# TL;DR
The ensure_literal call in workflow.py was a duplicate that we just didn't realize was a duplicate.  Removing and updating the existing function in promise with the correct union handling behavior.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
This was discovered while implementing the now-defunct https://github.com/flyteorg/flytekit/pull/1700

## Tracking Issue
NA
