### PR TITLE
Fix: Make sure decks created in elastic task workers are transferred to parent process

### DIFF
--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -5,7 +5,7 @@ Kubernetes. It leverages `Pytorch Job <https://github.com/kubeflow/pytorch-opera
 import os
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Dict, NamedTuple, Optional, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Union
 
 import cloudpickle
 from flyteidl.plugins.kubeflow import common_pb2 as kubeflow_common

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -213,7 +213,7 @@ class ElasticWorkerResult(NamedTuple):
     """
 
     return_value: Any
-    decks: list[flytekit.Deck]
+    decks: List[flytekit.Deck]
 
 
 def spawn_helper(

--- a/plugins/flytekit-kf-pytorch/tests/test_elastic_task.py
+++ b/plugins/flytekit-kf-pytorch/tests/test_elastic_task.py
@@ -111,3 +111,41 @@ def test_rdzv_configs(start_method: str) -> None:
     with mock.patch("torch.distributed.launcher.api.LaunchConfig", side_effect=LaunchConfig) as mock_launch_config:
         test_task()
         assert mock_launch_config.call_args[1]["rdzv_configs"] == rdzv_configs
+
+
+@pytest.mark.parametrize("start_method", ["spawn", "fork"])
+def test_deck(start_method: str) -> None:
+    """Test that decks created in the main worker process are transferred to the parent process."""
+    world_size = 2
+
+    @task(
+        task_config=Elastic(nnodes=1, nproc_per_node=world_size, start_method=start_method),
+        disable_deck=False,
+    )
+    def train():
+        import os
+
+        ctx = flytekit.current_context()
+        deck = flytekit.Deck("test-deck", f"Hello Flyte Deck viewer from worker process {os.environ.get('RANK')}")
+        ctx.decks.append(deck)
+        default_deck = ctx.default_deck
+        default_deck.append("Hello from default deck")
+
+    @workflow
+    def wf():
+        train()
+
+    wf()
+
+    ctx = flytekit.current_context()
+
+    expected_deck_names = {"timeline", "default", "test-deck"}
+    found_deck_names = set(d.name for d in ctx.decks)
+
+    assert expected_deck_names.issubset(found_deck_names)
+
+    default_deck = [d for d in ctx.decks if d.name == "default"][0]
+    assert "Hello from default deck" == default_deck.html.strip()
+
+    test_deck = [d for d in ctx.decks if d.name == "test-deck"][0]
+    assert "Hello Flyte Deck viewer from worker process 0" in test_deck.html


### PR DESCRIPTION
# TL;DR
Currently, Flyte decks don't work with the elastic tasks. This PR fixes this.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue <- no pending items

## Complete description
The reason is that the elastic task starts worker processes (as `torchrun` does). When a user creates a deck, this deck is appended to `flytekit.current_context().decks` *in the worker processes*. However, the upload of the deck happens based on the `ctx` in the parent process where these decks are never appended. The decks are, thus, never shown in the UI.

This PR fixes this by returning the list of decks from the worker processes and, for rank `0`, attaches those decks to the parent processes context.


## Tracking Issue
_NA_

## Follow-up issue
_NA_
