### PR TITLE
MAINT Adds support for pytest-xdist and enables it in the CI

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -38,6 +38,8 @@ jobs:
         run: |
           make setup && pip freeze
       - name: Test with coverage
+        env:
+          PYTEST_OPTS: -n2
         run: |
           make unit_test_codecov
       - name: Codecov
@@ -82,6 +84,7 @@ jobs:
         env:
           FLYTEKIT_IMAGE: localhost:30000/flytekit:dev
           FLYTEKIT_CI: 1
+          PYTEST_OPTS: -n2
         run: make integration_test_codecov
       - name: Codecov
         uses: codecov/codecov-action@v3.1.0

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ export REPOSITORY=flytekit
 
 PIP_COMPILE = pip-compile --upgrade --verbose --resolver=backtracking
 MOCK_FLYTE_REPO=tests/flytekit/integration/remote/mock_flyte_repo/workflows
+PYTEST_OPTS ?=
+PYTEST = pytest ${PYTEST_OPTS}
 
 .SILENT: help
 .PHONY: help
@@ -55,8 +57,8 @@ unit_test_codecov:
 unit_test:
 	# Skip tensorflow tests and run them with the necessary env var set so that a working (albeit slower)
 	# library is used to serialize/deserialize protobufs is used.
-	pytest -m "not sandbox_test" tests/flytekit/unit/ --ignore=tests/flytekit/unit/extras/tensorflow ${CODECOV_OPTS} && \
-		PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python pytest tests/flytekit/unit/extras/tensorflow ${CODECOV_OPTS}
+	$(PYTEST) -m "not sandbox_test" tests/flytekit/unit/ --ignore=tests/flytekit/unit/extras/tensorflow ${CODECOV_OPTS} && \
+		PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python $(PYTEST) tests/flytekit/unit/extras/tensorflow ${CODECOV_OPTS}
 
 .PHONY: integration_test_codecov
 integration_test_codecov:
@@ -64,7 +66,7 @@ integration_test_codecov:
 
 .PHONY: integration_test
 integration_test:
-	pytest tests/flytekit/integration ${CODECOV_OPTS}
+	$(PYTEST) tests/flytekit/integration ${CODECOV_OPTS}
 
 doc-requirements.txt: export CUSTOM_COMPILE_COMMAND := make doc-requirements.txt
 doc-requirements.txt: doc-requirements.in install-piptools

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -9,6 +9,7 @@ pytest-asyncio
 pytest-cov
 pytest-timeout
 pytest-mock
+pytest-xdist
 mypy<1.7.0
 pre-commit
 codespell

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -121,6 +121,8 @@ exceptiongroup==1.1.3
     #   hypothesis
     #   ipython
     #   pytest
+execnet==2.0.2
+    # via pytest-xdist
 executing==2.0.1
     # via stack-data
 filelock==3.13.1
@@ -400,6 +402,7 @@ pytest==7.4.3
     #   pytest-cov
     #   pytest-mock
     #   pytest-timeout
+    #   pytest-xdist
 pytest-asyncio==0.21.1
     # via -r dev-requirements.in
 pytest-cov==4.1.0
@@ -407,6 +410,8 @@ pytest-cov==4.1.0
 pytest-mock==3.12.0
     # via -r dev-requirements.in
 pytest-timeout==2.2.0
+    # via -r dev-requirements.in
+pytest-xdist==3.4.0
     # via -r dev-requirements.in
 python-dateutil==2.8.2
     # via

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -1,3 +1,4 @@
+import os
 import typing
 from collections import OrderedDict
 
@@ -139,11 +140,15 @@ def test_condition_tuple_branches():
     assert x == 5
     assert y == 1
 
+    # pytest-xdist uses `__channelexec__` as the top-level environment
+    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
+    prefix = "__channelexec__." if running_xdist else ""
+
     wf_spec = get_serializable(OrderedDict(), serialization_settings, math_ops)
     assert len(wf_spec.template.nodes) == 1
     assert (
         wf_spec.template.nodes[0].branch_node.if_else.case.then_node.task_node.reference_id.name
-        == "tests.flytekit.unit.core.test_conditions.sum_sub"
+        == f"{prefix}tests.flytekit.unit.core.test_conditions.sum_sub"
     )
 
 

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -140,7 +140,7 @@ def test_condition_tuple_branches():
     assert x == 5
     assert y == 1
 
-    # pytest-xdist uses `__channelexec__` as the top-level environment
+    # pytest-xdist uses `__channelexec__` as the top-level module
     running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
     prefix = "__channelexec__." if running_xdist else ""
 

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1841,9 +1841,9 @@ def test_list_containing_multiple_annotated_pandas_dataframes():
         return str(pandas.util.hash_pandas_object(df))
 
     @task
-    def produce_list_of_annotated_dataframes() -> (
-        typing.List[Annotated[pandas.DataFrame, HashMethod(hash_pandas_dataframe)]]
-    ):
+    def produce_list_of_annotated_dataframes() -> typing.List[
+        Annotated[pandas.DataFrame, HashMethod(hash_pandas_dataframe)]
+    ]:
         return [pandas.DataFrame({"column_1": [1, 2, 3]}), pandas.DataFrame({"column_1": [4, 5, 6]})]
 
     @task(cache=True, cache_version="v0")

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1191,7 +1191,6 @@ def test_flyte_schema_dataclass():
 
     @task
     def t1(x: int) -> Result:
-
         return Result(result=InnerResult(number=x, schema=schema), schema=schema)
 
     @workflow
@@ -1555,7 +1554,7 @@ def test_error_messages():
     def foo3(a: typing.Dict) -> typing.Dict:
         return a
 
-    # pytest-xdist uses `__channelexec__` as the top-level environment
+    # pytest-xdist uses `__channelexec__` as the top-level module
     running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
     prefix = "__channelexec__." if running_xdist else ""
 
@@ -1616,7 +1615,7 @@ def test_union_type():
     def wf2(a: typing.Union[int, str]) -> typing.Union[int, str]:
         return t2(a=a)
 
-    # pytest-xdist uses `__channelexec__` as the top-level environment
+    # pytest-xdist uses `__channelexec__` as the top-level module
     running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
     prefix = "__channelexec__." if running_xdist else ""
 
@@ -1842,9 +1841,9 @@ def test_list_containing_multiple_annotated_pandas_dataframes():
         return str(pandas.util.hash_pandas_object(df))
 
     @task
-    def produce_list_of_annotated_dataframes() -> typing.List[
-        Annotated[pandas.DataFrame, HashMethod(hash_pandas_dataframe)]
-    ]:
+    def produce_list_of_annotated_dataframes() -> (
+        typing.List[Annotated[pandas.DataFrame, HashMethod(hash_pandas_dataframe)]]
+    ):
         return [pandas.DataFrame({"column_1": [1, 2, 3]}), pandas.DataFrame({"column_1": [4, 5, 6]})]
 
     @task(cache=True, cache_version="v0")

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1191,6 +1191,7 @@ def test_flyte_schema_dataclass():
 
     @task
     def t1(x: int) -> Result:
+
         return Result(result=InnerResult(number=x, schema=schema), schema=schema)
 
     @workflow

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -283,7 +283,7 @@ def test_wf_nested_comp():
     assert len(model_wf.template.nodes) == 2
     assert model_wf.template.nodes[1].workflow_node is not None
 
-    # pytest-xdist uses `__channelexec__` as the top-level environment
+    # pytest-xdist uses `__channelexec__` as the top-level module
     running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
     prefix = "__channelexec__." if running_xdist else ""
 

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -1,3 +1,4 @@
+import os
 import typing
 from collections import OrderedDict
 
@@ -282,10 +283,14 @@ def test_wf_nested_comp():
     assert len(model_wf.template.nodes) == 2
     assert model_wf.template.nodes[1].workflow_node is not None
 
+    # pytest-xdist uses `__channelexec__` as the top-level environment
+    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
+    prefix = "__channelexec__." if running_xdist else ""
+
     sub_wf = model_wf.sub_workflows[0]
     assert len(sub_wf.nodes) == 1
     assert sub_wf.nodes[0].id == "n0"
-    assert sub_wf.nodes[0].task_node.reference_id.name == "tests.flytekit.unit.core.test_workflows.t1"
+    assert sub_wf.nodes[0].task_node.reference_id.name == f"{prefix}tests.flytekit.unit.core.test_workflows.t1"
 
 
 @task


### PR DESCRIPTION
Support `pytest-xdist` and enable it in the CI.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin
 - [x] Housekeeping

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
`pytest-xdist` uses `__channelexec__` as the top level environment so the function names are prefixed with `__channelexec__`.

## Tracking Issue
Closes https://github.com/flyteorg/flyte/issues/4446