### PR TITLE
Fix union transformer

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1510,7 +1510,7 @@ class UnionTransformer(TypeTransformer[T]):
                         )
                     res_tag = trans.name
                     found_res = True
-            except (TypeTransformerFailedError, AttributeError) as e:
+            except Exception as e:
                 logger.debug(f"Failed to convert from {lv} to {v}", e)
 
         if found_res:

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -2034,6 +2034,20 @@ def test_schema_in_dataclass():
     assert o == ot
 
 
+def test_union_in_dataclass():
+    schema = TestSchema()
+    df = pd.DataFrame(data={"some_str": ["a", "b", "c"]})
+    schema.open().write(df)
+    o = Result(result=InnerResult(number=1, schema=schema), schema=schema)
+    ctx = FlyteContext.current_context()
+    tf = UnionTransformer()
+    pt = typing.Union[Result, InnerResult]
+    lt = tf.get_literal_type(pt)
+    lv = tf.to_literal(ctx, o, pt, lt)
+    ot = tf.to_python_value(ctx, lv=lv, expected_python_type=pt)
+    return o == ot
+
+
 @dataclass
 class InnerResult_dataclassjsonmixin(DataClassJSONMixin):
     number: int


### PR DESCRIPTION
## Why are the changes needed?
Failed to convert  a literal to python value`union[dataclass, dataclass]`.
```python
from dataclasses import dataclass
from typing import Union

from mashumaro.mixins.json import DataClassJSONMixin

from flytekitplugins.flyin import vscode
from flytekit import task


@dataclass
class Cat(DataClassJSONMixin):
    name: str
    age: int


@dataclass
class Yarn(DataClassJSONMixin):
    color: str
    length: int

@task
def t1(num: int) -> Union[Cat, Yarn]:
    return Cat(name="Mittens", age=num)


if __name__ == '__main__':
    print(t1(num=1))
```

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
When converting literal to python value, union transformer should catch any kind of exception. 
https://github.com/flyteorg/flytekit/blob/5c6802c97388c40d0431e4fc308e2ed651528952/flytekit/core/type_engine.py#L1513-L1514. Therefore, if one of transformers in the union fails, it will try next one.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Run above workflow locally

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
