### PR TITLE
Enable Azure Workload Identity for `fsspec` in `flytekit`

### DIFF
--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -119,6 +119,9 @@ class FileAccessProvider(object):
             if anonymous:
                 kwargs["token"] = _ANON
             return fsspec.filesystem(protocol, **kwargs)  # type: ignore
+        elif protocol == "abfs":
+            kwargs["anon"] = False
+            return fsspec.filesystem(protocol, **kwargs)  # type: ignore
 
         # Preserve old behavior of returning None for file systems that don't have an explicit anonymous option.
         if anonymous:


### PR DESCRIPTION
# TL;DR
This change enables flytekit to make use of aks enabled workload identities. Before this change, reading and writing data to a storage account was only possible with setting env variables for the storage account key. With setting `anon` to False, the Default Credentials, which are provides by aks workload identities can be used. [See](https://github.com/fsspec/adlfs/blob/main/adlfs/spec.py#L193)

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 I tried the change myself by following this [guide](https://learn.microsoft.com/en-us/azure/aks/learn/tutorial-kubernetes-workload-identity). IMO, using workload identities should be default on azure since when connecting to other Azure Services like Key Vaults, workload identities are the way to go as well. 

## Tracking Issue
[3962](https://github.com/flyteorg/flyte/issues/3962)

## Follow-up issue
_NA_
