### PR TITLE
Skip problematic pyyaml versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,7 @@ setup(
         "python-json-logger>=2.0.0",
         "pytimeparse>=1.1.8,<2.0.0",
         "pytz",
-        "pyyaml>=6.0.0; python_version>='3.10'",
-        "pyyaml<6.0.0; python_version<'3.10'",
+        "pyyaml!=6.0.0,!=5.4.0,!=5.4.1", # pyyaml is broken with cython 3: https://github.com/yaml/pyyaml/issues/601
         "keyring>=18.0.1",
         "requests>=2.18.4,<3.0.0",
         "responses>=0.10.7",


### PR DESCRIPTION
# TL;DR
cython 3.0 broke a bunch of projects, including pyyaml (which is a hard dependency of flytekit)

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
was overly cautious and only really worked for the combination of architecture+python versions we are running in CI. The root cause is detailed https://github.com/yaml/pyyaml/issues/601 and it revolves around a mishap involving Cython+pyyaml. This PR proposes a more sane fix.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
