### PR TITLE
Separate agent from pyflyte serve

### DIFF
--- a/flytekit/clis/sdk_in_container/serve.py
+++ b/flytekit/clis/sdk_in_container/serve.py
@@ -9,7 +9,7 @@ from grpc import aio
 @click.pass_context
 def serve(ctx: click.Context):
     """
-    start the specific server.
+    Start the specific service.
     """
     pass
 

--- a/flytekit/clis/sdk_in_container/serve.py
+++ b/flytekit/clis/sdk_in_container/serve.py
@@ -4,8 +4,6 @@ import rich_click as click
 from flyteidl.service.agent_pb2_grpc import add_AsyncAgentServiceServicer_to_server
 from grpc import aio
 
-_serve_help = """Start a grpc server for the agent service."""
-
 
 @click.group("serve")
 @click.pass_context

--- a/flytekit/clis/sdk_in_container/serve.py
+++ b/flytekit/clis/sdk_in_container/serve.py
@@ -1,13 +1,22 @@
 from concurrent import futures
 
-import click
+import rich_click as click
 from flyteidl.service.agent_pb2_grpc import add_AsyncAgentServiceServicer_to_server
 from grpc import aio
 
 _serve_help = """Start a grpc server for the agent service."""
 
 
-@click.command("serve", help=_serve_help)
+@click.group("serve")
+@click.pass_context
+def serve(ctx: click.Context):
+    """
+    start the specific server.
+    """
+    pass
+
+
+@serve.command()
 @click.option(
     "--port",
     default="8000",
@@ -31,7 +40,7 @@ _serve_help = """Start a grpc server for the agent service."""
     "for testing.",
 )
 @click.pass_context
-def serve(_: click.Context, port, worker, timeout):
+def agent(_: click.Context, port, worker, timeout):
     """
     Start a grpc server for the agent service.
     """

--- a/tests/flytekit/unit/cli/pyflyte/test_serve.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_serve.py
@@ -5,5 +5,5 @@ from flytekit.clis.sdk_in_container import pyflyte
 
 def test_pyflyte_serve():
     runner = CliRunner()
-    result = runner.invoke(pyflyte.main, ["serve", "--port", "0", "--timeout", "1"], catch_exceptions=False)
+    result = runner.invoke(pyflyte.main, ["serve", "agent", "--port", "0", "--timeout", "1"], catch_exceptions=False)
     assert result.exit_code == 0


### PR DESCRIPTION
## Tracking issue
_https://github.com/flyteorg/flyte/issues/3936_

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?

We might have the demands of using `pyflyte serve <other service>` 
So separate agent as one of the serve group's commands.

## What changes were proposed in this pull request?

Make `serve` as group and move `agent` as one of the group's commands.

### Screenshots
![image](https://github.com/flyteorg/flytekit/assets/106939297/8bde538d-a25a-4cd0-b07c-83933f928450)


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
