### PR TITLE
use default settings for timeline deck width

### DIFF
--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -282,7 +282,7 @@ class ExecutionParameters(object):
                 time_line_deck = deck
                 break
         if time_line_deck is None:
-            time_line_deck = TimeLineDeck("Timeline")
+            time_line_deck = TimeLineDeck("timeline")
 
         return time_line_deck
 

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -114,12 +114,10 @@ class TimeLineDeck(Deck):
         df["ProcessTime"] = df["ProcessTime"].apply(lambda time: "{:.6f}".format(time))
         df["WallTime"] = df["WallTime"].apply(lambda time: "{:.6f}".format(time))
 
-        width = 1400
-        gantt_chart_html = GanttChartRenderer().to_html(df, chart_width=width)
+        gantt_chart_html = GanttChartRenderer().to_html(df)
         time_table_html = TableRenderer().to_html(
             df[["Name", "WallTime", "ProcessTime"]],
             header_labels=["Name", "Wall Time(s)", "Process Time(s)"],
-            table_width=width,
         )
         return gantt_chart_html + time_table_html + note
 

--- a/tests/flytekit/unit/deck/test_deck.py
+++ b/tests/flytekit/unit/deck/test_deck.py
@@ -37,7 +37,7 @@ def test_timeline_deck():
     ctx.user_space_params._decks = []
     timeline_deck = ctx.user_space_params.timeline_deck
     timeline_deck.append_time_info(time_info)
-    assert timeline_deck.name == "Timeline"
+    assert timeline_deck.name == "timeline"
     assert len(timeline_deck.time_info) == 1
     assert timeline_deck.time_info[0] == time_info
     assert len(ctx.user_space_params.decks) == 1


### PR DESCRIPTION
# TL;DR
Use default width settings for timeline deck

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Before this change, the timeline deck will occupy 1400px of width on any of the mediums it's rendered in. For example, if we turn on execution on some of the flytesnacks docs pages, we get:

![image](https://github.com/flyteorg/flytekit/assets/2816689/c2c6c1ef-c2ec-4698-b1c6-44bb88d8ec63)

This PR will just use the default plotly settings, which will occupy the maximum width inside whatever container the plotly graphs are contained in.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
