### PR TITLE
Fix: Improve error handling in elastic tasks

### DIFF
--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -349,6 +349,7 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
             logger.warning(msg)
 
         from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
+
         try:
             out = elastic_launch(
                 config=config,

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -340,10 +340,22 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
         else:
             raise Exception("Bad start method")
 
-        out = elastic_launch(
-            config=config,
-            entrypoint=launcher_target_func,
-        )(*launcher_args)
+        if self.metadata.retries > 0 and self.task_config.max_restarts == 0:
+            msg = (
+                "Flyte considers exceptions in worker processes of torch elastic tasks as non-recoverable as "
+                "Flyte does not have access to the type of the original exception raised in the child process. Use "
+                "`@task(task_config=Elastic(..., max_restarts=<n>))` to configure retries on the torch elastic launch level."
+            )
+            logger.warning(msg)
+
+        from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
+        try:
+            out = elastic_launch(
+                config=config,
+                entrypoint=launcher_target_func,
+            )(*launcher_args)
+        except ChildFailedError as e:
+            raise RuntimeError(e.format_msg())
 
         # `out` is a dictionary of rank (not local rank) -> result
         # Rank 0 returns the result of the task function


### PR DESCRIPTION
# TL;DR

* This PR fixes a small bug that made it more difficult to find the original exception in the stack trace that made an elastic task worker process crash.
* The PR also adds a warning that users should to use the retry mechanism of torch elastic launch instead of the retry mechanism of flyte when it comes to exceptions raised within the worker processes.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description


Let's consider this minimal task:

```python
@task(
    task_config=Elastic(
        nnodes=1,
        nproc_per_node=1,
    ),
)
def train():
    raise FooException("foo")
```

This currently results in this stack trace:

```console
FlyteScopedUserException:
…
      raise FooException("foo")
  FooException: foo

============================================================

During handling of the above exception, another exception occurred:



…
 729  return exception_scopes.user_entry_point(self._workflow_function)(**kwargs) 

 /home/fabiogratz/miniconda3/envs/flyte-dev/lib/python3.10/site-packages/flytekit/exceptions/scopes.py:202 in user_entry_point     

 202  raise exc.type(f"Error encountered while executing '{fn_name}':\n  {exc.                               

TypeError: Encountered error while executing workflow 'wf':
  ChildFailedError.__init__() missing 1 required positional argument: 'failures'
```

The original `FooException` is not the last exception the user sees!

Reason:

* The worker process crashes with `FooException`
* [`elastic_launch` in the elastic task](https://github.com/flyteorg/flytekit/blob/480c41e9c7c66598ff3d7c8b4e7becf610ded241/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py#L343) raises `ChildFailedError`
* Since all this is executed within `exception_scopes.user_entry_point(self._execute)(**kwargs)` [here](https://github.com/flyteorg/flytekit/blob/480c41e9c7c66598ff3d7c8b4e7becf610ded241/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py#L363C16-L363C74), we re-raise the `ChildFailedError` using `raise exc.type(f"Error encountered while executing '{fn_name}':\n  {exc.value}") from exc` [here](https://github.com/flyteorg/flytekit/blob/480c41e9c7c66598ff3d7c8b4e7becf610ded241/flytekit/exceptions/scopes.py#L201C17-L201C106).
* However, `ChildFailedError` [needs an additional argument called `failures`](https://github.com/pytorch/pytorch/blob/979f826015cbd2b353f02e93865a9b9a8877b414/torch/distributed/elastic/multiprocessing/errors/__init__.py#L223) so `exc.type("some message")` fails.

In this PR, I therefore catch the `ChildFailedError` and re-raise a `RuntimeError` with the message of the original `ChildFailedError`.

---

Unfortunately torch elastic launch gives us access to the exception in the child process only as a message in string format. We don't know the type of the original exception in the child process (or would have to try to parse this from the string). This means we don't know whether the exception in the child process is recoverable. Therefore I add a warning to the user that they should use the `Elastic(..., max_retries)` argument to control retries for elastic tasks. (This means that not the pod is restarted but the worker processes within the elastic task while the main agent process doesn't crash.)

## Tracking Issue
_NA_

## Follow-up issue
_NA_
