### PR TITLE
Detect if min_success_ratio is set and adjust interface of map_task accordingly

### DIFF
--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -249,10 +249,12 @@ def transform_interface_to_typed_interface(
     return _interface_models.TypedInterface(inputs_map, outputs_map)
 
 
-def transform_types_to_list_of_type(m: Dict[str, type], bound_inputs: typing.Set[str]) -> Dict[str, type]:
+def transform_types_to_list_of_type(
+    m: Dict[str, type], bound_inputs: typing.Set[str], list_as_optional: bool = False
+) -> Dict[str, type]:
     """
-    Converts a given variables to be collections of their type. This is useful for array jobs / map style code.
-    It will create a collection of types even if any one these types is not a collection type
+    Converts unbound inputs into the equivalent (optional) collections. This is useful for array jobs / map style code.
+    It will create a collection of types even if any one these types is not a collection type.
     """
     if m is None:
         return {}
@@ -276,11 +278,13 @@ def transform_types_to_list_of_type(m: Dict[str, type], bound_inputs: typing.Set
         if k in bound_inputs:
             om[k] = v
         else:
-            om[k] = typing.List[v]  # type: ignore
+            om[k] = typing.List[typing.Optional[v] if list_as_optional else v]  # type: ignore
     return om  # type: ignore
 
 
-def transform_interface_to_list_interface(interface: Interface, bound_inputs: typing.Set[str]) -> Interface:
+def transform_interface_to_list_interface(
+    interface: Interface, bound_inputs: typing.Set[str], optional_outputs: bool = False
+) -> Interface:
     """
     Takes a single task interface and interpolates it to an array interface - to allow performing distributed python map
     like functions
@@ -288,7 +292,7 @@ def transform_interface_to_list_interface(interface: Interface, bound_inputs: ty
     :param bound_inputs: fixed inputs that should not upgraded to a list and will be maintained as scalars.
     """
     map_inputs = transform_types_to_list_of_type(interface.inputs, bound_inputs)
-    map_outputs = transform_types_to_list_of_type(interface.outputs, set())
+    map_outputs = transform_types_to_list_of_type(interface.outputs, set(), optional_outputs)
 
     return Interface(inputs=map_inputs, outputs=map_outputs)
 

--- a/flytekit/core/map_task.py
+++ b/flytekit/core/map_task.py
@@ -18,7 +18,6 @@ from flytekit.core.context_manager import ExecutionState, FlyteContext, FlyteCon
 from flytekit.core.interface import transform_interface_to_list_interface
 from flytekit.core.python_function_task import PythonFunctionTask, PythonInstanceTask
 from flytekit.core.tracker import TrackedInstance
-from flytekit.core.type_engine import UnionTransformer
 from flytekit.core.utils import timeit
 from flytekit.exceptions import scopes as exception_scopes
 from flytekit.models.array_job import ArrayJob
@@ -71,21 +70,20 @@ class MapPythonTask(PythonTask):
             else:
                 raise ValueError("Map tasks can only compose of PythonFuncton and PythonInstanceTasks currently")
 
-        if len(actual_task.python_interface.outputs.keys()) > 1:
+        n_outputs = len(actual_task.python_interface.outputs.keys())
+        if n_outputs > 1:
             raise ValueError("Map tasks only accept python function tasks with 0 or 1 outputs")
-
-        if (
-            min_success_ratio
-            and min_success_ratio != 1
-            and not UnionTransformer.is_optional_type(actual_task.python_interface.outputs["o0"])
-        ):
-            raise ValueError("Map tasks with min_success_ratio < 1 must have an optional output")
 
         self._bound_inputs: typing.Set[str] = set(bound_inputs) if bound_inputs else set()
         if self._partial:
             self._bound_inputs = set(self._partial.keywords.keys())
 
-        collection_interface = transform_interface_to_list_interface(actual_task.python_interface, self._bound_inputs)
+        # Transform the interface to List[Optional[T]] in case `min_success_ratio` is set
+        output_as_list_of_optionals = min_success_ratio is not None and min_success_ratio != 1 and n_outputs == 1
+        collection_interface = transform_interface_to_list_interface(
+            actual_task.python_interface, self._bound_inputs, output_as_list_of_optionals
+        )
+
         self._run_task: typing.Union[PythonFunctionTask, PythonInstanceTask] = actual_task  # type: ignore
         if isinstance(actual_task, PythonInstanceTask):
             mod = actual_task.task_type

--- a/tests/flytekit/unit/core/test_map_task.py
+++ b/tests/flytekit/unit/core/test_map_task.py
@@ -264,24 +264,18 @@ def test_map_task_resolver(serialization_settings):
     assert t.python_interface.outputs == mt.python_interface.outputs
 
 
-def test_map_task_min_success_ratio():
+@pytest.mark.parametrize("min_success_ratio, type_t", [
+    (None, int),
+    (1, int),
+    (0.5, typing.Optional[int]),
+])
+def test_map_task_min_success_ratio(min_success_ratio, type_t):
     @task
     def some_task1(inputs: int) -> int:
         return inputs
 
     @workflow
-    def my_wf1() -> typing.List[int]:
-        return map_task(some_task1, min_success_ratio=0.5)(inputs=[1, 2, 3, 4])
+    def my_wf1() -> typing.List[type_t]:
+        return map_task(some_task1, min_success_ratio=min_success_ratio)(inputs=[1, 2, 3, 4])
 
-    with pytest.raises(ValueError, match="Map tasks with min_success_ratio < 1 must have an optional output"):
-        my_wf1()
-
-    @task
-    def some_task2(inputs: int) -> typing.Optional[int]:
-        return inputs
-
-    @workflow
-    def my_wf2() -> typing.List[typing.Optional[int]]:
-        return map_task(some_task2, min_success_ratio=0.5)(inputs=[1, 2, 3, 4])
-
-    my_wf2()
+    my_wf1()

--- a/tests/flytekit/unit/core/test_map_task.py
+++ b/tests/flytekit/unit/core/test_map_task.py
@@ -264,11 +264,14 @@ def test_map_task_resolver(serialization_settings):
     assert t.python_interface.outputs == mt.python_interface.outputs
 
 
-@pytest.mark.parametrize("min_success_ratio, type_t", [
-    (None, int),
-    (1, int),
-    (0.5, typing.Optional[int]),
-])
+@pytest.mark.parametrize(
+    "min_success_ratio, type_t",
+    [
+        (None, int),
+        (1, int),
+        (0.5, typing.Optional[int]),
+    ],
+)
 def test_map_task_min_success_ratio(min_success_ratio, type_t):
     @task
     def some_task1(inputs: int) -> int:


### PR DESCRIPTION
# TL;DR
Modify the interface of a map_task where min_success_ratio is set

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Modify the interface of a map_task where min_success_ratio is set, instead of erroring during registration. 

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3794

## Follow-up issue
_NA_
