### PR TITLE
Restrict grpcio<1.53.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setup(
         "python-dateutil>=2.1",
         # Restrict grpcio and grpcio-status.  Version 1.50.0 pulls in a version of protobuf that is not compatible
         # with the old protobuf library (as described in https://developers.google.com/protocol-buffers/docs/news/2022-05-06)
-        "grpcio>=1.50.0,!=1.55.0,<2.0",
-        "grpcio-status>=1.50.0,!=1.55.0,<2.0",
+        "grpcio>=1.50.0,!=1.55.0,<1.53.1,<2.0",
+        "grpcio-status>=1.50.0,!=1.55.0,<1.53.1,<2.0",
         "importlib-metadata",
         "fsspec>=2023.3.0",
         "adlfs",


### PR DESCRIPTION
# TL;DR
Constrain grpcio to a working version while we investigate the weird "Stream removed" issue

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
