### PR TITLE
Remove ref in output

### DIFF
--- a/flytekit/core/condition.py
+++ b/flytekit/core/condition.py
@@ -298,7 +298,7 @@ class Case(object):
         self._output_promise = p
         if isinstance(p, Promise):
             if not p.is_ready:
-                self._output_node = p.ref.node
+                self._output_node = p.ref.node  # type: ignore
         elif isinstance(p, VoidPromise):
             if p.ref is not None:
                 self._output_node = p.ref.node

--- a/flytekit/core/condition.py
+++ b/flytekit/core/condition.py
@@ -293,13 +293,14 @@ class Case(object):
         if isinstance(p, Promise):
             if not p.is_ready:
                 self._output_node = p.ref.node
+        elif isinstance(p, VoidPromise):
+            if p.ref is not None:
+                self._output_node = p.ref.node
         elif hasattr(p, "_fields"):
             for f in p._fields:
                 prom = getattr(p, f)
                 if not prom.is_ready:
                     self._output_node = prom.ref.node
-        else:
-            raise AssertionError(f"Unexpected output type {type(p)}")
 
         # We can always mark branch as completed
         return self._cs.end_branch()

--- a/flytekit/core/condition.py
+++ b/flytekit/core/condition.py
@@ -292,7 +292,7 @@ class Case(object):
         self._output_node = None
         if isinstance(p, Promise):
             if not p.is_ready:
-                self._output_node = p.ref
+                self._output_node = p.ref.node
         elif hasattr(p, "_fields"):
             for f in p._fields:
                 prom = getattr(p, f)

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -499,13 +499,6 @@ def create_task_output(
             val.with_overrides(*args, **kwargs)
             return self
 
-        @property
-        def ref(self):
-            for p in promises:
-                if p.ref:
-                    return p.ref
-            return None
-
         def runs_before(self, other: Any):
             """
             This function is just here to allow local workflow execution to run. See the corresponding function in

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1865,7 +1865,17 @@ def test_list_containing_multiple_annotated_pandas_dataframes():
     assert expected_df.equals(df)
 
 
-typing.NamedTuple
-import collections
+def test_ref_as_key_name():
+    class MyOutput(typing.NamedTuple):
+        # to make sure flytekit itself doesn't use this string
+        ref: str
 
-collections.namedtuple
+    @task
+    def produce_things() -> MyOutput:
+        return MyOutput(ref="ref")
+
+    @workflow
+    def run_things() -> MyOutput:
+        return produce_things()
+
+    assert run_things().ref == "ref"

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1863,3 +1863,9 @@ def test_list_containing_multiple_annotated_pandas_dataframes():
 
     expected_df = pandas.DataFrame({"column_1": [5, 7, 9]})
     assert expected_df.equals(df)
+
+
+typing.NamedTuple
+import collections
+
+collections.namedtuple


### PR DESCRIPTION
# TL;DR
This removes the `ref` property in the default NamedTuple object that gets used when a user want to name outputs.  This is done so that some can use an output named "ref" if they wanted to.  Previously it was getting co-opted by this property.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
The property iterates through the list of outputs, and returns the first `NodeOutput` it sees, and the node gets extracted from that.  Instead of doing this, just store the Node object in the Case object, upon construction.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3923
