### PR TITLE
Fix default paramaters when launching launchplans from within other workflows

### DIFF
--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -99,6 +99,10 @@ class LaunchPlan(object):
             fixed_inputs=_literal_models.LiteralMap(literals={}),
         )
 
+        # Ensure default parameters are available when using lp.__call__()
+        default_inputs = {name: default for name, (type, default) in workflow.python_interface.inputs_with_defaults.items()}
+        lp._saved_inputs = default_inputs
+
         LaunchPlan.CACHE[workflow.name] = lp
         return lp
 

--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -100,7 +100,9 @@ class LaunchPlan(object):
         )
 
         # Ensure default parameters are available when using lp.__call__()
-        default_inputs = {name: default for name, (type, default) in workflow.python_interface.inputs_with_defaults.items()}
+        default_inputs = {
+            name: default for name, (type, default) in workflow.python_interface.inputs_with_defaults.items()
+        }
         lp._saved_inputs = default_inputs
 
         LaunchPlan.CACHE[workflow.name] = lp

--- a/tests/flytekit/unit/core/test_launch_plan.py
+++ b/tests/flytekit/unit/core/test_launch_plan.py
@@ -403,7 +403,7 @@ def test_lp_default_paramaters_work_when_called_from_another_workflow():
     def my_wf(a: int) -> int:
         return lp(a=a)
 
-    my_wf(a=8)
+    assert my_wf(a=8) == 13
 
 
 def test_lp_with_docstring():

--- a/tests/flytekit/unit/core/test_launch_plan.py
+++ b/tests/flytekit/unit/core/test_launch_plan.py
@@ -388,6 +388,24 @@ def test_lp_nodes():
     assert wf_spec.template.nodes[1].workflow_node.launchplan_ref.name == "my_sub_wf_lp1"
 
 
+def test_lp_default_paramaters_work_when_called_from_another_workflow():
+    @task
+    def t1(a: int, b: int) -> int:
+        return a + b
+
+    @workflow
+    def my_sub_wf(a: int, b: int = 5) -> int:
+        return t1(a=a, b=b)
+
+    lp = launch_plan.LaunchPlan.get_or_create(my_sub_wf)
+
+    @workflow
+    def my_wf(a: int) -> int:
+        return lp(a=a)
+
+    my_wf(a=8)
+
+
 def test_lp_with_docstring():
     @task
     def t1(a: int) -> typing.NamedTuple("OutputsBC", t1_int_output=int, c=str):


### PR DESCRIPTION
# TL;DR
Fix default parameters when launching launchplans from within other workflows. 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested - I have been using this change on a real flyte deployment for some time. 
 - [x] Unit tests added
 - [x] Code documentation added - No documentation changes required
 - [x] Any pending items have an associated Issue - No pending items. 

## Complete description
Save the default inputs during `LaunchPlan.get_default_launch_plan` the same as in `LaunchPlan.create`

## Tracking Issue
https://github.com/flyteorg/flyte/issues/4444

## Follow-up issue
_NA_
