### PR TITLE
Add Azure-specific headers when uploading to blob storage

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -806,6 +806,7 @@ class FlyteRemote(object):
                 else self._config.platform.ca_cert_file_path,
             )
 
+            # Check both HTTP 201 and 200, because some storage backends (e.g. Azure) return 201 instead of 200.
             if rsp.status_code not in (requests.codes["OK"], requests.codes["created"]):
                 raise FlyteValueException(
                     rsp.status_code,

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -203,6 +203,18 @@ def test_more_stuff(mock_client):
     assert computed_v2 != computed_v3
 
 
+def test_get_extra_headers_azure_blob_storage():
+    native_url = "abfs://flyte@storageaccount/container/path/to/file"
+    headers = FlyteRemote.get_extra_headers_for_protocol(native_url)
+    assert headers["x-ms-blob-type"] == "BlockBlob"
+
+
+def test_get_extra_headers_s3():
+    native_url = "s3://flyte@storageaccount/container/path/to/file"
+    headers = FlyteRemote.get_extra_headers_for_protocol(native_url)
+    assert headers == {}
+
+
 @patch("flytekit.remote.remote.SynchronousFlyteClient")
 def test_generate_console_http_domain_sandbox_rewrite(mock_client):
     _, temp_filename = tempfile.mkstemp(suffix=".yaml")


### PR DESCRIPTION
# TL;DR
This PR fixes an issue causing `pyflyte run --remote`  to fail when using Azure. 

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [] Any pending items have an associated Issue

## Complete description
The PUT call to Azure Blob Storage returned an HTTP 400 Error: 
```
<?xml version="1.0" encoding="utf-8"?>
<Error>
    <Code>MissingRequiredHeader</Code>
    <Message>
        An HTTP header that's mandatory for this request is not specified.
        RequestId:ebd5dfbc-f01e-001d-5074-cb4f26000000
        Time:2023-08-10T10:24:58.6553767Z
    </Message>
    <HeaderName>x-ms-blob-type</HeaderName>
</Error>
```

This is a starting point that unblocks me, but there's a discussion to be had regarding where you would like to handle such cases. Some open questions:

1. Should this be done on the client? And if yes, is that the right place?
2. Or should the response that contains the signed URL also specify headers based on configuration options?

I have tested this locally by tweaking the class and trying to run a workflow

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3942

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
