### PR TITLE
MAINT Adds more timeout for flakey test

### DIFF
--- a/tests/flytekit/unit/extras/tasks/test_shell.py
+++ b/tests/flytekit/unit/extras/tasks/test_shell.py
@@ -314,7 +314,7 @@ bash {inputs.script_file} {inputs.script_args}
     assert "second_arg" in cap.out
 
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(20)
 def test_long_run_script():
     script = os.path.join(testdata, "long-running.sh")
     ShellTask(

--- a/tests/flytekit/unit/extras/tasks/testdata/long-running.sh
+++ b/tests/flytekit/unit/extras/tasks/testdata/long-running.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-for _ in $(seq 1 200000); do
+for _ in $(seq 1 100000); do
   echo "This is an error message" >&2
 done
 


### PR DESCRIPTION
This test is flakey on CI and can sometimes fail between runs with:

```
FAILED tests/flytekit/unit/extras/tasks/test_shell.py::test_long_run_script - Failed: Timeout >10.0s
```

Increasing the timeout should help.

## Type
 - [x] Housekeeping

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue