### PR TITLE
Add is none function

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -249,7 +249,7 @@ flask==2.3.2
     # via mlflow
 flatbuffers==23.5.26
     # via tensorflow
-flyteidl==1.5.14
+flyteidl==1.5.16
     # via flytekit
 fonttools==4.41.1
     # via matplotlib

--- a/flytekit/core/condition.py
+++ b/flytekit/core/condition.py
@@ -391,6 +391,8 @@ def transform_to_conj_expr(
 def transform_to_operand(v: Union[Promise, Literal]) -> Tuple[_core_cond.Operand, Optional[Promise]]:
     if isinstance(v, Promise):
         return _core_cond.Operand(var=create_branch_node_promise_var(v.ref.node_id, v.var)), v
+    if v.scalar.none_type:
+        return _core_cond.Operand(scalar=v.scalar), None
     return _core_cond.Operand(primitive=v.scalar.primitive), None
 
 

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -372,7 +372,7 @@ class Promise(object):
         return self.is_(True)
 
     def is_none(self) -> ComparisonExpression:
-        return self.is_(None)
+        return ComparisonExpression(self, ComparisonOps.EQ, None)
 
     def __eq__(self, other) -> ComparisonExpression:  # type: ignore
         return ComparisonExpression(self, ComparisonOps.EQ, other)

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -862,7 +862,7 @@ class TypeEngine(typing.Generic[T]):
                 "actual attribute that you want to use. For example, in NamedTuple('OP', x=int) then"
                 "return v.x, instead of v, even if this has a single element"
             )
-        if python_val is None and expected.union_type is None:
+        if python_val is None and expected and expected.union_type is None:
             raise TypeTransformerFailedError(f"Python value cannot be None, expected {python_type}/{expected}")
         transformer = cls.get_transformer(python_type)
         if transformer.type_assertions_enabled:

--- a/flytekit/models/core/condition.py
+++ b/flytekit/models/core/condition.py
@@ -137,8 +137,9 @@ class Operand(_common.FlyteIdlEntity):
     def __init__(self, primitive=None, var=None, scalar=None):
         """
         Defines an operand to a comparison expression.
-        :param flytekit.models.literals.Primitive primitive:
-        :param Text var:
+        :param flytekit.models.literals.Primitive primitive: A primitive value
+        :param Text var: A variable name
+        :param flytekit.models.literals.Scalar scalar: A scalar value
         """
 
         self._primitive = primitive

--- a/flytekit/models/core/condition.py
+++ b/flytekit/models/core/condition.py
@@ -186,7 +186,7 @@ class Operand(_common.FlyteIdlEntity):
             if pb2_object.HasField("primitive")
             else None,
             var=pb2_object.var if pb2_object.HasField("var") else None,
-            scalar=pb2_object.scalar if pb2_object.HasField("scalar") else None,
+            scalar=_literals.Scalar.from_flyte_idl(pb2_object.scalar) if pb2_object.HasField("scalar") else None,
         )
 
 

--- a/flytekit/models/core/condition.py
+++ b/flytekit/models/core/condition.py
@@ -134,7 +134,7 @@ class ConjunctionExpression(_common.FlyteIdlEntity):
 
 
 class Operand(_common.FlyteIdlEntity):
-    def __init__(self, primitive=None, var=None):
+    def __init__(self, primitive=None, var=None, scalar=None):
         """
         Defines an operand to a comparison expression.
         :param flytekit.models.literals.Primitive primitive:
@@ -143,6 +143,7 @@ class Operand(_common.FlyteIdlEntity):
 
         self._primitive = primitive
         self._var = var
+        self._scalar = scalar
 
     @property
     def primitive(self):
@@ -160,6 +161,14 @@ class Operand(_common.FlyteIdlEntity):
 
         return self._var
 
+    @property
+    def scalar(self):
+        """
+        :rtype: flytekit.models.literals.Scalar
+        """
+
+        return self._scalar
+
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.core.condition_pb2.Operand
@@ -167,6 +176,7 @@ class Operand(_common.FlyteIdlEntity):
         return _condition.Operand(
             primitive=self.primitive.to_flyte_idl() if self.primitive else None,
             var=self.var if self.var else None,
+            scalar=self.scalar.to_flyte_idl() if self.scalar else None,
         )
 
     @classmethod
@@ -176,6 +186,7 @@ class Operand(_common.FlyteIdlEntity):
             if pb2_object.HasField("primitive")
             else None,
             var=pb2_object.var if pb2_object.HasField("var") else None,
+            scalar=pb2_object.scalar if pb2_object.HasField("scalar") else None,
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     },
     install_requires=[
         "googleapis-common-protos>=1.57",
-        "flyteidl>=1.5.10",
+        # "flyteidl>=1.5.10",
         "wheel>=0.30.0,<1.0.0",
         "pandas>=1.0.0,<2.0.0",
         "pyarrow>=4.0.0,<11.0.0",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     },
     install_requires=[
         "googleapis-common-protos>=1.57",
-        # "flyteidl>=1.5.10",
+        "flyteidl>=1.5.16",
         "wheel>=0.30.0,<1.0.0",
         "pandas>=1.0.0,<2.0.0",
         "pyarrow>=4.0.0,<11.0.0",

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -194,6 +194,25 @@ def test_condition_unary_bool():
     assert decompose() == 20
 
 
+def test_condition_is_none():
+    @task
+    def return_true() -> typing.Optional[None]:
+        return None
+
+    @workflow
+    def failed() -> int:
+        return 10
+
+    @workflow
+    def success() -> int:
+        return 20
+
+    @workflow
+    def decompose_unary() -> int:
+        result = return_true()
+        return conditional("test").if_(result.is_none()).then(success()).else_().then(failed())
+
+
 def test_subworkflow_condition_serialization():
     """Test that subworkflows are correctly extracted from serialized workflows with condiationals."""
 

--- a/tests/flytekit/unit/models/core/test_workflow.py
+++ b/tests/flytekit/unit/models/core/test_workflow.py
@@ -228,6 +228,73 @@ def test_branch_node():
     assert bn.if_else.case.then_node == obj
 
 
+def test_branch_node_with_none():
+    nm = _get_sample_node_metadata()
+    task = _workflow.TaskNode(reference_id=_generic_id)
+    bd = _literals.BindingData(scalar=_literals.Scalar(none_type=_literals.Void()))
+    lt = _literals.Literal(scalar=_literals.Scalar(primitive=_literals.Primitive(integer=99)))
+    bd2 = _literals.BindingData(
+        scalar=_literals.Scalar(
+            union=_literals.Union(value=lt, stored_type=_types.LiteralType(_types.SimpleType.INTEGER))
+        )
+    )
+    binding = _literals.Binding(var="myvar", binding=bd)
+    binding2 = _literals.Binding(var="myothervar", binding=bd2)
+
+    obj = _workflow.Node(
+        id="some:node:id",
+        metadata=nm,
+        inputs=[binding, binding2],
+        upstream_node_ids=[],
+        output_aliases=[],
+        task_node=task,
+    )
+
+    bn = _workflow.BranchNode(
+        _workflow.IfElseBlock(
+            case=_workflow.IfBlock(
+                condition=_condition.BooleanExpression(
+                    comparison=_condition.ComparisonExpression(
+                        _condition.ComparisonExpression.Operator.EQ,
+                        _condition.Operand(scalar=_literals.Scalar(none_type=_literals.Void())),
+                        _condition.Operand(primitive=_literals.Primitive(integer=2)),
+                    )
+                ),
+                then_node=obj,
+            ),
+            other=[
+                _workflow.IfBlock(
+                    condition=_condition.BooleanExpression(
+                        conjunction=_condition.ConjunctionExpression(
+                            _condition.ConjunctionExpression.LogicalOperator.AND,
+                            _condition.BooleanExpression(
+                                comparison=_condition.ComparisonExpression(
+                                    _condition.ComparisonExpression.Operator.EQ,
+                                    _condition.Operand(scalar=_literals.Scalar(none_type=_literals.Void())),
+                                    _condition.Operand(primitive=_literals.Primitive(integer=2)),
+                                )
+                            ),
+                            _condition.BooleanExpression(
+                                comparison=_condition.ComparisonExpression(
+                                    _condition.ComparisonExpression.Operator.EQ,
+                                    _condition.Operand(scalar=_literals.Scalar(none_type=_literals.Void())),
+                                    _condition.Operand(primitive=_literals.Primitive(integer=2)),
+                                )
+                            ),
+                        )
+                    ),
+                    then_node=obj,
+                )
+            ],
+            else_node=obj,
+        )
+    )
+
+    bn2 = _workflow.BranchNode.from_flyte_idl(bn.to_flyte_idl())
+    assert bn == bn2
+    assert bn.if_else.case.then_node == obj
+
+
 def test_task_node_overrides():
     overrides = _workflow.TaskNodeOverrides(
         Resources(


### PR DESCRIPTION
# TL;DR
Add support `is_none` in the condition

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
```python
import random
import typing
from flytekit import conditional, task, workflow


@task
def coin_toss(seed: int) -> typing.Optional[bool]:
    r = random.Random(seed)
    if r.random() < 0.5:
        return True
    return None


@task
def failed() -> int:
    return -1


@task
def success() -> int:
    return 0


@workflow
def wf(seed: int = 5) -> int:
    result = coin_toss(seed=seed)
    return conditional("test").if_(result.is_none()).then(success()).else_().then(failed())


if __name__ == '__main__':
    wf()
```

<img width="1859" alt="image" src="https://github.com/flyteorg/flytepropeller/assets/37936015/b5554157-48c5-425d-a1c9-31b96a61dc1a">


## Tracking Issue
https://github.com/flyteorg/flyte/issues/3514

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
