### PR TITLE
Run task first and detect local execution

### DIFF
--- a/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
+++ b/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
@@ -220,7 +220,7 @@ def vscode(
                 try:
                     return fn(*args, **kwargs)
                 except Exception as e:
-                    logger.warning(f"Task Error: {e}")
+                    logger.error(f"Task Error: {e}")
                     logger.info("Launching VSCode server")
 
             # 0. Executes the pre_execute function if provided.

--- a/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
+++ b/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
@@ -209,6 +209,7 @@ def vscode(
         @wraps(fn)
         def inner_wrapper(*args, **kwargs):
             logger = flytekit.current_context().logging
+
             # When user use pyflyte run or python to execute the task, we don't launch the VSCode server.
             # Only when user use pyflyte run --remote to submit the task to cluster, we launch the VSCode server.
             if FlyteContextManager.current_context().execution_state.is_local_execution():
@@ -221,8 +222,6 @@ def vscode(
                 except Exception as e:
                     logger.warning(f"Task Error: {e}")
                     logger.info("Launching VSCode server")
-
-            
 
             # 0. Executes the pre_execute function if provided.
             if pre_execute is not None:

--- a/plugins/flytekit-flyin/tests/test_flyin_plugin.py
+++ b/plugins/flytekit-flyin/tests/test_flyin_plugin.py
@@ -1,8 +1,7 @@
 import mock
-from flytekitplugins.flyin import vscode
 import pytest
-from flytekitplugins.flyin import jupyter
 
+from flytekitplugins.flyin import vscode, jupyter
 from flytekit import task, workflow
 from flytekit.core.context_manager import ExecutionState
 

--- a/plugins/flytekit-flyin/tests/test_flyin_plugin.py
+++ b/plugins/flytekit-flyin/tests/test_flyin_plugin.py
@@ -1,14 +1,28 @@
 import mock
 from flytekitplugins.flyin import vscode
+import pytest
 from flytekitplugins.flyin import jupyter
 
 from flytekit import task, workflow
+from flytekit.core.context_manager import ExecutionState
+
+
+@pytest.fixture
+def mock_local_execution():
+    with mock.patch.object(ExecutionState, "is_local_execution", return_value=True) as mock_func:
+        yield mock_func
+
+
+@pytest.fixture
+def mock_remote_execution():
+    with mock.patch.object(ExecutionState, "is_local_execution", return_value=False) as mock_func:
+        yield mock_func
 
 
 @mock.patch("multiprocessing.Process")
 @mock.patch("flytekitplugins.flyin.vscode_lib.decorator.exit_handler")
 @mock.patch("flytekitplugins.flyin.vscode_lib.decorator.download_vscode")
-def test_vscode(mock_download_vscode, mock_exit_handler, mock_process):
+def test_vscode_remote_execution(mock_download_vscode, mock_exit_handler, mock_process, mock_remote_execution):
     @task
     @vscode
     def t():
@@ -19,6 +33,60 @@ def test_vscode(mock_download_vscode, mock_exit_handler, mock_process):
         t()
 
     wf()
+    mock_download_vscode.assert_called_once()
+    mock_process.assert_called_once()
+    mock_exit_handler.assert_called_once()
+
+
+@mock.patch("multiprocessing.Process")
+@mock.patch("flytekitplugins.flyin.vscode_lib.decorator.exit_handler")
+@mock.patch("flytekitplugins.flyin.vscode_lib.decorator.download_vscode")
+def test_vscode_local_execution(mock_download_vscode, mock_exit_handler, mock_process, mock_local_execution):
+    @task
+    @vscode
+    def t():
+        return
+
+    @workflow
+    def wf():
+        t()
+
+    wf()
+    mock_download_vscode.assert_not_called()
+    mock_process.assert_not_called()
+    mock_exit_handler.assert_not_called()
+
+
+def test_vscode_run_task_first_succeed(mock_remote_execution):
+    @task
+    @vscode(run_task_first=True)
+    def t(a: int, b: int) -> int:
+        return a + b
+
+    @workflow
+    def wf(a: int, b: int) -> int:
+        out = t(a=a, b=b)
+        return out
+
+    res = wf(a=10, b=5)
+    assert res == 15
+
+
+@mock.patch("multiprocessing.Process")
+@mock.patch("flytekitplugins.flyin.vscode_lib.decorator.exit_handler")
+@mock.patch("flytekitplugins.flyin.vscode_lib.decorator.download_vscode")
+def test_vscode_run_task_first_fail(mock_download_vscode, mock_exit_handler, mock_process, mock_remote_execution):
+    @task
+    @vscode
+    def t(a: int, b: int):
+        dummy = a // b  # noqa: F841
+        return
+
+    @workflow
+    def wf(a: int, b: int):
+        t(a=a, b=b)
+
+    wf(a=10, b=0)
     mock_download_vscode.assert_called_once()
     mock_process.assert_called_once()
     mock_exit_handler.assert_called_once()


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4284

## Describe your changes
This PR introduces two enhancements to the Flyin VSCode decorator:

1. Conditional VSCode Server Launching: The VSCode server launch behavior is now context-sensitive:
- Local Execution: When a task is executed locally (using commands like python xxx.py or pyflyte run xxx), the VSCode server will not be initiated.
- Remote Execution: In contrast, when a task is run remotely (using pyflyte run --remote ...), the VSCode server will be launched.

2. New Argument - run_task_first: A new argument has been added to the decorator:

- Functionality: When set to True, this argument ensures that the user's task is executed first.
- Server Launching Condition: The VSCode server will only be launched if the user's task execution fails.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.
