### PR TITLE
Set protobuf to <4.25.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,7 @@ setup(
         "rich",
         "rich_click",
         "jsonpickle",
-        # There is a bug in the protobuf 4.25.0 release that breaks the unit tests. https://github.com/flyteorg/flytekit/pull/1934
-        # TODO: Remove upper-bound after they fix it.
+        # TODO: Remove upper-bound after protobuf community fixes it. https://github.com/flyteorg/flyte/issues/4359
         "protobuf<4.25.0",
     ],
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,8 @@ setup(
         "rich",
         "rich_click",
         "jsonpickle",
+        # There is a bug in the protobuf 4.25.0 release that breaks the unit tests. https://github.com/flyteorg/flytekit/pull/1934
+        # TODO: Remove upper-bound after they fix it.
         "protobuf<4.25.0",
     ],
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         "rich",
         "rich_click",
         "jsonpickle",
+        "protobuf<4.25.0",
     ],
     extras_require=extras_require,
     scripts=[


### PR DESCRIPTION
# TL;DR
Set protobuf to <4.25.0.
Some of unit tests are failing due to the changes in the latest protobuf. https://github.com/flyteorg/flytekit/actions/runs/6741354377/job/18325816188?pr=1918

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
