### PR TITLE
Improve error message in ListTransformer when not passing a list

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1141,7 +1141,12 @@ class ListTransformer(TypeTransformer[T]):
         try:
             lits = lv.collection.literals
         except AttributeError:
-            raise TypeTransformerFailedError()
+            raise TypeTransformerFailedError(
+                (
+                    f"The expected python type is '{expected_python_type}' but the received Flyte literal value "
+                    f"is not a collection (Flyte's representation of Python lists)."
+                )
+            )
         if self.is_batchable(expected_python_type):
             from flytekit.types.pickle import FlytePickle
 


### PR DESCRIPTION
# TL;DR

Improve error message in `ListTransformer` in a way that would have saved us time debugging a failing workflow.


## Type
Neither of the following:
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description

This workflow ...

```python
from flytekit import task, workflow

@task
def foo() -> int:
    return 1

@task
def bar(inp: list[int]):
    print(inp)

@workflow
def wf():
    bar(inp=foo())


if __name__ == "__main__":
    wf()
```

... fails with:

```console
Traceback (most recent call last):
  File ".../test.py", line 17, in <module>
    wf()
  File ".../flytekit/flytekit/core/workflow.py", line 279, in __call__
    raise exc
  File ".../flytekit/flytekit/core/workflow.py", line 276, in __call__
    return flyte_entity_call_handler(self, *args, **input_kwargs)
  File ".../flytekit/flytekit/core/promise.py", line 1051, in flyte_entity_call_handler
    result = cast(LocallyExecutable, entity).local_execute(child_ctx, **kwargs)
  File ".../flytekit/flytekit/core/workflow.py", line 298, in local_execute
    function_outputs = self.execute(**kwargs_literals)
  File ".../flytekit/flytekit/core/workflow.py", line 746, in execute
    return exception_scopes.user_entry_point(self._workflow_function)(**kwargs)
  File ".../flytekit/flytekit/exceptions/scopes.py", line 203, in user_entry_point
    raise type(exc)(f"Error encountered while executing '{fn_name}':\n  {exc}") from exc
flytekit.core.type_engine.TypeTransformerFailedError: Encountered error while executing workflow 'wf':
  Error encountered while executing 'wf':
  Failed to convert inputs of task 'test.bar':
  Error converting input 'inp' at position 0:
```

In this minimal example, the error is quickly apparent but one of our engineers struggled to find the issue in a large training workflow.
A hint that a list/collection is expected but not provided (as [here](https://github.com/flyteorg/flytekit/blob/1f0d12063c6875e01524cd36bf190bbf9f62a08c/flytekit/core/type_engine.py#L1119) in the respective `to_literal` method) would have greatly simplified the search.

## Tracking Issue
_NA_

## Follow-up issue
_NA_
