### PR TITLE
Update the comments so that use ImageConfig.auto can support all the use case.

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -227,11 +227,13 @@ class Image(object):
 @dataclass(init=True, repr=True, eq=True, frozen=True)
 class ImageConfig(object):
     """
+    We recommend you to use ImageConfig.auto(img_name=None) to create an ImageConfig.
+    For example, ImageConfig.auto(img_name=""ghcr.io/flyteorg/flytecookbook:v1.0.0"") will create an ImageConfig.
+
     ImageConfig holds available images which can be used at registration time. A default image can be specified
     along with optional additional images. Each image in the config must have a unique name.
 
     Attributes:
-        default_image (str): The default image to be used as a container for task serialization.
         images (List[Image]): Optional, additional images which can be used in task container definitions.
     """
 


### PR DESCRIPTION


# TL;DR
Update the comments so that use ImageConfig.auto can support all the use case.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
I am using the flyte documentation, and I found that flytesnacks doesn't teach how to specify ImageConfig.
After tracing the code in ImageConfig, I found that the old use case (default str) is not a good option.
And I am going to update the flytesnacks !
