### PR TITLE
Adds setuptools and wheel back in the CI for plugins

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          pip install build twine setuptools wheel
       - name: Build and publish
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
Fixes deployment issue seen in https://github.com/flyteorg/flytekit/actions/runs/7186707178/job/19572701206

The plugins still require `setuptool` and `wheel` to be installed to build.