### PR TITLE
Do not check if image builder exists in the dynamic task

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -147,13 +147,13 @@ class ImageBuildEngine:
 
     @classmethod
     def build(cls, image_spec: ImageSpec):
-        if image_spec.builder not in cls._REGISTRY:
-            raise Exception(f"Builder {image_spec.builder} is not registered.")
         img_name = image_spec.image_name()
         if img_name in cls._BUILT_IMAGES or image_spec.exist():
             click.secho(f"Image {img_name} found. Skip building.", fg="blue")
         else:
             click.secho(f"Image {img_name} not found. Building...", fg="blue")
+            if image_spec.builder not in cls._REGISTRY:
+                raise Exception(f"Builder {image_spec.builder} is not registered.")
             cls._REGISTRY[image_spec.builder].build_image(image_spec)
             cls._BUILT_IMAGES.add(img_name)
 

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -14,6 +14,7 @@ REGISTRY_CONFIG_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 def test_image_spec():
     image_spec = ImageSpec(
         name="FLYTEKIT",
+        builder="dummy",
         packages=["pandas"],
         apt_packages=["git"],
         python_version="3.8",
@@ -35,7 +36,7 @@ def test_image_spec():
     assert image_spec.cuda == "11.2.2"
     assert image_spec.cudnn == "8"
     assert image_spec.name == "flytekit"
-    assert image_spec.builder == "envd"
+    assert image_spec.builder == "dummy"
     assert image_spec.source_root is None
     assert image_spec.env is None
     assert image_spec.pip_index is None
@@ -55,11 +56,16 @@ def test_image_spec():
             ...
 
     ImageBuildEngine.register("dummy", DummyImageSpecBuilder())
-    ImageBuildEngine._REGISTRY["dummy"].build_image(image_spec)
+    ImageBuildEngine.build(image_spec)
 
     assert "dummy" in ImageBuildEngine._REGISTRY
     assert calculate_hash_from_image_spec(image_spec) == tag
     assert image_spec.exist() is False
+
+    # Remove the dummy builder, and build the image again
+    # The image has already been built, so it shouldn't fail.
+    del ImageBuildEngine._REGISTRY["dummy"]
+    ImageBuildEngine.build(image_spec)
 
     with pytest.raises(Exception):
         image_spec.builder = "flyte"


### PR DESCRIPTION
# TL;DR
There is an error when using imageSpec for dynamic task.
<img width="1453" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/4bf8ee16-39d6-4ad4-a564-a8c194c38b60">

The builder should only be checked if the image does not exist 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
```python
from flytekit import ImageSpec, task, dynamic, workflow

new_flytekit = "git+https://github.com/flyteorg/flytekit.git@90c7750b99d53b44dd92633fb8225b3bed51fb21"
repro_img = ImageSpec(
    name="repro",
    apt_packages=["curl", "git"],
    packages=[new_flytekit],
    registry="pingsutw",
)


@task(container_image=repro_img)
def foo():
    print("foo")


@dynamic(container_image=repro_img)
def bar():
    foo()


@workflow
def wf():
    bar()


if __name__ == '__main__':
    wf()

```

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
