### PR TITLE
Migrates developer tooling to use ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,13 @@
 repos:
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.1.6
     hooks:
-      - id: flake8
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-      - id: black
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
+      # Run the linter.
+      - id: ruff
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ setup: install-piptools ## Install requirements
 .PHONY: fmt
 fmt:
 	pre-commit run ruff --all-files || true
+	pre-commit run ruff-format --all-files || true
 
 .PHONY: lint
 lint: ## Run linters

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,8 @@ setup: install-piptools ## Install requirements
 	pip install -r dev-requirements.in
 
 .PHONY: fmt
-fmt: ## Format code with black and isort
-	autoflake --remove-all-unused-imports --ignore-init-module-imports --ignore-pass-after-docstring --in-place -r flytekit plugins tests
-	pre-commit run black --all-files || true
-	pre-commit run isort --all-files || true
+fmt:
+	pre-commit run ruff --all-files || true
 
 .PHONY: lint
 lint: ## Run linters

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -82,7 +82,7 @@ Some helpful make commands ::
 
     $ make
       setup        Install requirements
-      fmt          Format code with black and isort
+      fmt          Format code ruff
       lint         Run linters
       test         Run tests
       requirements Compile requirements
@@ -124,7 +124,7 @@ Pre-commit hooks
 ================
 
 We use `pre-commit <https://pre-commit.com/>`__ to automate linting and code formatting on every commit.
-Configured hooks include `black <https://github.com/psf/black>`__, `isort <https://github.com/PyCQA/isort>`__, and `flake8 <https://github.com/PyCQA/flake8>`__ and also linters to check for the validity of YAML files and ensuring that newlines are added to the end of files.
+Configured hooks include `ruff <https://github.com/astral-sh/ruff>`__ and also linters to check for the validity of YAML files and ensuring that newlines are added to the end of files.
 
 We run all those hooks in CI, but if you want to run them locally on every commit, run `pre-commit install` after installing the dev environment requirements. In case you want to disable `pre-commit` hooks locally, for example, while you're iterating on some feature, run `pre-commit uninstall`. More info in https://pre-commit.com/.
 
@@ -132,7 +132,7 @@ We run all those hooks in CI, but if you want to run them locally on every commi
 Formatting
 ==========
 
-We use `black <https://github.com/psf/black>`__ and `isort <https://github.com/PyCQA/isort>`__ to autoformat code. In fact, they have been configured as git hooks in `pre-commit`. Run the following commands to execute the formatters. ::
+We use `ruff <https://github.com/astral-sh/ruff>`__  to autoformat code. In fact, they have been configured as git hooks in `pre-commit`. Run the following commands to execute the formatters. ::
 
     source ~/.virtualenvs/flytekit/bin/activate
     make fmt

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -82,7 +82,7 @@ Some helpful make commands ::
 
     $ make
       setup        Install requirements
-      fmt          Format code ruff
+      fmt          Format code with ruff
       lint         Run linters
       test         Run tests
       requirements Compile requirements

--- a/flytekit/clients/auth/authenticator.py
+++ b/flytekit/clients/auth/authenticator.py
@@ -116,7 +116,6 @@ class PKCEAuthenticator(Authenticator):
 
     def _initialize_auth_client(self):
         if not self._auth_client:
-
             from .auth_client import _create_code_challenge, _generate_code_verifier
 
             code_verifier = _generate_code_verifier()

--- a/flytekit/clis/helpers.py
+++ b/flytekit/clis/helpers.py
@@ -29,7 +29,7 @@ def str2bool(str):
     :param Text str:
     :rtype: bool
     """
-    return not str.lower() in ["false", "0", "off", "no"]
+    return str.lower() not in ["false", "0", "off", "no"]
 
 
 # TODO Deprecated delete after deleting flyte_cli register

--- a/flytekit/clis/sdk_in_container/build.py
+++ b/flytekit/clis/sdk_in_container/build.py
@@ -14,7 +14,6 @@ from flytekit.tools.translator import get_serializable
 
 @dataclass
 class BuildParams(RunLevelParams):
-
     fast: bool = make_field(
         click.Option(
             param_decls=["--fast"],

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -159,7 +159,6 @@ def serialize(
 @click.option("-f", "--folder", type=click.Path(exists=True))
 @click.pass_context
 def workflows(ctx, folder=None):
-
     if folder:
         click.echo(f"Writing output to {folder}")
 
@@ -194,7 +193,6 @@ def fast(ctx):
 @click.option("-f", "--folder", type=click.Path(exists=True))
 @click.pass_context
 def fast_workflows(ctx, folder=None, deref_symlinks=False):
-
     if folder:
         click.echo(f"Writing output to {folder}")
 

--- a/flytekit/configuration/file.py
+++ b/flytekit/configuration/file.py
@@ -99,7 +99,7 @@ class YamlConfigEntry(object):
 
 def bool_transformer(config_val: typing.Any) -> bool:
     if type(config_val) is str:
-        return True if config_val and not config_val.lower() in ["false", "0", "off", "no"] else False
+        return True if config_val and config_val.lower() not in ["false", "0", "off", "no"] else False
     else:
         return config_val
 

--- a/flytekit/core/checkpointer.py
+++ b/flytekit/core/checkpointer.py
@@ -90,7 +90,6 @@ class SyncCheckpoint(Checkpoint):
         return self._checkpoint_src is not None
 
     def restore(self, path: typing.Optional[typing.Union[Path, str]] = None) -> typing.Optional[Path]:
-
         # We have to lazy load, until we fix the imports
         from flytekit.core.context_manager import FlyteContextManager
 

--- a/flytekit/core/notification.py
+++ b/flytekit/core/notification.py
@@ -23,7 +23,6 @@ from flytekit.models.core import execution as _execution_model
 
 # Duplicates flytekit.common.notifications.Notification to avoid using the ExtendedSdkType metaclass.
 class Notification(_common_model.Notification):
-
     VALID_PHASES = {
         _execution_model.WorkflowExecutionPhase.ABORTED,
         _execution_model.WorkflowExecutionPhase.FAILED,

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -148,7 +148,6 @@ class TrackedInstance(metaclass=InstanceTrackingMeta):
         # Try to find object in module when the tracked instance is defined in the __main__ module.
         # This section tries to find the matching object in the module when the module is loaded from the __file__.
         if self._module_file is not None:
-
             # Since the module loaded from the file is different from the original module that defined self, we need
             # to match by variable name and type.
             module = import_module_from_file(self._instantiated_in, self._module_file)

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1726,10 +1726,10 @@ def convert_mashumaro_json_schema_to_python_class(
 
 def _get_element_type(element_property: typing.Dict[str, str]) -> Type:
     element_type = (
-        [e_property["type"] for e_property in element_property["anyOf"]]
+        [e_property["type"] for e_property in element_property["anyOf"]]  # type: ignore
         if element_property.get("anyOf")
         else element_property["type"]
-    )  # type: ignore
+    )
     element_format = element_property["format"] if "format" in element_property else None
 
     if type(element_type) == list:

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1176,7 +1176,10 @@ class ListTransformer(TypeTransformer[T]):
                         batch_size = annotation.val
                         break
             if batch_size > 0:
-                lit_list = [TypeEngine.to_literal(ctx, python_val[i : i + batch_size], FlytePickle, expected.collection_type) for i in range(0, len(python_val), batch_size)]  # type: ignore
+                lit_list = [
+                    TypeEngine.to_literal(ctx, python_val[i : i + batch_size], FlytePickle, expected.collection_type)
+                    for i in range(0, len(python_val), batch_size)
+                ]  # type: ignore
             else:
                 lit_list = []
         else:
@@ -1695,7 +1698,9 @@ def generate_attribute_list_from_dataclass_json(schema: dict, schema_name: typin
     return attribute_list
 
 
-def convert_marshmallow_json_schema_to_python_class(schema: dict, schema_name: typing.Any) -> Type[dataclasses.dataclass()]:  # type: ignore
+def convert_marshmallow_json_schema_to_python_class(
+    schema: dict, schema_name: typing.Any
+) -> Type[dataclasses.dataclass()]:  # type: ignore
     """
     Generate a model class based on the provided JSON Schema
     :param schema: dict representing valid JSON schema
@@ -1706,7 +1711,9 @@ def convert_marshmallow_json_schema_to_python_class(schema: dict, schema_name: t
     return dataclass_json(dataclasses.make_dataclass(schema_name, attribute_list))
 
 
-def convert_mashumaro_json_schema_to_python_class(schema: dict, schema_name: typing.Any) -> Type[dataclasses.dataclass()]:  # type: ignore
+def convert_mashumaro_json_schema_to_python_class(
+    schema: dict, schema_name: typing.Any
+) -> Type[dataclasses.dataclass()]:  # type: ignore
     """
     Generate a model class based on the provided JSON Schema
     :param schema: dict representing valid JSON schema
@@ -1718,7 +1725,11 @@ def convert_mashumaro_json_schema_to_python_class(schema: dict, schema_name: typ
 
 
 def _get_element_type(element_property: typing.Dict[str, str]) -> Type:
-    element_type = [e_property["type"] for e_property in element_property["anyOf"]] if element_property.get("anyOf") else element_property["type"]  # type: ignore
+    element_type = (
+        [e_property["type"] for e_property in element_property["anyOf"]]
+        if element_property.get("anyOf")
+        else element_property["type"]
+    )  # type: ignore
     element_format = element_property["format"] if "format" in element_property else None
 
     if type(element_type) == list:

--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -45,7 +45,6 @@ class FlyteTypeException(FlyteUserException, TypeError):
 
 
 class FlyteValueException(FlyteUserException, ValueError):
-
     _ERROR_CODE = "USER:ValueError"
 
     @classmethod

--- a/flytekit/interfaces/cli_identifiers.py
+++ b/flytekit/interfaces/cli_identifiers.py
@@ -3,7 +3,6 @@ from flytekit.models.core import identifier as _core_identifier
 
 
 class Identifier(_core_identifier.Identifier):
-
     _STRING_TO_TYPE_MAP = {
         "lp": _core_identifier.ResourceType.LAUNCH_PLAN,
         "wf": _core_identifier.ResourceType.WORKFLOW,

--- a/flytekit/models/filters.py
+++ b/flytekit/models/filters.py
@@ -21,7 +21,6 @@ class FilterList(_FlyteIdlEntity):
 
 
 class Filter(_FlyteIdlEntity):
-
     _comparator = "nil"
 
     def __init__(self, key, value):

--- a/flytekit/remote/remote_callable.py
+++ b/flytekit/remote/remote_callable.py
@@ -10,7 +10,6 @@ from flytekit.models.core.workflow import NodeMetadata
 
 class RemoteEntity(ABC):
     def __init__(self, *args, **kwargs):
-
         # In cases where we make a FlyteTask/Workflow/LaunchPlan from a locally created Python object (i.e. an @task
         # or an @workflow decorated function), we actually have the Python interface, so
         self._python_interface: Optional[Dict[str, Type]] = None

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -59,7 +59,6 @@ def compute_digest(source: os.PathLike, filter: Optional[callable] = None) -> st
     """
     hasher = hashlib.md5()
     for root, _, files in os.walk(source, topdown=True):
-
         files.sort()
 
         for fname in files:

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -320,7 +320,6 @@ class FlyteDirToMultipartBlobTransformer(TypeTransformer[FlyteDirectory]):
         python_type: typing.Type[FlyteDirectory],
         expected: LiteralType,
     ) -> Literal:
-
         remote_directory = None
         should_upload = True
         batch_size = get_batch_size(python_type)
@@ -371,7 +370,6 @@ class FlyteDirToMultipartBlobTransformer(TypeTransformer[FlyteDirectory]):
     def to_python_value(
         self, ctx: FlyteContext, lv: Literal, expected_python_type: typing.Type[FlyteDirectory]
     ) -> FlyteDirectory:
-
         uri = lv.scalar.blob.uri
 
         # This is a local file path, like /usr/local/my_dir, don't mess with it. Certainly, downloading it doesn't

--- a/flytekit/types/file/__init__.py
+++ b/flytekit/types/file/__init__.py
@@ -47,7 +47,7 @@ class FileExt:
 
     @staticmethod
     def check_and_convert_to_str(item: typing.Union[typing.Type, str]) -> str:
-        if not get_origin(item) is Annotated:
+        if get_origin(item) is not Annotated:
             return str(item)
         if get_args(item)[0] == str:
             return str(get_args(item)[1])

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -29,9 +29,7 @@ T = typing.TypeVar("T")
 
 @dataclass
 class FlyteFile(os.PathLike, typing.Generic[T], DataClassJSONMixin):
-    path: typing.Union[str, os.PathLike] = field(
-        default=None, metadata=config(mm_field=fields.String())
-    )  # type: ignore
+    path: typing.Union[str, os.PathLike] = field(default=None, metadata=config(mm_field=fields.String()))  # type: ignore
     """
     Since there is no native Python implementation of files and directories for the Flyte Blob type, (like how int
     exists for Flyte's Integer type) we need to create one so that users can express that their tasks take

--- a/flytekit/types/file/image.py
+++ b/flytekit/types/file/image.py
@@ -33,7 +33,6 @@ class PILImageTransformer(TypeTransformer[T]):
     def to_literal(
         self, ctx: FlyteContext, python_val: PIL.Image.Image, python_type: Type[T], expected: LiteralType
     ) -> Literal:
-
         meta = BlobMetadata(
             type=_core_types.BlobType(
                 format=self.FILE_FORMAT, dimensionality=_core_types.BlobType.BlobDimensionality.SINGLE

--- a/flytekit/types/structured/__init__.py
+++ b/flytekit/types/structured/__init__.py
@@ -25,7 +25,6 @@ from .structured_dataset import (
 
 
 def register_csv_handlers():
-
     from .basic_dfs import CSVToPandasDecodingHandler, PandasToCSVEncodingHandler
 
     StructuredDatasetTransformerEngine.register(PandasToCSVEncodingHandler(), default_format_for_type=True)

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/hpo.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/hpo.py
@@ -46,7 +46,7 @@ class SagemakerHPOTask(PythonTask[HPOJob]):
         name: str,
         task_config: HPOJob,
         training_task: Union[SagemakerCustomTrainingTask, SagemakerBuiltinAlgorithmsTask],
-        **kwargs
+        **kwargs,
     ):
         if training_task is None or not (
             isinstance(training_task, SagemakerCustomTrainingTask)
@@ -72,7 +72,7 @@ class SagemakerHPOTask(PythonTask[HPOJob]):
             name=name,
             interface=updated_iface,
             task_config=task_config,
-            **kwargs
+            **kwargs,
         )
 
     def execute(self, **kwargs) -> Any:

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/models/hpo_job.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/models/hpo_job.py
@@ -45,7 +45,6 @@ class HyperparameterTuningObjective(_common.FlyteIdlEntity):
         return self._metric_name
 
     def to_flyte_idl(self) -> _pb2_hpo_job.HyperparameterTuningObjective:
-
         return _pb2_hpo_job.HyperparameterTuningObjective(
             objective_type=self.objective_type,
             metric_name=self._metric_name,
@@ -53,7 +52,6 @@ class HyperparameterTuningObjective(_common.FlyteIdlEntity):
 
     @classmethod
     def from_flyte_idl(cls, pb2_object: _pb2_hpo_job.HyperparameterTuningObjective):
-
         return cls(
             objective_type=pb2_object.objective_type,
             metric_name=pb2_object.metric_name,
@@ -115,7 +113,6 @@ class HyperparameterTuningJobConfig(_common.FlyteIdlEntity):
         return self._training_job_early_stopping_type
 
     def to_flyte_idl(self) -> _pb2_hpo_job.HyperparameterTuningJobConfig:
-
         return _pb2_hpo_job.HyperparameterTuningJobConfig(
             tuning_strategy=self._tuning_strategy,
             tuning_objective=self._tuning_objective.to_flyte_idl(),
@@ -124,7 +121,6 @@ class HyperparameterTuningJobConfig(_common.FlyteIdlEntity):
 
     @classmethod
     def from_flyte_idl(cls, pb2_object: _pb2_hpo_job.HyperparameterTuningJobConfig):
-
         return cls(
             tuning_strategy=pb2_object.tuning_strategy,
             tuning_objective=HyperparameterTuningObjective.from_flyte_idl(pb2_object.tuning_objective),

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/models/training_job.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker/models/training_job.py
@@ -255,7 +255,6 @@ class AlgorithmSpecification(_common.FlyteIdlEntity):
         return self._metric_definitions
 
     def to_flyte_idl(self) -> _training_job_pb2.AlgorithmSpecification:
-
         return _training_job_pb2.AlgorithmSpecification(
             input_mode=self.input_mode,
             algorithm_name=self.algorithm_name,
@@ -266,7 +265,6 @@ class AlgorithmSpecification(_common.FlyteIdlEntity):
 
     @classmethod
     def from_flyte_idl(cls, pb2_object: _training_job_pb2.AlgorithmSpecification):
-
         return cls(
             input_mode=pb2_object.input_mode,
             algorithm_name=pb2_object.algorithm_name,

--- a/plugins/flytekit-dolt/flytekitplugins/dolt/schema.py
+++ b/plugins/flytekit-dolt/flytekitplugins/dolt/schema.py
@@ -48,7 +48,6 @@ class DoltTableNameTransformer(TypeTransformer[DoltTable]):
         python_type: typing.Type[DoltTable],
         expected: LiteralType,
     ) -> Literal:
-
         if not isinstance(python_val, DoltTable):
             raise AssertionError(f"Value cannot be converted to a table: {python_val}")
 

--- a/plugins/flytekit-greatexpectations/tests/test_schema.py
+++ b/plugins/flytekit-greatexpectations/tests/test_schema.py
@@ -110,7 +110,7 @@ def test_ge_schema_batchrequest_pandas_config():
                     },
                 ),
             ),
-        ]
+        ],
     ) -> str:
         return directory
 
@@ -236,7 +236,7 @@ def test_ge_schema_flyteschema():
                 batch_request_config=BatchRequestConfig(data_connector_query={"limit": 10}),
                 local_file_path="/tmp/test3.parquet",  # noqa: F722
             ),
-        ]
+        ],
     ) -> int:
         return dataframe.open().all().shape[0]
 
@@ -261,7 +261,7 @@ def test_ge_schema_flyteschema_literal():
                 batch_request_config=BatchRequestConfig(data_connector_query={"limit": 10}),
                 local_file_path="/tmp/test3.parquet",  # noqa: F722
             ),
-        ]
+        ],
     ) -> int:
         return dataframe.open().all().shape[0]
 

--- a/plugins/flytekit-mmcloud/tests/test_mmcloud.py
+++ b/plugins/flytekit-mmcloud/tests/test_mmcloud.py
@@ -86,7 +86,7 @@ def test_flyte_to_mmcloud_resources():
         ("2", "2Gi", "1", "1Gi"),
         ("2", "1Gi", "1", "2Gi"),
     }
-    for (req_cpu, req_mem, lim_cpu, lim_mem) in error_cases:
+    for req_cpu, req_mem, lim_cpu, lim_mem in error_cases:
         with pytest.raises(ValueError):
             flyte_to_mmcloud_resources(
                 requests=Resources(cpu=req_cpu, mem=req_mem),

--- a/plugins/flytekit-onnx-pytorch/tests/test_onnx_pytorch.py
+++ b/plugins/flytekit-onnx-pytorch/tests/test_onnx_pytorch.py
@@ -47,18 +47,20 @@ class SuperResolutionNet(nn.Module):
 
 def test_onnx_pytorch():
     @task
-    def train() -> Annotated[
-        PyTorch2ONNX,
-        PyTorch2ONNXConfig(
-            args=torch.randn(1, 1, 224, 224, requires_grad=True),
-            export_params=True,  # store the trained parameter weights inside
-            opset_version=10,  # the ONNX version to export the model to
-            do_constant_folding=True,  # whether to execute constant folding for optimization
-            input_names=["input"],  # the model's input names
-            output_names=["output"],  # the model's output names
-            dynamic_axes={"input": {0: "batch_size"}, "output": {0: "batch_size"}},  # variable length axes
-        ),
-    ]:
+    def train() -> (
+        Annotated[
+            PyTorch2ONNX,
+            PyTorch2ONNXConfig(
+                args=torch.randn(1, 1, 224, 224, requires_grad=True),
+                export_params=True,  # store the trained parameter weights inside
+                opset_version=10,  # the ONNX version to export the model to
+                do_constant_folding=True,  # whether to execute constant folding for optimization
+                input_names=["input"],  # the model's input names
+                output_names=["output"],  # the model's output names
+                dynamic_axes={"input": {0: "batch_size"}, "output": {0: "batch_size"}},  # variable length axes
+            ),
+        ]
+    ):
         # Create the super-resolution model by using the above model definition.
         torch_model = SuperResolutionNet(upscale_factor=3)
 

--- a/plugins/flytekit-onnx-scikitlearn/tests/test_onnx_scikitlearn.py
+++ b/plugins/flytekit-onnx-scikitlearn/tests/test_onnx_scikitlearn.py
@@ -94,15 +94,17 @@ def custom_tranform_converter(scope, operator, container):
 
 def test_onnx_scikitlearn():
     @task
-    def get_model() -> Annotated[
-        ScikitLearn2ONNX,
-        ScikitLearn2ONNXConfig(
-            initial_types=[("input", FloatTensorType([None, numpy.array([[1, 2], [3, 4], [4, 5]]).shape[1]]))],
-            custom_shape_calculators={CustomTransform: custom_transform_shape_calculator},
-            custom_conversion_functions={CustomTransform: custom_tranform_converter},
-            target_opset=12,
-        ),
-    ]:
+    def get_model() -> (
+        Annotated[
+            ScikitLearn2ONNX,
+            ScikitLearn2ONNXConfig(
+                initial_types=[("input", FloatTensorType([None, numpy.array([[1, 2], [3, 4], [4, 5]]).shape[1]]))],
+                custom_shape_calculators={CustomTransform: custom_transform_shape_calculator},
+                custom_conversion_functions={CustomTransform: custom_tranform_converter},
+                target_opset=12,
+            ),
+        ]
+    ):
         model = CustomTransform()
         return ScikitLearn2ONNX(model)
 

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -266,7 +266,9 @@ class NotebookTask(PythonInstanceTask[T]):
                 kwargs[k] = save_python_val_to_file(v)
 
         # Execute Notebook via Papermill.
-        pm.execute_notebook(self._notebook_path, self.output_notebook_path, parameters=kwargs, log_output=self._stream_logs)  # type: ignore
+        pm.execute_notebook(
+            self._notebook_path, self.output_notebook_path, parameters=kwargs, log_output=self._stream_logs
+        )  # type: ignore
 
         outputs = self.extract_outputs(self.output_notebook_path)
         self.render_nb_html(self.output_notebook_path, self.rendered_output_path)

--- a/plugins/flytekit-papermill/tests/test_spark_notebook.py
+++ b/plugins/flytekit-papermill/tests/test_spark_notebook.py
@@ -19,7 +19,6 @@ def _get_nb_path(name: str, suffix: str = "", abs: bool = True, ext: str = ".ipy
 
 
 def test_notebook_task_simple():
-
     if sys.version_info[:2] >= (3, 11):
         pytest.xfail(
             "pyspark serialization issues will be addressed in version 3.4.0, issue tracking at: "

--- a/plugins/flytekit-spark/tests/test_pyspark_transformers.py
+++ b/plugins/flytekit-spark/tests/test_pyspark_transformers.py
@@ -16,7 +16,6 @@ def test_type_resolution():
 
 
 def test_basic_get():
-
     ctx = FlyteContextManager.current_context()
     e = StructuredDatasetTransformerEngine()
     prot = e._protocol_from_type_or_prefix(ctx, pyspark.sql.DataFrame, uri="/tmp/blah")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,3 @@
-[tool.black]
-line-length = 120
-
-[tool.isort]
-profile = "black"
-line_length = 120
-
 [tool.pytest.ini_options]
 norecursedirs = ["common", "workflows", "spark", "fsspec"]
 log_cli = true
@@ -16,3 +9,29 @@ markers = [
 
 [tool.coverage.run]
 branch = true
+
+[tool.ruff]
+line-length = 120
+select = ["E", "W", "F"]
+ignore = [
+    # Whitespace before '{symbol}'
+    "E203",
+    # Too many leading # before block comment
+    "E266",
+    # Line too long ({width} > {limit})
+    "E501",
+    # Ambiguous variable name: {name}
+    "E741",
+    # Undefined name {name}
+    "F821",
+    # Do not compare types, use isinstance()
+    "E721",
+    # Do not assign a lambda expression, use a def
+    "E731",
+]
+
+[tool.ruff.extend-per-file-ignores]
+"*/__init__.py" = [
+    # unused-import
+    "F401",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,3 @@
-[flake8]
-max-line-length = 120
-extend-ignore = E203, E266, E501, W503, E741
-exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,venv/*,src/*,tests/unit/common/protos/*,build
-max-complexity=32
-per-file-ignores =
-    *:F821
-    */__init__.py: F401
-
 [mypy]
 strict_optional = True
 ignore_missing_imports = True

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -83,7 +83,6 @@ def test_monitor_workflow_execution(register):
 
     execution = remote.sync_execution(execution, sync_nodes=True)
     while datetime.datetime.utcnow() < time_to_give_up:
-
         if execution.is_done:
             break
 

--- a/tests/flytekit/unit/cli/test_cli_helpers.py
+++ b/tests/flytekit/unit/cli/test_cli_helpers.py
@@ -130,7 +130,6 @@ def test_hydrate_workflow_template():
 
 
 def test_hydrate_workflow_template__branch_node():
-
     workflow_template = _core_workflow_pb2.WorkflowTemplate()
     branch_node = _core_workflow_pb2.Node(
         id="branch_node",

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -278,7 +278,7 @@ def test_raw_execute_with_min_success_ratio(min_success_ratio, should_raise_erro
         return array_node_map_task(some_task1, min_success_ratio=min_success_ratio)(inputs=[1, 2, 3, 4])
 
     if should_raise_error:
-        with (pytest.raises(ValueError)):
+        with pytest.raises(ValueError):
             my_wf1()
     else:
         assert my_wf1() == [1, None, 3, 4]

--- a/tests/flytekit/unit/core/test_container_task.py
+++ b/tests/flytekit/unit/core/test_container_task.py
@@ -108,7 +108,6 @@ def mock_image_spec_builder():
 
 
 def test_container_task_image_spec(mock_image_spec_builder):
-
     default_image = Image(name="default", fqn="docker.io/xyz", tag="some-git-hash")
     default_image_config = ImageConfig(default_image=default_image)
 

--- a/tests/flytekit/unit/core/test_dynamic_conditional.py
+++ b/tests/flytekit/unit/core/test_dynamic_conditional.py
@@ -90,7 +90,6 @@ def test_dynamic_conditional():
             )
         )
     ) as ctx:
-
         with context_manager.FlyteContextManager.with_context(
             ctx.with_execution_state(ctx.execution_state.with_params(mode=ExecutionState.Mode.TASK_EXECUTION))
         ) as ctx:

--- a/tests/flytekit/unit/core/test_map_task.py
+++ b/tests/flytekit/unit/core/test_map_task.py
@@ -51,9 +51,12 @@ def test_map_docs():
 
     @workflow
     def my_wf(x: typing.List[int]) -> typing.List[typing.Optional[str]]:
-        return map_task(my_mappable_task, metadata=TaskMetadata(retries=1), concurrency=10, min_success_ratio=0.75,)(
-            a=x
-        ).with_overrides(requests=Resources(cpu="10M"))
+        return map_task(
+            my_mappable_task,
+            metadata=TaskMetadata(retries=1),
+            concurrency=10,
+            min_success_ratio=0.75,
+        )(a=x).with_overrides(requests=Resources(cpu="10M"))
 
     # test_map_task_end
 
@@ -329,7 +332,7 @@ def test_raw_execute_with_min_success_ratio(min_success_ratio, should_raise_erro
         return map_task(some_task1, min_success_ratio=min_success_ratio)(inputs=[1, 2, 3, 4])
 
     if should_raise_error:
-        with (pytest.raises(ValueError)):
+        with pytest.raises(ValueError):
             my_wf1()
     else:
         assert my_wf1() == [1, None, 3, 4]

--- a/tests/flytekit/unit/core/test_python_auto_container.py
+++ b/tests/flytekit/unit/core/test_python_auto_container.py
@@ -250,7 +250,6 @@ task_with_minimum_pod_template = DummyAutoContainerTask(
 
 
 def test_minimum_pod_template(default_serialization_settings):
-
     #################
     # Test get_k8s_pod
     #################
@@ -354,7 +353,6 @@ image_spec_task = DummyAutoContainerTask(
 
 
 def test_pod_template_with_image_spec(default_serialization_settings, mock_image_spec_builder):
-
     ImageBuildEngine.register("test", mock_image_spec_builder)
 
     pod = image_spec_task.get_k8s_pod(default_serialization_settings)

--- a/tests/flytekit/unit/core/test_realworld_examples.py
+++ b/tests/flytekit/unit/core/test_realworld_examples.py
@@ -60,7 +60,7 @@ def test_diabetes():
             objective="binary:logistic",
             booster="gbtree",
             n_jobs=1,
-            **kwargs
+            **kwargs,
         ):
             self.n_jobs = int(n_jobs)
             self.booster = booster

--- a/tests/flytekit/unit/core/test_resolver.py
+++ b/tests/flytekit/unit/core/test_resolver.py
@@ -38,7 +38,6 @@ def my_wf(a: int, b: str) -> typing.Tuple[int, str]:
 
 
 def test_wf_resolving():
-
     x = my_wf(a=3, b="hello")
     assert x == (5, "helloworld")
 

--- a/tests/flytekit/unit/extras/tensorflow/record/test_record.py
+++ b/tests/flytekit/unit/extras/tensorflow/record/test_record.py
@@ -56,7 +56,7 @@ def t1(
     dataset: Annotated[
         TFRecordFile,
         TFRecordDatasetConfig(buffer_size=1024, num_parallel_reads=3, compression_type="GZIP"),
-    ]
+    ],
 ):
     assert isinstance(dataset, TFRecordDatasetV2)
     assert dataset._compression_type == "GZIP"
@@ -66,7 +66,6 @@ def t1(
 
 @task
 def t2(dataset: TFRecordFile):
-
     # if not annotated with TFRecordDatasetConfig, all attributes should default to None
     assert isinstance(dataset, TFRecordDatasetV2)
     assert dataset._compression_type is None
@@ -76,7 +75,6 @@ def t2(dataset: TFRecordFile):
 
 @task
 def t3(dataset: TFRecordsDirectory):
-
     # if not annotated with TFRecordDatasetConfig, all attributes should default to None
     assert isinstance(dataset, TFRecordDatasetV2)
     assert dataset._compression_type is None


### PR DESCRIPTION
This PR migrates the development tooling to use `ruff`. A majority of the PR is https://github.com/flyteorg/flytekit/commit/a12c522f85fe3bb006ad3fcfb2a225a785c330d3 which is the result of `make fmt`.

## Type
 - [x] Housekeeping

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
I migrated over all the ignored rules from:

https://github.com/flyteorg/flytekit/blob/16a405480a01c4a1bbf43bdb35f87eb46bd996a3/setup.cfg#L1-L8

And added a few more that are currently violated to focus this PR on the `ruff` configuration. If we want to follow more of the rules, we can remove them from the ignore section and update the code in follow up PRs.

## Tracking Issue
Closes https://github.com/flyteorg/flyte/issues/4447