### PR TITLE
Change ref to _Fref in Promise object

### DIFF
--- a/flytekit/core/condition.py
+++ b/flytekit/core/condition.py
@@ -97,8 +97,8 @@ class ConditionalSection:
             upstream_nodes = set()
             for p in promises:
                 if not p.is_ready:
-                    bindings.append(Binding(var=p.var, binding=BindingData(promise=p.ref)))
-                    upstream_nodes.add(p.ref.node)
+                    bindings.append(Binding(var=p.var, binding=BindingData(promise=p._Fref)))
+                    upstream_nodes.add(p._Fref.node)
 
             n = Node(
                 id=f"{ctx.compilation_state.prefix}n{len(ctx.compilation_state.nodes)}",  # type: ignore
@@ -364,10 +364,10 @@ def merge_promises(*args: Optional[Promise]) -> typing.List[Promise]:
     node_vars: typing.Set[typing.Tuple[str, str]] = set()
     merged_promises: typing.List[Promise] = []
     for p in args:
-        if p is not None and p.ref:
-            node_var = (p.ref.node_id, p.ref.var)
+        if p is not None and p._Fref:
+            node_var = (p._Fref.node_id, p._Fref.var)
             if node_var not in node_vars:
-                new_p = p.with_var(create_branch_node_promise_var(p.ref.node_id, p.ref.var))
+                new_p = p.with_var(create_branch_node_promise_var(p._Fref.node_id, p._Fref.var))
                 merged_promises.append(new_p)
                 node_vars.add(node_var)
     return merged_promises
@@ -390,7 +390,7 @@ def transform_to_conj_expr(
 
 def transform_to_operand(v: Union[Promise, Literal]) -> Tuple[_core_cond.Operand, Optional[Promise]]:
     if isinstance(v, Promise):
-        return _core_cond.Operand(var=create_branch_node_promise_var(v.ref.node_id, v.var)), v
+        return _core_cond.Operand(var=create_branch_node_promise_var(v._Fref.node_id, v.var)), v
     return _core_cond.Operand(primitive=v.scalar.primitive), None
 
 
@@ -415,7 +415,7 @@ def transform_to_boolexpr(
 
 def to_case_block(c: Case) -> Tuple[Union[_core_wf.IfBlock], typing.List[Promise]]:
     expr, promises = transform_to_boolexpr(cast(Union[ComparisonExpression, ConjunctionExpression], c.expr))
-    n = c.output_promise.ref.node  # type: ignore
+    n = c.output_promise._Fref.node  # type: ignore
     return _core_wf.IfBlock(condition=expr, then_node=n), promises
 
 
@@ -438,7 +438,7 @@ def to_ifelse_block(node_id: str, cs: ConditionalSection) -> Tuple[_core_wf.IfEl
     node = None
     err = None
     if last_case.output_promise is not None:
-        node = last_case.output_promise.ref.node  # type: ignore
+        node = last_case.output_promise._Fref.node  # type: ignore
     else:
         err = Error(failed_node_id=node_id, message=last_case.err if last_case.err else "Condition failed")
     return (

--- a/flytekit/core/gate.py
+++ b/flytekit/core/gate.py
@@ -172,15 +172,15 @@ def approve(upstream_item: Union[Tuple[Promise], Promise, VoidPromise], name: st
     ctx = FlyteContextManager.current_context()
     upstream_item = typing.cast(Promise, upstream_item)
     if ctx.compilation_state is not None and ctx.compilation_state.mode == 1:
-        if not upstream_item.ref.node.flyte_entity.python_interface:
+        if not upstream_item._Fref.node.flyte_entity.python_interface:
             raise ValueError(
                 f"Upstream node doesn't have a Python interface. Node entity is: "
-                f"{upstream_item.ref.node.flyte_entity}"
+                f"{upstream_item._Fref.node.flyte_entity}"
             )
 
         # We have reach back up to the entity that this promise came from, to get the python type, since
         # the approve function itself doesn't have a python interface.
-        io_type = upstream_item.ref.node.flyte_entity.python_interface.outputs[upstream_item.var]
+        io_type = upstream_item._Fref.node.flyte_entity.python_interface.outputs[upstream_item.var]
         io_var_name = upstream_item.var
     else:
         # We don't know the python type here. in local execution, downstream doesn't really use the type

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -94,10 +94,10 @@ class Interface(object):
                     return self
 
                 @property
-                def ref(self):
+                def _Fref(self):
                     for var_name in variables:
-                        if self.__getattribute__(var_name).ref:
-                            return self.__getattribute__(var_name).ref
+                        if self.__getattribute__(var_name)._Fref:
+                            return self.__getattribute__(var_name)._Fref
                     return None
 
                 def runs_before(self, *args, **kwargs):

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -563,7 +563,7 @@ class ImperativeWorkflow(WorkflowBase):
                     f" starting with the container type (e.g. List[int]"
                 )
             promise = cast(Promise, p)
-            python_type = promise.ref.node.flyte_entity.python_interface.outputs[promise.var]
+            python_type = promise._Fref.node.flyte_entity.python_interface.outputs[promise.var]
             logger.debug(f"Inferring python type for wf output {output_name} from Promise provided {python_type}")
 
         flyte_type = TypeEngine.to_literal_type(python_type=python_type)

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -29,17 +29,17 @@ def test_create_and_link_node():
 
     ctx = context_manager.FlyteContext.current_context().with_compilation_state(CompilationState(prefix=""))
     p = create_and_link_node(ctx, t1, a=3)
-    assert p.ref.node_id == "n0"
-    assert p.ref.var == "o0"
-    assert len(p.ref.node.bindings) == 1
+    assert p._Fref.node_id == "n0"
+    assert p._Fref.var == "o0"
+    assert len(p._Fref.node.bindings) == 1
 
     @task
     def t2(a: typing.Optional[int] = None) -> typing.Optional[int]:
         return a
 
     p = create_and_link_node(ctx, t2)
-    assert p.ref.var == "o0"
-    assert len(p.ref.node.bindings) == 0
+    assert p._Fref.var == "o0"
+    assert len(p._Fref.node.bindings) == 0
 
 
 def test_create_and_link_node_from_remote():
@@ -53,17 +53,17 @@ def test_create_and_link_node_from_remote():
 
     ctx = context_manager.FlyteContext.current_context().with_compilation_state(CompilationState(prefix=""))
     p = create_and_link_node_from_remote(ctx, t1)
-    assert p.ref.node_id == "n0"
-    assert p.ref.var == "placeholder"
-    assert len(p.ref.node.bindings) == 0
+    assert p._Fref.node_id == "n0"
+    assert p._Fref.var == "placeholder"
+    assert len(p._Fref.node.bindings) == 0
 
     @task
     def t2(a: int) -> int:
         return a
 
     p = create_and_link_node_from_remote(ctx, t2, a=3)
-    assert p.ref.var == "o0"
-    assert len(p.ref.node.bindings) == 1
+    assert p._Fref.var == "o0"
+    assert len(p._Fref.node.bindings) == 1
 
 
 def test_create_and_link_node_from_remote_ignore():

--- a/tests/flytekit/unit/core/test_references.py
+++ b/tests/flytekit/unit/core/test_references.py
@@ -227,11 +227,11 @@ def test_ref_plain_two_outputs():
     with context_manager.FlyteContextManager.with_context(ctx.with_new_compilation_state()):
         xx, yy = r1(a="five", b=6)
         # Note - misnomer, these are not SdkNodes, they are core.Nodes
-        assert xx.ref.node is yy.ref.node
+        assert xx._Fref.node is yy._Fref.node
         assert xx.var == "x"
         assert yy.var == "y"
-        assert xx.ref.node_id == "n0"
-        assert len(xx.ref.node.bindings) == 2
+        assert xx._Fref.node_id == "n0"
+        assert len(xx._Fref.node.bindings) == 2
 
     @task
     def t2(q: bool, r: int) -> str:

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -127,7 +127,7 @@ def test_single_output():
         nodes = ctx.compilation_state.nodes
         assert len(nodes) == 1
         assert outputs.is_ready is False
-        assert outputs.ref.node is nodes[0]
+        assert outputs._Fref.node is nodes[0]
 
     assert context_manager.FlyteContextManager.size() == 1
 


### PR DESCRIPTION
# TL;DR
_Please replace this text with a description of what this PR accomplishes._

Changes `ref` to `_Fref` to make sure there's no conflict with tasks that have `ref` as output.

closes https://github.com/flyteorg/flyte/issues/3923

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

Renamed `ref` to `_Fref`


## Tracking Issue
https://github.com/flyteorg/flyte/issues/3923

## Follow-up issue
_NA_
