### PR TITLE
[v1.7 Patch] Gate grpc to <1.53.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setup(
         "python-dateutil>=2.1",
         # Restrict grpcio and grpcio-status.  Version 1.50.0 pulls in a version of protobuf that is not compatible
         # with the old protobuf library (as described in https://developers.google.com/protocol-buffers/docs/news/2022-05-06)
-        "grpcio>=1.50.0,!=1.55.0,<2.0",
-        "grpcio-status>=1.50.0,!=1.55.0,<2.0",
+        "grpcio>=1.50.0,!=1.55.0,<1.53.1",
+        "grpcio-status>=1.50.0,!=1.55.0,<1.53.1",
         "importlib-metadata",
         "fsspec>=2023.3.0",
         "adlfs",


### PR DESCRIPTION
We are still investigating issues with grpcio/grpcio-status library versions 1.53.1 and later.  In some environments it has consistently been producing "Stream removed" errors.