### PR TITLE
Name field is incorrect assigned

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -424,12 +424,13 @@ def run_remote(
     Helper method that executes the given remote FlyteLaunchplan, FlyteWorkflow or FlyteTask
     """
 
+    print(f"Running {run_level_params.name} with inputs {inputs}")
     execution = remote.execute(
         entity,
         inputs=inputs,
         project=project,
         domain=domain,
-        name=run_level_params.name,
+        execution_name=run_level_params.name,
         wait=run_level_params.wait_execution,
         options=options_from_run_params(run_level_params),
         type_hints=type_hints,


### PR DESCRIPTION
# TL;DR
`pyflyte run --remote --name f78b0145-016a-44d8-bac0-fffa2e722f9c test2.py wf --n 10`

Name is not used correctly

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

