### PR TITLE
use getattr to access task_def.disable_deck in entrypoint

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -160,7 +160,7 @@ def _dispatch_execute(
     ctx.file_access.put_data(ctx.execution_state.engine_dir, output_prefix, is_multipart=True)
     logger.info(f"Engine folder written successfully to the output prefix {output_prefix}")
 
-    if getattr(task_def, "disable_deck", False):
+    if not getattr(task_def, "disable_deck", True):
         _output_deck(task_def.name.split(".")[-1], ctx.user_space_params)
 
     logger.debug("Finished _dispatch_execute")

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -160,7 +160,7 @@ def _dispatch_execute(
     ctx.file_access.put_data(ctx.execution_state.engine_dir, output_prefix, is_multipart=True)
     logger.info(f"Engine folder written successfully to the output prefix {output_prefix}")
 
-    if not task_def.disable_deck:
+    if getattr(task_def, "disable_deck", False):
         _output_deck(task_def.name.split(".")[-1], ctx.user_space_params)
 
     logger.debug("Finished _dispatch_execute")


### PR DESCRIPTION
Fixes https://github.com/flyteorg/flyte/issues/3841

# TL;DR

https://github.com/flyteorg/flytekit/pull/1693 introduced a bug in task templates like `SQlite3Task`. This PR fixes an issue in the execution entrypoint that assumes the all task objects have the `disable_deck` attribute.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

Use the `getattr` function to get `disable_deck`, and return `False` if not present.

## Tracking Issue
[https://github.com/flyteorg/flyte/issues/<number>](https://github.com/flyteorg/flyte/issues/3841)
