### PR TITLE
Fix: Detection of wrong type transformer for multi-inheritance enum

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -919,6 +919,7 @@ class TypeEngine(typing.Generic[T]):
 
             python_type = args[0]
 
+        # Step 2
         # this makes sure that if it's a list/dict of annotated types, we hit the unwrapping code in step 2
         # see test_list_of_annotated in test_structured_dataset.py
         if (
@@ -930,7 +931,7 @@ class TypeEngine(typing.Generic[T]):
         ) and python_type in cls._REGISTRY:
             return cls._REGISTRY[python_type]
 
-        # Step 2
+        # Step 3
         if hasattr(python_type, "__origin__"):
             # Handling of annotated generics, eg:
             # Annotated[typing.List[int], 'foo']
@@ -942,7 +943,7 @@ class TypeEngine(typing.Generic[T]):
 
             raise ValueError(f"Generic Type {python_type.__origin__} not supported currently in Flytekit.")
 
-        # Step 3
+        # Step 4
         # To facilitate cases where users may specify one transformer for multiple types that all inherit from one
         # parent.
         if inspect.isclass(python_type) and issubclass(python_type, enum.Enum):
@@ -962,11 +963,11 @@ class TypeEngine(typing.Generic[T]):
                 # is the case for one of the restricted types, namely NamedTuple.
                 logger.debug(f"Invalid base type {base_type} in call to isinstance", exc_info=True)
 
-        # Step 4
+        # Step 5
         if dataclasses.is_dataclass(python_type):
             return cls._DATACLASS_TRANSFORMER
 
-        # Step 5
+        # Step 6
         display_pickle_warning(str(python_type))
         from flytekit.types.pickle.pickle import FlytePickleTransformer
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -945,6 +945,10 @@ class TypeEngine(typing.Generic[T]):
         # Step 3
         # To facilitate cases where users may specify one transformer for multiple types that all inherit from one
         # parent.
+        if inspect.isclass(python_type) and issubclass(python_type, enum.Enum):
+            # Special case: prevent that for a type `FooEnum(str, Enum)`, the str transformer is used.
+            return cls._ENUM_TRANSFORMER
+
         for base_type in cls._REGISTRY.keys():
             if base_type is None:
                 continue  # None is actually one of the keys, but isinstance/issubclass doesn't work on it

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -757,6 +757,83 @@ class ProtobufTransformer(TypeTransformer[Message]):
         raise ValueError(f"Transformer {self} cannot reverse {literal_type}")
 
 
+class EnumTransformer(TypeTransformer[enum.Enum]):
+    """
+    Enables converting a python type enum.Enum to LiteralType.EnumType
+    """
+
+    def __init__(self):
+        super().__init__(name="DefaultEnumTransformer", t=enum.Enum)
+
+    def get_literal_type(self, t: Type[T]) -> LiteralType:
+        if is_annotated(t):
+            raise ValueError(
+                f"Flytekit does not currently have support \
+                    for FlyteAnnotations applied to enums. {t} cannot be \
+                    parsed."
+            )
+
+        values = [v.value for v in t]  # type: ignore
+        if not isinstance(values[0], str):
+            raise TypeTransformerFailedError("Only EnumTypes with value of string are supported")
+        return LiteralType(enum_type=_core_types.EnumType(values=values))
+
+    def to_literal(
+        self, ctx: FlyteContext, python_val: enum.Enum, python_type: Type[T], expected: LiteralType
+    ) -> Literal:
+        if type(python_val).__class__ != enum.EnumMeta:
+            raise TypeTransformerFailedError("Expected an enum")
+        if type(python_val.value) != str:
+            raise TypeTransformerFailedError("Only string-valued enums are supportedd")
+
+        return Literal(scalar=Scalar(primitive=Primitive(string_value=python_val.value)))  # type: ignore
+
+    def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
+        return expected_python_type(lv.scalar.primitive.string_value)  # type: ignore
+
+    def guess_python_type(self, literal_type: LiteralType) -> Type[enum.Enum]:
+        if literal_type.enum_type:
+            return enum.Enum("DynamicEnum", {f"{i}": i for i in literal_type.enum_type.values})  # type: ignore
+        raise ValueError(f"Enum transformer cannot reverse {literal_type}")
+
+
+def generate_attribute_list_from_dataclass_json_mixin(schema: dict, schema_name: typing.Any):
+    attribute_list = []
+    for property_key, property_val in schema["properties"].items():
+        if property_val.get("anyOf"):
+            property_type = property_val["anyOf"][0]["type"]
+        elif property_val.get("enum"):
+            property_type = "enum"
+        else:
+            property_type = property_val["type"]
+        # Handle list
+        if property_type == "array":
+            attribute_list.append((property_key, typing.List[_get_element_type(property_val["items"])]))  # type: ignore
+        # Handle dataclass and dict
+        elif property_type == "object":
+            if property_val.get("anyOf"):
+                sub_schemea = property_val["anyOf"][0]
+                sub_schemea_name = sub_schemea["title"]
+                attribute_list.append(
+                    (property_key, convert_mashumaro_json_schema_to_python_class(sub_schemea, sub_schemea_name))
+                )
+            elif property_val.get("additionalProperties"):
+                attribute_list.append(
+                    (property_key, typing.Dict[str, _get_element_type(property_val["additionalProperties"])])  # type: ignore
+                )
+            else:
+                sub_schemea_name = property_val["title"]
+                attribute_list.append(
+                    (property_key, convert_mashumaro_json_schema_to_python_class(property_val, sub_schemea_name))
+                )
+        elif property_type == "enum":
+            attribute_list.append([property_key, str])  # type: ignore
+        # Handle int, float, bool or str
+        else:
+            attribute_list.append([property_key, _get_element_type(property_val)])  # type: ignore
+    return attribute_list
+
+
 class TypeEngine(typing.Generic[T]):
     """
     Core Extensible TypeEngine of Flytekit. This should be used to extend the capabilities of FlyteKits type system.
@@ -767,6 +844,7 @@ class TypeEngine(typing.Generic[T]):
     _REGISTRY: typing.Dict[type, TypeTransformer[T]] = {}
     _RESTRICTED_TYPES: typing.List[type] = []
     _DATACLASS_TRANSFORMER: TypeTransformer = DataclassTransformer()  # type: ignore
+    _ENUM_TRANSFORMER: TypeTransformer = EnumTransformer()  # type: ignore
     has_lazy_import = False
 
     @classmethod
@@ -822,6 +900,9 @@ class TypeEngine(typing.Generic[T]):
         Step 4:
             Walk the inheritance hierarchy of v and find a transformer that matches the first base class.
             This is potentially non-deterministic - will depend on the registration pattern.
+
+            Special case:
+                If v inherits from Enum, use the Enum transformer even if Enum is not the first base class.
 
             TODO lets make this deterministic by using an ordered dict
 
@@ -1605,83 +1686,6 @@ class BinaryIOTransformer(TypeTransformer[typing.BinaryIO]):
         ctx.file_access.get_data(lv.scalar.blob.uri, local_path, is_multipart=False)
         # TODO it is probability the responsibility of the framework to close this
         return open(local_path, "rb")
-
-
-class EnumTransformer(TypeTransformer[enum.Enum]):
-    """
-    Enables converting a python type enum.Enum to LiteralType.EnumType
-    """
-
-    def __init__(self):
-        super().__init__(name="DefaultEnumTransformer", t=enum.Enum)
-
-    def get_literal_type(self, t: Type[T]) -> LiteralType:
-        if is_annotated(t):
-            raise ValueError(
-                f"Flytekit does not currently have support \
-                    for FlyteAnnotations applied to enums. {t} cannot be \
-                    parsed."
-            )
-
-        values = [v.value for v in t]  # type: ignore
-        if not isinstance(values[0], str):
-            raise TypeTransformerFailedError("Only EnumTypes with value of string are supported")
-        return LiteralType(enum_type=_core_types.EnumType(values=values))
-
-    def to_literal(
-        self, ctx: FlyteContext, python_val: enum.Enum, python_type: Type[T], expected: LiteralType
-    ) -> Literal:
-        if type(python_val).__class__ != enum.EnumMeta:
-            raise TypeTransformerFailedError("Expected an enum")
-        if type(python_val.value) != str:
-            raise TypeTransformerFailedError("Only string-valued enums are supportedd")
-
-        return Literal(scalar=Scalar(primitive=Primitive(string_value=python_val.value)))  # type: ignore
-
-    def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
-        return expected_python_type(lv.scalar.primitive.string_value)  # type: ignore
-
-    def guess_python_type(self, literal_type: LiteralType) -> Type[enum.Enum]:
-        if literal_type.enum_type:
-            return enum.Enum("DynamicEnum", {f"{i}": i for i in literal_type.enum_type.values})  # type: ignore
-        raise ValueError(f"Enum transformer cannot reverse {literal_type}")
-
-
-def generate_attribute_list_from_dataclass_json_mixin(schema: dict, schema_name: typing.Any):
-    attribute_list = []
-    for property_key, property_val in schema["properties"].items():
-        if property_val.get("anyOf"):
-            property_type = property_val["anyOf"][0]["type"]
-        elif property_val.get("enum"):
-            property_type = "enum"
-        else:
-            property_type = property_val["type"]
-        # Handle list
-        if property_type == "array":
-            attribute_list.append((property_key, typing.List[_get_element_type(property_val["items"])]))  # type: ignore
-        # Handle dataclass and dict
-        elif property_type == "object":
-            if property_val.get("anyOf"):
-                sub_schemea = property_val["anyOf"][0]
-                sub_schemea_name = sub_schemea["title"]
-                attribute_list.append(
-                    (property_key, convert_mashumaro_json_schema_to_python_class(sub_schemea, sub_schemea_name))
-                )
-            elif property_val.get("additionalProperties"):
-                attribute_list.append(
-                    (property_key, typing.Dict[str, _get_element_type(property_val["additionalProperties"])])  # type: ignore
-                )
-            else:
-                sub_schemea_name = property_val["title"]
-                attribute_list.append(
-                    (property_key, convert_mashumaro_json_schema_to_python_class(property_val, sub_schemea_name))
-                )
-        elif property_type == "enum":
-            attribute_list.append([property_key, str])  # type: ignore
-        # Handle int, float, bool or str
-        else:
-            attribute_list.append([property_key, _get_element_type(property_val)])  # type: ignore
-    return attribute_list
 
 
 def generate_attribute_list_from_dataclass_json(schema: dict, schema_name: typing.Any):

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -6,7 +6,7 @@ import tempfile
 import typing
 from dataclasses import asdict, dataclass, field
 from datetime import timedelta
-from enum import Enum
+from enum import Enum, auto
 from typing import Optional, Type
 
 import mock
@@ -33,6 +33,7 @@ from flytekit.core.hash import HashMethod
 from flytekit.core.task import task
 from flytekit.core.type_engine import (
     DataclassTransformer,
+    EnumTransformer,
     DictTransformer,
     ListTransformer,
     LiteralsResolver,
@@ -1246,6 +1247,12 @@ class Color(Enum):
     BLUE = "blue"
 
 
+class MultiInheritanceColor(str, Enum):
+    RED = auto()
+    GREEN = auto()
+    BLUE = auto()
+
+
 # Enums with integer values are not supported
 class UnsupportedEnumValues(Enum):
     RED = 1
@@ -1329,6 +1336,11 @@ def test_enum_type():
 
     with pytest.raises(AssertionError):
         TypeEngine.to_literal_type(UnsupportedEnumValues)
+
+
+def test_multi_inheritance_enum_type():
+    tfm = TypeEngine.get_transformer(MultiInheritanceColor)
+    assert isinstance(tfm, EnumTransformer)
 
 
 def union_type_tags_unique(t: LiteralType):


### PR DESCRIPTION
## Describe your changes

Flytekit's type engine has support for string enums but not for e.g. int enums:

```py
class TestEnum(Enum):
    A = auto()
    B = auto()

@task
def foo(e: TestEnum) -> str:
    return str(e)

@workflow
def wf() -> str:
    return foo(e=TestEnum.A)
```

This fails with:

```console
    raise TypeTransformerFailedError("Only EnumTypes with value of string are supported")
```

If one changes the definition of the enum as follows, everything works:

```py
class TestEnum(Enum):
    A = "a"
    B = "b"
```

Unfortunately, in python [it is rather common to use this syntax](https://stackoverflow.com/questions/58608361/string-based-enum-in-python/58608362#58608362):

```py
class TestEnum(str, Enum):
    A = auto()
    B = auto()
```

With this syntax, the detection of the correct type transformer unfortunately fails: When walking the inheritance hierarchy, we find a transformer that matches *the first base class* (see [here](https://github.com/flyteorg/flytekit/blob/a7596019dfe76970587cf4171abb0145b1559c9d/flytekit/core/type_engine.py#L822)).

Unfortunately, the first base class that is detected is `str` which gives us the `SimpleTransformer` defined for `str` [here](https://github.com/flyteorg/flytekit/blob/a7596019dfe76970587cf4171abb0145b1559c9d/flytekit/core/type_engine.py#L1824). The reason is that the str transformer is registered before the enum transformer.

Our example then fails [in the `SimpleTransformer`](https://github.com/flyteorg/flytekit/blob/a7596019dfe76970587cf4171abb0145b1559c9d/flytekit/core/type_engine.py#L233) with:

```console
flytekit.core.type_engine.TypeTransformerFailedError: Expected value of type <class 'str'> but got '1' of type <enum 'TestEnum'>
...
AssertionError: Error encountered while executing 'wf':
  Failed to Bind variable e for function test.foo.
```


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Note to reviewers

While this problem doesn't occur when one doesn't use multi-inheritance, unfortunately this syntax appears to be rather common in python and if users do use it, it is rather difficult for them to understand where the error comes from. It requires detailed understanding of the way the type transformer is determined for a given type.

Alternatives I considered:

* We could just register the `EnumTransformer` before the string transformer but this is a lot more implicit and easy to break in the future.
* Instead of supporting the multi-inheritance syntax, I tried catching it and raising a user oriented exception that this is not supported. However, we never enter the `EnumTransformer` where I feel this should be handled but instead immediately run into the error in the `SimpleTransformer` - where I feel this shouldn't be handled.


