### PR TITLE
Remove incorrect error line

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -999,11 +999,6 @@ def flyte_entity_call_handler(
             )
 
     ctx = FlyteContextManager.current_context()
-    if ctx.execution_state and (
-        ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION
-        or ctx.execution_state.mode == ExecutionState.Mode.LOCAL_TASK_EXECUTION
-    ):
-        logger.error("You are not supposed to nest @Task/@Workflow inside a @Task!")
     if ctx.compilation_state is not None and ctx.compilation_state.mode == 1:
         return create_and_link_node(ctx, entity=entity, **kwargs)
     if ctx.execution_state and ctx.execution_state.is_local_execution():


### PR DESCRIPTION
# TL;DR
This is an errorneous error line.  This comes up multiple times when running the merge sort example, which does not call a task within a task.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
```
2023-08-21 16:49:11,422980 ERROR    {"asctime": "2023-08-21 16:49:11,422", "name": "flytekit", "levelname": "ERROR", "message": "You are not supposed to nest   promise.py:1006
                                    @Task/@Workflow inside a @Task!"}
2023-08-21 16:49:11,427233 ERROR    {"asctime": "2023-08-21 16:49:11,427", "name": "flytekit", "levelname": "ERROR", "message": "You are not supposed to nest   promise.py:1006
                                    @Task/@Workflow inside a @Task!"}
2023-08-21 16:49:11,428440 ERROR    {"asctime": "2023-08-21 16:49:11,428", "name": "flytekit", "levelname": "ERROR", "message": "You are not supposed to nest   promise.py:1006
                                    @Task/@Workflow inside a @Task!"}
2023-08-21 16:49:11,429852 ERROR    {"asctime": "2023-08-21 16:49:11,429", "name": "flytekit", "levelname": "ERROR", "message": "You are not supposed to nest   promise.py:1006
                                    @Task/@Workflow inside a @Task!"}
2023-08-21 16:49:11,431182 ERROR    {"asctime": "2023-08-21 16:49:11,431", "name": "flytekit", "levelname": "ERROR", "message": "You are not supposed to nest   promise.py:1006
                                    @Task/@Workflow inside a @Task!"}
2023-08-21 16:49:11,432417 ERROR    {"asctime": "2023-08-21 16:49:11,432", "name": "flytekit", "levelname": "ERROR", "message": "You are not supposed to nest   promise.py:1006
                                    @Task/@Workflow inside a @Task!"}
```

## Tracking Issue
NA
