### PR TITLE
Better Azure blob storage support 

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -560,7 +560,8 @@ class GCSConfig(object):
         kwargs = {}
         kwargs = set_if_exists(kwargs, "gsutil_parallelism", _internal.GCP.GSUTIL_PARALLELISM.read(config_file))
         return GCSConfig(**kwargs)
-    
+
+
 @dataclass(init=True, repr=True, eq=True, frozen=True)
 class AzureBlobStorageConfig(object):
     """

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -569,6 +569,7 @@ class AzureBlobStorageConfig(object):
 
     account_name: typing.Optional[str] = None
     account_key: typing.Optional[str] = None
+    tenant_id: typing.Optional[str] = None
     client_id: typing.Optional[str] = None
     client_secret: typing.Optional[str] = None
 
@@ -578,6 +579,7 @@ class AzureBlobStorageConfig(object):
         kwargs = {}
         kwargs = set_if_exists(kwargs, "account_name", _internal.AZURE.ACCOUNT_NAME.read(config_file))
         kwargs = set_if_exists(kwargs, "account_key", _internal.AZURE.ACCOUNT_KEY.read(config_file))
+        kwargs = set_if_exists(kwargs, "tenant_id", _internal.AZURE.TENANT_ID.read(config_file))
         kwargs = set_if_exists(kwargs, "client_id", _internal.AZURE.CLIENT_ID.read(config_file))
         kwargs = set_if_exists(kwargs, "client_secret", _internal.AZURE.CLIENT_SECRET.read(config_file))
         return AzureBlobStorageConfig(**kwargs)

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -578,8 +578,8 @@ class AzureBlobStorageConfig(object):
     def auto(cls, config_file: typing.Union[str, ConfigFile] = None) -> GCSConfig:
         config_file = get_config_file(config_file)
         kwargs = {}
-        kwargs = set_if_exists(kwargs, "account_name", _internal.AZURE.ACCOUNT_NAME.read(config_file))
-        kwargs = set_if_exists(kwargs, "account_key", _internal.AZURE.ACCOUNT_KEY.read(config_file))
+        kwargs = set_if_exists(kwargs, "account_name", _internal.AZURE.STORAGE_ACCOUNT_NAME.read(config_file))
+        kwargs = set_if_exists(kwargs, "account_key", _internal.AZURE.STORAGE_ACCOUNT_KEY.read(config_file))
         kwargs = set_if_exists(kwargs, "tenant_id", _internal.AZURE.TENANT_ID.read(config_file))
         kwargs = set_if_exists(kwargs, "client_id", _internal.AZURE.CLIENT_ID.read(config_file))
         kwargs = set_if_exists(kwargs, "client_secret", _internal.AZURE.CLIENT_SECRET.read(config_file))

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -560,6 +560,27 @@ class GCSConfig(object):
         kwargs = {}
         kwargs = set_if_exists(kwargs, "gsutil_parallelism", _internal.GCP.GSUTIL_PARALLELISM.read(config_file))
         return GCSConfig(**kwargs)
+    
+@dataclass(init=True, repr=True, eq=True, frozen=True)
+class AzureBlobStorageConfig(object):
+    """
+    Any Azure Blob Storage specific configuration.
+    """
+
+    account_name: typing.Optional[str] = None
+    account_key: typing.Optional[str] = None
+    client_id: typing.Optional[str] = None
+    client_secret: typing.Optional[str] = None
+
+    @classmethod
+    def auto(cls, config_file: typing.Union[str, ConfigFile] = None) -> GCSConfig:
+        config_file = get_config_file(config_file)
+        kwargs = {}
+        kwargs = set_if_exists(kwargs, "account_name", _internal.AZURE.ACCOUNT_NAME.read(config_file))
+        kwargs = set_if_exists(kwargs, "account_key", _internal.AZURE.ACCOUNT_KEY.read(config_file))
+        kwargs = set_if_exists(kwargs, "client_id", _internal.AZURE.CLIENT_ID.read(config_file))
+        kwargs = set_if_exists(kwargs, "client_secret", _internal.AZURE.CLIENT_SECRET.read(config_file))
+        return AzureBlobStorageConfig(**kwargs)
 
 
 @dataclass(init=True, repr=True, eq=True, frozen=True)
@@ -572,11 +593,13 @@ class DataConfig(object):
 
     s3: S3Config = S3Config()
     gcs: GCSConfig = GCSConfig()
+    azure: AzureBlobStorageConfig = AzureBlobStorageConfig()
 
     @classmethod
     def auto(cls, config_file: typing.Union[str, ConfigFile] = None) -> DataConfig:
         config_file = get_config_file(config_file)
         return DataConfig(
+            azure=AzureBlobStorageConfig.auto(config_file),
             s3=S3Config.auto(config_file),
             gcs=GCSConfig.auto(config_file),
         )

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -57,6 +57,14 @@ class GCP(object):
     GSUTIL_PARALLELISM = ConfigEntry(LegacyConfigEntry(SECTION, "gsutil_parallelism", bool))
 
 
+class AZURE(object):
+    SECTION = "azure"
+    ACCOUNT_NAME = ConfigEntry(LegacyConfigEntry(SECTION, "account_name"))
+    ACCOUNT_KEY = ConfigEntry(LegacyConfigEntry(SECTION, "account_key"))
+    CLIENT_ID = ConfigEntry(LegacyConfigEntry(SECTION, "account_key"))
+    CLIENT_SECRET = ConfigEntry(LegacyConfigEntry(SECTION, "access_key_id"))
+
+
 class Credentials(object):
     SECTION = "credentials"
     COMMAND = ConfigEntry(LegacyConfigEntry(SECTION, "command", list), YamlConfigEntry("admin.command", list))

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -61,8 +61,9 @@ class AZURE(object):
     SECTION = "azure"
     ACCOUNT_NAME = ConfigEntry(LegacyConfigEntry(SECTION, "account_name"))
     ACCOUNT_KEY = ConfigEntry(LegacyConfigEntry(SECTION, "account_key"))
-    CLIENT_ID = ConfigEntry(LegacyConfigEntry(SECTION, "account_key"))
-    CLIENT_SECRET = ConfigEntry(LegacyConfigEntry(SECTION, "access_key_id"))
+    TENANT_ID = ConfigEntry(LegacyConfigEntry(SECTION, "tenant_id"))
+    CLIENT_ID = ConfigEntry(LegacyConfigEntry(SECTION, "client_id"))
+    CLIENT_SECRET = ConfigEntry(LegacyConfigEntry(SECTION, "client_secret"))
 
 
 class Credentials(object):

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -59,8 +59,8 @@ class GCP(object):
 
 class AZURE(object):
     SECTION = "azure"
-    ACCOUNT_NAME = ConfigEntry(LegacyConfigEntry(SECTION, "account_name"))
-    ACCOUNT_KEY = ConfigEntry(LegacyConfigEntry(SECTION, "account_key"))
+    STORAGE_ACCOUNT_NAME = ConfigEntry(LegacyConfigEntry(SECTION, "storage_account_name"))
+    STORAGE_ACCOUNT_KEY = ConfigEntry(LegacyConfigEntry(SECTION, "storage_account_key"))
     TENANT_ID = ConfigEntry(LegacyConfigEntry(SECTION, "tenant_id"))
     CLIENT_ID = ConfigEntry(LegacyConfigEntry(SECTION, "client_id"))
     CLIENT_SECRET = ConfigEntry(LegacyConfigEntry(SECTION, "client_secret"))

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -66,21 +66,15 @@ def azure_setup_args(azure_cfg: configuration.AzureBlobStorageConfig, anonymous:
 
     if azure_cfg.account_name:
         kwargs["account_name"] = azure_cfg.account_name
-
     if azure_cfg.account_key:
         kwargs["account_key"] = azure_cfg.account_key
-
     if azure_cfg.client_id:
         kwargs["client_id"] = azure_cfg.client_id
-
     if azure_cfg.client_secret:
         kwargs["client_secret"] = azure_cfg.client_secret
-
     if azure_cfg.tenant_id:
         kwargs["tenant_id"] = azure_cfg.tenant_id
-
     kwargs[_ANON] = anonymous
-
     return kwargs
 
 
@@ -97,7 +91,7 @@ def get_fsspec_storage_options(
         if anonymous:
             kwargs["token"] = _ANON
         return kwargs
-    if protocol == "abfs":
+    if protocol in ("abfs", "abfss"):
         return {**azure_setup_args(data_config.azure, anonymous=anonymous), **kwargs}
     return {}
 

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -79,8 +79,7 @@ def azure_setup_args(azure_cfg: configuration.AzureBlobStorageConfig, anonymous:
     if azure_cfg.tenant_id:
         kwargs["tenant_id"] = azure_cfg.tenant_id
 
-    if anonymous:
-        kwargs[_ANON] = True
+    kwargs[_ANON] = anonymous
 
     return kwargs
 

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -148,9 +148,10 @@ class FileAccessProvider(object):
         if not protocol:
             return self._default_remote
         
-        storage_options = get_storage_options_for_filesystem(protocol=protocol, anonymous=anonymous, data_config=self._data_config, **kwargs)
+        storage_options = get_storage_options(protocol=protocol, anonymous=anonymous, data_config=self._data_config, **kwargs)
 
         return fsspec.filesystem(protocol, **storage_options)
+
     def get_filesystem_for_path(self, path: str = "", anonymous: bool = False, **kwargs) -> fsspec.AbstractFileSystem:
         protocol = get_protocol(path)
         return self.get_filesystem(protocol, anonymous=anonymous, **kwargs)

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -71,10 +71,13 @@ def azure_setup_args(azure_cfg: configuration.AzureBlobStorageConfig, anonymous:
         kwargs["account_key"] = azure_cfg.account_key
 
     if azure_cfg.client_id:
-        kwargs["account_key"] = azure_cfg.client_id
+        kwargs["client_id"] = azure_cfg.client_id
 
     if azure_cfg.client_secret:
-        kwargs["account_key"] = azure_cfg.client_secret
+        kwargs["client_secret"] = azure_cfg.client_secret
+
+    if azure_cfg.tenant_id:
+        kwargs["tenant_id"] = azure_cfg.tenant_id
 
     if anonymous:
         kwargs[_ANON] = True

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -85,7 +85,11 @@ def azure_setup_args(azure_cfg: configuration.AzureBlobStorageConfig, anonymous:
     return kwargs
 
 
-def get_fsspec_storage_options(protocol: str, data_config: typing.Optional[DataConfig] = None, anonymous: bool = False, **kwargs) -> typing.Dict:
+def get_fsspec_storage_options(
+    protocol: str, data_config: typing.Optional[DataConfig] = None, anonymous: bool = False, **kwargs
+) -> typing.Dict:
+    data_config = data_config or DataConfig.auto()
+
     if protocol == "file":
         return {"auto_mkdir": True, **kwargs}
     if protocol == "s3":
@@ -147,8 +151,10 @@ class FileAccessProvider(object):
     ) -> fsspec.AbstractFileSystem:
         if not protocol:
             return self._default_remote
-        
-        storage_options = get_fsspec_storage_options(protocol=protocol, anonymous=anonymous, data_config=self._data_config, **kwargs)
+
+        storage_options = get_fsspec_storage_options(
+            protocol=protocol, anonymous=anonymous, data_config=self._data_config, **kwargs
+        )
 
         return fsspec.filesystem(protocol, **storage_options)
 

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -25,7 +25,6 @@ from typing import Any, Dict, Union, cast
 from uuid import UUID
 
 import fsspec
-from fsspec.core import url_to_fs
 from fsspec.utils import get_protocol
 
 from flytekit import configuration

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -41,7 +41,7 @@ _FSSPEC_S3_SECRET = "secret"
 _ANON = "anon"
 
 
-def s3_setup_args(s3_cfg: configuration.S3Config, anonymous: bool = False):
+def s3_setup_args(s3_cfg: configuration.S3Config, anonymous: bool = False) -> Dict[str, Any]:
     kwargs: Dict[str, Any] = {
         "cache_regions": True,
     }
@@ -61,7 +61,7 @@ def s3_setup_args(s3_cfg: configuration.S3Config, anonymous: bool = False):
     return kwargs
 
 
-def azure_setup_args(azure_cfg: configuration.AzureBlobStorageConfig, anonymous: bool = False):
+def azure_setup_args(azure_cfg: configuration.AzureBlobStorageConfig, anonymous: bool = False) -> Dict[str, Any]:
     kwargs: Dict[str, Any] = {}
 
     if azure_cfg.account_name:
@@ -80,7 +80,7 @@ def azure_setup_args(azure_cfg: configuration.AzureBlobStorageConfig, anonymous:
 
 def get_fsspec_storage_options(
     protocol: str, data_config: typing.Optional[DataConfig] = None, anonymous: bool = False, **kwargs
-) -> typing.Dict:
+) -> Dict[str, Any]:
     data_config = data_config or DataConfig.auto()
 
     if protocol == "file":

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -85,7 +85,7 @@ def azure_setup_args(azure_cfg: configuration.AzureBlobStorageConfig, anonymous:
     return kwargs
 
 
-def get_storage_options(protocol: str, data_config: typing.Optional[DataConfig] = None, anonymous: bool = False, **kwargs) -> typing.Dict[str, Any]:
+def get_fsspec_storage_options(protocol: str, data_config: typing.Optional[DataConfig] = None, anonymous: bool = False, **kwargs) -> typing.Dict:
     if protocol == "file":
         return {"auto_mkdir": True, **kwargs}
     if protocol == "s3":
@@ -96,6 +96,7 @@ def get_storage_options(protocol: str, data_config: typing.Optional[DataConfig] 
         return kwargs
     if protocol == "abfs":
         return {**azure_setup_args(data_config.azure, anonymous=anonymous), **kwargs}
+    return {}
 
 
 class FileAccessProvider(object):
@@ -147,7 +148,7 @@ class FileAccessProvider(object):
         if not protocol:
             return self._default_remote
         
-        storage_options = get_storage_options(protocol=protocol, anonymous=anonymous, data_config=self._data_config, **kwargs)
+        storage_options = get_fsspec_storage_options(protocol=protocol, anonymous=anonymous, data_config=self._data_config, **kwargs)
 
         return fsspec.filesystem(protocol, **storage_options)
 

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -67,7 +67,7 @@ def azure_setup_args(azure_cfg: configuration.AzureBlobStorageConfig, anonymous:
     if azure_cfg.account_name:
         kwargs["account_name"] = azure_cfg.account_name
 
-    if azure_cfg.account_name:
+    if azure_cfg.account_key:
         kwargs["account_key"] = azure_cfg.account_key
 
     if azure_cfg.client_id:
@@ -146,7 +146,7 @@ class FileAccessProvider(object):
         elif protocol == "abfs":
             azurekwargs = azure_setup_args(self._data_config.azure, anonymous=anonymous)
             azurekwargs.update(kwargs)
-            return fsspec.filesystem(protocol, **kwargs)  # type: ignore
+            return fsspec.filesystem(protocol, **azurekwargs)  # type: ignore
 
         # Preserve old behavior of returning None for file systems that don't have an explicit anonymous option.
         if anonymous:

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -86,7 +86,7 @@ def azure_setup_args(azure_cfg: configuration.AzureBlobStorageConfig, anonymous:
     return kwargs
 
 
-def get_storage_options_for_filesystem(protocol: str, data_config: typing.Optional[DataConfig] = None, anonymous: bool = False, **kwargs) -> typing.Dict[str, Any]:
+def get_storage_options(protocol: str, data_config: typing.Optional[DataConfig] = None, anonymous: bool = False, **kwargs) -> typing.Dict[str, Any]:
     if protocol == "file":
         return {"auto_mkdir": True, **kwargs}
     if protocol == "s3":

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -61,6 +61,27 @@ def s3_setup_args(s3_cfg: configuration.S3Config, anonymous: bool = False):
     return kwargs
 
 
+def azure_setup_args(azure_cfg: configuration.AzureBlobStorageConfig, anonymous: bool = False):
+    kwargs: Dict[str, Any] = {}
+
+    if azure_cfg.account_name:
+        kwargs["account_name"] = azure_cfg.account_name
+
+    if azure_cfg.account_name:
+        kwargs["account_key"] = azure_cfg.account_key
+
+    if azure_cfg.client_id:
+        kwargs["account_key"] = azure_cfg.client_id
+
+    if azure_cfg.client_secret:
+        kwargs["account_key"] = azure_cfg.client_secret
+
+    if anonymous:
+        kwargs[_ANON] = True
+
+    return kwargs
+
+
 class FileAccessProvider(object):
     """
     This is the class that is available through the FlyteContext and can be used for persisting data to the remote
@@ -120,7 +141,8 @@ class FileAccessProvider(object):
                 kwargs["token"] = _ANON
             return fsspec.filesystem(protocol, **kwargs)  # type: ignore
         elif protocol == "abfs":
-            kwargs["anon"] = False
+            azurekwargs = azure_setup_args(self._data_config.azure, anonymous=anonymous)
+            azurekwargs.update(kwargs)
             return fsspec.filesystem(protocol, **kwargs)  # type: ignore
 
         # Preserve old behavior of returning None for file systems that don't have an explicit anonymous option.

--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -30,9 +30,12 @@ T = TypeVar("T")
 def get_pandas_storage_options(
     uri: str, data_config: DataConfig, anonymous: bool = False
 ) -> typing.Optional[typing.Dict]:
-    if pd.io.common.is_url(uri):
+    print(f"check is uri, uri = {uri}")
+    print(get_fsspec_storage_options)
+    if pd.io.common.is_fsspec_url(uri):
         return get_fsspec_storage_options(protocol=get_protocol(uri), data_config=data_config, anonymous=anonymous)
-    # Pandas does not allow storage_options for non-url paths.
+
+    # Pandas does not allow storage_options for on-fsspec paths e.g. local. 
     return None
 
 

--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -11,8 +11,7 @@ from fsspec.core import split_protocol, strip_protocol
 from fsspec.utils import get_protocol
 
 from flytekit import FlyteContext, logger
-from flytekit.configuration import DataConfig
-from flytekit.core.data_persistence import s3_setup_args
+from flytekit.core.data_persistence import get_storage_options
 from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
@@ -25,15 +24,6 @@ from flytekit.types.structured.structured_dataset import (
 )
 
 T = TypeVar("T")
-
-
-def get_storage_options(cfg: DataConfig, uri: str, anon: bool = False) -> typing.Optional[typing.Dict]:
-    protocol = get_protocol(uri)
-    if protocol == "s3":
-        kwargs = s3_setup_args(cfg.s3, anon)
-        if kwargs:
-            return kwargs
-    return None
 
 
 class PandasToCSVEncodingHandler(StructuredDatasetEncoder):
@@ -54,7 +44,7 @@ class PandasToCSVEncodingHandler(StructuredDatasetEncoder):
         df.to_csv(
             path,
             index=False,
-            storage_options=get_storage_options(ctx.file_access.data_config, path),
+            storage_options=get_storage_options(protocol=get_protocol(path), data_config=ctx.file_access.data_config),
         )
         structured_dataset_type.format = CSV
         return literals.StructuredDataset(uri=uri, metadata=StructuredDatasetMetadata(structured_dataset_type))
@@ -72,7 +62,7 @@ class CSVToPandasDecodingHandler(StructuredDatasetDecoder):
     ) -> pd.DataFrame:
         uri = flyte_value.uri
         columns = None
-        kwargs = get_storage_options(ctx.file_access.data_config, uri)
+        kwargs = get_storage_options(protocol=get_protocol(uri), data_config=ctx.file_access.data_config)
         path = os.path.join(uri, ".csv")
         if current_task_metadata.structured_dataset_type and current_task_metadata.structured_dataset_type.columns:
             columns = [c.name for c in current_task_metadata.structured_dataset_type.columns]
@@ -80,7 +70,7 @@ class CSVToPandasDecodingHandler(StructuredDatasetDecoder):
             return pd.read_csv(path, usecols=columns, storage_options=kwargs)
         except NoCredentialsError:
             logger.debug("S3 source detected, attempting anonymous S3 access")
-            kwargs = get_storage_options(ctx.file_access.data_config, uri, anon=True)
+            kwargs = get_storage_options(protocol=get_protocol(uri), data_config=ctx.file_access.data_config, anon=True)
             return pd.read_csv(path, usecols=columns, storage_options=kwargs)
 
 
@@ -103,7 +93,7 @@ class PandasToParquetEncodingHandler(StructuredDatasetEncoder):
             path,
             coerce_timestamps="us",
             allow_truncated_timestamps=False,
-            storage_options=get_storage_options(ctx.file_access.data_config, path),
+            storage_options=get_storage_options(protocol=get_protocol(path), data_config=ctx.file_access.data_config),
         )
         structured_dataset_type.format = PARQUET
         return literals.StructuredDataset(uri=uri, metadata=StructuredDatasetMetadata(structured_dataset_type))
@@ -121,14 +111,14 @@ class ParquetToPandasDecodingHandler(StructuredDatasetDecoder):
     ) -> pd.DataFrame:
         uri = flyte_value.uri
         columns = None
-        kwargs = get_storage_options(ctx.file_access.data_config, uri)
+        kwargs = get_storage_options(protocol=get_protocol(uri), data_config=ctx.file_access.data_config)
         if current_task_metadata.structured_dataset_type and current_task_metadata.structured_dataset_type.columns:
             columns = [c.name for c in current_task_metadata.structured_dataset_type.columns]
         try:
             return pd.read_parquet(uri, columns=columns, storage_options=kwargs)
         except NoCredentialsError:
             logger.debug("S3 source detected, attempting anonymous S3 access")
-            kwargs = get_storage_options(ctx.file_access.data_config, uri, anon=True)
+            kwargs = get_storage_options(protocol=get_protocol(uri), data_config=ctx.file_access.data_config, anon=True)
             return pd.read_parquet(uri, columns=columns, storage_options=kwargs)
 
 

--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -30,12 +30,10 @@ T = TypeVar("T")
 def get_pandas_storage_options(
     uri: str, data_config: DataConfig, anonymous: bool = False
 ) -> typing.Optional[typing.Dict]:
-    print(f"check is uri, uri = {uri}")
-    print(get_fsspec_storage_options)
     if pd.io.common.is_fsspec_url(uri):
         return get_fsspec_storage_options(protocol=get_protocol(uri), data_config=data_config, anonymous=anonymous)
 
-    # Pandas does not allow storage_options for on-fsspec paths e.g. local. 
+    # Pandas does not allow storage_options for non-fsspec paths e.g. local.
     return None
 
 

--- a/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
+++ b/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
@@ -2,12 +2,13 @@ import typing
 
 import pandas as pd
 import polars as pl
+from fsspec.utils import get_protocol
 
 from flytekit import FlyteContext
+from flytekit.core.data_persistence import get_fsspec_storage_options
 from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
-from flytekit.types.structured.basic_dfs import get_storage_options
 from flytekit.types.structured.structured_dataset import (
     PARQUET,
     StructuredDataset,
@@ -64,7 +65,7 @@ class ParquetToPolarsDataFrameDecodingHandler(StructuredDatasetDecoder):
         current_task_metadata: StructuredDatasetMetadata,
     ) -> pl.DataFrame:
         uri = flyte_value.uri
-        kwargs = get_storage_options(ctx.file_access.data_config, uri)
+        kwargs = get_fsspec_storage_options(protocol=get_protocol(uri), data_config=ctx.file_access.data_config)
         if current_task_metadata.structured_dataset_type and current_task_metadata.structured_dataset_type.columns:
             columns = [c.name for c in current_task_metadata.structured_dataset_type.columns]
             return pl.read_parquet(uri, columns=columns, use_pyarrow=True, storage_options=kwargs)

--- a/tests/flytekit/unit/core/test_data.py
+++ b/tests/flytekit/unit/core/test_data.py
@@ -227,44 +227,41 @@ def test_s3_setup_args_env_aws(mock_os, mock_get_config_file):
 
 
 @mock.patch("flytekit.configuration.get_config_file")
-@mock.patch.dict(
-    os.environ,
-    {
-        "FLYTE_GCP_GSUTIL_PARALLELISM": "False",
-    },
-)
-def test_get_fsspec_storage_options_gcs(mock_get_config_file):
+@mock.patch("os.environ")
+def test_get_fsspec_storage_options_gcs(mock_os, mock_get_config_file):
     mock_get_config_file.return_value = None
+    ee = {
+        "FLYTE_GCP_GSUTIL_PARALLELISM": "False",
+    }
+    mock_os.get.side_effect = lambda x, y: ee.get(x)
     storage_options = get_fsspec_storage_options("gs", DataConfig.auto())
     assert storage_options == {}
 
 
 @mock.patch("flytekit.configuration.get_config_file")
-@mock.patch.dict(
-    os.environ,
-    {
-        "FLYTE_GCP_GSUTIL_PARALLELISM": "False",
-    },
-)
-def test_get_fsspec_storage_options_gcs_with_overrides(mock_get_config_file):
+@mock.patch("os.environ")
+def test_get_fsspec_storage_options_gcs_with_overrides(mock_os, mock_get_config_file):
     mock_get_config_file.return_value = None
+    ee = {
+        "FLYTE_GCP_GSUTIL_PARALLELISM": "False",
+    }
+    mock_os.get.side_effect = lambda x, y: ee.get(x)
     storage_options = get_fsspec_storage_options("gs", DataConfig.auto(), anonymous=True, other_argument="value")
     assert storage_options == {"token": "anon", "other_argument": "value"}
 
 
 @mock.patch("flytekit.configuration.get_config_file")
-@mock.patch.dict(
-    os.environ,
-    {
+@mock.patch("os.environ")
+def test_get_fsspec_storage_options_azure(mock_os, mock_get_config_file):
+    mock_get_config_file.return_value = None
+    ee = {
         "FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname",
         "FLYTE_AZURE_STORAGE_ACCOUNT_KEY": "accountkey",
         "FLYTE_AZURE_TENANT_ID": "tenantid",
         "FLYTE_AZURE_CLIENT_ID": "clientid",
         "FLYTE_AZURE_CLIENT_SECRET": "clientsecret",
-    },
-)
-def test_get_fsspec_storage_options_azure(mock_get_config_file):
-    mock_get_config_file.return_value = None
+    }
+    mock_os.get.side_effect = lambda x, y: ee.get(x)
     storage_options = get_fsspec_storage_options("abfs", DataConfig.auto())
     assert storage_options == {
         "account_name": "accountname",
@@ -277,15 +274,14 @@ def test_get_fsspec_storage_options_azure(mock_get_config_file):
 
 
 @mock.patch("flytekit.configuration.get_config_file")
-@mock.patch.dict(
-    os.environ,
-    {
+@mock.patch("os.environ")
+def test_get_fsspec_storage_options_azure_with_overrides(mock_os, mock_get_config_file):
+    mock_get_config_file.return_value = None
+    ee = {
         "FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname",
         "FLYTE_AZURE_STORAGE_ACCOUNT_KEY": "accountkey",
-    },
-)
-def test_get_fsspec_storage_options_azure_with_overrides(mock_get_config_file):
-    mock_get_config_file.return_value = None
+    }
+    mock_os.get.side_effect = lambda x, y: ee.get(x)
     storage_options = get_fsspec_storage_options(
         "abfs", DataConfig.auto(), anonymous=True, account_name="other_accountname", other_argument="value"
     )

--- a/tests/flytekit/unit/core/test_data.py
+++ b/tests/flytekit/unit/core/test_data.py
@@ -8,11 +8,10 @@ import fsspec
 import mock
 import pytest
 
-from flytekit.configuration import AzureBlobStorageConfig, Config, DataConfig, S3Config
+from flytekit.configuration import Config, DataConfig, S3Config
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.data_persistence import (
     FileAccessProvider,
-    azure_setup_args,
     default_local_file_access_provider,
     get_fsspec_storage_options,
     s3_setup_args,
@@ -228,9 +227,12 @@ def test_s3_setup_args_env_aws(mock_os, mock_get_config_file):
 
 
 @mock.patch("flytekit.configuration.get_config_file")
-@mock.patch.dict(os.environ, {
+@mock.patch.dict(
+    os.environ,
+    {
         "FLYTE_GCP_GSUTIL_PARALLELISM": "False",
-    })
+    },
+)
 def test_get_fsspec_storage_options_gcs(mock_get_config_file):
     mock_get_config_file.return_value = None
     storage_options = get_fsspec_storage_options("gs", DataConfig.auto())
@@ -238,23 +240,29 @@ def test_get_fsspec_storage_options_gcs(mock_get_config_file):
 
 
 @mock.patch("flytekit.configuration.get_config_file")
-@mock.patch.dict(os.environ, {
+@mock.patch.dict(
+    os.environ,
+    {
         "FLYTE_GCP_GSUTIL_PARALLELISM": "False",
-    })
-def test_get_fsspec_storage_options_gcs(mock_get_config_file):
+    },
+)
+def test_get_fsspec_storage_options_gcs_with_overrides(mock_get_config_file):
     mock_get_config_file.return_value = None
     storage_options = get_fsspec_storage_options("gs", DataConfig.auto(), anonymous=True, other_argument="value")
     assert storage_options == {"token": "anon", "other_argument": "value"}
 
 
 @mock.patch("flytekit.configuration.get_config_file")
-@mock.patch.dict(os.environ, {
-        "FLYTE_AZURE_ACCOUNT_NAME": "accountname",
-        "FLYTE_AZURE_ACCOUNT_KEY": "accountkey",
+@mock.patch.dict(
+    os.environ,
+    {
+        "FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname",
+        "FLYTE_AZURE_STORAGE_ACCOUNT_KEY": "accountkey",
         "FLYTE_AZURE_TENANT_ID": "tenantid",
         "FLYTE_AZURE_CLIENT_ID": "clientid",
         "FLYTE_AZURE_CLIENT_SECRET": "clientsecret",
-    })
+    },
+)
 def test_get_fsspec_storage_options_azure(mock_get_config_file):
     mock_get_config_file.return_value = None
     storage_options = get_fsspec_storage_options("abfs", DataConfig.auto())
@@ -267,14 +275,20 @@ def test_get_fsspec_storage_options_azure(mock_get_config_file):
         "anon": False,
     }
 
+
 @mock.patch("flytekit.configuration.get_config_file")
-@mock.patch.dict(os.environ, {
+@mock.patch.dict(
+    os.environ,
+    {
         "FLYTE_AZURE_ACCOUNT_NAME": "accountname",
         "FLYTE_AZURE_ACCOUNT_KEY": "accountkey",
-    })
+    },
+)
 def test_get_fsspec_storage_options_azure_with_overrides(mock_get_config_file):
     mock_get_config_file.return_value = None
-    storage_options = get_fsspec_storage_options("abfs", DataConfig.auto(), anonymous=True, account_name="other_accountname", other_argument="value")
+    storage_options = get_fsspec_storage_options(
+        "abfs", DataConfig.auto(), anonymous=True, account_name="other_accountname", other_argument="value"
+    )
     assert storage_options == {
         "account_name": "other_accountname",
         "account_key": "accountkey",

--- a/tests/flytekit/unit/core/test_data.py
+++ b/tests/flytekit/unit/core/test_data.py
@@ -245,6 +245,7 @@ def test_azure_setup_env_args(mock_os, mock_get_config_file):
         "client_id": "clientid",
         "client_secret": "clientsecret",
         "tenant_id": "tenantid",
+        "anon": False,
     }
 
 

--- a/tests/flytekit/unit/core/test_data.py
+++ b/tests/flytekit/unit/core/test_data.py
@@ -8,12 +8,13 @@ import fsspec
 import mock
 import pytest
 
-from flytekit.configuration import AzureBlobStorageConfig, Config, S3Config
+from flytekit.configuration import AzureBlobStorageConfig, Config, DataConfig, S3Config
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.data_persistence import (
     FileAccessProvider,
     azure_setup_args,
     default_local_file_access_provider,
+    get_fsspec_storage_options,
     s3_setup_args,
 )
 from flytekit.types.directory.types import FlyteDirectory
@@ -227,25 +228,58 @@ def test_s3_setup_args_env_aws(mock_os, mock_get_config_file):
 
 
 @mock.patch("flytekit.configuration.get_config_file")
-@mock.patch("os.environ")
-def test_azure_setup_env_args(mock_os, mock_get_config_file):
+@mock.patch.dict(os.environ, {
+        "FLYTE_GCP_GSUTIL_PARALLELISM": "False",
+    })
+def test_get_fsspec_storage_options_gcs(mock_get_config_file):
     mock_get_config_file.return_value = None
-    ee = {
+    storage_options = get_fsspec_storage_options("gs", DataConfig.auto())
+    assert storage_options == {}
+
+
+@mock.patch("flytekit.configuration.get_config_file")
+@mock.patch.dict(os.environ, {
+        "FLYTE_GCP_GSUTIL_PARALLELISM": "False",
+    })
+def test_get_fsspec_storage_options_gcs(mock_get_config_file):
+    mock_get_config_file.return_value = None
+    storage_options = get_fsspec_storage_options("gs", DataConfig.auto(), anonymous=True, other_argument="value")
+    assert storage_options == {"token": "anon", "other_argument": "value"}
+
+
+@mock.patch("flytekit.configuration.get_config_file")
+@mock.patch.dict(os.environ, {
         "FLYTE_AZURE_ACCOUNT_NAME": "accountname",
         "FLYTE_AZURE_ACCOUNT_KEY": "accountkey",
         "FLYTE_AZURE_TENANT_ID": "tenantid",
         "FLYTE_AZURE_CLIENT_ID": "clientid",
         "FLYTE_AZURE_CLIENT_SECRET": "clientsecret",
-    }
-    mock_os.get.side_effect = lambda x, y: ee.get(x)
-    kwargs = azure_setup_args(AzureBlobStorageConfig.auto())
-    assert kwargs == {
+    })
+def test_get_fsspec_storage_options_azure(mock_get_config_file):
+    mock_get_config_file.return_value = None
+    storage_options = get_fsspec_storage_options("abfs", DataConfig.auto())
+    assert storage_options == {
         "account_name": "accountname",
         "account_key": "accountkey",
         "client_id": "clientid",
         "client_secret": "clientsecret",
         "tenant_id": "tenantid",
         "anon": False,
+    }
+
+@mock.patch("flytekit.configuration.get_config_file")
+@mock.patch.dict(os.environ, {
+        "FLYTE_AZURE_ACCOUNT_NAME": "accountname",
+        "FLYTE_AZURE_ACCOUNT_KEY": "accountkey",
+    })
+def test_get_fsspec_storage_options_azure_with_overrides(mock_get_config_file):
+    mock_get_config_file.return_value = None
+    storage_options = get_fsspec_storage_options("abfs", DataConfig.auto(), anonymous=True, account_name="other_accountname", other_argument="value")
+    assert storage_options == {
+        "account_name": "other_accountname",
+        "account_key": "accountkey",
+        "anon": True,
+        "other_argument": "value",
     }
 
 

--- a/tests/flytekit/unit/core/test_data.py
+++ b/tests/flytekit/unit/core/test_data.py
@@ -280,8 +280,8 @@ def test_get_fsspec_storage_options_azure(mock_get_config_file):
 @mock.patch.dict(
     os.environ,
     {
-        "FLYTE_AZURE_ACCOUNT_NAME": "accountname",
-        "FLYTE_AZURE_ACCOUNT_KEY": "accountkey",
+        "FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname",
+        "FLYTE_AZURE_STORAGE_ACCOUNT_KEY": "accountkey",
     },
 )
 def test_get_fsspec_storage_options_azure_with_overrides(mock_get_config_file):

--- a/tests/flytekit/unit/core/test_data_persistence.py
+++ b/tests/flytekit/unit/core/test_data_persistence.py
@@ -2,6 +2,7 @@ import os
 
 from azure.identity import ClientSecretCredential, DefaultAzureCredential
 from mock import patch
+
 from flytekit.core.data_persistence import FileAccessProvider
 
 
@@ -21,22 +22,33 @@ def test_is_remote():
 
 
 def test_initialise_azure_file_provider_with_account_key():
-    with patch.dict(os.environ, {"FLYTE_AZURE_ACCOUNT_NAME": "accountname", "FLYTE_AZURE_ACCOUNT_KEY": "accountkey"}, clear=True):
+    with patch.dict(
+        os.environ, {"FLYTE_AZURE_ACCOUNT_NAME": "accountname", "FLYTE_AZURE_ACCOUNT_KEY": "accountkey"}, clear=True
+    ):
         fp = FileAccessProvider("/tmp", "abfs://container/path/within/container")
         assert fp.get_filesystem().account_name == "accountname"
         assert fp.get_filesystem().account_key == "accountkey"
         assert fp.get_filesystem().sync_credential is None
 
+
 def test_initialise_azure_file_provider_with_service_principal():
-    with patch.dict(os.environ, {"FLYTE_AZURE_ACCOUNT_NAME": "accountname", "FLYTE_AZURE_CLIENT_SECRET": "clientsecret", "FLYTE_AZURE_CLIENT_ID": "clientid", 
-                                 "FLYTE_AZURE_TENANT_ID": "tenantid"
-                                 }, clear=True):
+    with patch.dict(
+        os.environ,
+        {
+            "FLYTE_AZURE_ACCOUNT_NAME": "accountname",
+            "FLYTE_AZURE_CLIENT_SECRET": "clientsecret",
+            "FLYTE_AZURE_CLIENT_ID": "clientid",
+            "FLYTE_AZURE_TENANT_ID": "tenantid",
+        },
+        clear=True,
+    ):
         fp = FileAccessProvider("/tmp", "abfs://container/path/within/container")
         assert fp.get_filesystem().account_name == "accountname"
         assert isinstance(fp.get_filesystem().sync_credential, ClientSecretCredential)
         assert fp.get_filesystem().client_secret == "clientsecret"
         assert fp.get_filesystem().client_id == "clientid"
         assert fp.get_filesystem().tenant_id == "tenantid"
+
 
 def test_initialise_azure_file_provider_with_default_credential():
     with patch.dict(os.environ, {"FLYTE_AZURE_ACCOUNT_NAME": "accountname"}, clear=True):

--- a/tests/flytekit/unit/core/test_data_persistence.py
+++ b/tests/flytekit/unit/core/test_data_persistence.py
@@ -1,7 +1,7 @@
 import os
 
+import mock
 from azure.identity import ClientSecretCredential, DefaultAzureCredential
-from mock import patch
 
 from flytekit.core.data_persistence import FileAccessProvider
 
@@ -22,10 +22,9 @@ def test_is_remote():
 
 
 def test_initialise_azure_file_provider_with_account_key():
-    with patch.dict(
+    with mock.patch.dict(
         os.environ,
         {"FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname", "FLYTE_AZURE_STORAGE_ACCOUNT_KEY": "accountkey"},
-        clear=True,
     ):
         fp = FileAccessProvider("/tmp", "abfs://container/path/within/container")
         assert fp.get_filesystem().account_name == "accountname"
@@ -34,7 +33,7 @@ def test_initialise_azure_file_provider_with_account_key():
 
 
 def test_initialise_azure_file_provider_with_service_principal():
-    with patch.dict(
+    with mock.patch.dict(
         os.environ,
         {
             "FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname",
@@ -42,7 +41,6 @@ def test_initialise_azure_file_provider_with_service_principal():
             "FLYTE_AZURE_CLIENT_ID": "clientid",
             "FLYTE_AZURE_TENANT_ID": "tenantid",
         },
-        clear=True,
     ):
         fp = FileAccessProvider("/tmp", "abfs://container/path/within/container")
         assert fp.get_filesystem().account_name == "accountname"
@@ -53,7 +51,7 @@ def test_initialise_azure_file_provider_with_service_principal():
 
 
 def test_initialise_azure_file_provider_with_default_credential():
-    with patch.dict(os.environ, {"FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname"}, clear=True):
+    with mock.patch.dict(os.environ, {"FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname"}):
         fp = FileAccessProvider("/tmp", "abfs://container/path/within/container")
         assert fp.get_filesystem().account_name == "accountname"
         assert isinstance(fp.get_filesystem().sync_credential, DefaultAzureCredential)

--- a/tests/flytekit/unit/core/test_data_persistence.py
+++ b/tests/flytekit/unit/core/test_data_persistence.py
@@ -23,7 +23,9 @@ def test_is_remote():
 
 def test_initialise_azure_file_provider_with_account_key():
     with patch.dict(
-        os.environ, {"FLYTE_AZURE_ACCOUNT_NAME": "accountname", "FLYTE_AZURE_ACCOUNT_KEY": "accountkey"}, clear=True
+        os.environ,
+        {"FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname", "FLYTE_AZURE_STORAGE_ACCOUNT_KEY": "accountkey"},
+        clear=True,
     ):
         fp = FileAccessProvider("/tmp", "abfs://container/path/within/container")
         assert fp.get_filesystem().account_name == "accountname"
@@ -35,7 +37,7 @@ def test_initialise_azure_file_provider_with_service_principal():
     with patch.dict(
         os.environ,
         {
-            "FLYTE_AZURE_ACCOUNT_NAME": "accountname",
+            "FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname",
             "FLYTE_AZURE_CLIENT_SECRET": "clientsecret",
             "FLYTE_AZURE_CLIENT_ID": "clientid",
             "FLYTE_AZURE_TENANT_ID": "tenantid",
@@ -51,7 +53,7 @@ def test_initialise_azure_file_provider_with_service_principal():
 
 
 def test_initialise_azure_file_provider_with_default_credential():
-    with patch.dict(os.environ, {"FLYTE_AZURE_ACCOUNT_NAME": "accountname"}, clear=True):
+    with patch.dict(os.environ, {"FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname"}, clear=True):
         fp = FileAccessProvider("/tmp", "abfs://container/path/within/container")
         assert fp.get_filesystem().account_name == "accountname"
         assert isinstance(fp.get_filesystem().sync_credential, DefaultAzureCredential)

--- a/tests/flytekit/unit/core/test_data_persistence.py
+++ b/tests/flytekit/unit/core/test_data_persistence.py
@@ -1,3 +1,7 @@
+import os
+
+from azure.identity import ClientSecretCredential, DefaultAzureCredential
+from mock import patch
 from flytekit.core.data_persistence import FileAccessProvider
 
 
@@ -14,3 +18,28 @@ def test_is_remote():
     assert fp.is_remote("/tmp/foo/bar") is False
     assert fp.is_remote("file://foo/bar") is False
     assert fp.is_remote("s3://my-bucket/foo/bar") is True
+
+
+def test_initialise_azure_file_provider_with_account_key():
+    with patch.dict(os.environ, {"FLYTE_AZURE_ACCOUNT_NAME": "accountname", "FLYTE_AZURE_ACCOUNT_KEY": "accountkey"}, clear=True):
+        fp = FileAccessProvider("/tmp", "abfs://container/path/within/container")
+        assert fp.get_filesystem().account_name == "accountname"
+        assert fp.get_filesystem().account_key == "accountkey"
+        assert fp.get_filesystem().sync_credential is None
+
+def test_initialise_azure_file_provider_with_service_principal():
+    with patch.dict(os.environ, {"FLYTE_AZURE_ACCOUNT_NAME": "accountname", "FLYTE_AZURE_CLIENT_SECRET": "clientsecret", "FLYTE_AZURE_CLIENT_ID": "clientid", 
+                                 "FLYTE_AZURE_TENANT_ID": "tenantid"
+                                 }, clear=True):
+        fp = FileAccessProvider("/tmp", "abfs://container/path/within/container")
+        assert fp.get_filesystem().account_name == "accountname"
+        assert isinstance(fp.get_filesystem().sync_credential, ClientSecretCredential)
+        assert fp.get_filesystem().client_secret == "clientsecret"
+        assert fp.get_filesystem().client_id == "clientid"
+        assert fp.get_filesystem().tenant_id == "tenantid"
+
+def test_initialise_azure_file_provider_with_default_credential():
+    with patch.dict(os.environ, {"FLYTE_AZURE_ACCOUNT_NAME": "accountname"}, clear=True):
+        fp = FileAccessProvider("/tmp", "abfs://container/path/within/container")
+        assert fp.get_filesystem().account_name == "accountname"
+        assert isinstance(fp.get_filesystem().sync_credential, DefaultAzureCredential)

--- a/tests/flytekit/unit/core/test_structured_dataset_handlers.py
+++ b/tests/flytekit/unit/core/test_structured_dataset_handlers.py
@@ -54,9 +54,7 @@ def test_csv():
 @mock.patch("pandas.DataFrame.to_parquet")
 @mock.patch("pandas.read_parquet")
 @mock.patch("flytekit.types.structured.basic_dfs.get_fsspec_storage_options")
-def test_pandas_to_parquet_azure_storage_options(
-    mock_get_fsspec_storage_options, mock_read_parquet, mock_to_parquet
-):
+def test_pandas_to_parquet_azure_storage_options(mock_get_fsspec_storage_options, mock_read_parquet, mock_to_parquet):
     df = pd.DataFrame({"Name": ["Tom", "Joseph"], "Age": [20, 22]})
     encoder = basic_dfs.PandasToParquetEncodingHandler()
     decoder = basic_dfs.ParquetToPandasDecodingHandler()
@@ -84,9 +82,7 @@ def test_pandas_to_parquet_azure_storage_options(
 @mock.patch("pandas.DataFrame.to_csv")
 @mock.patch("pandas.read_csv")
 @mock.patch("flytekit.types.structured.basic_dfs.get_fsspec_storage_options")
-def test_pandas_to_csv_azure_storage_options(
-    mock_get_fsspec_storage_options, mock_read_parquet, mock_to_parquet
-):
+def test_pandas_to_csv_azure_storage_options(mock_get_fsspec_storage_options, mock_read_parquet, mock_to_parquet):
     df = pd.DataFrame({"Name": ["Tom", "Joseph"], "Age": [20, 22]})
     encoder = basic_dfs.PandasToCSVEncodingHandler()
     decoder = basic_dfs.CSVToPandasDecodingHandler()

--- a/tests/flytekit/unit/core/test_structured_dataset_handlers.py
+++ b/tests/flytekit/unit/core/test_structured_dataset_handlers.py
@@ -54,7 +54,7 @@ def test_csv():
 @mock.patch("pandas.DataFrame.to_parquet")
 @mock.patch("pandas.read_parquet")
 @mock.patch("flytekit.types.structured.basic_dfs.get_fsspec_storage_options")
-def test_pandas_to_parquet_correct_storage_options_for_azure(
+def test_pandas_to_parquet_azure_storage_options(
     mock_get_fsspec_storage_options, mock_read_parquet, mock_to_parquet
 ):
     df = pd.DataFrame({"Name": ["Tom", "Joseph"], "Age": [20, 22]})
@@ -84,7 +84,7 @@ def test_pandas_to_parquet_correct_storage_options_for_azure(
 @mock.patch("pandas.DataFrame.to_csv")
 @mock.patch("pandas.read_csv")
 @mock.patch("flytekit.types.structured.basic_dfs.get_fsspec_storage_options")
-def test_pandas_to_csv_correct_storage_options_for_azure(
+def test_pandas_to_csv_azure_storage_options(
     mock_get_fsspec_storage_options, mock_read_parquet, mock_to_parquet
 ):
     df = pd.DataFrame({"Name": ["Tom", "Joseph"], "Age": [20, 22]})

--- a/tests/flytekit/unit/core/test_structured_dataset_handlers.py
+++ b/tests/flytekit/unit/core/test_structured_dataset_handlers.py
@@ -1,5 +1,6 @@
 import typing
 
+import mock
 import pandas as pd
 import pyarrow as pa
 import pytest
@@ -49,20 +50,64 @@ def test_csv():
     df2 = decoder.decode(ctx, sd_lit, StructuredDatasetMetadata(sd_type))
     assert df.equals(df2)
 
-@pytest.mark.parametrize("format,encoder", [("parquet", basic_dfs.PandasToParquetEncodingHandler()), ("csv", basic_dfs.PandasToCSVEncodingHandler())])
-@mock.patch("pyarrow.parquet.write_table")
-@mock.patch("flytekit.types.structured.basic_dfs.get_fsspec_storage_options")
-def test_pandas_to_azure_initialises_filesystem_without_error(mock_get_fsspec_storage_options, mock_write_table, format, encoder):
-    mock_get_fsspec_storage_options.return_value = {"account_name": "accountname_from_storage_options"}
-    df = pd.DataFrame({"Name": ["Tom", "Joseph"], "Age": [20, 22]})
 
+@mock.patch("pandas.DataFrame.to_parquet")
+@mock.patch("pandas.read_parquet")
+@mock.patch("flytekit.types.structured.basic_dfs.get_fsspec_storage_options")
+def test_pandas_to_parquet_correct_storage_options_for_azure(
+    mock_get_fsspec_storage_options, mock_read_parquet, mock_to_parquet
+):
+    df = pd.DataFrame({"Name": ["Tom", "Joseph"], "Age": [20, 22]})
+    encoder = basic_dfs.PandasToParquetEncodingHandler()
+    decoder = basic_dfs.ParquetToPandasDecodingHandler()
+
+    mock_get_fsspec_storage_options.return_value = {"account_name": "accountname_from_storage_options"}
     ctx = context_manager.FlyteContextManager.current_context()
-    sd = StructuredDataset(dataframe=df, uri="abfs://container/path/within/container")
-    sd_type = StructuredDatasetType(format=format)
-    encoder.encode(ctx, sd, sd_type)
-    mock_write_table.assert_called_once()
-    filesystem = mock_write_table.mock_calls[0].kwargs["filesystem"]
-    assert filesystem.account_name == "accountname_from_fsspec_storage_options"
+    sd = StructuredDataset(dataframe=df, uri="abfs://container/parquet_df")
+    sd_type = StructuredDatasetType(format="parquet")
+    sd_lit = encoder.encode(ctx, sd, sd_type)
+    mock_to_parquet.assert_called_once_with(
+        "abfs://container/parquet_df/00000",
+        coerce_timestamps=mock.ANY,
+        allow_truncated_timestamps=mock.ANY,
+        storage_options={"account_name": "accountname_from_storage_options"},
+    )
+
+    decoder.decode(ctx, sd_lit, StructuredDatasetMetadata(sd_type))
+    mock_read_parquet.assert_called_once_with(
+        "abfs://container/parquet_df",
+        columns=mock.ANY,
+        storage_options={"account_name": "accountname_from_storage_options"},
+    )
+
+
+@mock.patch("pandas.DataFrame.to_csv")
+@mock.patch("pandas.read_csv")
+@mock.patch("flytekit.types.structured.basic_dfs.get_fsspec_storage_options")
+def test_pandas_to_csv_correct_storage_options_for_azure(
+    mock_get_fsspec_storage_options, mock_read_parquet, mock_to_parquet
+):
+    df = pd.DataFrame({"Name": ["Tom", "Joseph"], "Age": [20, 22]})
+    encoder = basic_dfs.PandasToCSVEncodingHandler()
+    decoder = basic_dfs.CSVToPandasDecodingHandler()
+
+    mock_get_fsspec_storage_options.return_value = {"account_name": "accountname_from_storage_options"}
+    ctx = context_manager.FlyteContextManager.current_context()
+    sd = StructuredDataset(dataframe=df, uri="abfs://container/csv_df")
+    sd_type = StructuredDatasetType(format="csv")
+    sd_lit = encoder.encode(ctx, sd, sd_type)
+    mock_to_parquet.assert_called_once_with(
+        "abfs://container/csv_df/.csv",
+        index=mock.ANY,
+        storage_options={"account_name": "accountname_from_storage_options"},
+    )
+
+    decoder.decode(ctx, sd_lit, StructuredDatasetMetadata(sd_type))
+    mock_read_parquet.assert_called_once_with(
+        "abfs://container/csv_df/.csv",
+        usecols=mock.ANY,
+        storage_options={"account_name": "accountname_from_storage_options"},
+    )
 
 
 def test_base_isnt_instantiable():

--- a/tests/flytekit/unit/core/test_structured_dataset_handlers.py
+++ b/tests/flytekit/unit/core/test_structured_dataset_handlers.py
@@ -64,19 +64,14 @@ def test_pandas_to_parquet_azure_storage_options(mock_get_fsspec_storage_options
     sd = StructuredDataset(dataframe=df, uri="abfs://container/parquet_df")
     sd_type = StructuredDatasetType(format="parquet")
     sd_lit = encoder.encode(ctx, sd, sd_type)
-    mock_to_parquet.assert_called_once_with(
-        "abfs://container/parquet_df/00000",
-        coerce_timestamps=mock.ANY,
-        allow_truncated_timestamps=mock.ANY,
-        storage_options={"account_name": "accountname_from_storage_options"},
-    )
+    mock_to_parquet.assert_called_once()
+    write_storage_options = mock_to_parquet.call_args.kwargs["storage_options"]
+    assert write_storage_options == {"account_name": "accountname_from_storage_options"}
 
     decoder.decode(ctx, sd_lit, StructuredDatasetMetadata(sd_type))
-    mock_read_parquet.assert_called_once_with(
-        "abfs://container/parquet_df",
-        columns=mock.ANY,
-        storage_options={"account_name": "accountname_from_storage_options"},
-    )
+    mock_read_parquet.assert_called_once()
+    read_storage_options = mock_read_parquet.call_args.kwargs["storage_options"]
+    read_storage_options == {"account_name": "accountname_from_storage_options"}
 
 
 @mock.patch("pandas.DataFrame.to_csv")
@@ -92,18 +87,14 @@ def test_pandas_to_csv_azure_storage_options(mock_get_fsspec_storage_options, mo
     sd = StructuredDataset(dataframe=df, uri="abfs://container/csv_df")
     sd_type = StructuredDatasetType(format="csv")
     sd_lit = encoder.encode(ctx, sd, sd_type)
-    mock_to_parquet.assert_called_once_with(
-        "abfs://container/csv_df/.csv",
-        index=mock.ANY,
-        storage_options={"account_name": "accountname_from_storage_options"},
-    )
+    mock_to_parquet.assert_called_once()
+    write_storage_options = mock_to_parquet.call_args.kwargs["storage_options"]
+    assert write_storage_options == {"account_name": "accountname_from_storage_options"}
 
     decoder.decode(ctx, sd_lit, StructuredDatasetMetadata(sd_type))
-    mock_read_parquet.assert_called_once_with(
-        "abfs://container/csv_df/.csv",
-        usecols=mock.ANY,
-        storage_options={"account_name": "accountname_from_storage_options"},
-    )
+    mock_read_parquet.assert_called_once()
+    read_storage_options = mock_read_parquet.call_args.kwargs["storage_options"]
+    read_storage_options == {"account_name": "accountname_from_storage_options"}
 
 
 def test_base_isnt_instantiable():


### PR DESCRIPTION
# TL;DR
Support Azure blob storage for storing metadata and raw data including structured datasets, without interrupting other standard Azure authentication. Also ensure `storage_options` are set consistently for all uses of fsspec. 

## Type
Its debatable. The original github issue was a bug for fixing Azure authentication but it could be argued that Azure blob storage support is a new feature. 
 - [x] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested - Not really sure what is expected but I have used these change to deploy real workflows. 
 - [x] Unit tests added - I added a bit of new coverage, e.g. initialising the `AzureBlobFilesystem`.
 - [x] Code documentation added - There are code comments, but I think ideally there would be a page in the documentation for Azure. 
 - [x] Any pending items have an associated Issue - There aren't any

## Complete description
Added a new component to `DataConfig` for Azure similar to the ones for S3 and GCS. This allows configuring the flytekit's  storage account without disrupting other Azure auth that may be used by flyte task implementations. This is done by setting the environment variables `FLYTE_AZURE_STORAGE_ACCOUNT_NAME`, `FLYTE_AZURE_STORAGE_ACCOUNT_KEY`, `FLYTE_AZURE_TENANT_ID`, `FLYTE_AZURE_CLIENT_ID`, `FLYTE_AZURE_CLIENT_SECRET`. You can set these using a pod template so that authentication to your flyte storage account works across your whole flyte deployment, inrespective of what authentication each task uses. 

Use `DataConfig` to construct fsspec storage options in `data_persistence.py`. We reuse the same function for fetchign `storage_options` elsewhere inlcuding for encode and decode of structured datasets. This ensures local, S3, GCS and Azure work wherever fsspec is used. 

You should specify `configmap.core.propeller.rawoutput-prefix` to be in the format `abfs://<container-name>/<path-within-container>`. 

## Tracking Issue
Related discussion was on https://github.com/flyteorg/flyte/issues/3962 but technically that issues was about workload identity which was mostly fixed by https://github.com/flyteorg/flytekit/pull/1813

## Follow-up issue
_NA_