### PR TITLE
Fix lint test

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -8,7 +8,7 @@ pytest
 pytest-asyncio
 pytest-cov
 pytest-timeout
-mypy
+mypy<1.7.0
 pre-commit
 codespell
 google-cloud-bigquery


### PR DESCRIPTION
# TL;DR
Failed to run lint test when using [latest mypy](https://pypi.org/project/mypy/#history). Temporarily set the upper bound for mypy.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
