### PR TITLE
Removes docker-image-py dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -111,8 +111,6 @@ distlib==0.3.7
     # via virtualenv
 docker==6.1.3
     # via flytekit
-docker-image-py==0.1.12
-    # via flytekit
 docstring-parser==0.15
     # via flytekit
 exceptiongroup==1.1.3
@@ -429,8 +427,6 @@ pyyaml==6.0.1
     #   flytekit
     #   kubernetes
     #   pre-commit
-regex==2023.10.3
-    # via docker-image-py
 requests==2.31.0
     # via
     #   azure-core

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -230,8 +230,6 @@ docker==6.1.3
     # via
     #   flytekit
     #   mlflow
-docker-image-py==0.1.12
-    # via flytekit
 docstring-parser==0.15
     # via flytekit
 docutils==0.17.1
@@ -1023,8 +1021,6 @@ referencing==0.30.2
     #   jsonschema
     #   jsonschema-specifications
     #   jupyter-events
-regex==2023.8.8
-    # via docker-image-py
 requests==2.31.0
     # via
     #   azure-core

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -207,7 +207,7 @@ class Image(DataClassJsonMixin):
         :param Text tag: e.g. somedocker.com/myimage:someversion123
         :rtype: Text
         """
-        from docker_image import reference
+        from docker.utils import parse_repository_tag
 
         if pathlib.Path(tag).is_file():
             with open(tag, "r") as f:
@@ -216,11 +216,11 @@ class Image(DataClassJsonMixin):
                 ImageBuildEngine.build(image_spec)
                 tag = image_spec.image_name()
 
-        ref = reference.Reference.parse(tag)
-        if not optional_tag and ref["tag"] is None:
+        fqn, parsed_tag = parse_repository_tag(tag)
+        if not optional_tag and parsed_tag is None:
             raise AssertionError(f"Incorrectly formatted image {tag}, missing tag value")
         else:
-            return Image(name=name, fqn=ref["name"], tag=ref["tag"])
+            return Image(name=name, fqn=fqn, tag=parsed_tag)
 
 
 @dataclass(init=True, repr=True, eq=True, frozen=True)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         "dataclasses-json>=0.5.2,<0.5.12",  # TODO: remove upper-bound after fixing change in contract
         "deprecated>=1.0,<2.0",
         "diskcache>=5.2.1",
-        "docker-image-py>=0.1.10",
         "docker>=4.0.0,<7.0.0",
         "docstring-parser>=0.9.0",
         "flyteidl>=1.10.0",

--- a/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
+++ b/tests/flytekit/integration/remote/mock_flyte_repo/workflows/requirements.txt
@@ -87,8 +87,6 @@ diskcache==5.6.1
     # via flytekit
 docker==6.1.3
     # via flytekit
-docker-image-py==0.1.12
-    # via flytekit
 docstring-parser==0.15
     # via flytekit
 flyteidl==1.5.13
@@ -278,8 +276,6 @@ pyyaml==6.0.1
     #   flytekit
     #   kubernetes
     #   responses
-regex==2023.6.3
-    # via docker-image-py
 requests==2.31.0
     # via
     #   azure-core


### PR DESCRIPTION
This PR removes the `docker-image-py` dependency.

## Type
 - [x] Housekeeping

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Instead of using `docker-image-py`, we can use the `docker` library, to parse the tag.

## Tracking Issue
Towards https://github.com/flyteorg/flyte/issues/4418