### PR TITLE
Improve error message when omitting task kwarg in workflows

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -916,7 +916,17 @@ def create_and_link_node(
                             )
                         is_optional = True
             if not is_optional:
-                raise _user_exceptions.FlyteAssertion("Input was not specified for: {} of type {}".format(k, var.type))
+                from flytekit.core.base_task import Task
+
+                error_msg = f"Input {k} of type {var.type} was not specified for function {entity.name}"
+
+                if isinstance(entity, Task):
+                    error_msg += (
+                        ". Flyte workflow syntax is a domain-specific language (DSL) for building execution graphs which "
+                        "supports a subset of Python’s semantics. When calling tasks, all kwargs have to be provided."
+                    )
+
+                raise _user_exceptions.FlyteAssertion(error_msg)
             else:
                 continue
         v = kwargs[k]

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -918,7 +918,7 @@ def create_and_link_node(
             if not is_optional:
                 from flytekit.core.base_task import Task
 
-                error_msg = f"Input {k} of type {var.type} was not specified for function {entity.name}"
+                error_msg = f"Input {k} of type {interface.inputs[k]} was not specified for function {entity.name}"
 
                 _, _default = interface.inputs_with_defaults[k]
                 if isinstance(entity, Task) and _default is not None:

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -920,7 +920,8 @@ def create_and_link_node(
 
                 error_msg = f"Input {k} of type {var.type} was not specified for function {entity.name}"
 
-                if isinstance(entity, Task):
+                _, _default = interface.inputs_with_defaults[k]
+                if isinstance(entity, Task) and _default is not None:
                     error_msg += (
                         ". Flyte workflow syntax is a domain-specific language (DSL) for building execution graphs which "
                         "supports a subset of Python’s semantics. When calling tasks, all kwargs have to be provided."

--- a/tests/flytekit/unit/core/test_references.py
+++ b/tests/flytekit/unit/core/test_references.py
@@ -274,7 +274,7 @@ def test_lps(resource_type):
     with context_manager.FlyteContextManager.with_context(ctx.with_new_compilation_state()) as ctx:
         with pytest.raises(Exception) as e:
             ref_entity()
-        assert "Input was not specified" in f"{e}"
+        assert "was not specified for function" in f"{e}"
 
         output = ref_entity(a="hello", b=3)
         assert isinstance(output, VoidPromise)
@@ -321,7 +321,7 @@ def test_ref_sub_wf():
     with context_manager.FlyteContextManager.with_context(ctx.with_new_compilation_state()) as ctx:
         with pytest.raises(Exception) as e:
             ref_entity()
-        assert "Input was not specified" in f"{e}"
+        assert "was not specified for function" in f"{e}"
 
         output = ref_entity(a="hello", b=3)
         assert isinstance(output, VoidPromise)


### PR DESCRIPTION
# TL;DR
Improve error message when, in a workflow, one omits to pass an optional kwarg to a task.

---

In python, the following is perfectly valid:

```python
def foo(bar: int=1) -> int:
    return bar

def wf() -> int:
    return foo()
```

In Flyte, the following workflow (which only adds task/workflow decorators) is not:

```python
@task
def foo(bar: int=1) -> int:
    return bar


@workflow
def wf() -> int:
    return foo()
```

The user is confronted with this error message:

```console
flytekit.exceptions.user.FlyteAssertion: Error encountered while executing 'wf':
  Input was not specified for: bar of type <FlyteLiteral simple: INTEGER>
```

Many Flyte users are ML engineers that are not necessarily aware of the following ([source](https://docs.flyte.org/projects/cookbook/en/stable/getting_started/tasks_and_workflows.html#workflows-versus-tasks-under-the-hood)):

> Although Flyte workflow syntax looks like Python code, it’s actually a [domain-specific language (DSL)](https://en.wikipedia.org/wiki/Domain-specific_language) for building execution graphs where tasks – and other workflows – serve as the building blocks. This means that the workflow function body only supports a subset of Python’s semantics

For these users, the above error message is very confusing and does not give a hint why something that works in python wouldn't work in a flyte workflow.

---

Since I was asked about this particular limitation by several of our platform users, I propose that we improve the error message so that the error explains itself and users are informed about flyte workflows being a DSL, not python.



## Type
Neither of the following but improved error message.

 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
_NA_

## Tracking Issue
_NA_

## Follow-up issue
_NA_
