### PR TITLE
[WIP] Fix: Allow elastic tasks to be recoverable

### DIFF
--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/error_handling.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/error_handling.py
@@ -34,6 +34,9 @@ def is_recoverable_worker_error(failure) -> bool:
 
     Args:
         failure(torch.distributed.elastic.multiprocessing.errors.ProcessFailure): The error in the worker process.
+
+    Returns:
+        bool: True if the error is recoverable, False otherwise.
     """
     error_file_path = failure.error_file
     error_file_dir = os.path.dirname(error_file_path)

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/error_handling.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/error_handling.py
@@ -1,0 +1,41 @@
+"""Handle errors in elastic training jobs."""
+import os
+
+RECOVERABLE_ERROR_FILE_NAME = "recoverable_error"
+
+
+def create_recoverable_error_file() -> None:
+    """Create a file to signal to the agent process that an exception in the worker process is recoverable.
+
+    Torch's `elastic_launch` gives the agent process access to exceptions raised in the worker
+    processes only as strings in an error file. Instead of parsing this error file in the agent process for
+    the string `FlyteRecoverableException` - which would not detect exceptions inheriting from
+    `FlyteRecoverableException` - we create a file in the worker process to signal to the agent process
+    that the exception is recoverable. The file is created in the directory where the default
+    torch elastic error file is written.
+
+    Raises:
+        ValueError: If the environment variable `TORCHELASTIC_ERROR_FILE` is not set.
+    """
+    error_file_path = os.environ.get("TORCHELASTIC_ERROR_FILE")
+    if error_file_path is None:
+        raise ValueError("`TORCHELASTIC_ERROR_FILE` environment variable not set")
+
+    recoverable_error_file_path = os.path.join(os.path.dirname(error_file_path), RECOVERABLE_ERROR_FILE_NAME)
+    with open(recoverable_error_file_path, "w") as f:
+        f.write("")
+
+
+def is_recoverable_worker_error(failure) -> bool:
+    """Check if the error in the worker process is recoverable.
+
+    The error is considered recoverable if the directory containing the torch elastic error file contains
+    a file named `recoverable_error`.
+
+    Args:
+        failure(torch.distributed.elastic.multiprocessing.errors.ProcessFailure): The error in the worker process.
+    """
+    error_file_path = failure.error_file
+    error_file_dir = os.path.dirname(error_file_path)
+    recoverable_error_file_path = os.path.join(error_file_dir, RECOVERABLE_ERROR_FILE_NAME)
+    return os.path.exists(recoverable_error_file_path)

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -249,9 +249,12 @@ def spawn_helper(
         prev_checkpoint=checkpoint_src,
     ):
         fn = cloudpickle.loads(fn)
+
         try:
             return_val = fn(**kwargs)
         except Exception as e:
+            # See explanation in `create_recoverable_error_file` why we check
+            # for recoverable errors here in the worker processes.
             if isinstance(e, FlyteRecoverableException):
                 create_recoverable_error_file()
             raise
@@ -369,6 +372,8 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
                 try:
                     return_val = self._task_function(**kwargs)
                 except Exception as e:
+                    # See explanation in `create_recoverable_error_file` why we check
+                    # for recoverable errors here in the worker processes.
                     if isinstance(e, FlyteRecoverableException):
                         create_recoverable_error_file()
                     raise

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -317,7 +317,7 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
                 `FlyteRecoverableException`.
             RuntimeError: If the first exception raised in the worker group with index 0 is not a
                 `FlyteRecoverableException`.
-            IgnoreOutputs: Always raised by default, even if the task is succesfull, in any worker group with index > 0.
+            IgnoreOutputs: Always raised by default, even if the task is successful, in any worker group with index > 0.
         """
         try:
             from torch.distributed.launcher.api import LaunchConfig, elastic_launch

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -385,14 +385,6 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
         else:
             raise Exception("Bad start method")
 
-        if self.metadata.retries > 0 and self.task_config.max_restarts == 0:
-            msg = (
-                "Flyte considers exceptions in worker processes of torch elastic tasks as non-recoverable as "
-                "Flyte does not have access to the type of the original exception raised in the child process. Use "
-                "`@task(task_config=Elastic(..., max_restarts=<n>))` to configure retries on the torch elastic launch level."
-            )
-            logger.warning(msg)
-
         from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
 
         try:


### PR DESCRIPTION
# TL;DR

For some failures, users might want to retry a flyte task, for other failures not.
Flyte tasks can be marked as retriable by raising a `FlyteRecoverableException`.

Torch's `elastic_launch` (which is used by flytekit's `Elastic` task type) always raises a `ChildFailedError` even if in the worker process e.g. a `FlyteRecoverableException` was raised.

This means that Flyte's retry mechanism cannot be used for user errors in elastic tasks.

Elastic tasks offer `torchrun`'s retry mechanism by specifying `max_retries`. However, this retry mechanism (which doesn't restart the pod but the worker processes within the pod) will retry *all* exceptions which is not always desireable.

This PR makes elastic tasks work with Flyte's retry mechanism by propagating `FlyteRecoverableException` up from the worker processes.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_NA_

## Follow-up issue
_NA_
