### PR TITLE
Use communicate in shell task

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -7,6 +7,7 @@ mock
 pytest
 pytest-asyncio
 pytest-cov
+pytest-timeout
 mypy
 pre-commit
 codespell

--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -113,14 +113,14 @@ def _run_script(script) -> typing.Tuple[int, str, str]:
     """
     process = subprocess.Popen(script, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0, shell=True, text=True)
 
-    # print stdout so that long-running subprocess will not appear unresponsive
+    process_stdout, process_stderr = process.communicate()
     out = ""
-    for line in process.stdout:
+    for line in process_stdout.splitlines():
         print(line)
         out += line
 
     code = process.wait()
-    return code, out, process.stderr.read()
+    return code, out, process_stderr
 
 
 class ShellTask(PythonInstanceTask[T]):

--- a/tests/flytekit/unit/extras/tasks/test_shell.py
+++ b/tests/flytekit/unit/extras/tasks/test_shell.py
@@ -2,6 +2,7 @@ import datetime
 import os
 import tempfile
 import typing
+import pytest
 from dataclasses import dataclass
 
 import pytest
@@ -313,3 +314,18 @@ bash {inputs.script_file} {inputs.script_args}
     cap = capfd.readouterr()
     assert "first_arg" in cap.out
     assert "second_arg" in cap.out
+
+
+@pytest.mark.timeout(10)
+def test_long_run_script():
+    ShellTask(
+        name="long-running",
+        script="""
+for i in $(seq 1 200000)
+do
+  echo "This is an error message" >&2
+done
+
+echo "This is the output of the program"
+""",
+    )()


### PR DESCRIPTION
# TL;DR
Use a different method to wait for child task in a ShellTask

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The current implementation of `ShellTask` might hit the deadlock described in https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait if the child process ends up writing more than the pipe buffer size (which in most Linux systems sits around 65KB, or 16 pages).

The fix is to use [Popen.communicate](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.communicate), which waits for the process to terminate and returns a tuple `(stdout_data, stderr_data)`. The one downside of this is that it keeps both stdout and stderr in memory. We might expose a flag to use the slower method of using temporary files to hold the child process's stdout and stderr in the future.

The test I added demonstrates the deadlock with the old code.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/4313

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
