### PR TITLE
Add more clear error  message when fetching secrets

### DIFF
--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -363,7 +363,7 @@ class SecretsManager(object):
             with open(fpath, "r") as f:
                 return f.read().strip()
         raise ValueError(
-            f"Unable to find secret for key {key} in group {group} " f"in Env Var:{env_var} and FilePath: {fpath}"
+            f"Please make sure to add secret_requests=[Secret(group={group}, key={key})] in @task. Unable to find secret for key {key} in group {group} " f"in Env Var:{env_var} and FilePath: {fpath}"
         )
 
     def get_secrets_env_var(self, group: str, key: Optional[str] = None, group_version: Optional[str] = None) -> str:

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -363,7 +363,8 @@ class SecretsManager(object):
             with open(fpath, "r") as f:
                 return f.read().strip()
         raise ValueError(
-            f"Please make sure to add secret_requests=[Secret(group={group}, key={key})] in @task. Unable to find secret for key {key} in group {group} " f"in Env Var:{env_var} and FilePath: {fpath}"
+            f"Please make sure to add secret_requests=[Secret(group={group}, key={key})] in @task. Unable to find secret for key {key} in group {group} "
+            f"in Env Var:{env_var} and FilePath: {fpath}"
         )
 
     def get_secrets_env_var(self, group: str, key: Optional[str] = None, group_version: Optional[str] = None) -> str:


### PR DESCRIPTION
# TL;DR
User gets confused as error message is missing useful prompts when they did not add secret_requests in task config to get secrets, this PR adds more clear error message.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
