### PR TITLE
add rdzv_configs to kfpytorch elastic

### DIFF
--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -123,6 +123,7 @@ class Elastic(object):
         start_method (str): Multiprocessing start method to use when creating workers.
         monitor_interval (int): Interval, in seconds, to monitor the state of workers.
         max_restarts (int): Maximum number of worker group restarts before failing.
+        rdzv_configs (Dict[str, Any]): Additional rendezvous configs to pass to torch elastic.
     """
 
     nnodes: Union[int, str] = 1
@@ -130,6 +131,7 @@ class Elastic(object):
     start_method: str = "spawn"
     monitor_interval: int = 5
     max_restarts: int = 0
+    rdzv_configs: Dict[str, Any] = field(default_factory=dict)
 
 
 class PyTorchFunctionTask(PythonFunctionTask[PyTorch]):
@@ -295,6 +297,7 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
             max_nodes=self.max_nodes,
             nproc_per_node=self.task_config.nproc_per_node,
             rdzv_backend=self.rdzv_backend,  # rdzv settings
+            rdzv_configs=self.task_config.rdzv_configs,  # additional rdzv configs
             rdzv_endpoint=os.environ.get("PET_RDZV_ENDPOINT", "localhost:0"),
             max_restarts=self.task_config.max_restarts,
             monitor_interval=self.task_config.monitor_interval,

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -123,7 +123,8 @@ class Elastic(object):
         start_method (str): Multiprocessing start method to use when creating workers.
         monitor_interval (int): Interval, in seconds, to monitor the state of workers.
         max_restarts (int): Maximum number of worker group restarts before failing.
-        rdzv_configs (Dict[str, Any]): Additional rendezvous configs to pass to torch elastic.
+        rdzv_configs (Dict[str, Any]): Additional rendezvous configs to pass to torch elastic, e.g. `{"timeout": 1200, "join_timeout": 900}`.
+            See `torch.distributed.launcher.api.LaunchConfig` and `torch.distributed.elastic.rendezvous.dynamic_rendezvous.create_handler`.
     """
 
     nnodes: Union[int, str] = 1
@@ -297,7 +298,7 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
             max_nodes=self.max_nodes,
             nproc_per_node=self.task_config.nproc_per_node,
             rdzv_backend=self.rdzv_backend,  # rdzv settings
-            rdzv_configs=self.task_config.rdzv_configs,  # additional rdzv configs
+            rdzv_configs=self.task_config.rdzv_configs,
             rdzv_endpoint=os.environ.get("PET_RDZV_ENDPOINT", "localhost:0"),
             max_restarts=self.task_config.max_restarts,
             monitor_interval=self.task_config.monitor_interval,

--- a/plugins/flytekit-kf-pytorch/tests/test_elastic_task.py
+++ b/plugins/flytekit-kf-pytorch/tests/test_elastic_task.py
@@ -1,6 +1,7 @@
 import os
 import typing
 from dataclasses import dataclass
+from unittest import mock
 
 import pytest
 import torch
@@ -95,3 +96,19 @@ def test_execution_params(
         return n + 1
 
     test_task(n=1)
+
+
+@pytest.mark.parametrize("start_method", ["spawn", "fork"])
+def test_rdzv_configs(start_method: str) -> None:
+    """Test that rendezvous configs are passed to torch distributed."""
+    from torch.distributed.launcher.api import LaunchConfig
+
+    rdzv_configs = {"join_timeout": 10}
+
+    @task(task_config=Elastic(nnodes=1, nproc_per_node=2, start_method=start_method, rdzv_configs=rdzv_configs))
+    def test_task():
+        pass
+
+    with mock.patch("torch.distributed.launcher.api.LaunchConfig", side_effect=LaunchConfig) as mock_launch_config:
+        test_task()
+        assert mock_launch_config.call_args[1]["rdzv_configs"] == rdzv_configs


### PR DESCRIPTION
# TL;DR
Adds `rdzv_configs` to `flytekitplugins.kfpytorch.Elastic` for[ additional rdzv configs](https://github.com/pytorch/pytorch/blob/main/torch/distributed/launcher/api.py#L45C18-L45C18).

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

