### PR TITLE
Carry over hash from literal maps in cache key computation

### DIFF
--- a/flytekit/core/local_cache.py
+++ b/flytekit/core/local_cache.py
@@ -13,18 +13,17 @@ CACHE_LOCATION = "~/.flyte/local-cache"
 
 
 def _recursive_hash_placement(literal: Literal) -> Literal:
-    if literal.collection is not None:
-        literals = [_recursive_hash_placement(literal) for literal in literal.collection.literals]
+    # Base case, hash gets passed through always if set
+    if literal.hash is not None:
+        return Literal(hash=literal.hash)
+    elif literal.collection is not None:
+        literals = [_recursive_hash_placement(lit) for lit in literal.collection.literals]
         return Literal(collection=LiteralCollection(literals=literals))
     elif literal.map is not None:
         literal_map = {}
-        for key, literal in literal.map.literals.items():
-            literal_map[key] = _recursive_hash_placement(literal)
+        for key, literal_value in literal.map.literals.items():
+            literal_map[key] = _recursive_hash_placement(literal_value)
         return Literal(map=LiteralMap(literal_map))
-
-    # Base case
-    if literal.hash is not None:
-        return Literal(hash=literal.hash)
     else:
         return literal
 

--- a/tests/flytekit/unit/core/test_local_cache.py
+++ b/tests/flytekit/unit/core/test_local_cache.py
@@ -15,12 +15,12 @@ from flytekit.core.base_task import kwtypes
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.dynamic_workflow_task import dynamic
 from flytekit.core.hash import HashMethod
-from flytekit.core.local_cache import LocalTaskCache, _calculate_cache_key
+from flytekit.core.local_cache import LocalTaskCache, _calculate_cache_key, _recursive_hash_placement
 from flytekit.core.task import TaskMetadata, task
 from flytekit.core.testing import task_mock
 from flytekit.core.type_engine import TypeEngine
 from flytekit.core.workflow import workflow
-from flytekit.models.literals import LiteralMap
+from flytekit.models.literals import Literal, LiteralCollection, LiteralMap, Primitive, Scalar
 from flytekit.models.types import LiteralType, SimpleType
 from flytekit.types.schema import FlyteSchema
 
@@ -483,3 +483,17 @@ def calculate_cache_key_multiple_times(x, n=1000):
 )
 def test_cache_key_consistency(d):
     assert len(calculate_cache_key_multiple_times(d)) == 1
+
+
+def test_literal_hash_placement():
+    """
+    Test that hashes on literal collections and maps are preserved by the
+    _recursive_hash_placement function used in cache key calculations.
+    """
+    lit = Literal(scalar=Scalar(primitive=Primitive(string_value="test")))
+
+    litmap = Literal(map=LiteralMap(literals={"test": lit}), hash="0xffff")
+    litcoll = Literal(collection=LiteralCollection(literals=[lit]), hash="0xffff")
+
+    assert litmap.hash == _recursive_hash_placement(litmap).hash
+    assert litcoll.hash == _recursive_hash_placement(litcoll).hash


### PR DESCRIPTION
# TL;DR
Until now, the hash of a literal map is not carried over into the representative literal map entering the cache key computation, despite the code clearly stating so.

This commit enables carrying hashes from `LiteralMap`s over by explicitly setting the hashes on the representer literal map.

Also fixes a shadowing bug in the key-value loop over the literal map, which happened since the value argument and the input name were both `literal`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [x] Any pending items have an associated Issue (there aren't any I guess)

## Complete description

This came up during internal tests, where it broke existing tests when I changed from a single `Literal` to a `LiteralMap` in a type transformer with an explicitly set hash value.

Minimal reproducer:

```py
# test.py
from flytekit import Literal
from flytekit.core.local_cache import _recursive_hash_placement
from flytekit.models.literals import LiteralMap, Scalar, Primitive

lit = Literal(
    map=LiteralMap(
        literals={
            "hello": Literal(scalar=Scalar(primitive=Primitive(string_value="hello"))),
        }
    ),
    hash="0xffff",
)

if __name__ == "__main__":
    print(lit)
# --> prints <FlyteLiteral map { literals { key: "hello" value { scalar { primitive { string_value: "hello" } } } } } hash: "0xffff">
    print(_recursive_hash_placement(lit))
# --> prints <FlyteLiteral map { literals { key: "hello" value { scalar { primitive { string_value: "hello" } } } } }>
```

This means that the `_recursive_hash_placement` function, which facilitates part of the hash key computation, silently scrubs hash values from input literal maps, which can cause involuntary cache hits if the values inside the map stay the same.

I would be happy for a discussion - maybe the repro can go in as a unit test in a suitable location.

## Tracking Issue
N/A

## Follow-up issue
N/A
