### PR TITLE
Fix: Restore of corrupt checkpoints

### DIFF
--- a/flytekit/core/checkpointer.py
+++ b/flytekit/core/checkpointer.py
@@ -102,8 +102,7 @@ class SyncCheckpoint(Checkpoint):
         if path is None:
             p = Path(self._td.name)
             path = p.joinpath(self.SRC_LOCAL_FOLDER)
-            if not path.exists():
-                path.mkdir()
+            path.mkdir(exist_ok=True)
         elif isinstance(path, str):
             path = Path(path)
 

--- a/flytekit/core/checkpointer.py
+++ b/flytekit/core/checkpointer.py
@@ -102,7 +102,8 @@ class SyncCheckpoint(Checkpoint):
         if path is None:
             p = Path(self._td.name)
             path = p.joinpath(self.SRC_LOCAL_FOLDER)
-            path.mkdir()
+            if not path.exists():
+                path.mkdir()
         elif isinstance(path, str):
             path = Path(path)
 


### PR DESCRIPTION
## Tracking issue
Closes #4478

https://github.com/flyteorg/flyte/issues/4478

## Describe your changes

Make flytekit restore handle existing tmp dir if one tries to restore multiple times from a corrupt checkpoint.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
