### PR TITLE
Throw warning for nested @Task functions

### DIFF
--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -301,7 +301,7 @@ class Task(object):
         return create_task_output(vals, self.python_interface)
 
     def __call__(self, *args, **kwargs) -> Union[Tuple[Promise], Promise, VoidPromise, Tuple, None]:
-        return flyte_entity_call_handler(self, mode=ExecutionState.Mode.LOCAL_TASK_EXECUTION, *args, **kwargs)  # type: ignore
+        return flyte_entity_call_handler(self, *args, **kwargs)  # type: ignore
 
     def compile(self, ctx: FlyteContext, *args, **kwargs):
         raise Exception("not implemented")
@@ -336,6 +336,10 @@ class Task(object):
         defined for this task.
         """
         return None
+
+    def local_excution_model(self) -> ExecutionState.Mode:
+        """ """
+        return ExecutionState.Mode.LOCAL_TASK_EXECUTION
 
     def sandbox_execute(
         self,

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -301,7 +301,7 @@ class Task(object):
         return create_task_output(vals, self.python_interface)
 
     def __call__(self, *args, **kwargs) -> Union[Tuple[Promise], Promise, VoidPromise, Tuple, None]:
-        return flyte_entity_call_handler(self, *args, **kwargs)  # type: ignore
+        return flyte_entity_call_handler(self, mode=ExecutionState.Mode.LOCAL_TASK_EXECUTION, *args, **kwargs)  # type: ignore
 
     def compile(self, ctx: FlyteContext, *args, **kwargs):
         raise Exception("not implemented")

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -337,7 +337,7 @@ class Task(object):
         """
         return None
 
-    def local_execution_model(self) -> ExecutionState.Mode:
+    def local_execution_mode(self) -> ExecutionState.Mode:
         """ """
         return ExecutionState.Mode.LOCAL_TASK_EXECUTION
 

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -337,7 +337,7 @@ class Task(object):
         """
         return None
 
-    def local_excution_model(self) -> ExecutionState.Mode:
+    def local_execution_model(self) -> ExecutionState.Mode:
         """ """
         return ExecutionState.Mode.LOCAL_TASK_EXECUTION
 

--- a/flytekit/core/gate.py
+++ b/flytekit/core/gate.py
@@ -7,7 +7,7 @@ from typing import Tuple, Union
 import click
 
 from flytekit.core import interface as flyte_interface
-from flytekit.core.context_manager import FlyteContext, FlyteContextManager
+from flytekit.core.context_manager import FlyteContext, FlyteContextManager, ExecutionState
 from flytekit.core.promise import Promise, VoidPromise, flyte_entity_call_handler
 from flytekit.core.type_engine import TypeEngine
 from flytekit.exceptions.user import FlyteDisapprovalException
@@ -115,6 +115,9 @@ class Gate(object):
             return kwargs[output_name]
         else:
             raise FlyteDisapprovalException(f"User did not approve the transaction for gate node {self.name}")
+
+    def local_execution_mode(self):
+        return ExecutionState.Mode.LOCAL_TASK_EXECUTION
 
 
 def wait_for_input(name: str, timeout: datetime.timedelta, expected_type: typing.Type):

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -963,7 +963,7 @@ class LocallyExecutable(Protocol):
     def local_execute(self, ctx: FlyteContext, **kwargs) -> Union[Tuple[Promise], Promise, VoidPromise, None]:
         ...
 
-    def local_execution_model(self) -> ExecutionState.Mode:
+    def local_execution_mode(self) -> ExecutionState.Mode:
         ...
 
 
@@ -1007,7 +1007,7 @@ def flyte_entity_call_handler(
     if ctx.compilation_state is not None and ctx.compilation_state.mode == 1:
         return create_and_link_node(ctx, entity=entity, **kwargs)
     elif ctx.execution_state is not None and ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION:
-        mode = cast(LocallyExecutable, entity).local_execution_model()
+        mode = cast(LocallyExecutable, entity).local_execution_mode()
         with FlyteContextManager.with_context(
             ctx.with_execution_state(ctx.new_execution_state().with_params(mode=mode))
         ) as child_ctx:

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -963,9 +963,12 @@ class LocallyExecutable(Protocol):
     def local_execute(self, ctx: FlyteContext, **kwargs) -> Union[Tuple[Promise], Promise, VoidPromise, None]:
         ...
 
+    def local_excution_model(self) -> ExecutionState.Mode:
+        ...
+
 
 def flyte_entity_call_handler(
-    entity: SupportsNodeCreation, mode: Optional(ExecutionState.Mode) = None, *args, **kwargs
+    entity: SupportsNodeCreation, *args, **kwargs
 ) -> Union[Tuple[Promise], Promise, VoidPromise, Tuple, None]:
     """
     This function is the call handler for tasks, workflows, and launch plans (which redirects to the underlying
@@ -996,15 +999,15 @@ def flyte_entity_call_handler(
             )
 
     ctx = FlyteContextManager.current_context()
-    if (
-        ctx.execution_state
-        and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION
+    if ctx.execution_state and (
+        ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION
         or ctx.execution_state.mode == ExecutionState.Mode.LOCAL_TASK_EXECUTION
     ):
         logger.error("You are not supposed to nest @Task/@Workflow inside a @Task!")
     if ctx.compilation_state is not None and ctx.compilation_state.mode == 1:
         return create_and_link_node(ctx, entity=entity, **kwargs)
     elif ctx.execution_state is not None and ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION:
+        mode = cast(LocallyExecutable, entity).local_excution_model()
         with FlyteContextManager.with_context(
             ctx.with_execution_state(ctx.new_execution_state().with_params(mode=mode))
         ) as child_ctx:

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1011,7 +1011,7 @@ def flyte_entity_call_handler(
         with FlyteContextManager.with_context(
             ctx.with_execution_state(ctx.new_execution_state().with_params(mode=mode))
         ) as child_ctx:
-            if ctx.execution_state.branch_eval_mode == BranchEvalMode.BRANCH_SKIPPED:
+            if child_ctx.execution_state.branch_eval_mode == BranchEvalMode.BRANCH_SKIPPED:
                 if (
                     len(cast(SupportsNodeCreation, entity).python_interface.inputs) > 0
                     or len(cast(SupportsNodeCreation, entity).python_interface.outputs) > 0

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -963,7 +963,7 @@ class LocallyExecutable(Protocol):
     def local_execute(self, ctx: FlyteContext, **kwargs) -> Union[Tuple[Promise], Promise, VoidPromise, None]:
         ...
 
-    def local_excution_model(self) -> ExecutionState.Mode:
+    def local_execution_model(self) -> ExecutionState.Mode:
         ...
 
 
@@ -1007,7 +1007,7 @@ def flyte_entity_call_handler(
     if ctx.compilation_state is not None and ctx.compilation_state.mode == 1:
         return create_and_link_node(ctx, entity=entity, **kwargs)
     elif ctx.execution_state is not None and ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION:
-        mode = cast(LocallyExecutable, entity).local_excution_model()
+        mode = cast(LocallyExecutable, entity).local_execution_model()
         with FlyteContextManager.with_context(
             ctx.with_execution_state(ctx.new_execution_state().with_params(mode=mode))
         ) as child_ctx:

--- a/flytekit/core/reference_entity.py
+++ b/flytekit/core/reference_entity.py
@@ -10,6 +10,7 @@ from flytekit.core.promise import (
     create_and_link_node,
     create_task_output,
     extract_obj_name,
+    flyte_entity_call_handler,
     translate_inputs_to_literals,
 )
 from flytekit.core.type_engine import TypeEngine
@@ -182,40 +183,14 @@ class ReferenceEntity(object):
         vals = [Promise(var, outputs_literals[var]) for var in output_names]
         return create_task_output(vals, self.python_interface)
 
+    def local_execution_mode(self):
+        return ExecutionState.Mode.LOCAL_TASK_EXECUTION
+
     def construct_node_metadata(self) -> _workflow_model.NodeMetadata:
         return _workflow_model.NodeMetadata(name=extract_obj_name(self.name))
 
-    def compile(self, ctx: FlyteContext, *args, **kwargs):
-        return create_and_link_node(ctx, entity=self, **kwargs)
-
     def __call__(self, *args, **kwargs):
-        # When a Task is () aka __called__, there are three things we may do:
-        #  a. Plain execution Mode - just run the execute function. If not overridden, we should raise an exception
-        #  b. Compilation Mode - this happens when the function is called as part of a workflow (potentially
-        #     dynamic task). Produce promise objects and create a node.
-        #  c. Workflow Execution Mode - when a workflow is being run locally. Even though workflows are functions
-        #     and everything should be able to be passed through naturally, we'll want to wrap output values of the
-        #     function into objects, so that potential .with_cpu or other ancillary functions can be attached to do
-        #     nothing. Subsequent tasks will have to know how to unwrap these. If by chance a non-Flyte task uses a
-        #     task output as an input, things probably will fail pretty obviously.
-        #     Since this is a reference entity, it still needs to be mocked otherwise an exception will be raised.
-        if len(args) > 0:
-            raise _user_exceptions.FlyteAssertion(
-                f"Cannot call reference entity with args - detected {len(args)} positional args {args}"
-            )
-
-        ctx = FlyteContext.current_context()
-        if ctx.compilation_state is not None and ctx.compilation_state.mode == 1:
-            return self.compile(ctx, *args, **kwargs)
-        elif (
-            ctx.execution_state is not None and ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION
-        ):
-            if ctx.execution_state.branch_eval_mode == BranchEvalMode.BRANCH_SKIPPED:
-                return
-            return self.local_execute(ctx, **kwargs)
-        else:
-            logger.debug("Reference entity - running raw execute")
-            return self.execute(**kwargs)
+        return flyte_entity_call_handler(self, *args, **kwargs)  # type: ignore
 
 
 # ReferenceEntity is not a registerable entity and therefore the below classes do not need to inherit from

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -271,9 +271,7 @@ class WorkflowBase(object):
         input_kwargs.update(kwargs)
         self.compile()
         try:
-            return flyte_entity_call_handler(
-                self, mode=ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION, *args, **input_kwargs
-            )
+            return flyte_entity_call_handler(self, *args, **input_kwargs)
         except Exception as exc:
             exc.args = (f"Encountered error while executing workflow '{self.name}':\n  {exc}", *exc.args[1:])
             raise exc
@@ -341,6 +339,10 @@ class WorkflowBase(object):
         new_promises = [Promise(var, wf_outputs_as_literal_dict[var]) for var in expected_output_names]
 
         return create_task_output(new_promises, self.python_interface)
+
+    def local_excution_model(self) -> ExecutionState.Mode:
+        """ """
+        return ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION
 
 
 class ImperativeWorkflow(WorkflowBase):

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -340,7 +340,7 @@ class WorkflowBase(object):
 
         return create_task_output(new_promises, self.python_interface)
 
-    def local_excution_model(self) -> ExecutionState.Mode:
+    def local_execution_model(self) -> ExecutionState.Mode:
         """ """
         return ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION
 

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -10,7 +10,13 @@ from flytekit.core import constants as _common_constants
 from flytekit.core.base_task import PythonTask
 from flytekit.core.class_based_resolver import ClassStorageTaskResolver
 from flytekit.core.condition import ConditionalSection
-from flytekit.core.context_manager import CompilationState, FlyteContext, FlyteContextManager, FlyteEntities
+from flytekit.core.context_manager import (
+    CompilationState,
+    ExecutionState,
+    FlyteContext,
+    FlyteContextManager,
+    FlyteEntities,
+)
 from flytekit.core.docstring import Docstring
 from flytekit.core.interface import (
     Interface,
@@ -265,7 +271,9 @@ class WorkflowBase(object):
         input_kwargs.update(kwargs)
         self.compile()
         try:
-            return flyte_entity_call_handler(self, *args, **input_kwargs)
+            return flyte_entity_call_handler(
+                self, mode=ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION, *args, **input_kwargs
+            )
         except Exception as exc:
             exc.args = (f"Encountered error while executing workflow '{self.name}':\n  {exc}", *exc.args[1:])
             raise exc

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -340,7 +340,7 @@ class WorkflowBase(object):
 
         return create_task_output(new_promises, self.python_interface)
 
-    def local_execution_model(self) -> ExecutionState.Mode:
+    def local_execution_mode(self) -> ExecutionState.Mode:
         """ """
         return ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION
 

--- a/flytekit/remote/remote_callable.py
+++ b/flytekit/remote/remote_callable.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional, Tuple, Type, Union
 
 from flytekit.core.context_manager import BranchEvalMode, ExecutionState, FlyteContext
-from flytekit.core.promise import Promise, VoidPromise, create_and_link_node_from_remote, extract_obj_name
+from flytekit.core.promise import flyte_entity_call_handler, Promise, VoidPromise, extract_obj_name
 from flytekit.exceptions import user as user_exceptions
 from flytekit.loggers import remote_logger as logger
 from flytekit.models.core.workflow import NodeMetadata
@@ -30,40 +30,14 @@ class RemoteEntity(ABC):
             name=extract_obj_name(self.name),
         )
 
-    def compile(self, ctx: FlyteContext, *args, **kwargs):
-        return create_and_link_node_from_remote(ctx, entity=self, **kwargs)  # noqa
-
     def __call__(self, *args, **kwargs):
-        # When a Task is () aka __called__, there are three things we may do:
-        #  a. Plain execution Mode - just run the execute function. If not overridden, we should raise an exception
-        #  b. Compilation Mode - this happens when the function is called as part of a workflow (potentially
-        #     dynamic task). Produce promise objects and create a node.
-        #  c. Workflow Execution Mode - when a workflow is being run locally. Even though workflows are functions
-        #     and everything should be able to be passed through naturally, we'll want to wrap output values of the
-        #     function into objects, so that potential .with_cpu or other ancillary functions can be attached to do
-        #     nothing. Subsequent tasks will have to know how to unwrap these. If by chance a non-Flyte task uses a
-        #     task output as an input, things probably will fail pretty obviously.
-        #     Since this is a reference entity, it still needs to be mocked otherwise an exception will be raised.
-        if len(args) > 0:
-            raise user_exceptions.FlyteAssertion(
-                f"Cannot call remotely fetched entity with args - detected {len(args)} positional args {args}"
-            )
-
-        ctx = FlyteContext.current_context()
-        if ctx.compilation_state is not None and ctx.compilation_state.mode == 1:
-            return self.compile(ctx, *args, **kwargs)
-        elif (
-            ctx.execution_state is not None and ctx.execution_state.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION
-        ):
-            if ctx.execution_state.branch_eval_mode == BranchEvalMode.BRANCH_SKIPPED:
-                return
-            return self.local_execute(ctx, **kwargs)
-        else:
-            logger.debug("Fetched entity, running raw execute.")
-            return self.execute(**kwargs)
+        return flyte_entity_call_handler(self, *args, **kwargs)  # type: ignore
 
     def local_execute(self, ctx: FlyteContext, **kwargs) -> Optional[Union[Tuple[Promise], Promise, VoidPromise]]:
         return self.execute(**kwargs)
+
+    def local_execution_mode(self):
+        return ExecutionState.Mode.LOCAL_TASK_EXECUTION
 
     def execute(self, **kwargs) -> Any:
         raise AssertionError(f"Remotely fetched entities cannot be run locally. Please mock the {self.name}.execute.")


### PR DESCRIPTION
[BUG] Nested @task invocations should not supported #3734

# TL;DR
Address https://github.com/flyteorg/flyte/issues/3734 that nested Tasks/Workflows is not warned. In this PR, we fixed two things:

1. During local execution, pass proper `execution_state.mode` to `flyte_entity_call_handler`, so the underlying entity handler can create the correct FlyteContext (not always LOCAL_WORKFLOW_EXECUTION).
2. If `flyte_entity_call_handler` is invoked inside LOCAL_TASK_EXECUTION or TASK_EXECUTION, warn the users of nested tasks/workflows.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
