### PR TITLE
Use Airflow task insdie dynamic workflow

### DIFF
--- a/plugins/flytekit-airflow/flytekitplugins/airflow/task.py
+++ b/plugins/flytekit-airflow/flytekitplugins/airflow/task.py
@@ -51,7 +51,8 @@ def _flyte_operator(*args, **kwargs):
     task instead.
     """
     cls = args[0]
-    if FlyteContextManager.current_context().user_space_params.get_original_task:
+    user_params = FlyteContextManager.current_context().user_space_params
+    if hasattr(user_params, "get_original_task") and user_params.get_original_task:
         # Return original task when running in the agent.
         return object.__new__(cls)
     config = AirflowConfig(task_module=cls.__module__, task_name=cls.__name__, task_config=kwargs)


### PR DESCRIPTION
# TL;DR
A flyte context has an [attribute](https://github.com/flyteorg/flytekit/pull/1912/files#diff-a1d44bc50c6abe11f7528e5162fe0140184607314e1a71ee2916a5e17977a5ccR75), but dynamic tasks override the current context, so airflow agent cannot get the attribute.

With this PR, `_flyte_operator` will return a flyte task if it fails to get the attribute from the flyte context.


```bash
Traceback (most recent call last):

      File "/usr/local/lib/python3.10/site-packages/flytekit/exceptions/scopes.py", line 206, in user_entry_point
        return wrapped(*args, **kwargs)
      File "/root/flyte-example/airflow_example/bash_operator.py", line 15, in d1
        b = BashOperator(task_id=f"airflow_bash_operator", bash_command="echo hello")
      File "/usr/local/lib/python3.10/site-packages/flytekitplugins/airflow/task.py", line 55, in _flyte_operator
        if hasattr(user_params, "get_original_task") and user_params.get_original_task:
      File "/usr/local/lib/python3.10/site-packages/flytekit/core/context_manager.py", line 296, in __getattr__
        raise AssertionError(f"{attr_name} not available as a parameter in Flyte context - are you in right task-type?")

```

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
```python
from airflow.operators.bash import BashOperator
from flytekit import workflow, ImageSpec, task, dynamic

new_airflow_plugin = "git+https://github.com/flyteorg/flytekit.git@1775025f7e0db48e0115781e7012493b4aebb79f#subdirectory=plugins/flytekit-airflow"
image_spec = ImageSpec(packages=[new_airflow_plugin, "flytekitplugins-envd"], registry="pingsutw", apt_packages=["git"])


@task(container_image=image_spec)
def t1():
    print("flyte")


@dynamic(container_image=image_spec)
def d1():
    b = BashOperator(task_id=f"airflow_bash_operator", bash_command="echo hello")
    b >> t1()


@workflow
def wf():
    d1()


if __name__ == '__main__':
    wf()
```

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3936

## Follow-up issue
_NA_
