### PR TITLE
Flyin - fix vscode task path

### DIFF
--- a/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/constants.py
+++ b/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/constants.py
@@ -34,4 +34,5 @@ RESUME_TASK_FILE_NAME = "flyin_resume_task.py"
 VSCODE_TYPE_KEY = "flyin_type"
 VSCODE_PORT_KEY = "flyin_port"
 
+# Context attribute name of the task function's source file path
 TASK_FUNCTION_SOURCE_PATH = "TASK_FUNCTION_SOURCE_PATH"

--- a/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/constants.py
+++ b/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/constants.py
@@ -33,3 +33,5 @@ RESUME_TASK_FILE_NAME = "flyin_resume_task.py"
 # Config keys to store in task template
 VSCODE_TYPE_KEY = "flyin_type"
 VSCODE_PORT_KEY = "flyin_port"
+
+TASK_FUNCTION_SOURCE_PATH = "TASK_FUNCTION_SOURCE_PATH"

--- a/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
+++ b/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
@@ -101,9 +101,8 @@ def exit_handler(
     terminate_process()
 
     # Reload the task function since it may be modified.
-    task_function = getattr(
-        load_module_from_path(fn.__module__, os.path.join(os.getcwd(), f"{fn.__module__}.py")), fn.__name__
-    )
+    task_function_source_path = FlyteContextManager.current_context().user_space_params.TASK_FUNCTION_SOURCE_PATH
+    task_function = getattr(load_module_from_path(fn.__module__, task_function_source_path), fn.__name__)
 
     # Get the actual function from the task.
     while hasattr(task_function, "__wrapped__"):

--- a/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
+++ b/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
@@ -416,14 +416,14 @@ class vscode(ClassDecorator):
         # 1. Downloads the VSCode server from Internet to local.
         download_vscode(self._config)
 
-        # 2. Prepare the interactive debugging Python script.
-        prepare_interactive_python(self.fn)
+        # # 2. Prepare the interactive debugging Python script.
+        # prepare_interactive_python(self.fn)
 
-        # 3. Prepare the task resumption Python script.
-        prepare_resume_task_python()
+        # # 3. Prepare the task resumption Python script.
+        # prepare_resume_task_python()
 
-        # 4. Prepare the launch.json
-        prepare_launch_json()
+        # # 4. Prepare the launch.json
+        # prepare_launch_json()
 
         # 5. Launches and monitors the VSCode server.
         # Run the function in the background


### PR DESCRIPTION
## Tracking issue
_https://github.com/flyteorg/flyte/issues/4284_



## Why are the changes needed?
Current implementation of vscode decorator wrongly assumes that _current working dir_ == the directory of task function module. For example, the working dir of imagespec is `/`. Therefore, when we run
```python
    shutil.copy(
        f"{task_function.__module__}.py",
        os.path.join(context_working_dir, f"{task_function.__module__}.py"),
    )
```
wf.py will not be found because it is actually at /root/wf.py.

## What changes were proposed in this pull request?
1. Use inspect.getsourcefile(self.fn) to get the path of the source of the task function.
2. In `exit_handler`, `prepare_interactive_python`, `prepare_resume_task_python`, and `prepare_launch_json`, use this path instead of _current working dir_, which we wrongly assumed before.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

