### PR TITLE
Use utf-8 to encode flyte deck

### DIFF
--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -151,7 +151,8 @@ def _output_deck(task_name: str, new_user_params: ExecutionParameters):
             f.write(_get_deck(new_user_params, ignore_jupyter=True))
         logger.info(f"{task_name} task creates flyte deck html to file://{local_path}")
         if ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
-            remote_path = f"{new_user_params.output_metadata_prefix}{os.sep}{DECK_FILE_NAME}"
+            fs = ctx.file_access.get_filesystem_for_path(new_user_params.output_metadata_prefix)
+            remote_path = f"{new_user_params.output_metadata_prefix}{ctx.file_access.sep(fs)}{DECK_FILE_NAME}"
             kwargs: typing.Dict[str, str] = {
                 "ContentType": "text/html",  # For s3
                 "content_type": "text/html",  # For gcs

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -55,7 +55,6 @@ class Deck:
 
     def __init__(self, name: str, html: Optional[str] = ""):
         self._name = name
-        # self.renderers = renderers if isinstance(renderers, list) else [renderers]
         self._html = html
         FlyteContextManager.current_context().user_space_params.decks.append(self)
 
@@ -147,16 +146,19 @@ def _output_deck(task_name: str, new_user_params: ExecutionParameters):
     ctx = FlyteContext.current_context()
     local_dir = ctx.file_access.get_random_local_directory()
     local_path = f"{local_dir}{os.sep}{DECK_FILE_NAME}"
-    with open(local_path, "w") as f:
-        f.write(_get_deck(new_user_params, ignore_jupyter=True))
-    logger.info(f"{task_name} task creates flyte deck html to file://{local_path}")
-    if ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
-        remote_path = f"{new_user_params.output_metadata_prefix}{os.sep}{DECK_FILE_NAME}"
-        kwargs: typing.Dict[str, str] = {
-            "ContentType": "text/html",  # For s3
-            "content_type": "text/html",  # For gcs
-        }
-        ctx.file_access.put_data(local_path, remote_path, **kwargs)
+    try:
+        with open(local_path, "w", encoding="utf-8") as f:
+            f.write(_get_deck(new_user_params, ignore_jupyter=True))
+        logger.info(f"{task_name} task creates flyte deck html to file://{local_path}")
+        if ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
+            remote_path = f"{new_user_params.output_metadata_prefix}{os.sep}{DECK_FILE_NAME}"
+            kwargs: typing.Dict[str, str] = {
+                "ContentType": "text/html",  # For s3
+                "content_type": "text/html",  # For gcs
+            }
+            ctx.file_access.put_data(local_path, remote_path, **kwargs)
+    except Exception:
+        logger.error("Failed to write flyte deck html.")
 
 
 def get_deck_template() -> "Template":

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -157,8 +157,8 @@ def _output_deck(task_name: str, new_user_params: ExecutionParameters):
                 "content_type": "text/html",  # For gcs
             }
             ctx.file_access.put_data(local_path, remote_path, **kwargs)
-    except Exception:
-        logger.error("Failed to write flyte deck html.")
+    except Exception as e:
+        logger.error(f"Failed to write flyte deck html with error {e}.")
 
 
 def get_deck_template() -> "Template":

--- a/tests/flytekit/unit/deck/test_deck.py
+++ b/tests/flytekit/unit/deck/test_deck.py
@@ -116,6 +116,7 @@ def test_deck_in_jupyter(mock_ipython_check):
 
 def test_get_deck():
     old_locale = locale.getlocale()
+    locale.setlocale(locale.LC_ALL, "en_US.US-ASCII")
     html = "你好，Flyte"
     ctx = FlyteContextManager.current_context()
     ctx.user_space_params._decks = [ctx.user_space_params.default_deck]

--- a/tests/flytekit/unit/deck/test_deck.py
+++ b/tests/flytekit/unit/deck/test_deck.py
@@ -1,5 +1,4 @@
 import datetime
-import locale
 
 import pandas as pd
 import pytest
@@ -115,11 +114,8 @@ def test_deck_in_jupyter(mock_ipython_check):
 
 
 def test_get_deck():
-    old_locale = locale.getlocale()
     html = "你好，Flyte"
     ctx = FlyteContextManager.current_context()
     ctx.user_space_params._decks = [ctx.user_space_params.default_deck]
     ctx.user_space_params._decks[0] = flytekit.Deck("test", html)
     _output_deck("test_task", ctx.user_space_params)
-    # Restore locale
-    locale.setlocale(locale.LC_ALL, old_locale)

--- a/tests/flytekit/unit/deck/test_deck.py
+++ b/tests/flytekit/unit/deck/test_deck.py
@@ -116,7 +116,6 @@ def test_deck_in_jupyter(mock_ipython_check):
 
 def test_get_deck():
     old_locale = locale.getlocale()
-    locale.setlocale(locale.LC_ALL, "en_US.US-ASCII")
     html = "你好，Flyte"
     ctx = FlyteContextManager.current_context()
     ctx.user_space_params._decks = [ctx.user_space_params.default_deck]

--- a/tests/flytekit/unit/deck/test_deck.py
+++ b/tests/flytekit/unit/deck/test_deck.py
@@ -1,4 +1,5 @@
 import datetime
+import locale
 
 import pandas as pd
 import pytest
@@ -114,8 +115,11 @@ def test_deck_in_jupyter(mock_ipython_check):
 
 
 def test_get_deck():
+    old_locale = locale.getlocale()
     html = "你好，Flyte"
     ctx = FlyteContextManager.current_context()
     ctx.user_space_params._decks = [ctx.user_space_params.default_deck]
     ctx.user_space_params._decks[0] = flytekit.Deck("test", html)
     _output_deck("test_task", ctx.user_space_params)
+    # Restore locale
+    locale.setlocale(locale.LC_ALL, old_locale)

--- a/tests/flytekit/unit/deck/test_deck.py
+++ b/tests/flytekit/unit/deck/test_deck.py
@@ -111,3 +111,11 @@ def test_deck_in_jupyter(mock_ipython_check):
         t1(a=3)
         deck = ctx.get_deck()
         assert deck is not None
+
+
+def test_get_deck():
+    html = "你好，Flyte"
+    ctx = FlyteContextManager.current_context()
+    ctx.user_space_params._decks = [ctx.user_space_params.default_deck]
+    ctx.user_space_params._decks[0] = flytekit.Deck("test", html)
+    _output_deck("test_task", ctx.user_space_params)


### PR DESCRIPTION
# TL;DR
Use `utf-8` to encode flyte deck, and catch the error during generating the deck file to prevent the entire task from failing)
Fixes https://github.com/unionai/cloud/issues/3733

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
