### PR TITLE
add default project domain in execute launch plan

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1232,6 +1232,7 @@ class FlyteRemote(object):
                 version=version,
                 project=project,
                 domain=domain,
+                name=name,
                 execution_name=execution_name,
                 execution_name_prefix=execution_name_prefix,
                 options=options,
@@ -1426,7 +1427,6 @@ class FlyteRemote(object):
         """
         resolved_identifiers = self._resolve_identifier_kwargs(entity, project, domain, name, version)
         resolved_identifiers_dict = asdict(resolved_identifiers)
-
         ss = SerializationSettings(
             image_config=image_config,
             project=resolved_identifiers.project,

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1505,10 +1505,12 @@ class FlyteRemote(object):
         :param cluster_pool: Specify cluster pool on which newly created execution should be placed.
         :return: FlyteWorkflowExecution object
         """
+        resolved_identifiers = self._resolve_identifier_kwargs(entity, project, domain, entity.name, version)
+        resolved_identifiers_dict = asdict(resolved_identifiers)
         try:
             flyte_launchplan: FlyteLaunchPlan = self.fetch_launch_plan(
-                project=project,
-                domain=domain,
+                project=resolved_identifiers_dict.project,
+                domain=resolved_identifiers_dict.domain,
                 name=entity.name,
                 version=version,
             )
@@ -1516,14 +1518,14 @@ class FlyteRemote(object):
             flyte_launchplan: FlyteLaunchPlan = self.register_launch_plan(
                 entity,
                 version=version,
-                project=project,
-                domain=domain,
+                project=resolved_identifiers_dict.project,
+                domain=resolved_identifiers_dict.domain,
             )
         return self.execute_remote_task_lp(
             flyte_launchplan,
             inputs,
-            project=project,
-            domain=domain,
+            project=resolved_identifiers_dict.project,
+            domain=resolved_identifiers_dict.domain,
             execution_name=execution_name,
             execution_name_prefix=execution_name_prefix,
             options=options,


### PR DESCRIPTION
# TL;DR
1. add default project domain in execute launch plan
2. add name as a parameter
## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
When I executed a launch plan with FlyteRemote, it didn't run with default project domain of the remote but needed specified project domain. So, I fixed it with if there is no specified project domain, use default project domain of the remote.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/4249

## Follow-up issue
_NA_
