### PR TITLE
Remove upper bound on pyarrow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "pandas>=1.0.0,<2.0.0",
         # TODO: Remove upper-bound after protobuf community fixes it. https://github.com/flyteorg/flyte/issues/4359
         "protobuf<4.25.0",
-        "pyarrow>=4.0.0,<11.0.0",
+        "pyarrow>=4.0.0",
         "python-json-logger>=2.0.0",
         "pytimeparse>=1.1.8,<2.0.0",
         "pyyaml!=6.0.0,!=5.4.0,!=5.4.1",  # pyyaml is broken with cython 3: https://github.com/yaml/pyyaml/issues/601


### PR DESCRIPTION
Attempt to resolve https://github.com/flyteorg/flyte/issues/4465 by removing the upper bound on pyarrow dependency.