### PR TITLE
add monodocs ci build in flytekit

### DIFF
--- a/.github/workflows/monodocs_build.yml
+++ b/.github/workflows/monodocs_build.yml
@@ -1,4 +1,4 @@
-name: Docs Build
+name: Monodocs Build
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/monodocs_build.yml
+++ b/.github/workflows/monodocs_build.yml
@@ -1,0 +1,52 @@
+name: Docs Build
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  docs:
+    name: Docs Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch flytekit code
+        uses: actions/checkout@v4
+        with:
+          path: "${{ github.workspace }}/flytekit"
+      - name: Fetch flyte code
+        uses: actions/checkout@v4
+        with:
+          repository: flyteorg/flyte
+          path: "${{ github.workspace }}/flyte"
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: 3.9
+      - shell: bash -el {0}
+        working-directory: ${{ github.workspace }}/flyte
+        run: |
+          conda install -c conda-forge conda-lock
+          conda-lock install -n monodocs-env monodocs-environment.lock.yaml
+      - shell: bash -el {0}
+        run: |
+          conda activate monodocs-env
+          conda info
+          conda list
+          conda config --show-sources
+          conda config --show
+          printenv | sort
+      - name: Build the documentation
+        working-directory: ${{ github.workspace }}/flyte
+        shell: bash -el {0}
+        env:
+            FLYTEKIT_LOCAL_PATH: ${{ github.workspace }}/flytekit
+        run: |
+          conda activate monodocs-env
+          make docs

--- a/.github/workflows/monodocs_build.yml
+++ b/.github/workflows/monodocs_build.yml
@@ -13,7 +13,7 @@ on:
       - master
 jobs:
   docs:
-    name: Docs Build
+    name: Monodocs Build
     runs-on: ubuntu-latest
     steps:
       - name: Fetch flytekit code


### PR DESCRIPTION
## Tracking issue
Fixes [_https://github.com/flyteorg/flyte/issues/<number>_](https://github.com/flyteorg/flyte/issues/4557)

## Why are the changes needed?

With the monodocs build process in `flyteorg/flyte`, we need a way of making sure upstream changes in the `flytekit` repo do not break the overall build.

## What changes were proposed in this pull request?

Adds a github action workflow to build the docs.
