### PR TITLE
Dep: Pin min required flytekit version in IAP plugin

### DIFF
--- a/plugins/flytekit-identity-aware-proxy/setup.py
+++ b/plugins/flytekit-identity-aware-proxy/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "identity_aware_proxy"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["click", "google-cloud-secret-manager", "google-auth", "flytekit"]
+plugin_requires = ["click", "google-cloud-secret-manager", "google-auth", "flytekit>=1.10"]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
# TL;DR
The flytekit identity aware proxy plugin introduced in https://github.com/flyteorg/flytekit/pull/1787 requires changes in flytekit's authentication logic which were introduced in the same PR. At the moment, the flytekit version is not pinned in the new plugin's `setup.py` though. In this PR I pin it to `>=1.10`, the next release that will contain those changes to the auth logic.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

