### PR TITLE
Fix Flyin Dockerfile

### DIFF
--- a/plugins/flytekit-flyin/Dockerfile
+++ b/plugins/flytekit-flyin/Dockerfile
@@ -1,4 +1,3 @@
-ARG PYTHON_VERSION
 FROM python:3.10-slim-buster
 MAINTAINER Flyte Team <users@flyte.org>
 LABEL org.opencontainers.image.source https://github.com/flyteorg/flytekit
@@ -16,14 +15,14 @@ ARG TARGETARCH
 # 6. Some packages will create config file under /home by default, so we need to make sure it's writable
 # 7. Change the permission of /tmp, so that others can run command on it
 RUN apt-get update \
-    && apt-get install build-essential git wget -y \
+    && apt-get install build-essential wget -y \
     && mkdir -p /tmp/ \
     && mkdir -p /tmp/code-server \
     && wget --no-check-certificate -O /tmp/code-server/code-server-4.19.0-linux-${TARGETARCH}.tar.gz https://github.com/coder/code-server/releases/download/v4.19.0/code-server-4.19.0-linux-${TARGETARCH}.tar.gz \
     && tar -xzf /tmp/code-server/code-server-4.19.0-linux-${TARGETARCH}.tar.gz -C /tmp/code-server/ \
     && wget --no-check-certificate https://open-vsx.org/api/ms-python/python/2023.20.0/file/ms-python.python-2023.20.0.vsix -P /tmp/code-server \
     && wget --no-check-certificate https://open-vsx.org/api/ms-toolsai/jupyter/2023.9.100/file/ms-toolsai.jupyter-2023.9.100.vsix -P /tmp/code-server \
-    && pip install --no-cache-dir -U flytekit-flyin==$VERSION flytekit==$VERSION \
+    && pip install --no-cache-dir -U flytekitplugins-flyin==$VERSION flytekit==$VERSION \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/ \


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4284
https://github.com/flyteorg/flytekit/pull/2036

### Setup process
```Dockerfile
FROM python:3.10-slim-buster

MAINTAINER Flyte Team <users@flyte.org>
LABEL org.opencontainers.image.source https://github.com/flyteorg/flytekit
WORKDIR /root
ENV PYTHONPATH /root

ARG VERSION
ARG TARGETARCH

# 1. Update the necessary packages for flytekit
# 2. Install code-server
# 3. Download code-server extensions for Python and Jupyter via wget
# 4. Install flytekit and flytekit-flyin with no cache
# 5. Delete apt cache. Reference: https://gist.github.com/marvell/7c812736565928e602c4
# 6. Some packages will create config file under /home by default, so we need to make sure it's writable
# 7. Change the permission of /tmp, so that others can run command on it
RUN apt-get update \
    && apt-get install build-essential git wget -y \
    && mkdir -p /tmp/ \
    && mkdir -p /tmp/code-server \
    && wget --no-check-certificate -O /tmp/code-server/code-server-4.19.0-linux-${TARGETARCH}.tar.gz https://github.com/coder/code-server/releases/download/v4.19.0/code-server-4.19.0-linux-${TARGETARCH}.tar.gz \
    && tar -xzf /tmp/code-server/code-server-4.19.0-linux-${TARGETARCH}.tar.gz -C /tmp/code-server/ \
    && wget --no-check-certificate https://open-vsx.org/api/ms-python/python/2023.20.0/file/ms-python.python-2023.20.0.vsix -P /tmp/code-server \
    && wget --no-check-certificate https://open-vsx.org/api/ms-toolsai/jupyter/2023.9.100/file/ms-toolsai.jupyter-2023.9.100.vsix -P /tmp/code-server \
    && pip install -U git+https://github.com/flyteorg/flytekit.git@f0d4f1357a770b66dc8344ab97b8b41d19eca9df#subdirectory=plugins/flytekit-flyin \
    && apt-get clean autoclean \
    && apt-get autoremove --yes \
    && rm -rf /var/lib/{apt,dpkg,cache,log}/ \
    && useradd -u 1000 flytekit \
    && chown flytekit: /root \
    && chown flytekit: /home \
    && :

# Set the environment variable for code-server
ENV PATH="/tmp/code-server/code-server-4.19.0-linux-${TARGETARCH}/bin:${PATH}"

USER flytekit

# Install extensions using code-server
# Execution is performed here as code-server configuration depends on the USER setting
# If we install it as ROOT, the config will be stored in /root/.config/code-server/config.yaml
# Now, the config of code-server will be stored in /home/flytekit/.config/code-server/config.yaml
RUN code-server --install-extension /tmp/code-server/ms-python.python-2023.20.0.vsix \
    && code-server --install-extension /tmp/code-server/ms-toolsai.jupyter-2023.9.100.vsix
```

```bash
docker buildx build --platform=linux/amd64 -t localhost:30000/flyin-1210:0936 -f DockerfileFlyin .
docker run -it localhost:30000/flyin-1210:0936  /bin/bash
```
```bash
code-server --list-extensions
```
```python
from flytekitplugins.flyin import COPILOT_EXTENSION, VscodeConfig, vscode
```

### Screenshots
![image](https://github.com/flyteorg/flytekit/assets/76461262/c7d03ffe-673b-45fa-be45-b1ce0a37cb2b)
![image](https://github.com/flyteorg/flytekit/assets/76461262/8dac3fbe-cbd7-47ad-97a4-6acca0b614f3)
![image](https://github.com/flyteorg/flytekit/assets/76461262/c0c9eb9e-8b40-4237-a97c-5d53754ca1ca)
1. test code-server
2. test python-pip Flyin module
3. test /tmp folder's permission

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
