### PR TITLE
add imagespec cache

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -129,6 +129,7 @@ class ImageBuildEngine:
     """
 
     _REGISTRY: typing.Dict[str, ImageSpecBuilder] = {}
+    _BUILT_IMAGES: typing.Set[str] = set()
 
     @classmethod
     def register(cls, builder_type: str, image_spec_builder: ImageSpecBuilder):
@@ -138,11 +139,13 @@ class ImageBuildEngine:
     def build(cls, image_spec: ImageSpec):
         if image_spec.builder not in cls._REGISTRY:
             raise Exception(f"Builder {image_spec.builder} is not registered.")
-        if not image_spec.exist():
-            click.secho(f"Image {image_spec.image_name()} not found. Building...", fg="blue")
-            cls._REGISTRY[image_spec.builder].build_image(image_spec)
+        img_name = image_spec.image_name()
+        if img_name in cls._BUILT_IMAGES or image_spec.exist():
+            click.secho(f"Image {img_name} found. Skip building.", fg="blue")
         else:
-            click.secho(f"Image {image_spec.image_name()} found. Skip building.", fg="blue")
+            click.secho(f"Image {img_name} not found. Building...", fg="blue")
+            cls._REGISTRY[image_spec.builder].build_image(image_spec)
+            cls._BUILT_IMAGES.add(img_name)
 
 
 @lru_cache


### PR DESCRIPTION
# TL;DR
Cache the name of built images locally in order to have strong consistency. Otherwise, flytekit might rebuild the same image because some registries don't have strong consistency.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
