### PR TITLE
Run serialization test individually

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  unit-test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -42,6 +42,40 @@ jobs:
           PYTEST_OPTS: -n2
         run: |
           make unit_test_codecov
+      - name: Codecov
+        uses: codecov/codecov-action@v3.1.4
+        with:
+          fail_ci_if_error: false
+          files: coverage.xml
+
+  test-serialization:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        python-version: [ "3.8", "3.11" ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          # This path is specific to Ubuntu
+          path: ~/.cache/pip
+          # Look to see if there is a cache hit for the corresponding requirements files
+          key: ${{ format('{0}-pip-{1}', runner.os, hashFiles('dev-requirements.in', 'requirements.in')) }}
+      - name: Install dependencies
+        run: |
+          make setup && pip freeze
+      - name: Test with coverage
+        env:
+          PYTEST_OPTS: -n2
+        run: |
+          make test_serialization_codecov
       - name: Codecov
         uses: codecov/codecov-action@v3.1.4
         with:

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -127,7 +127,7 @@ jobs:
           fail_ci_if_error: false
 
   build-plugins:
-    needs: build
+    needs: unit-test
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -82,7 +82,7 @@ jobs:
           fail_ci_if_error: false
           files: coverage.xml
 
-  build-integration:
+  integration:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -126,7 +126,7 @@ jobs:
         with:
           fail_ci_if_error: false
 
-  build-plugins:
+  test-plugins:
     needs: unit-test
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -126,7 +126,7 @@ jobs:
         with:
           fail_ci_if_error: false
 
-  test-plugins:
+  build-plugins:
     needs: build
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit-test:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -127,7 +127,7 @@ jobs:
           fail_ci_if_error: false
 
   test-plugins:
-    needs: unit-test
+    needs: build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,17 @@ unit_test_codecov:
 unit_test:
 	# Skip tensorflow tests and run them with the necessary env var set so that a working (albeit slower)
 	# library is used to serialize/deserialize protobufs is used.
-	$(PYTEST) -m "not sandbox_test" tests/flytekit/unit/ --ignore=tests/flytekit/unit/extras/tensorflow ${CODECOV_OPTS} && \
+	$(PYTEST) -m "not sandbox_test" tests/flytekit/unit/ --ignore=tests/flytekit/unit/extras/tensorflow --ignore=tests/flytekit/unit/models ${CODECOV_OPTS} && \
 		PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python $(PYTEST) tests/flytekit/unit/extras/tensorflow ${CODECOV_OPTS}
+
+.PHONY: test_serialization_codecov
+test_serialization_codecov:
+	$(MAKE) CODECOV_OPTS="--cov=./ --cov-report=xml --cov-append" test_serialization
+
+.PHONY: test_serialization
+test_serialization:
+	$(PYTEST) tests/flytekit/unit/models ${CODECOV_OPTS}
+
 
 .PHONY: integration_test_codecov
 integration_test_codecov:


### PR DESCRIPTION
## Tracking issue
_NA_

## Docs link
_NA_

## Describe your changes
- Add a new command `test-serialization` in the makefile. 
- Add a new GA workflow to run `test-serialization`

The reason to do this because
1. It's hard to find the specific test log in the [github action](https://github.com/flyteorg/flytekit/actions/runs/6944772256/job/18907513537?pr=1976) since we run 20000+ tests in the build test
2. It always takes 10-20 mins to run the unit test locally. `test-serialization` takes 10~15 mins to run. sometimes I want to run all the unit-tests except `test-serialization`

In test-serialization, we only test `to_flyte_idl`, `from_flyte_idl`. In most cases, it won't break when the user changes the code. Therefore, I think it's fine to run it individually.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Setup Process

<!-- Describe how you set up this PR's environment to help maintainers reproduce your results more easily -->

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

<!-- Add notes to reviewers if applicable -->

## Related PRs

<!-- Add related pull requests for reviewers to check -->
