### PR TITLE
Add various executions phases which are available in flyteidl, but not in flytekit

### DIFF
--- a/flytekit/models/core/execution.py
+++ b/flytekit/models/core/execution.py
@@ -18,6 +18,7 @@ class WorkflowExecutionPhase(object):
     FAILED = _execution_pb2.WorkflowExecution.FAILED
     ABORTED = _execution_pb2.WorkflowExecution.ABORTED
     TIMED_OUT = _execution_pb2.WorkflowExecution.TIMED_OUT
+    ABORTING = _execution_pb2.WorkflowExecution.ABORTING
 
     @classmethod
     def enum_to_string(cls, int_value):
@@ -43,6 +44,8 @@ class WorkflowExecutionPhase(object):
             return "ABORTED"
         elif int_value == cls.TIMED_OUT:
             return "TIMED_OUT"
+        elif int_value == cls.ABORTING:
+            return "ABORTING"
         else:
             return "{}".format(int_value)
 
@@ -57,6 +60,8 @@ class NodeExecutionPhase(object):
     ABORTED = _execution_pb2.NodeExecution.ABORTED
     SKIPPED = _execution_pb2.NodeExecution.SKIPPED
     TIMED_OUT = _execution_pb2.NodeExecution.TIMED_OUT
+    DYNAMIC_RUNNING = _execution_pb2.NodeExecution.DYNAMIC_RUNNING
+    RECOVERED = _execution_pb2.NodeExecution.RECOVERED
 
     @classmethod
     def enum_to_string(cls, int_value):
@@ -82,6 +87,10 @@ class NodeExecutionPhase(object):
             return "SKIPPED"
         elif int_value == cls.TIMED_OUT:
             return "TIMED_OUT"
+        elif int_value == cls.DYNAMIC_RUNNING:
+            return "DYNAMIC_RUNNING"
+        elif int_value == cls.RECOVERED:
+            return "RECOVERED"
         else:
             return "{}".format(int_value)
 
@@ -93,6 +102,8 @@ class TaskExecutionPhase(object):
     FAILED = _execution_pb2.TaskExecution.FAILED
     ABORTED = _execution_pb2.TaskExecution.ABORTED
     QUEUED = _execution_pb2.TaskExecution.QUEUED
+    INITIALIZING = _execution_pb2.TaskExecution.INITIALIZING
+    WAITING_FOR_RESOURCES = _execution_pb2.TaskExecution.WAITING_FOR_RESOURCES
 
     @classmethod
     def enum_to_string(cls, int_value):
@@ -112,6 +123,10 @@ class TaskExecutionPhase(object):
             return "ABORTED"
         elif int_value == cls.QUEUED:
             return "QUEUED"
+        elif int_value == cls.INITIALIZING:
+            return "INITIALIZING"
+        elif int_value == cls.WAITING_FOR_RESOURCES:
+            return "WAITING_FOR_RESOURCES"
         else:
             return "{}".format(int_value)
 

--- a/flytekit/models/core/execution.py
+++ b/flytekit/models/core/execution.py
@@ -26,28 +26,10 @@ class WorkflowExecutionPhase(object):
         :param int_value:
         :rtype: Text
         """
-        if int_value == cls.UNDEFINED:
-            return "UNDEFINED"
-        elif int_value == cls.QUEUED:
-            return "QUEUED"
-        elif int_value == cls.RUNNING:
-            return "RUNNING"
-        elif int_value == cls.SUCCEEDING:
-            return "SUCCEEDING"
-        elif int_value == cls.SUCCEEDED:
-            return "SUCCEEDED"
-        elif int_value == cls.FAILED:
-            return "FAILED"
-        elif int_value == cls.FAILING:
-            return "FAILING"
-        elif int_value == cls.ABORTED:
-            return "ABORTED"
-        elif int_value == cls.TIMED_OUT:
-            return "TIMED_OUT"
-        elif int_value == cls.ABORTING:
-            return "ABORTING"
-        else:
-            return "{}".format(int_value)
+        for name, value in cls.__dict__.items():
+            if value == int_value:
+                return name
+        return str(int_value)
 
 
 class NodeExecutionPhase(object):
@@ -69,30 +51,10 @@ class NodeExecutionPhase(object):
         :param int_value:
         :rtype: Text
         """
-        if int_value == cls.UNDEFINED:
-            return "UNDEFINED"
-        elif int_value == cls.QUEUED:
-            return "QUEUED"
-        elif int_value == cls.RUNNING:
-            return "RUNNING"
-        elif int_value == cls.SUCCEEDED:
-            return "SUCCEEDED"
-        elif int_value == cls.FAILED:
-            return "FAILED"
-        elif int_value == cls.FAILING:
-            return "FAILING"
-        elif int_value == cls.ABORTED:
-            return "ABORTED"
-        elif int_value == cls.SKIPPED:
-            return "SKIPPED"
-        elif int_value == cls.TIMED_OUT:
-            return "TIMED_OUT"
-        elif int_value == cls.DYNAMIC_RUNNING:
-            return "DYNAMIC_RUNNING"
-        elif int_value == cls.RECOVERED:
-            return "RECOVERED"
-        else:
-            return "{}".format(int_value)
+        for name, value in cls.__dict__.items():
+            if value == int_value:
+                return name
+        return str(int_value)
 
 
 class TaskExecutionPhase(object):
@@ -111,24 +73,10 @@ class TaskExecutionPhase(object):
         :param int_value:
         :rtype: Text
         """
-        if int_value == cls.UNDEFINED:
-            return "UNDEFINED"
-        elif int_value == cls.RUNNING:
-            return "RUNNING"
-        elif int_value == cls.SUCCEEDED:
-            return "SUCCEEDED"
-        elif int_value == cls.FAILED:
-            return "FAILED"
-        elif int_value == cls.ABORTED:
-            return "ABORTED"
-        elif int_value == cls.QUEUED:
-            return "QUEUED"
-        elif int_value == cls.INITIALIZING:
-            return "INITIALIZING"
-        elif int_value == cls.WAITING_FOR_RESOURCES:
-            return "WAITING_FOR_RESOURCES"
-        else:
-            return "{}".format(int_value)
+        for name, value in cls.__dict__.items():
+            if value == int_value:
+                return name
+        return str(int_value)
 
 
 class ExecutionError(_common.FlyteIdlEntity):


### PR DESCRIPTION
## Tracking issue
None afaik

## Why are the changes needed?
So that we can access all possible phases returned by Flyte within `flytekit`.

Also suggesting a refactoring to `enum_to_string()` in the [second commit](https://github.com/flyteorg/flytekit/pull/2022/commits/c3ed4e6f0d7fa7bbb3fe72dddffd909949347e7f). Happy to drop that if it's deemed unnecessary.

## How was this patch tested?

I ran `make test` locally and it ran through. I didn't add any more tests because as much as I could find everything would fall apart already if I messed up `enum_to_string()`, so expecting that that is still functional after this PR :)

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.