### PR TITLE
Support the flytectl config.yaml admin.clientSecretEnvVar option in flytekit

### DIFF
--- a/flytekit/configuration/file.py
+++ b/flytekit/configuration/file.py
@@ -308,3 +308,16 @@ def read_file_if_exists(filename: typing.Optional[str], encoding=None) -> typing
     filename = pathlib.Path(filename)
     logger.debug(f"Reading file contents from [{filename}] with current directory [{os.getcwd()}].")
     return filename.read_text(encoding=encoding)
+
+
+def read_env_var_if_exists(k: typing.Optional[str]) -> typing.Optional[str]:
+    """
+    Reads the value of the environment variable. Otherwise, returns None.
+
+    :param k: The environment variable to fetch.
+    :return: The value of the environment variable as a string or None.
+    """
+    if not k:
+        return None
+
+    return getenv(k)

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -85,6 +85,14 @@ class Credentials(object):
     password from a mounted file.
     """
 
+    CLIENT_CREDENTIALS_SECRET_ENV_VAR = ConfigEntry(
+        LegacyConfigEntry(SECTION, "client_secret_env_var"), YamlConfigEntry("admin.clientSecretEnvVar")
+    )
+    """
+    Used for basic auth, which is automatically called during pyflyte. This will allow the Flyte engine to read the
+    password from a mounted environment variable.
+    """
+
     SCOPES = ConfigEntry(LegacyConfigEntry(SECTION, "scopes", list), YamlConfigEntry("admin.scopes", list))
 
     AUTH_MODE = ConfigEntry(LegacyConfigEntry(SECTION, "auth_mode"), YamlConfigEntry("admin.authType"))

--- a/tests/flytekit/unit/configuration/configs/creds_secret_env_var.yaml
+++ b/tests/flytekit/unit/configuration/configs/creds_secret_env_var.yaml
@@ -1,0 +1,13 @@
+admin:
+  # For GRPC endpoints you might want to use dns:///flyte.myexample.com
+  endpoint: dns:///flyte.mycorp.io
+  clientSecretEnvVar: FAKE_SECRET_NAME
+  insecure: true
+  clientId: propeller
+  scopes:
+    - all
+storage:
+  connection:
+    access-key: minio
+    endpoint: http://localhost:30084
+    secret-key: miniostorage

--- a/tests/flytekit/unit/configuration/test_internal.py
+++ b/tests/flytekit/unit/configuration/test_internal.py
@@ -2,7 +2,13 @@ import os
 
 import mock
 
-from flytekit.configuration import PlatformConfig, get_config_file, read_file_if_exists
+from flytekit.configuration import (
+    AuthType,
+    PlatformConfig,
+    get_config_file,
+    read_env_var_if_exists,
+    read_file_if_exists,
+)
 from flytekit.configuration.internal import AWS, Credentials, Images
 
 
@@ -45,6 +51,25 @@ def test_client_secret_location():
     # Assert that secret in platform config does not contain a newline
     platform_cfg = PlatformConfig.auto(cfg)
     assert platform_cfg.client_credentials_secret == "hello"
+    assert platform_cfg.auth_mode == AuthType.CLIENTSECRET.value
+
+
+@mock.patch.dict("os.environ")
+def test_client_secret_env_var():
+    cfg = get_config_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/sample.yaml"))
+    secret_env_var = Credentials.CLIENT_CREDENTIALS_SECRET_ENV_VAR.read(cfg)
+    assert secret_env_var is None
+
+    cfg = get_config_file(
+        os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/creds_secret_env_var.yaml")
+    )
+    secret_env_var = Credentials.CLIENT_CREDENTIALS_SECRET_ENV_VAR.read(cfg)
+    assert secret_env_var == "FAKE_SECRET_NAME"
+
+    os.environ["FAKE_SECRET_NAME"] = "fake_secret_value"
+    platform_cfg = PlatformConfig.auto(cfg)
+    assert platform_cfg.client_credentials_secret == "fake_secret_value"
+    assert platform_cfg.auth_mode == AuthType.CLIENTSECRET.value
 
 
 def test_read_file_if_exists():
@@ -54,6 +79,16 @@ def test_read_file_if_exists():
 
     assert read_file_if_exists(None) is None
     assert read_file_if_exists("") is None
+
+
+@mock.patch.dict("os.environ")
+def test_read_env_var_if_exists():
+    os.environ["TEST_READ_ENV_VAR"] = "exists"
+    v = read_env_var_if_exists("TEST_READ_ENV_VAR")
+    assert "exists" == v
+
+    assert read_env_var_if_exists(None) is None
+    assert read_env_var_if_exists("") is None
 
 
 def test_command():


### PR DESCRIPTION
# TL;DR
Support the flytectl config.yaml admin.clientSecretEnvVar option in flytekit

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 
1. read and set the client secret env var if exists.
2. set `auth_mode` to `ClientSecret` automatically if `clientSecretLocation` or `clientSecretLocation` present.
3. add test yaml file.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3482

