### PR TITLE
Override the container image of map task

### DIFF
--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import datetime
 import typing
 from typing import Any, List
@@ -61,7 +60,7 @@ class Node(object):
         self._metadata = metadata
         self._bindings = bindings
         self._upstream_nodes = upstream_nodes
-        self._flyte_entity = copy.deepcopy(flyte_entity)
+        self._flyte_entity = flyte_entity
         self._aliases: _workflow_model.Alias = None
         self._outputs = None
         self._resources: typing.Optional[_resources_model] = None

--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -124,7 +124,6 @@ class Node(object):
         return self._metadata
 
     def with_overrides(self, *args, **kwargs):
-        print("with_overrides")
         if "node_name" in kwargs:
             # Convert the node name into a DNS-compliant.
             # https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -292,7 +292,5 @@ def test_map_task_override(serialization_settings):
     @workflow
     def wf(x: typing.List[int]):
         array_node_map_task(my_mappable_task)(a=x).with_overrides(container_image="random:image")
-        array_node_map_task(my_mappable_task)(a=x)
 
     assert wf.nodes[0].run_entity.container_image == "random:image"
-    assert wf.nodes[1].run_entity.container_image is None

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -282,3 +282,17 @@ def test_raw_execute_with_min_success_ratio(min_success_ratio, should_raise_erro
             my_wf1()
     else:
         assert my_wf1() == [1, None, 3, 4]
+
+
+def test_map_task_override(serialization_settings):
+    @task
+    def my_mappable_task(a: int) -> typing.Optional[str]:
+        return str(a)
+
+    @workflow
+    def wf(x: typing.List[int]):
+        array_node_map_task(my_mappable_task)(a=x).with_overrides(container_image="random:image")
+        array_node_map_task(my_mappable_task)(a=x)
+
+    assert wf.nodes[0].run_entity.container_image == "random:image"
+    assert wf.nodes[1].run_entity.container_image is None

--- a/tests/flytekit/unit/core/test_map_task.py
+++ b/tests/flytekit/unit/core/test_map_task.py
@@ -336,3 +336,17 @@ def test_raw_execute_with_min_success_ratio(min_success_ratio, should_raise_erro
             my_wf1()
     else:
         assert my_wf1() == [1, None, 3, 4]
+
+
+def test_map_task_override(serialization_settings):
+    @task
+    def my_mappable_task(a: int) -> typing.Optional[str]:
+        return str(a)
+
+    @workflow
+    def wf(x: typing.List[int]):
+        map_task(my_mappable_task)(a=x).with_overrides(container_image="random:image")
+        map_task(my_mappable_task)(a=x)
+
+    assert wf.nodes[0].flyte_entity.run_task.container_image == "random:image"
+    assert wf.nodes[1].flyte_entity.run_task.container_image is None

--- a/tests/flytekit/unit/core/test_map_task.py
+++ b/tests/flytekit/unit/core/test_map_task.py
@@ -346,7 +346,5 @@ def test_map_task_override(serialization_settings):
     @workflow
     def wf(x: typing.List[int]):
         map_task(my_mappable_task)(a=x).with_overrides(container_image="random:image")
-        map_task(my_mappable_task)(a=x)
 
     assert wf.nodes[0].flyte_entity.run_task.container_image == "random:image"
-    assert wf.nodes[1].flyte_entity.run_task.container_image is None


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4493

## Describe your changes
This PR allows users to override the `python_function_task` inside of map task.

`with_override` doesn't work with map task since we didn't override the `python_function_task` inside of map task.


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Setup Process
```python
import typing

from flytekit import task, workflow, map_task
# from flytekit.experimental import map_task

@task
def my_mappable_task(a: int) -> typing.Optional[str]:
    return str(a)


@workflow
def wf(x: typing.List[int]=[1, 2, 3, 5]) -> typing.List[typing.Optional[str]]:
    map_task(my_mappable_task, concurrency=10, min_success_ratio=0.75)(a=x)
    a = map_task(my_mappable_task, concurrency=10, min_success_ratio=0.75)(a=x).with_overrides(container_image="random:image")
    return a


if __name__ == '__main__':
    wf(x=[1, 2, 3])

```