### PR TITLE
Enable SecretsManager.get to load and return bytes

### DIFF
--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -349,7 +349,9 @@ class SecretsManager(object):
         """
         return self._GroupSecrets(item, self)
 
-    def get(self, group: str, key: Optional[str] = None, group_version: Optional[str] = None, encode_mode: str = "r") -> str:
+    def get(
+        self, group: str, key: Optional[str] = None, group_version: Optional[str] = None, encode_mode: str = "r"
+    ) -> str:
         """
         Retrieves a secret using the resolution order -> Env followed by file. If not found raises a ValueError
         """

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -350,10 +350,11 @@ class SecretsManager(object):
         return self._GroupSecrets(item, self)
 
     def get(
-        self, group: str, key: Optional[str] = None, group_version: Optional[str] = None, encode_mode: str = "r"
+        self, group: str, key: Optional[str] = None, group_version: Optional[str] = None, encode_mode: Optional[str] = "r"
     ) -> str:
         """
         Retrieves a secret using the resolution order -> Env followed by file. If not found raises a ValueError
+        param encode_mode, defines the mode to open files, it can either be "r" to read file, or "rb" to read binary file
         """
         self.check_group_key(group)
         env_var = self.get_secrets_env_var(group, key, group_version)

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -349,7 +349,7 @@ class SecretsManager(object):
         """
         return self._GroupSecrets(item, self)
 
-    def get(self, group: str, key: Optional[str] = None, group_version: Optional[str] = None) -> str:
+    def get(self, group: str, key: Optional[str] = None, group_version: Optional[str] = None, encode_mode: str = "r") -> str:
         """
         Retrieves a secret using the resolution order -> Env followed by file. If not found raises a ValueError
         """
@@ -360,7 +360,7 @@ class SecretsManager(object):
         if v is not None:
             return v
         if os.path.exists(fpath):
-            with open(fpath, "r") as f:
+            with open(fpath, encode_mode) as f:
                 return f.read().strip()
         raise ValueError(
             f"Unable to find secret for key {key} in group {group} " f"in Env Var:{env_var} and FilePath: {fpath}"

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -350,7 +350,7 @@ class SecretsManager(object):
         return self._GroupSecrets(item, self)
 
     def get(
-        self, group: str, key: Optional[str] = None, group_version: Optional[str] = None, encode_mode: Optional[str] = "r"
+        self, group: str, key: Optional[str] = None, group_version: Optional[str] = None, encode_mode: str = "r"
     ) -> str:
         """
         Retrieves a secret using the resolution order -> Env followed by file. If not found raises a ValueError

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
 
+import base64
 import mock
 import py
 import pytest
@@ -166,6 +167,15 @@ def test_secrets_manager_file(tmpdir: py.path.local):
         w.write("my-password")
     assert sec.get("group", "test") == "my-password"
     assert sec.group.test == "my-password"
+
+    base64_string ="R2Vla3NGb3JHZWV =="
+    base64_bytes = base64_string.encode("ascii")
+    base64_str = base64.b64encode(base64_bytes)
+    with open(f, "wb") as w:
+        w.write(base64_str)
+    assert sec.get("group", "test") != base64_str
+    assert sec.get("group", "test", encode_mode="rb") == base64_str
+
     del os.environ["FLYTE_SECRETS_DEFAULT_DIR"]
 
 

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -1,7 +1,7 @@
+import base64
 import os
 from datetime import datetime
 
-import base64
 import mock
 import py
 import pytest
@@ -168,7 +168,7 @@ def test_secrets_manager_file(tmpdir: py.path.local):
     assert sec.get("group", "test") == "my-password"
     assert sec.group.test == "my-password"
 
-    base64_string ="R2Vla3NGb3JHZWV =="
+    base64_string = "R2Vla3NGb3JHZWV =="
     base64_bytes = base64_string.encode("ascii")
     base64_str = base64.b64encode(base64_bytes)
     with open(f, "wb") as w:


### PR DESCRIPTION
# TL;DR
If the secrets are a base-64 encoded string, `SecretsManager.get` will raise exception. So add `encoded_mode` to the function here to fix and help to load and return bytes.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
