### PR TITLE
Add image transformer

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -26,6 +26,7 @@ torch<=1.12.1; python_version<'3.11'
 # pytorch 2 supports python 3.11
 torch<=2.0.0; python_version>='3.11' or platform_system!='Windows'
 
+pillow
 scikit-learn
 types-protobuf
 types-croniter

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -874,6 +874,9 @@ class TypeEngine(typing.Generic[T]):
             register_bigquery_handlers()
         if is_imported("numpy"):
             from flytekit.types import numpy  # noqa: F401
+        if is_imported("PIL"):
+            print("PIL is imported")
+            from flytekit.types.file import image  # noqa: F401
 
     @classmethod
     def to_literal_type(cls, python_type: Type) -> LiteralType:

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -875,7 +875,6 @@ class TypeEngine(typing.Generic[T]):
         if is_imported("numpy"):
             from flytekit.types import numpy  # noqa: F401
         if is_imported("PIL"):
-            print("PIL is imported")
             from flytekit.types.file import image  # noqa: F401
 
     @classmethod

--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -531,7 +531,7 @@ def eager(
     return task(
         wrapper,
         secret_requests=secret_requests,
-        disable_deck=False,
+        enable_deck=True,
         execution_mode=PythonFunctionTask.ExecutionBehavior.EAGER,
         **kwargs,
     )

--- a/flytekit/types/file/image.py
+++ b/flytekit/types/file/image.py
@@ -1,6 +1,6 @@
 import pathlib
 import typing
-from typing import Dict, Tuple, Type
+from typing import Type
 
 import PIL.Image
 
@@ -72,11 +72,12 @@ class PILImageTransformer(TypeTransformer[T]):
         raise ValueError(f"Transformer {self} cannot reverse {literal_type}")
 
     def to_html(self, ctx: FlyteContext, python_val: PIL.Image.Image, expected_python_type: Type[T]) -> str:
-        try:
-            from flytekitplugins.deck import ImageRenderer
-        except ImportError:
-            return "failed"
-        return ImageRenderer().to_html(image_src=python_val)
+        import base64
+        from io import BytesIO
+        buffered = BytesIO()
+        python_val.save(buffered, format="PNG")
+        img_base64 = base64.b64encode(buffered.getvalue()).decode()
+        return f'<img src="data:image/png;base64,{img_base64}" alt="Rendered Image" />'
 
 
 TypeEngine.register(PILImageTransformer())

--- a/flytekit/types/file/image.py
+++ b/flytekit/types/file/image.py
@@ -1,0 +1,82 @@
+import pathlib
+import typing
+from typing import Dict, Tuple, Type
+
+import PIL.Image
+
+from flytekit.core.context_manager import FlyteContext
+from flytekit.core.type_engine import TypeEngine, TypeTransformer, TypeTransformerFailedError
+from flytekit.models.core import types as _core_types
+from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
+from flytekit.models.types import LiteralType
+
+
+T = typing.TypeVar("T")
+
+
+class PILImageTransformer(TypeTransformer[T]):
+    """
+    TypeTransformer that supports np.ndarray as a native type.
+    """
+
+    FILE_FORMAT = "image"
+
+    def __init__(self):
+        super().__init__(name="PIL.Image", t=PIL.Image.Image)
+
+    def get_literal_type(self, t: Type[T]) -> LiteralType:
+        return LiteralType(
+            blob=_core_types.BlobType(
+                format=self.FILE_FORMAT, dimensionality=_core_types.BlobType.BlobDimensionality.SINGLE
+            )
+        )
+
+    def to_literal(
+        self, ctx: FlyteContext, python_val: PIL.Image.Image, python_type: Type[T], expected: LiteralType
+    ) -> Literal:
+
+        meta = BlobMetadata(
+            type=_core_types.BlobType(
+                format=self.FILE_FORMAT, dimensionality=_core_types.BlobType.BlobDimensionality.SINGLE
+            )
+        )
+
+        local_path = ctx.file_access.get_random_local_path() + ".png"
+        pathlib.Path(local_path).parent.mkdir(parents=True, exist_ok=True)
+        print(local_path)
+        python_val.save(local_path)
+
+        remote_path = ctx.file_access.get_random_remote_path(local_path)
+        ctx.file_access.put_data(local_path, remote_path, is_multipart=False)
+        return Literal(scalar=Scalar(blob=Blob(metadata=meta, uri=remote_path)))
+
+    def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> PIL.Image.Image:
+        try:
+            uri = lv.scalar.blob.uri
+        except AttributeError:
+            raise TypeTransformerFailedError(f"Cannot convert from {lv} to {expected_python_type}")
+
+        local_path = ctx.file_access.get_random_local_path()
+        ctx.file_access.get_data(uri, local_path, is_multipart=False)
+
+        return PIL.Image.open(local_path)
+
+    def guess_python_type(self, literal_type: LiteralType) -> Type[T]:
+        if (
+            literal_type.blob is not None
+            and literal_type.blob.dimensionality == _core_types.BlobType.BlobDimensionality.SINGLE
+            and literal_type.blob.format == self.FILE_FORMAT
+        ):
+            return PIL.Image.Image
+
+        raise ValueError(f"Transformer {self} cannot reverse {literal_type}")
+
+    def to_html(self, ctx: FlyteContext, python_val: PIL.Image.Image, expected_python_type: Type[T]) -> str:
+        try:
+            from flytekitplugins.deck import ImageRenderer
+        except ImportError:
+            return "failed"
+        return ImageRenderer().to_html(image_src=python_val)
+
+
+TypeEngine.register(PILImageTransformer())

--- a/flytekit/types/file/image.py
+++ b/flytekit/types/file/image.py
@@ -43,7 +43,6 @@ class PILImageTransformer(TypeTransformer[T]):
 
         local_path = ctx.file_access.get_random_local_path() + ".png"
         pathlib.Path(local_path).parent.mkdir(parents=True, exist_ok=True)
-        print(local_path)
         python_val.save(local_path)
 
         remote_path = ctx.file_access.get_random_remote_path(local_path)

--- a/flytekit/types/file/image.py
+++ b/flytekit/types/file/image.py
@@ -10,7 +10,6 @@ from flytekit.models.core import types as _core_types
 from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
 
-
 T = typing.TypeVar("T")
 
 
@@ -73,6 +72,7 @@ class PILImageTransformer(TypeTransformer[T]):
     def to_html(self, ctx: FlyteContext, python_val: PIL.Image.Image, expected_python_type: Type[T]) -> str:
         import base64
         from io import BytesIO
+
         buffered = BytesIO()
         python_val.save(buffered, format="PNG")
         img_base64 = base64.b64encode(buffered.getvalue()).decode()

--- a/flytekit/types/file/image.py
+++ b/flytekit/types/file/image.py
@@ -16,10 +16,10 @@ T = typing.TypeVar("T")
 
 class PILImageTransformer(TypeTransformer[T]):
     """
-    TypeTransformer that supports np.ndarray as a native type.
+    TypeTransformer that supports PIL.Image as a native type.
     """
 
-    FILE_FORMAT = "image"
+    FILE_FORMAT = "PIL.Image"
 
     def __init__(self):
         super().__init__(name="PIL.Image", t=PIL.Image.Image)

--- a/plugins/flytekit-deck-standard/flytekitplugins/deck/renderer.py
+++ b/plugins/flytekit-deck-standard/flytekitplugins/deck/renderer.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     import markdown
     import pandas as pd
     import PIL
+    import PIL.Image
     import plotly.express as px
 else:
     pd = lazy_module("pandas")

--- a/plugins/flytekit-deck-standard/flytekitplugins/deck/renderer.py
+++ b/plugins/flytekit-deck-standard/flytekitplugins/deck/renderer.py
@@ -6,7 +6,6 @@ from flytekit.types.file import FlyteFile
 if TYPE_CHECKING:
     import markdown
     import pandas as pd
-    import PIL
     import PIL.Image
     import plotly.express as px
 else:

--- a/plugins/flytekit-kf-pytorch/tests/test_elastic_task.py
+++ b/plugins/flytekit-kf-pytorch/tests/test_elastic_task.py
@@ -120,7 +120,7 @@ def test_deck(start_method: str) -> None:
 
     @task(
         task_config=Elastic(nnodes=1, nproc_per_node=world_size, start_method=start_method),
-        disable_deck=False,
+        enable_deck=True,
     )
     def train():
         import os

--- a/plugins/flytekit-mlflow/README.md
+++ b/plugins/flytekit-mlflow/README.md
@@ -15,7 +15,7 @@ from flytekit import task, workflow
 from flytekitplugins.mlflow import mlflow_autolog
 import mlflow
 
-@task(disable_deck=False)
+@task(enable_deck=True)
 @mlflow_autolog(framework=mlflow.keras)
 def train_model():
     ...

--- a/plugins/flytekit-mlflow/tests/test_mlflow_tracking.py
+++ b/plugins/flytekit-mlflow/tests/test_mlflow_tracking.py
@@ -6,7 +6,7 @@ import flytekit
 from flytekit import task
 
 
-@task(disable_deck=False)
+@task(enable_deck=True)
 @mlflow_autolog(framework=mlflow.keras)
 def train_model(epochs: int):
     fashion_mnist = tf.keras.datasets.fashion_mnist

--- a/tests/flytekit/unit/types/file/test_image.py
+++ b/tests/flytekit/unit/types/file/test_image.py
@@ -1,18 +1,10 @@
-import io
-
-import requests
-
 from flytekit import task, workflow
 import PIL.Image
 
 
 @task(disable_deck=False)
 def t1() -> PIL.Image.Image:
-    url = "https://miro.medium.com/v2/resize:fit:1400/1*0T9PjBnJB9H0Y4qrllkJtQ.png"
-    response = requests.get(url)
-    image_bytes = io.BytesIO(response.content)
-    im = PIL.Image.open(image_bytes)
-    return im
+    return PIL.Image.new("L", (100, 100), "black")
 
 
 @task

--- a/tests/flytekit/unit/types/file/test_image.py
+++ b/tests/flytekit/unit/types/file/test_image.py
@@ -3,7 +3,7 @@ import PIL.Image
 from flytekit import task, workflow
 
 
-@task(disable_deck=False)
+@task(enable_deck=True)
 def t1() -> PIL.Image.Image:
     return PIL.Image.new("L", (100, 100), "black")
 

--- a/tests/flytekit/unit/types/file/test_image.py
+++ b/tests/flytekit/unit/types/file/test_image.py
@@ -1,0 +1,29 @@
+import io
+
+import requests
+
+from flytekit import task, workflow
+import PIL.Image
+
+
+@task(disable_deck=False)
+def t1() -> PIL.Image.Image:
+    url = "https://miro.medium.com/v2/resize:fit:1400/1*0T9PjBnJB9H0Y4qrllkJtQ.png"
+    response = requests.get(url)
+    image_bytes = io.BytesIO(response.content)
+    im = PIL.Image.open(image_bytes)
+    return im
+
+
+@task
+def t2(im: PIL.Image.Image) -> PIL.Image.Image:
+    return im
+
+
+@workflow
+def wf():
+    t2(im=t1())
+
+
+def test_image_transformer():
+    wf()

--- a/tests/flytekit/unit/types/file/test_image.py
+++ b/tests/flytekit/unit/types/file/test_image.py
@@ -1,5 +1,6 @@
-from flytekit import task, workflow
 import PIL.Image
+
+from flytekit import task, workflow
 
 
 @task(disable_deck=False)


### PR DESCRIPTION
# TL;DR
Add an image transformer, so the task can return PIL.Image.Image as an output,

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
My example:
```python
import io
from typing_extensions import Annotated

import requests

from flytekit import task, workflow, ImageSpec
import PIL.Image

new_flytekit = "git+https://github.com/flyteorg/flytekit.git@da9f6645bb5e99580e38d89ef6824b81a1054279"
image_spec = ImageSpec(base_image="python:3.8-slim-buster", packages=[new_flytekit, "pillow"], apt_packages=["git"], registry="pingsutw")


@task(enable_deck=True, container_image=image_spec)
def t1() -> PIL.Image.Image:
    url = "https://miro.medium.com/v2/resize:fit:1400/1*0T9PjBnJB9H0Y4qrllkJtQ.png"
    response = requests.get(url)
    image_bytes = io.BytesIO(response.content)
    im = PIL.Image.open(image_bytes)
    return im


@workflow
def wf():
    t1()


if __name__ == "__main__":
    wf()
```

<img width="1648" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/9b82c5a7-6017-43e2-961e-c1088ea1caf7">


## Tracking Issue
https://github.com/flyteorg/flyte/issues/4193

## Follow-up issue
_NA_
