### PR TITLE
Feat: If PKCE AuthorizationClient cannot open browser, ask user to do so manually

### DIFF
--- a/flytekit/clients/auth/auth_client.py
+++ b/flytekit/clients/auth/auth_client.py
@@ -285,7 +285,7 @@ class AuthorizationClient(metaclass=_SingletonPerEndpoint):
 
         success = _webbrowser.open_new_tab(endpoint)
         if not success:
-            click.secho(f"Please open the following link in your browser to authenticate:\n{endpoint}")
+            click.secho(f"Please open the following link in your browser to authenticate: {endpoint}")
 
     def _credentials_from_response(self, auth_token_resp) -> Credentials:
         """

--- a/flytekit/clients/auth/auth_client.py
+++ b/flytekit/clients/auth/auth_client.py
@@ -15,6 +15,7 @@ from http import HTTPStatus as _StatusCodes
 from multiprocessing import get_context
 from urllib.parse import urlencode as _urlencode
 
+import click
 import requests as _requests
 
 from .default_html import get_default_success_html
@@ -281,7 +282,10 @@ class AuthorizationClient(metaclass=_SingletonPerEndpoint):
         query = _urlencode(self._request_auth_code_params)
         endpoint = _urlparse.urlunparse((scheme, netloc, path, None, query, None))
         logging.debug(f"Requesting authorization code through {endpoint}")
-        _webbrowser.open_new_tab(endpoint)
+
+        success = _webbrowser.open_new_tab(endpoint)
+        if not success:
+            click.secho(f"Please open the following link in your browser to authenticate:\n{endpoint}")
 
     def _credentials_from_response(self, auth_token_resp) -> Credentials:
         """


### PR DESCRIPTION
# TL;DR
The PKCE `AuthorizationClient` automatically opens a browser tab/window with the `/authorize` endpoint in order to receive the authorization code.

When ssh-ing into VMs, the browser window cannot be automatically opened. If one port-forwards the port used by the callback server, a pkce flow could still be done if only the authorization endpoint could be opened in the user's browser.

In this PR I change the `AuthorizationClient` so that it first tries to open the browser window automatically - as is already the case - but if this is not successful, simply asks the user to open the link.


## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
_NA_

## Tracking Issue
_NA_

## Follow-up issue
_NA_
