### PR TITLE
Better error messaging for overrides

### DIFF
--- a/flytekit/core/resources.py
+++ b/flytekit/core/resources.py
@@ -32,6 +32,19 @@ class Resources(object):
     storage: Optional[str] = None
     ephemeral_storage: Optional[str] = None
 
+    def __post_init__(self):
+        def _check_none_or_str(value):
+            if value is None:
+                return
+            if not isinstance(value, str):
+                raise AssertionError(f"{value} should be a string")
+
+        _check_none_or_str(self.cpu)
+        _check_none_or_str(self.mem)
+        _check_none_or_str(self.gpu)
+        _check_none_or_str(self.storage)
+        _check_none_or_str(self.ephemeral_storage)
+
 
 @dataclass
 class ResourceSpec(object):

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -158,7 +158,6 @@ class TrackedInstance(metaclass=InstanceTrackingMeta):
                     return k
             except ValueError as err:
                 logger.warning(f"Caught ValueError {err} while attempting to auto-assign name")
-                pass
 
         logger.error(f"Could not find LHS for {self} in {self._instantiated_in}")
         raise _system_exceptions.FlyteSystemException(f"Error looking for LHS in {self._instantiated_in}")

--- a/tests/flytekit/unit/core/test_resources.py
+++ b/tests/flytekit/unit/core/test_resources.py
@@ -66,3 +66,16 @@ def test_convert_limits(resource_dict: Dict[str, str], expected_resource_name: _
     assert limit.name == expected_resource_name
     assert limit.value == expected_resource_value
     assert len(resources_model.requests) == 0
+
+
+def test_incorrect_type_resources():
+    with pytest.raises(AssertionError):
+        Resources(cpu=1)  # type: ignore
+    with pytest.raises(AssertionError):
+        Resources(mem=1)  # type: ignore
+    with pytest.raises(AssertionError):
+        Resources(gpu=1)  # type: ignore
+    with pytest.raises(AssertionError):
+        Resources(storage=1)  # type: ignore
+    with pytest.raises(AssertionError):
+        Resources(ephemeral_storage=1)  # type: ignore

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1866,3 +1866,42 @@ def test_ref_as_key_name():
         return produce_things()
 
     assert run_things().ref == "ref"
+
+
+def test_promise_not_allowed_in_overrides():
+    @task
+    def t1(a: int) -> int:
+        return a + 1
+
+    @workflow
+    def my_wf(a: int, cpu: str) -> int:
+        return t1(a=a).with_overrides(requests=Resources(cpu=cpu))
+
+    with pytest.raises(AssertionError):
+        my_wf(a=1, cpu=1)
+
+
+def test_promise_illegal_resources():
+    @task
+    def t1(a: int) -> int:
+        return a + 1
+
+    @workflow
+    def my_wf(a: int) -> int:
+        return t1(a=a).with_overrides(requests=Resources(cpu=1))  # type: ignore
+
+    with pytest.raises(AssertionError):
+        my_wf(a=1)
+
+
+def test_promise_illegal_retries():
+    @task
+    def t1(a: int) -> int:
+        return a + 1
+
+    @workflow
+    def my_wf(a: int, retries: int) -> int:
+        return t1(a=a).with_overrides(retries=retries)
+
+    with pytest.raises(AssertionError):
+        my_wf(a=1, retries=1)


### PR DESCRIPTION
# TL;DR
This PR improves error messaging and disallows illegal operations in the following cases
 - using incorrect type of overrides
 - using incorrect type for resources
 - using promises in overrides

## Type
 - [x] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3990

