### PR TITLE
MAINT Remove natsort dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -300,8 +300,6 @@ mypy-extensions==1.0.0
     # via
     #   mypy
     #   typing-inspect
-natsort==8.4.0
-    # via flytekit
 nodeenv==1.8.0
     # via pre-commit
 numpy==1.23.5

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -670,8 +670,6 @@ multiprocess==0.70.15
     # via datasets
 mypy-extensions==1.0.0
     # via typing-inspect
-natsort==8.4.0
-    # via flytekit
 nbclient==0.8.0
     # via
     #   nbconvert

--- a/plugins/flytekit-aws-sagemaker/scripts/flytekit_sagemaker_runner.py
+++ b/plugins/flytekit-aws-sagemaker/scripts/flytekit_sagemaker_runner.py
@@ -4,8 +4,6 @@ import os
 import subprocess
 import sys
 
-from natsort import natsorted
-
 FLYTE_ARG_PREFIX = "--__FLYTE"
 FLYTE_ENV_VAR_PREFIX = f"{FLYTE_ARG_PREFIX}_ENV_VAR_"
 FLYTE_CMD_PREFIX = f"{FLYTE_ARG_PREFIX}_CMD_"
@@ -67,7 +65,7 @@ def parse_args(cli_args):
 
 def sort_flyte_cmd(flyte_cmd):
     # Order the cmd using the index (the first element in each tuple)
-    flyte_cmd = natsorted(flyte_cmd, key=lambda x: x[0])
+    flyte_cmd = sorted(flyte_cmd, key=lambda x: int(x[0]))
     flyte_cmd = [x[1] for x in flyte_cmd]
     return flyte_cmd
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
         # TODO: remove upper-bound after fixing change in contract
         "marshmallow-jsonschema>=0.12.0",
         "mashumaro>=3.9.1",
-        "natsort>=7.0.1",
         "numpy",
         "pandas>=1.0.0,<2.0.0",
         # TODO: Remove upper-bound after protobuf community fixes it. https://github.com/flyteorg/flyte/issues/4359

--- a/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
+++ b/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
@@ -212,8 +212,6 @@ multidict==6.0.4
     #   yarl
 mypy-extensions==1.0.0
     # via typing-inspect
-natsort==8.4.0
-    # via flytekit
 numpy==1.25.2
     # via
     #   contourpy


### PR DESCRIPTION
This PR removes the natsort dependency.

## Type
 - [x] Maintenance

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
From reading the example, the prefix `__FLYTE_CMD_` is always followed by an integer:

https://github.com/flyteorg/flytekit/blob/28612676b3820c73fb0ae8c4f2f4457dedf16651/plugins/flytekit-aws-sagemaker/scripts/flytekit_sagemaker_runner.py#L22-L27

Thus, we can cast the string into an integer for sorting purposes.

## Tracking Issue
Towards https://github.com/flyteorg/flyte/issues/4418
