### PR TITLE
Remove tangled_up_in_unicode from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,17 @@ ENV PYTHONPATH /root
 ARG VERSION
 ARG DOCKER_IMAGE
 
-RUN apt-get update && apt-get install build-essential -y
+RUN apt-get update \
+	&& apt-get install build-essential -y \
+	&& rm -rf /var/lib/apt/lists/*
 
 # Pod tasks should be exposed in the default image
-RUN pip install -U flytekit==$VERSION \
+RUN pip install -U --no-cache-dir flytekit==$VERSION \
 	flytekitplugins-pod==$VERSION \
 	flytekitplugins-deck-standard==$VERSION \
-	scikit-learn
+	scikit-learn \
+	&& pip uninstall tangled-up-in-unicode
+
 
 RUN useradd -u 1000 flytekit
 RUN chown flytekit: /root


### PR DESCRIPTION
Basically, the currently released `visions` package has the requirement `tangled-up-in-unicode`.  `visions:develop` does not have that requirement anymore.  `visions` hasn't had a release since 2021 - so I doubt it will be updated anytime soon.

The problem is, is that for some python versions the `tangled-up-in-unicode` package is 1.5 GB, which is not ideal.

If you run `pip uninstall` it should get rid of that unnecessary package. 

Before:
```
3.0M    /usr/local/lib/python3.10/site-packages/PIL                                                                                                                                                                     
3.1M    /usr/local/lib/python3.10/site-packages/regex                                                                                                                                                                   
3.2M    /usr/local/lib/python3.10/site-packages/prompt_toolkit                                                                                                                                                          
4.5M    /usr/local/lib/python3.10/site-packages/aiohttp                                                                                                                                                                 
4.9M    /usr/local/lib/python3.10/site-packages/setuptools                                                                                                                                                              
4.9M    /usr/local/lib/python3.10/site-packages/widgetsnbextension                                                                                                                                                      
5.8M    /usr/local/lib/python3.10/site-packages/IPython                                                                                                                                                                 
6.4M    /usr/local/lib/python3.10/site-packages/kiwisolver                                                                                                                                                              
7.2M    /usr/local/lib/python3.10/site-packages/google                                                                                                                                                                  
7.2M    /usr/local/lib/python3.10/site-packages/jupyterlab_plotly                                                                                                                                                       
7.5M    /usr/local/lib/python3.10/site-packages/azure                                                                                                                                                                   
8.0M    /usr/local/lib/python3.10/site-packages/pygments                                                                                                                                                                
9.1M    /usr/local/lib/python3.10/site-packages/Pillow.libs                                                                                                                                                             
9.2M    /usr/local/lib/python3.10/site-packages/pydantic                                                                                                                                                                
11M     /usr/local/lib/python3.10/site-packages/jedi                                                                                                                                                                    
13M     /usr/local/lib/python3.10/site-packages/grpc                                                                                                                                                                    
13M     /usr/local/lib/python3.10/site-packages/pip                                                                                                                                                                     
14M     /usr/local/lib/python3.10/site-packages/networkx                                                                                                                                                                
15M     /usr/local/lib/python3.10/site-packages/cryptography                                                                                                                                                            
18M     /usr/local/lib/python3.10/site-packages/pywt                                                                                                                                                                    
23M     /usr/local/lib/python3.10/site-packages/fontTools                                                                                                                                                               
25M     /usr/local/lib/python3.10/site-packages/kubernetes                                                                                                                                                              
26M     /usr/local/lib/python3.10/site-packages/numba                                                                                                                                                                   
35M     /usr/local/lib/python3.10/site-packages/scipy.libs                                                                                                                                                              
36M     /usr/local/lib/python3.10/site-packages/numpy                                                                                                                                                                   
37M     /usr/local/lib/python3.10/site-packages/numpy.libs                                                                                                                                                              
38M     /usr/local/lib/python3.10/site-packages/matplotlib                                                                                                                                                              
49M     /usr/local/lib/python3.10/site-packages/statsmodels                                                                                                                                                             
61M     /usr/local/lib/python3.10/site-packages/pandas                                                                                                                                                                  
83M     /usr/local/lib/python3.10/site-packages/botocore                                                                                                                                                                
90M     /usr/local/lib/python3.10/site-packages/scipy                                                                                                                                                                   
118M    /usr/local/lib/python3.10/site-packages/pyarrow                                                                                                                                                                 
129M    /usr/local/lib/python3.10/site-packages/llvmlite                                                                                                                                                                
152M    /usr/local/lib/python3.10/site-packages/plotly                                                                                                                                                                  
1.8G    /usr/local/lib/python3.10/site-packages/tangled_up_in_unicode
```

After:
```
3.0M    /usr/local/lib/python3.10/site-packages/PIL
3.1M    /usr/local/lib/python3.10/site-packages/regex
3.2M    /usr/local/lib/python3.10/site-packages/prompt_toolkit
4.5M    /usr/local/lib/python3.10/site-packages/aiohttp
4.9M    /usr/local/lib/python3.10/site-packages/setuptools
4.9M    /usr/local/lib/python3.10/site-packages/widgetsnbextension
5.8M    /usr/local/lib/python3.10/site-packages/IPython
6.4M    /usr/local/lib/python3.10/site-packages/kiwisolver
7.2M    /usr/local/lib/python3.10/site-packages/google
7.2M    /usr/local/lib/python3.10/site-packages/jupyterlab_plotly
7.5M    /usr/local/lib/python3.10/site-packages/azure
8.0M    /usr/local/lib/python3.10/site-packages/pygments
9.1M    /usr/local/lib/python3.10/site-packages/Pillow.libs
9.2M    /usr/local/lib/python3.10/site-packages/pydantic
11M     /usr/local/lib/python3.10/site-packages/jedi
13M     /usr/local/lib/python3.10/site-packages/grpc
13M     /usr/local/lib/python3.10/site-packages/pip
14M     /usr/local/lib/python3.10/site-packages/networkx
15M     /usr/local/lib/python3.10/site-packages/cryptography
18M     /usr/local/lib/python3.10/site-packages/pywt
23M     /usr/local/lib/python3.10/site-packages/fontTools
25M     /usr/local/lib/python3.10/site-packages/kubernetes
26M     /usr/local/lib/python3.10/site-packages/numba
35M     /usr/local/lib/python3.10/site-packages/scipy.libs
36M     /usr/local/lib/python3.10/site-packages/numpy
37M     /usr/local/lib/python3.10/site-packages/numpy.libs
38M     /usr/local/lib/python3.10/site-packages/matplotlib
49M     /usr/local/lib/python3.10/site-packages/statsmodels
61M     /usr/local/lib/python3.10/site-packages/pandas
83M     /usr/local/lib/python3.10/site-packages/botocore
90M     /usr/local/lib/python3.10/site-packages/polars
90M     /usr/local/lib/python3.10/site-packages/scipy
118M    /usr/local/lib/python3.10/site-packages/pyarrow
129M    /usr/local/lib/python3.10/site-packages/llvmlite
152M    /usr/local/lib/python3.10/site-packages/plotly
```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
 https://github.com/flyteorg/flyte/issues/3050

