### PR TITLE
Batch upload flyte directory

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -224,6 +224,7 @@ from flytekit.core.reference_entity import LaunchPlanReference, TaskReference, W
 from flytekit.core.resources import Resources
 from flytekit.core.schedule import CronSchedule, FixedRate
 from flytekit.core.task import Secret, reference_task, task
+from flytekit.core.type_engine import BatchSize
 from flytekit.core.workflow import ImperativeWorkflow as Workflow
 from flytekit.core.workflow import WorkflowFailurePolicy, reference_workflow, workflow
 from flytekit.deck import Deck
@@ -236,7 +237,6 @@ from flytekit.models.documentation import Description, Documentation, SourceCode
 from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
 from flytekit.types import directory, file, iterator
-from flytekit.types.pickle import BatchSize
 from flytekit.types.structured.structured_dataset import (
     StructuredDataset,
     StructuredDatasetFormat,

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -236,6 +236,7 @@ from flytekit.models.documentation import Description, Documentation, SourceCode
 from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
 from flytekit.types import directory, file, iterator
+from flytekit.types.pickle import BatchSize
 from flytekit.types.structured.structured_dataset import (
     StructuredDataset,
     StructuredDatasetFormat,

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -183,7 +183,7 @@ class FileAccessProvider(object):
                 return anon_fs.exists(path)
             raise oe
 
-    def get(self, from_path: str, to_path: str, recursive: bool = False):
+    def get(self, from_path: str, to_path: str, recursive: bool = False, **kwargs):
         file_system = self.get_filesystem_for_path(from_path)
         if recursive:
             from_path, to_path = self.recursive_paths(from_path, to_path)
@@ -194,13 +194,13 @@ class FileAccessProvider(object):
                 return shutil.copytree(
                     self.strip_file_header(from_path), self.strip_file_header(to_path), dirs_exist_ok=True
                 )
-            return file_system.get(from_path, to_path, recursive=recursive)
+            return file_system.get(from_path, to_path, recursive=recursive, **kwargs)
         except OSError as oe:
             logger.debug(f"Error in getting {from_path} to {to_path} rec {recursive} {oe}")
             file_system = self.get_filesystem(get_protocol(from_path), anonymous=True)
             if file_system is not None:
                 logger.debug(f"Attempting anonymous get with {file_system}")
-                return file_system.get(from_path, to_path, recursive=recursive)
+                return file_system.get(from_path, to_path, recursive=recursive, **kwargs)
             raise oe
 
     def put(self, from_path: str, to_path: str, recursive: bool = False, **kwargs):
@@ -287,7 +287,7 @@ class FileAccessProvider(object):
         """
         return self.put_data(local_path, remote_path, is_multipart=True)
 
-    def get_data(self, remote_path: str, local_path: str, is_multipart: bool = False):
+    def get_data(self, remote_path: str, local_path: str, is_multipart: bool = False, **kwargs):
         """
         :param remote_path:
         :param local_path:
@@ -296,7 +296,7 @@ class FileAccessProvider(object):
         try:
             pathlib.Path(local_path).parent.mkdir(parents=True, exist_ok=True)
             with timeit(f"Download data to local from {remote_path}"):
-                self.get(remote_path, to_path=local_path, recursive=is_multipart)
+                self.get(remote_path, to_path=local_path, recursive=is_multipart, **kwargs)
         except Exception as ex:
             raise FlyteAssertion(
                 f"Failed to get data from {remote_path} to {local_path} (recursive={is_multipart}).\n\n"

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -59,8 +59,12 @@ class BatchSize:
     """
     This is used to annotate a FlyteDirectory when we want to download/upload the contents of the directory in batches. For example,
 
+    @task
     def t1(Annotated[FlyteDirectory, BatchSize(10)]) -> Annotated[FlyteDirectory, BatchSize(100)]:
         ...
+
+    Flytekit will still download all files within the directory. It reads 10 files into memory, writes them to
+     files, and then clears the memory. Subsequently, it proceeds to read another set of 10 files. Similarly, for upload.
     """
 
     def __init__(self, val: int):

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -64,9 +64,9 @@ class BatchSize:
         ...
         return FlyteDirectory(...)
 
-    In the above example flytekit will download all files from the input `directory` in chunks of 10, i.e. first it 
-    downloads 10 files, loads them to memory, then writes those 10 to local disk, then it loads the next 10, so on 
-    and so forth. Similarly, for outputs, in this case flytekit is going to upload the resulting directory in chunks of 
+    In the above example flytekit will download all files from the input `directory` in chunks of 10, i.e. first it
+    downloads 10 files, loads them to memory, then writes those 10 to local disk, then it loads the next 10, so on
+    and so forth. Similarly, for outputs, in this case flytekit is going to upload the resulting directory in chunks of
     100.
     """
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -55,6 +55,27 @@ T = typing.TypeVar("T")
 DEFINITIONS = "definitions"
 
 
+class BatchSize:
+    """
+    Flyte-specific object used to wrap the hash function for a specific type
+    """
+
+    def __init__(self, val: int):
+        self._val = val
+
+    @property
+    def val(self) -> int:
+        return self._val
+
+
+def get_batch_size(t: Type) -> Optional[int]:
+    if is_annotated(t):
+        for annotation in get_args(t)[1:]:
+            if isinstance(annotation, BatchSize):
+                return annotation.val
+    return None
+
+
 class TypeTransformerFailedError(TypeError, AssertionError, ValueError):
     ...
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -57,7 +57,10 @@ DEFINITIONS = "definitions"
 
 class BatchSize:
     """
-    Flyte-specific object used to wrap the hash function for a specific type
+    This is used to annotate a FlyteDirectory when we want to download/upload the contents of the directory in batches. For example,
+
+    def t1(Annotated[FlyteDirectory, BatchSize(10)]) -> Annotated[FlyteDirectory, BatchSize(100)]:
+        ...
     """
 
     def __init__(self, val: int):

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -60,11 +60,14 @@ class BatchSize:
     This is used to annotate a FlyteDirectory when we want to download/upload the contents of the directory in batches. For example,
 
     @task
-    def t1(Annotated[FlyteDirectory, BatchSize(10)]) -> Annotated[FlyteDirectory, BatchSize(100)]:
+    def t1(directory: Annotated[FlyteDirectory, BatchSize(10)]) -> Annotated[FlyteDirectory, BatchSize(100)]:
         ...
+        return FlyteDirectory(...)
 
-    Flytekit will still download all files within the directory. It reads 10 files into memory, writes them to
-     files, and then clears the memory. Subsequently, it proceeds to read another set of 10 files. Similarly, for upload.
+    In the above example flytekit will download all files from the input `directory` in chunks of 10, i.e. first it 
+    downloads 10 files, loads them to memory, then writes those 10 to local disk, then it loads the next 10, so on 
+    and so forth. Similarly, for outputs, in this case flytekit is going to upload the resulting directory in chunks of 
+    100.
     """
 
     def __init__(self, val: int):

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -390,8 +390,17 @@ class FlyteDirToMultipartBlobTransformer(TypeTransformer[FlyteDirectory]):
         # For the remote case, return an FlyteDirectory object that can download
         local_folder = ctx.file_access.get_random_local_directory()
 
+        batch_size = 100  # default batch size
+        t = expected_python_type
+        if is_annotated(t):
+            expected_python_type = get_args(t)[0]
+            for annotation in get_args(t)[1:]:
+                if isinstance(annotation, BatchSize):
+                    batch_size = annotation.val
+                    break
+
         def _downloader():
-            return ctx.file_access.get_data(uri, local_folder, is_multipart=True)
+            return ctx.file_access.get_data(uri, local_folder, is_multipart=True, batch_size=batch_size)
 
         expected_format = self.get_format(expected_python_type)
 

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -13,10 +13,9 @@ import fsspec
 from dataclasses_json import config, dataclass_json
 from fsspec.utils import get_protocol
 from marshmallow import fields
-from typing_extensions import get_args
 
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
-from flytekit.core.type_engine import TypeEngine, TypeTransformer, get_batch_size, is_annotated
+from flytekit.core.type_engine import TypeEngine, TypeTransformer, get_batch_size
 from flytekit.models import types as _type_models
 from flytekit.models.core import types as _core_types
 from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
@@ -325,8 +324,6 @@ class FlyteDirToMultipartBlobTransformer(TypeTransformer[FlyteDirectory]):
         should_upload = True
         batch_size = get_batch_size(python_type)
 
-        if is_annotated(python_type):
-            python_type = get_args(python_type)[0]
         meta = BlobMetadata(type=self._blob_type(format=self.get_format(python_type)))
 
         # There are two kinds of literals we handle, either an actual FlyteDirectory, or a string path to a directory.
@@ -385,8 +382,6 @@ class FlyteDirToMultipartBlobTransformer(TypeTransformer[FlyteDirectory]):
         local_folder = ctx.file_access.get_random_local_directory()
 
         batch_size = get_batch_size(expected_python_type)
-        if is_annotated(expected_python_type):
-            expected_python_type = get_args(expected_python_type)[0]
 
         def _downloader():
             return ctx.file_access.get_data(uri, local_folder, is_multipart=True, batch_size=batch_size)

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -302,6 +302,16 @@ def test_dir_no_downloader_default():
     assert pv.download() == local_dir
 
 
+def test_dir_with_batch_size():
+    flyte_dir = Annotated[FlyteDirectory, BatchSize(100)]
+    val = flyte_dir("s3://bucket/key")
+    transformer = TypeEngine.get_transformer(flyte_dir)
+    ctx = FlyteContext.current_context()
+    lt = transformer.get_literal_type(flyte_dir)
+    lv = transformer.to_literal(ctx, val, flyte_dir, lt)
+    assert val.path == transformer.to_python_value(ctx, lv, flyte_dir).remote_source
+
+
 def test_dict_transformer():
     d = DictTransformer()
 


### PR DESCRIPTION
# TL;DR
s3fs will try to read all the files in the directory into memory by default. we can specify the batch size for `s3fsFileSystem.put`, and it will dramatically reduce memory consumption.

Before: 
![image](https://github.com/flyteorg/flytekit/assets/37936015/b0c19aa4-91f2-4ef9-b93f-9a149c275745)
After (batch size = 100):
![image](https://github.com/flyteorg/flytekit/assets/37936015/5f7be84a-af5b-4ade-9334-5ce38c6727bd)


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
```python
from typing_extensions import Annotated

from flytekit import task, workflow
from flytekit.types.directory import FlyteDirectory
import os
from memory_profiler import profile
from flytekit import BatchSize
directory = "/tmp/test"


@task
@profile
def generate_files(num_files: int, filesize_mb: int) -> Annotated[FlyteDirectory, BatchSize(100)]:
    os.mkdir(directory)
    for i in range(num_files):
        file_path = os.path.join(directory, f"file_{i}.txt")
        with open(file_path, "w") as f:
            f.write(str(os.urandom(filesize_mb * 1024 * 1024)))
    return FlyteDirectory(directory, remote_directory="s3://flyte-benchmark/test/")


@task
def get_files(d: Annotated[FlyteDirectory, BatchSize(100)]):
    d._downloader()


@workflow
def ton_of_files_wf(num_files: int = 1000, filesize_mb: int = 8):
    d = generate_files(num_files=num_files, filesize_mb=filesize_mb)
    get_files(d=d)


if __name__ == '__main__':
    print(ton_of_files_wf())
```

## Tracking Issue
_NA_

## Follow-up issue
_NA_

