### PR TITLE
Make sure `$HOME` is writable in dev image

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -29,4 +29,6 @@ ENV PYTHONPATH "/flytekit:/flytekit/plugins/flytekit-k8s-pod:/flytekit/plugins/f
 
 RUN useradd -u 1000 flytekit
 RUN chown flytekit: /root
+# Some packages will create config file under /home by default, so we need to make sure it's writable
+RUN chown flytekit: /home
 USER flytekit


### PR DESCRIPTION
# TL;DR

apply the same change as in https://github.com/flyteorg/flytekit/blob/master/Dockerfile#L24 to dev dockerfile because some pkgs implicitly create files under home

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
