### PR TITLE
Replaced user context spark session.

### DIFF
--- a/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
@@ -1,8 +1,7 @@
 import typing
 
 import pandas as pd
-import pyspark
-from pyspark.sql.dataframe import DataFrame, SparkSession
+from pyspark.sql import DataFrame, SparkSession
 
 from flytekit import FlyteContext
 from flytekit.models import literals
@@ -39,7 +38,7 @@ class SparkToParquetEncodingHandler(StructuredDatasetEncoder):
     ) -> literals.StructuredDataset:
         path = typing.cast(str, structured_dataset.uri) or ctx.file_access.get_random_remote_directory()
         df = typing.cast(DataFrame, structured_dataset.dataframe)
-        ss = pyspark.sql.SparkSession.builder.getOrCreate()
+        ss = SparkSession.builder.getOrCreate()
         # Avoid generating SUCCESS files
         ss.conf.set("mapreduce.fileoutputcommitter.marksuccessfuljobs", "false")
         df.write.mode("overwrite").parquet(path=path)

--- a/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
@@ -2,7 +2,7 @@ import typing
 
 import pandas as pd
 import pyspark
-from pyspark.sql.dataframe import DataFrame
+from pyspark.sql.dataframe import DataFrame, SparkSession
 
 from flytekit import FlyteContext
 from flytekit.models import literals
@@ -56,11 +56,12 @@ class ParquetToSparkDecodingHandler(StructuredDatasetDecoder):
         flyte_value: literals.StructuredDataset,
         current_task_metadata: StructuredDatasetMetadata,
     ) -> DataFrame:
-        user_ctx = FlyteContext.current_context().user_space_params
+        # The Spark session already exists at this stage - this command will get it
+        spark = SparkSession.builder.getOrCreate()
         if current_task_metadata.structured_dataset_type and current_task_metadata.structured_dataset_type.columns:
             columns = [c.name for c in current_task_metadata.structured_dataset_type.columns]
-            return user_ctx.spark_session.read.parquet(flyte_value.uri).select(*columns)
-        return user_ctx.spark_session.read.parquet(flyte_value.uri)
+            return spark.read.parquet(flyte_value.uri).select(*columns)
+        return spark.read.parquet(flyte_value.uri)
 
 
 StructuredDatasetTransformerEngine.register(SparkToParquetEncodingHandler())


### PR DESCRIPTION
# TL;DR
These changes allows the pyspark.DataFrame SD transformer to obtain the Spark session after new_session was invoked.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [X] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The solution is to get the spark session via the `SparkSession.builder.getOrCreate()` method call.

## Tracking Issue
[https://github.com/flyteorg/flyte/issues/<number>](https://github.com/flyteorg/flyte/issues/4247)

