### PR TITLE
don't make network calls in unit tests

### DIFF
--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -315,7 +315,8 @@ def test_setup_disk_prefix():
         assert ctx.file_access._default_remote.protocol == "file"
 
 
-def test_setup_cloud_prefix():
+@mock.patch("google.auth.compute_engine._metadata")
+def test_setup_cloud_prefix(mock_gcs):
     with setup_execution("s3://", checkpoint_path=None, prev_checkpoint=None) as ctx:
         assert ctx.file_access._default_remote.protocol[0] == "s3"
 


### PR DESCRIPTION
# TL;DR

Don't do a network call to gcs in the unit tests

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - ~~[ ] Code documentation added~~
 - ~~[ ] Any pending items have an associated Issue~~

## Complete description

Unit tests were failing locally because it was trying to make a network call to gcs. Not sure how these were passing in CI, but added a patch to the `google.auth.compute_engine._metadata` module so network calls aren't make.

## Tracking Issue
NA

## Follow-up issue
_NA_
