### PR TITLE
Beautified pyflyte run even for every task and workflow

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -832,7 +832,7 @@ class RunCommand(click.RichGroup):
     def get_command(self, ctx, filename):
         if ctx.obj:
             ctx.obj[RUN_LEVEL_PARAMS_KEY] = ctx.params
-        return WorkflowCommand(filename, name=filename, help="Run a [workflow|task] in a file using script mode")
+        return WorkflowCommand(filename, name=filename, help=f"Run a [workflow|task] from {filename}")
 
 
 _run_help = """

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -747,9 +747,11 @@ class WorkflowCommand(click.RichGroup):
         else:
             self._filename = pathlib.Path(filename).resolve()
             self._should_delete = False
+        self._entities = None
 
     def list_commands(self, ctx):
         entities = get_entities_in_file(self._filename, self._should_delete)
+        self._entities = entities
         return entities.all()
 
     def get_command(self, ctx, exe_entity):
@@ -762,7 +764,9 @@ class WorkflowCommand(click.RichGroup):
           function.
         :return:
         """
-
+        is_workflow = False
+        if self._entities:
+            is_workflow = exe_entity in self._entities.workflows
         rel_path = os.path.relpath(self._filename)
         if rel_path.startswith(".."):
             raise ValueError(
@@ -799,11 +803,16 @@ class WorkflowCommand(click.RichGroup):
             params.append(
                 to_click_option(ctx, flyte_ctx, input_name, literal_var, python_type, default_val, get_upload_url_fn)
             )
-        cmd = click.Command(
+
+        entity_type = "Workflow" if is_workflow else "Task"
+        h = f"{click.style(entity_type, bold=True)} ({module}.{exe_entity})"
+        if entity.__doc__:
+            h = h + click.style(f"{entity.__doc__}", dim=True)
+        cmd = click.RichCommand(
             name=exe_entity,
             params=params,
             callback=run_command(ctx, entity),
-            help=f"Run {module}.{exe_entity} in script mode",
+            help=h,
         )
         return cmd
 


### PR DESCRIPTION
# TL;DR
- identify a task or a workflow
- task or workflow help menus show types and use rich to beautify

Before:
<img width="881" alt="Screenshot 2023-08-09 at 10 07 39 PM" src="https://github.com/flyteorg/flytekit/assets/16888709/02cb7930-cf74-4a39-8212-9279644eea57">

After:
<img width="889" alt="Screenshot 2023-08-09 at 10 08 37 PM" src="https://github.com/flyteorg/flytekit/assets/16888709/b5a967ef-8d39-497e-b477-c0383ef823d2">


## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

