### PR TITLE
Add type transformer for datetime.date

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1665,6 +1665,18 @@ def _register_default_type_transformers():
 
     TypeEngine.register(
         SimpleTransformer(
+            "date",
+            _datetime.date,
+            _type_models.LiteralType(simple=_type_models.SimpleType.DATETIME),
+            lambda x: Literal(
+                scalar=Scalar(primitive=Primitive(datetime=_datetime.datetime.combine(x, _datetime.time.min)))
+            ),  # convert datetime to date
+            lambda x: x.scalar.primitive.datetime.date(),  # get date from datetime
+        )
+    )
+
+    TypeEngine.register(
+        SimpleTransformer(
             "none",
             type(None),
             _type_models.LiteralType(simple=_type_models.SimpleType.NONE),

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -90,6 +90,7 @@ def test_type_resolution():
     assert type(TypeEngine.get_transformer(dict)) == DictTransformer
 
     assert type(TypeEngine.get_transformer(int)) == SimpleTransformer
+    assert type(TypeEngine.get_transformer(datetime.date)) == SimpleTransformer
 
     assert type(TypeEngine.get_transformer(os.PathLike)) == FlyteFilePathTransformer
     assert type(TypeEngine.get_transformer(FlytePickle)) == FlytePickleTransformer
@@ -323,6 +324,7 @@ def test_dict_transformer():
     recursive_assert(d.get_literal_type(typing.Dict[str, int]), LiteralType(simple=SimpleType.INTEGER))
     recursive_assert(d.get_literal_type(typing.Dict[str, datetime.datetime]), LiteralType(simple=SimpleType.DATETIME))
     recursive_assert(d.get_literal_type(typing.Dict[str, datetime.timedelta]), LiteralType(simple=SimpleType.DURATION))
+    recursive_assert(d.get_literal_type(typing.Dict[str, datetime.date]), LiteralType(simple=SimpleType.DATETIME))
     recursive_assert(d.get_literal_type(typing.Dict[str, dict]), LiteralType(simple=SimpleType.STRUCT))
     recursive_assert(
         d.get_literal_type(typing.Dict[str, typing.Dict[str, str]]),


### PR DESCRIPTION
# TL;DR
As title

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Hi community,
This is my first pr in Flyte. I have followed the contribution guide and if there is anything I missed, feel free to leave a comment.
I added a simple transformer for datetime.date.
The `to_literal_transformer` convert datetime.date to datetime.datetime.
The `from_literal_transformer` convert datetime.datetime to datetime.date.
Also, I add corresponding tests to test_type_engine.


## Tracking Issue
https://github.com/flyteorg/flyte/issues/3026

## Follow-up issue
Add datetime.date to https://docs.flyte.org/projects/cookbook/en/latest/auto_examples/type_system/flyte_python_types.html#flytekit-to-flyte-type-mapping
