### PR TITLE
Detect upstream nodes from container nested promises

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -626,10 +626,10 @@ def binding_data_from_python_std(
         )
 
     elif isinstance(t_value, list):
-        sub_type: Optional[type] = ListTransformer.get_sub_type(t_value_type) if t_value_type else None
+        sub_type: type = ListTransformer.get_sub_type(t_value_type)
         collection = _literals_models.BindingDataCollection(
             bindings=[
-                binding_data_from_python_std(ctx, expected_literal_type.collection_type, t, sub_type or type(t), nodes)
+                binding_data_from_python_std(ctx, expected_literal_type.collection_type, t, sub_type, nodes)
                 for t in t_value
             ]
         )

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -629,7 +629,7 @@ def binding_data_from_python_std(
         sub_type: Optional[type] = ListTransformer.get_sub_type(t_value_type) if t_value_type else None
         collection = _literals_models.BindingDataCollection(
             bindings=[
-                binding_data_from_python_std(ctx, expected_literal_type.collection_type, t, sub_type, nodes)
+                binding_data_from_python_std(ctx, expected_literal_type.collection_type, t, sub_type or type(t), nodes)
                 for t in t_value
             ]
         )
@@ -648,13 +648,12 @@ def binding_data_from_python_std(
             lit = TypeEngine.to_literal(ctx, t_value, type(t_value), expected_literal_type)
             return _literals_models.BindingData(scalar=lit.scalar)
         else:
-            _, v_type = (
-                DictTransformer.get_dict_types(t_value_type) if t_value_type else None,
-                None,
-            )
+            _, v_type = DictTransformer.get_dict_types(t_value_type)
             m = _literals_models.BindingDataMap(
                 bindings={
-                    k: binding_data_from_python_std(ctx, expected_literal_type.map_value_type, v, v_type, nodes)
+                    k: binding_data_from_python_std(
+                        ctx, expected_literal_type.map_value_type, v, v_type or type(v), nodes
+                    )
                     for k, v in t_value.items()
                 }
             )

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -610,7 +610,7 @@ class ImperativeWorkflow(WorkflowBase):
         if ctx.compilation_state is not None:
             raise Exception("Can't already be compiling")
         with FlyteContextManager.with_context(ctx.with_compilation_state(self.compilation_state)) as ctx:
-            b = binding_from_python_std(
+            b, _ = binding_from_python_std(
                 ctx, output_name, expected_literal_type=flyte_type, t_value=p, t_value_type=python_type
             )
             self._output_bindings.append(b)
@@ -733,7 +733,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
                     )
                 workflow_outputs = workflow_outputs[0]
             t = self.python_interface.outputs[output_names[0]]
-            b = binding_from_python_std(
+            b, _ = binding_from_python_std(
                 ctx,
                 output_names[0],
                 self.interface.outputs[output_names[0]].type,
@@ -750,7 +750,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
                 if isinstance(workflow_outputs[i], ConditionalSection):
                     raise AssertionError("A Conditional block (if-else) should always end with an `else_()` clause")
                 t = self.python_interface.outputs[out]
-                b = binding_from_python_std(
+                b, _ = binding_from_python_std(
                     ctx,
                     out,
                     self.interface.outputs[out].type,

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1710,3 +1710,7 @@ def test_is_annotated(t, expected):
 )
 def test_get_underlying_type(t, expected):
     assert get_underlying_type(t) == expected
+
+
+def test_dict_get():
+    assert DictTransformer.get_dict_types(None) == (None, None)

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1071,6 +1071,9 @@ def test_dict_wf_with_constants():
     x = my_wf(a=5, b="hello")
     assert x == (7, "hello world")
 
+    spec = get_serializable(OrderedDict(), serialization_settings, my_wf)
+    assert spec.template.nodes[1].upstream_node_ids == ["n0"]
+
 
 def test_dict_wf_with_conversion():
     @task

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -192,6 +192,8 @@ def test_sub_wf_varying_types():
         "Int: 1"
     )
     assert x == expected
+    wf_spec = get_serializable(OrderedDict(), serialization_settings, wf)
+    assert set(wf_spec.template.nodes[5].upstream_node_ids) == {"n2", "n1", "n0", "n4", "n3"}
 
     @workflow
     def wf() -> str:


### PR DESCRIPTION
# TL;DR
Upstream nodes were not correctly being detected in cases where the inputs were behind a {} or a [].  For example, `n1` here

```
def my_wf(a: int, b: str) -> (int, str):
    x, y = t1(a=a)
    d = t2(a={"key1": b, "key2": y})
    return x, d
```
would not have picked up `n0` as an upstream node because we weren't correctly traversing the structure.

Found while implementing the now rejected generalized container types https://github.com/flyteorg/flytekit/pull/1700/files

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Instead of iterating through the kwargs again, save nodes found while traversing the bindings from the promises.
Also get rid of the mostly duplicate `binding_from_flyte_std`

## Tracking Issue
NA
