### PR TITLE
[flyin] Use current context logger instead of root logger to show info level logs

### DIFF
--- a/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
+++ b/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
@@ -10,9 +10,7 @@ from functools import wraps
 from typing import Callable, List, Optional
 
 import fsspec
-
-from flytekit.loggers import logger
-
+import flytekit
 from .constants import (
     DEFAULT_CODE_SERVER_DIR_NAME,
     DEFAULT_CODE_SERVER_EXTENSIONS,
@@ -47,6 +45,8 @@ def execute_command(cmd):
     Execute a command in the shell.
     """
 
+    logger = flytekit.current_context().logging
+
     process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     logger.info(f"cmd: {cmd}")
     stdout, stderr = process.communicate()
@@ -69,6 +69,8 @@ def exit_handler(
         max_idle_seconds (int, optional): The duration in seconds to live after no activity detected.
         post_execute (function, optional): The function to be executed before the vscode is self-terminated.
     """
+
+    logger = flytekit.current_context().logging
     start_time = time.time()
     delta = 0
 
@@ -105,7 +107,7 @@ def download_file(url, target_dir: Optional[str] = "."):
     Returns:
         str: The path to the downloaded file.
     """
-
+    logger = flytekit.current_context().logging
     if not url.startswith("http"):
         raise ValueError(f"URL {url} is not valid. Only http/https is supported.")
 
@@ -129,6 +131,7 @@ def download_vscode(vscode_config: VscodeConfig):
     Args:
         vscode_config (VscodeConfig): VSCode config contains default URLs of the VSCode server and extension remote paths.
     """
+    logger = flytekit.current_context().logging
 
     # If the code server already exists in the container, skip downloading
     executable_path = shutil.which(EXECUTABLE_NAME)
@@ -202,6 +205,8 @@ def vscode(
 
         @wraps(fn)
         def inner_wrapper(*args, **kwargs):
+            logger = flytekit.current_context().logging
+
             # 0. Executes the pre_execute function if provided.
             if pre_execute is not None:
                 pre_execute()


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4284

## Why?
Originally, we used the root logger imported from flytekit. However, it doesn't show the info level logs. The default level is a warning.

## What?

Switch to use the logger from flytekit current_context, which is used to print logs during execution. By default, it uses [user-space logger](https://github.com/flyteorg/flytekit/blob/a6f9991952f6f95a2de99cf187e0778f3abff4e8/flytekit/core/context_manager.py#L868), whose level is [INFO](https://github.com/flyteorg/flytekit/blob/a6f9991952f6f95a2de99cf187e0778f3abff4e8/flytekit/loggers.py#L78), so it can also print logs >= INFO level.

The usage is simple. We call `logger = flytekit.current_context().logging` to get the logger.

## Test
```python
IMAGE="localhost:30000/flytekit:0.0.4"

@task(
    container_image=IMAGE,
)
@vscode
def t():
    print("123123")
    ...
```
<img width="1228" alt="image" src="https://github.com/flyteorg/flytekit/assets/24364830/99182f4e-6e56-4145-9cf1-73b5c8c979b1">
