### PR TITLE
Do not cache packages in images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,11 @@ ARG DOCKER_IMAGE
 RUN apt-get update && apt-get install build-essential -y
 
 # Pod tasks should be exposed in the default image
-RUN pip install -U flytekit==$VERSION \
+RUN pip install --no-cache-dir -U flytekit==$VERSION \
 	flytekitplugins-pod==$VERSION \
 	flytekitplugins-deck-standard==$VERSION \
-	scikit-learn
+	scikit-learn \
+	&& :
 
 RUN useradd -u 1000 flytekit
 RUN chown flytekit: /root

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -8,7 +8,7 @@ ARG VERSION
 RUN apt-get update && apt-get install build-essential -y
 
 RUN pip install prometheus-client
-RUN pip install -U flytekit==$VERSION \
+RUN pip install --no-cache-dir -U flytekit==$VERSION \
   flytekitplugins-bigquery==$VERSION \
   flytekitplugins-airflow==$VERSION \
   flytekitplugins-mmcloud==$VERSION \


### PR DESCRIPTION
# TL;DR
Disable caching of packages in images

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Pass the `--no-cache-dir` flag in invocation of `pip install` in dockerfiles. This will have a bigger impact in the agent image, since currently we are using about ~800MB:
```
 docker run --rm -it ghcr.io/flyteorg/flyteagent:1.10.0 du -kh --max-depth=1 /root/.cache
813M    /root/.cache/pip
813M    /root/.cache
``` 

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
