### PR TITLE
add support for gate nodes in `sync_node_execution`

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1806,7 +1806,7 @@ class FlyteRemote(object):
         # Handle the case for gate nodes
         elif execution._node.gate_node is not None:
             remote_logger.info(
-                "Skipping gate node execution for now - gate nodes don't " "have inputs and outputs filled in"
+                "Skipping gate node execution for now - gate nodes don't have inputs and outputs filled in"
             )
             return execution
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1806,9 +1806,9 @@ class FlyteRemote(object):
         # Handle the case for gate nodes
         elif execution._node.gate_node is not None:
             remote_logger.info(
-                    "Skipping gate node execution for now - gate nodes don't "
-                    "have inputs and outputs filled in"
-                )
+                "Skipping gate node execution for now - gate nodes don't "
+                "have inputs and outputs filled in"
+            )
             return execution
 
         # This is the plain ol' task execution case

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1802,12 +1802,11 @@ class FlyteRemote(object):
             else:
                 remote_logger.error(f"NE {execution} undeterminable, {type(execution._node)}, {execution._node}")
                 raise Exception(f"Node execution undeterminable, entity has type {type(execution._node)}")
-            
+
         # Handle the case for gate nodes
         elif execution._node.gate_node is not None:
             remote_logger.info(
-                "Skipping gate node execution for now - gate nodes don't "
-                "have inputs and outputs filled in"
+                "Skipping gate node execution for now - gate nodes don't " "have inputs and outputs filled in"
             )
             return execution
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1802,6 +1802,14 @@ class FlyteRemote(object):
             else:
                 remote_logger.error(f"NE {execution} undeterminable, {type(execution._node)}, {execution._node}")
                 raise Exception(f"Node execution undeterminable, entity has type {type(execution._node)}")
+            
+        # Handle the case for gate nodes
+        elif execution._node.gate_node is not None:
+            remote_logger.info(
+                    "Skipping gate node execution for now - gate nodes don't "
+                    "have inputs and outputs filled in"
+                )
+            return execution
 
         # This is the plain ol' task execution case
         else:


### PR DESCRIPTION
# TL;DR
This PR handles the case for gate nodes while fetching an execution using flyte remote, preventing the `AttributeError: 'FlyteGateNode' object has no attribute 'interface'` error.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/4398

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
