### PR TITLE
Fix bug in polars parquet decoding handler

### DIFF
--- a/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
+++ b/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
@@ -40,11 +40,11 @@ class PolarsDataFrameToParquetEncodingHandler(StructuredDatasetEncoder):
         structured_dataset_type: StructuredDatasetType,
     ) -> literals.StructuredDataset:
         df = typing.cast(pl.DataFrame, structured_dataset.dataframe)
-        random_string = ctx.file_access.get_random_string()
+        default_parquet_fn = "00000"
         local_dir = ctx.file_access.get_random_local_directory()
         local_path = ctx.file_access.join(
             local_dir,
-            random_string,
+            default_parquet_fn,
         )
         # Polars 0.13.12 deprecated to_parquet in favor of write_parquet
         if hasattr(df, "write_parquet"):
@@ -56,13 +56,13 @@ class PolarsDataFrameToParquetEncodingHandler(StructuredDatasetEncoder):
             remote_dir = structured_dataset.uri
             sd_uri = ctx.file_access.join(
                 remote_dir,
-                random_string,
+                default_parquet_fn,
             )
         else:
             remote_dir = ctx.file_access.get_random_remote_directory()
             sd_uri = ctx.file_access.join(
                 remote_dir,
-                random_string,
+                default_parquet_fn,
             )
         ctx.file_access.upload_directory(local_dir, remote_dir)
         return literals.StructuredDataset(uri=sd_uri, metadata=StructuredDatasetMetadata(structured_dataset_type))

--- a/plugins/flytekit-polars/tests/test_polars_plugin_sd.py
+++ b/plugins/flytekit-polars/tests/test_polars_plugin_sd.py
@@ -75,7 +75,7 @@ def test_parquet_to_polars():
 
     @task
     def create_sd() -> StructuredDataset:
-        df = pd.DataFrame(data=data)
+        df = pl.DataFrame(data=data)
         return StructuredDataset(dataframe=df)
 
     sd = create_sd()
@@ -87,7 +87,14 @@ def test_parquet_to_polars():
 
     @task
     def t1(sd: StructuredDataset) -> pl.DataFrame:
-        return sd.open(pd.DataFrame).all()
+        return sd.open(pl.DataFrame).all()
 
     sd = StructuredDataset(uri=tmp)
-    t1(sd=sd).frame_equal(polars_df)
+    assert t1(sd=sd).frame_equal(polars_df)
+
+    @task
+    def t2(sd: StructuredDataset) -> StructuredDataset:
+        return StructuredDataset(dataframe=sd.open(pl.DataFrame).all())
+
+    sd = StructuredDataset(uri=tmp)
+    assert t2(sd=sd).open(pl.DataFrame).all().frame_equal(polars_df)


### PR DESCRIPTION
# TL;DR
When trying to use `flytekitplugins-polars` I would get the error:
```
Message:
    Could not open Parquet input source '<Buffer>': Parquet file size is 0 bytes
User error.
```

Checking out the code, the `PolarsDataFrameToParquetEncodingHandler` actually places the parquet file at '{location}/00000', but it tries to read it at '{location}'

I think this is the easy solution, but maybe `PolarsDataFrameToParquetEncodingHandler` should be returning the '{location}/00000' instead of the parent directory? 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
