### PR TITLE
MAINT Removes GitPython dependency

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -6,6 +6,7 @@ but in Python object form.
 from __future__ import annotations
 
 import base64
+import configparser
 import functools
 import hashlib
 import os
@@ -147,14 +148,25 @@ def _get_git_repo_url(source_path):
     Get git repo URL from remote.origin.url
     """
     try:
-        from git import Repo
+        git_config = source_path / ".git" / "config"
+        if not git_config.exists():
+            raise ValueError(f"{source_path} is not a git repo")
 
-        return "github.com/" + Repo(source_path).remotes.origin.url.split(".git")[0].split(":")[-1]
-    except ImportError:
-        remote_logger.warning("Could not import git. is the git executable installed?")
-    except Exception:
-        # If the file isn't in the git repo, we can't get the url from git config
-        remote_logger.debug(f"{source_path} is not a git repo.")
+        config = configparser.ConfigParser()
+        config.read(git_config)
+        url = config['remote "origin"']["url"]
+
+        if url.startswith("git@"):
+            prefix_len, suffix_len = len("git@"), len(".git")
+            return url[prefix_len:-suffix_len].replace(":", "/")
+        elif url.startswith("https://"):
+            prefix_len = len("https://")
+            return url[prefix_len:]
+        else:
+            raise ValueError("Unable to parse url")
+
+    except Exception as e:
+        remote_logger.debug(str(e))
         return ""
 
 


### PR DESCRIPTION
This PR removes GitPython dependency and adds more unit test to test the update function.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin
 - [x] Maintenance

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
`GitPython` was only used to read the remote url. This configuration is located in `.git/config`, which we can parse directly.

## Tracking Issue
Towards flyteorg/flyte#4418
