### PR TITLE
Remove dependency on responses

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -964,7 +964,6 @@ pyyaml==6.0.1
     #   papermill
     #   pre-commit
     #   ray
-    #   responses
     #   sphinx-autoapi
     #   uvicorn
     #   vaex-core
@@ -1012,7 +1011,6 @@ requests==2.31.0
     #   papermill
     #   ray
     #   requests-oauthlib
-    #   responses
     #   sphinx
     #   sphinxcontrib-youtube
     #   tensorboard
@@ -1023,8 +1021,6 @@ requests-oauthlib==1.3.1
     # via
     #   google-auth-oauthlib
     #   kubernetes
-responses==0.23.1
-    # via flytekit
 rfc3339-validator==0.1.4
     # via
     #   jsonschema
@@ -1276,8 +1272,6 @@ typed-ast==1.5.5
     # via doltcli
 typeguard==2.13.3
     # via ydata-profiling
-types-pyyaml==6.0.12.10
-    # via responses
 types-requests==2.31.0.1
     # via whylogs
 types-urllib3==1.26.25.13
@@ -1325,7 +1319,6 @@ urllib3==1.26.16
     #   great-expectations
     #   kubernetes
     #   requests
-    #   responses
     #   whylabs-client
 uvicorn[standard]==0.23.1
     # via vaex-server

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         "pyyaml!=6.0.0,!=5.4.0,!=5.4.1",  # pyyaml is broken with cython 3: https://github.com/yaml/pyyaml/issues/601
         "keyring>=18.0.1",
         "requests>=2.18.4,<3.0.0",
-        "responses>=0.10.7",
         "sortedcontainers>=1.5.9,<3.0.0",
         "statsd>=3.0.0,<4.0.0",
         "urllib3>=1.22,<2.0.0",


### PR DESCRIPTION
# TL;DR
Remove dependency on responses

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
As reported in https://github.com/flyteorg/flyte/issues/3895, there is no need to depend on `responses` package.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3895

## Follow-up issue
Closes https://github.com/flyteorg/flyte/issues/3895