### PR TITLE
Improve error handling in ShellTask

### DIFF
--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -114,11 +114,13 @@ def _run_script(script) -> typing.Tuple[int, str, str]:
     process = subprocess.Popen(script, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0, shell=True, text=True)
 
     # print stdout so that long-running subprocess will not appear unresponsive
+    out = ""
     for line in process.stdout:
         print(line)
+        out += line
 
     code = process.wait()
-    return code, process.stdout.read(), process.stderr.read()
+    return code, out, process.stderr.read()
 
 
 class ShellTask(PythonInstanceTask[T]):

--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -246,7 +246,7 @@ class ShellTask(PythonInstanceTask[T]):
             fstr = "\n-".join(files)
             error = (
                 f"Failed to Execute Script, return-code {returncode} \n"
-                f"Current directory contents: .\n-{fstr}"
+                f"Current directory contents: .\n-{fstr}\n"
                 f"StdOut: {stdout}\n"
                 f"StdErr: {stderr}\n"
             )

--- a/tests/flytekit/unit/extras/tasks/test_shell.py
+++ b/tests/flytekit/unit/extras/tasks/test_shell.py
@@ -3,13 +3,13 @@ import os
 import tempfile
 import typing
 from dataclasses import dataclass
-from subprocess import CalledProcessError
 
 import pytest
 from dataclasses_json import dataclass_json
 
 import flytekit
 from flytekit import kwtypes
+from flytekit.exceptions.user import FlyteRecoverableException
 from flytekit.extras.tasks.shell import OutputLocation, RawShellTask, ShellTask, get_raw_shell_task
 from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import CSVFile, FlyteFile
@@ -64,7 +64,7 @@ def test_input_substitution_primitive():
 
     t(f=os.path.join(test_file_path, "__init__.py"), y=5, j=datetime.datetime(2021, 11, 10, 12, 15, 0))
     t(f=os.path.join(test_file_path, "test_shell.py"), y=5, j=datetime.datetime(2021, 11, 10, 12, 15, 0))
-    with pytest.raises(CalledProcessError):
+    with pytest.raises(FlyteRecoverableException):
         t(f="non_exist.py", y=5, j=datetime.datetime(2021, 11, 10, 12, 15, 0))
 
 


### PR DESCRIPTION
# TL;DR
Improve the error returned by `ShellTask`. As of now, `ShellTask` error message is not helpful since it doesn't capture the `stderr` from the subprocess. Additionally, the error thrown by `ShellTask` is currently classified as system error instead of user error.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 
## Complete description

- Raise `FlyteRecoverableError` from `ShellTask` so that it's classified as user's error and the retry policy specified in the task is respected. 
- Improve the error message captured by `ShellTask`. As of now the error message generated by `ShellTask` in flyteconsole looks as follows. Notice that it doesn't contain any details of the failed command. 

```
[3/3] currentAttempt done. Last Error: SYSTEM::Traceback (most recent call last):

      File "/usr/local/lib/python3.8/site-packages/flytekit/exceptions/scopes.py", line 165, in system_entry_point
        return wrapped(*args, **kwargs)
      File "/usr/local/lib/python3.8/site-packages/flytekit/core/base_task.py", line 527, in dispatch_execute
        raise e
      File "/usr/local/lib/python3.8/site-packages/flytekit/core/base_task.py", line 524, in dispatch_execute
        native_outputs = self.execute(**native_inputs)
      File "/usr/local/lib/python3.8/site-packages/flytekit/extras/tasks/shell.py", line 220, in execute
        subprocess.check_call(gen_script, shell=True)
      File "/usr/local/lib/python3.8/subprocess.py", line 364, in check_call
        raise CalledProcessError(retcode, cmd)

Message:

    Command '
        export RUN_DATE=2023-07-04 &&
        make run
    ' returned non-zero exit status 2.

SYSTEM ERROR! Contact platform administrators.
```

With this change, users would be able to see `stdout` and `stderr` of the subprocess as part of the error message. 

## Tracking Issue
[https://github.com/flyteorg/flyte/issues/3559](https://github.com/flyteorg/flyte/issues/3559)

## Follow-up issue
N.A.