### PR TITLE
Add codecov exclude_lines configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,17 @@ markers = [
     "sandbox_test: fake integration tests",
 ]
 
+[tool.coverage.report]
+exclude_also = [
+    "def __repr__",
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "if (typing\\.)?TYPE_CHECKING:",
+    "@(typing\\.)?overload",
+    "@(abc\\.)?abstractmethod",
+    "raise NotImplementedError",
+]
+
 [tool.coverage.run]
 branch = true
 


### PR DESCRIPTION
## Describe your changes

Configure `exclude_lines` for Codecov. There are certain lines that shouldn't affect code velocity of a PR.

See: https://github.com/nedbat/coveragepy/issues/831#issuecomment-517778185

Apparently this isn't configurable through `codecov.yml` 🙈 : https://github.com/codecov/codecov-python/issues/107#issuecomment-793976712

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Related PRs

I opened this because I noticed this issue was affecting an existing PR: https://github.com/flyteorg/flytekit/pull/1818#discussion_r1357847730