### PR TITLE
Remove versions 3.9 and 3.10

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -16,13 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        exclude:
-          # Ignore this test because we failed to install docker-py
-          # docker-py will install pywin32==227, whereas pywin only added support for python 3.10 in version 301.
-          # For more detail, see https://github.com/flyteorg/flytekit/pull/856#issuecomment-1067152855
-          - python-version: 3.10
-            os: windows-latest
+        python-version: ["3.8", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -55,7 +49,7 @@ jobs:
         os: [ubuntu-latest]
         # python 3.11 has intermittent issues with the docker build + push step
         # https://github.com/flyteorg/flytekit/actions/runs/5800978835/job/15724237979?pr=1579
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -97,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.11"]
         plugin-names:
           # Please maintain an alphabetical order in the following list
           - flytekit-aws-athena
@@ -148,12 +142,6 @@ jobs:
             plugin-names: "flytekit-greatexpectations"
           # onnxruntime does not support python 3.10 yet
           # https://github.com/microsoft/onnxruntime/issues/9782
-          - python-version: 3.10
-            plugin-names: "flytekit-onnx-pytorch"
-          - python-version: 3.10
-            plugin-names: "flytekit-onnx-scikitlearn"
-          - python-version: 3.10
-            plugin-names: "flytekit-onnx-tensorflow"
           - python-version: 3.11
             plugin-names: "flytekit-onnx-pytorch"
           - python-version: 3.11


### PR DESCRIPTION
# TL;DR
Not too often see failures in 3.9/3.10 but not in 3.8 or 3.11.  plugins are the exception, some more thought may need to go into that - may need to add some back.