### PR TITLE
Sanitize URIs for pathlib.Path constructors

### DIFF
--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -30,6 +30,9 @@ else:
 
 T = TypeVar("T")
 
+def _path_from_uri(path: str) -> Path:
+    return Path(path.removeprefix("file://"))
+
 
 def get_pandas_storage_options(
     uri: str, data_config: DataConfig, anonymous: bool = False
@@ -53,7 +56,7 @@ class PandasToCSVEncodingHandler(StructuredDatasetEncoder):
     ) -> literals.StructuredDataset:
         uri = typing.cast(str, structured_dataset.uri) or ctx.file_access.get_random_remote_directory()
         if not ctx.file_access.is_remote(uri):
-            Path(uri).mkdir(parents=True, exist_ok=True)
+            _path_from_uri(uri).mkdir(parents=True, exist_ok=True)
         path = os.path.join(uri, ".csv")
         df = typing.cast(pd.DataFrame, structured_dataset.dataframe)
         df.to_csv(
@@ -103,7 +106,7 @@ class PandasToParquetEncodingHandler(StructuredDatasetEncoder):
             ctx.file_access.raw_output_prefix, ctx.file_access.get_random_string()
         )
         if not ctx.file_access.is_remote(uri):
-            Path(uri).mkdir(parents=True, exist_ok=True)
+            _path_from_uri(uri).mkdir(parents=True, exist_ok=True)
         path = os.path.join(uri, f"{0:05}")
         df = typing.cast(pd.DataFrame, structured_dataset.dataframe)
         df.to_parquet(
@@ -155,7 +158,7 @@ class ArrowToParquetEncodingHandler(StructuredDatasetEncoder):
             ctx.file_access.raw_output_prefix, ctx.file_access.get_random_string()
         )
         if not ctx.file_access.is_remote(uri):
-            Path(uri).mkdir(parents=True, exist_ok=True)
+            _path_from_uri(uri).mkdir(parents=True, exist_ok=True)
         path = os.path.join(uri, f"{0:05}")
         filesystem = ctx.file_access.get_filesystem_for_path(path)
         pq.write_table(structured_dataset.dataframe, strip_protocol(path), filesystem=filesystem)
@@ -176,7 +179,7 @@ class ParquetToArrowDecodingHandler(StructuredDatasetDecoder):
 
         uri = flyte_value.uri
         if not ctx.file_access.is_remote(uri):
-            Path(uri).parent.mkdir(parents=True, exist_ok=True)
+            _path_from_uri(uri).parent.mkdir(parents=True, exist_ok=True)
         _, path = split_protocol(uri)
 
         columns = None

--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -1,7 +1,7 @@
 import os
 import typing
 from pathlib import Path
-from typing import TypeVar
+from typing import Final, TypeVar
 
 from botocore.exceptions import NoCredentialsError
 from fsspec.core import split_protocol, strip_protocol
@@ -31,8 +31,13 @@ else:
 T = TypeVar("T")
 
 
+_FILE_PROTOCOL_PREFIX: Final[str] = "file://"
+
+
 def _path_from_uri(path: str) -> Path:
-    return Path(path.lstrip("file://"))
+    if path.find(_FILE_PROTOCOL_PREFIX) == 0:
+        return Path(path[len(_FILE_PROTOCOL_PREFIX) :])
+    return Path(path)
 
 
 def get_pandas_storage_options(

--- a/flytekit/types/structured/basic_dfs.py
+++ b/flytekit/types/structured/basic_dfs.py
@@ -30,8 +30,9 @@ else:
 
 T = TypeVar("T")
 
+
 def _path_from_uri(path: str) -> Path:
-    return Path(path.removeprefix("file://"))
+    return Path(path.lstrip("file://"))
 
 
 def get_pandas_storage_options(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "docker>=4.0.0,<7.0.0",
     "docstring-parser>=0.9.0",
     "flyteidl>=1.10.0",
-    "fsspec>=2023.3.0,<=2023.9.2",
+    "fsspec>=2023.3.0",
     "gcsfs",
     "googleapis-common-protos>=1.57",
     "grpcio",

--- a/tests/flytekit/unit/core/test_flyte_directory.py
+++ b/tests/flytekit/unit/core/test_flyte_directory.py
@@ -75,10 +75,11 @@ def test_transformer_to_literal_local():
         # Create a director with one file in it
         if os.path.exists(p):
             shutil.rmtree(p)
-        pathlib.Path(p).mkdir(parents=True)
-        with open(os.path.join(p, "xyz"), "w") as fh:
-            fh.write("Hello world\n")
+        path = pathlib.Path(p)
+        path.mkdir(parents=True)
+        path.joinpath("xyz").write_text("Hello world\n")
         literal = tf.to_literal(ctx, FlyteDirectory(p), FlyteDirectory, lt)
+        assert literal.scalar.blob.uri == "/tmp/flyte/test_fd_transformer"
 
         mock_remote_files = os.listdir(literal.scalar.blob.uri)
         assert mock_remote_files == ["xyz"]

--- a/tests/flytekit/unit/core/test_flyte_directory.py
+++ b/tests/flytekit/unit/core/test_flyte_directory.py
@@ -79,7 +79,6 @@ def test_transformer_to_literal_local():
         path.mkdir(parents=True)
         path.joinpath("xyz").write_text("Hello world\n")
         literal = tf.to_literal(ctx, FlyteDirectory(p), FlyteDirectory, lt)
-        assert literal.scalar.blob.uri == "/tmp/flyte/test_fd_transformer"
 
         mock_remote_files = os.listdir(literal.scalar.blob.uri)
         assert mock_remote_files == ["xyz"]

--- a/tests/flytekit/unit/experimental/test_eager_workflows.py
+++ b/tests/flytekit/unit/experimental/test_eager_workflows.py
@@ -236,9 +236,9 @@ def create_file() -> FlyteFile:
 @task
 def create_directory() -> FlyteDirectory:
     dirname = "/tmp/flytekit_test_dir"
-    Path(dirname).mkdir(exist_ok=True, parents=True)
-    with open(os.path.join(dirname, "file"), "w") as tmp:
-        tmp.write("some data\n")
+    path = Path(dirname)
+    path.mkdir(exist_ok=True, parents=True)
+    path.joinpath("file").write_text("some data\n")
     return FlyteDirectory(path=dirname)
 
 

--- a/tests/flytekit/unit/types/structured_dataset/test_basic_dfs.py
+++ b/tests/flytekit/unit/types/structured_dataset/test_basic_dfs.py
@@ -1,0 +1,7 @@
+import pathlib
+from flytekit.types.structured.basic_dfs import _path_from_uri
+
+
+def test_path_from_uri():
+    assert _path_from_uri("file:///test") == pathlib.Path("/test")
+    assert _path_from_uri("/test") == pathlib.Path("/test")

--- a/tests/flytekit/unit/types/structured_dataset/test_basic_dfs.py
+++ b/tests/flytekit/unit/types/structured_dataset/test_basic_dfs.py
@@ -1,7 +1,8 @@
 import pathlib
+
 from flytekit.types.structured.basic_dfs import _path_from_uri
 
 
-def test_path_from_uri():
+def test_path_from_uri() -> None:
     assert _path_from_uri("file:///test") == pathlib.Path("/test")
     assert _path_from_uri("/test") == pathlib.Path("/test")


### PR DESCRIPTION
# TL;DR
In newer versions of fsspec, local path URIs seem to always have the `file://` protocol specified, but `pathlib.Path`'s constructor takes filesystem paths, not URIs, so flytekit is broken for the latest version of fsspec.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Replace every instance of `Path(uri)` with a wrapper function that sanitizes the `file://` prefix away before invoking the constructor.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/4326

## Follow-up issue
_NA_