### PR TITLE
Fix: Disable rich logging handler when env var `FLYTE_SDK_RICH_TRACEBACKS=0` is set

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -228,7 +228,7 @@ from flytekit.core.workflow import ImperativeWorkflow as Workflow
 from flytekit.core.workflow import WorkflowFailurePolicy, reference_workflow, workflow
 from flytekit.deck import Deck
 from flytekit.image_spec import ImageSpec
-from flytekit.loggers import logger
+from flytekit.loggers import LOGGING_RICH_FMT_ENV_VAR, logger
 from flytekit.models.common import Annotations, AuthRole, Labels
 from flytekit.models.core.execution import WorkflowExecutionPhase
 from flytekit.models.core.types import BlobType
@@ -304,5 +304,5 @@ def load_implicit_plugins():
 load_implicit_plugins()
 
 # Pretty-print exception messages
-if os.environ.get("FLYTE_SDK_RICH_TRACEBACKS") != "0":
+if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0":
     traceback.install(width=None, extra_lines=0)

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -13,6 +13,7 @@ from rich.logging import RichHandler
 # loggers defined in this file.
 LOGGING_ENV_VAR = "FLYTE_SDK_LOGGING_LEVEL"
 LOGGING_FMT_ENV_VAR = "FLYTE_SDK_LOGGING_FORMAT"
+LOGGING_RICH_FMT_ENV_VAR = "FLYTE_SDK_RICH_TRACEBACKS"
 
 # By default, the root flytekit logger to debug so everything is logged, but enable fine-tuning
 logger = logging.getLogger("flytekit")
@@ -36,15 +37,18 @@ entrypoint_logger = child_loggers["entrypoint"]
 user_space_logger = child_loggers["user_space"]
 
 # create console handler
-try:
-    handler = RichHandler(
-        rich_tracebacks=True,
-        omit_repeated_times=False,
-        keywords=["[flytekit]"],
-        log_time_format="%Y-%m-%d %H:%M:%S,%f",
-        console=Console(width=os.get_terminal_size().columns),
-    )
-except OSError:
+if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0":
+    try:
+        handler = RichHandler(
+            rich_tracebacks=True,
+            omit_repeated_times=False,
+            keywords=["[flytekit]"],
+            log_time_format="%Y-%m-%d %H:%M:%S,%f",
+            console=Console(width=os.get_terminal_size().columns),
+        )
+    except OSError:
+        handler = logging.StreamHandler()
+else:
     handler = logging.StreamHandler()
 
 handler.setLevel(logging.DEBUG)


### PR DESCRIPTION
## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
In https://github.com/flyteorg/flytekit/pull/1695 I introduced an environment variable called `FLYTE_SDK_RICH_TRACEBACKS` which, when set to 0, disables rich tracebacks.

Setting this environment variable turns this

![image](https://github.com/flyteorg/flytekit/assets/36511035/1403b084-b714-4136-a06b-e08d3c9c0b32)

back into:

![image](https://github.com/flyteorg/flytekit/assets/36511035/fff25b65-e364-4c43-a233-38f9311eaf1a)


However, in this PR I overlooked that a `RichHandler` is added to the flytekit logger which also produces output in rich format. When executing this workflow

```python
from flytekit import task, workflow

@task
def train():
    raise Exception("This is a test")

@workflow
def wf():
    train()

if __name__ == "__main__":
    wf()
```

with `FLYTE_SDK_RICH_TRACEBACKS=0 python test.py`, the output still looks as follows:

<img width="1311" alt="Screenshot_2023-07-21_at_18_44_25" src="https://github.com/flyteorg/flytekit/assets/36511035/55c41dc7-47f0-4850-8cd6-1e5363a94b5a">


This PR disables this logger as well when the above mentioned environment variable is set.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
