### PR TITLE
Fail CI tests faster

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -38,8 +38,7 @@ jobs:
           key: ${{ format('{0}-pip-{1}', runner.os, hashFiles('dev-requirements.in', 'requirements.in')) }}
       - name: Install dependencies
         run: |
-          make setup
-          pip freeze
+          make setup && pip freeze
       - name: Test with coverage
         run: |
           make unit_test_codecov
@@ -49,6 +48,7 @@ jobs:
           fail_ci_if_error: false
 
   build-plugins:
+    needs: build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ htmlcov
 *dat
 docs/source/_tags/
 .hypothesis
+.npm


### PR DESCRIPTION
# TL;DR
Optimize for quicker feedback in CI by runnning flytekit tests first and then the plugins

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
This PR also forces dependencies to be installed successfully before running tests. We've had multiple instances where dependencies failed to install but tests still ran (and invariably failed due to the missing dependencies).

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
