### PR TITLE
all flytekit plugins use lazy module loading

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
-        args: [--fix, --show-fixes]
+        args: [--fix, --show-fixes, --show-source]
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
-        args: [--fix]
+        args: [--fix, --show-fixes]
       # Run the formatter.
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/plugins/flytekit-airflow/flytekitplugins/airflow/task.py
+++ b/plugins/flytekit-airflow/flytekitplugins/airflow/task.py
@@ -6,13 +6,7 @@ from typing import Any, Dict, Optional, Type
 
 import jsonpickle
 
-from airflow import DAG
-from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
-from airflow.sensors.base import BaseSensorOperator
-from airflow.triggers.base import BaseTrigger
-from airflow.utils.context import Context
-from flytekit import FlyteContextManager, logger
+from flytekit import FlyteContextManager, logger, lazy_module
 from flytekit.configuration import SerializationSettings
 from flytekit.core.base_task import PythonTask, TaskResolverMixin
 from flytekit.core.interface import Interface
@@ -20,6 +14,8 @@ from flytekit.core.python_auto_container import PythonAutoContainerTask
 from flytekit.core.tracker import TrackedInstance
 from flytekit.core.utils import timeit
 from flytekit.extend.backend.base_agent import AsyncAgentExecutorMixin
+
+airflow = lazy_module("airflow")
 
 
 @dataclass
@@ -51,7 +47,7 @@ class AirflowTaskResolver(TrackedInstance, TaskResolverMixin):
         return "AirflowTaskResolver"
 
     @timeit("Load airflow task")
-    def load_task(self, loader_args: typing.List[str]) -> typing.Union[BaseOperator, BaseSensorOperator, BaseTrigger]:
+    def load_task(self, loader_args: typing.List[str]) -> typing.Union[airflow.models.BaseOperator, airflow.sensors.base.BaseSensorOperator, airflow.triggers.base.BaseTrigger]:
         """
         This method is used to load an Airflow task.
         """
@@ -103,7 +99,7 @@ class AirflowContainerTask(PythonAutoContainerTask[AirflowObj]):
 
     def execute(self, **kwargs) -> Any:
         logger.info("Executing Airflow task")
-        _get_airflow_instance(self.task_config).execute(context=Context())
+        _get_airflow_instance(self.task_config).execute(context=airflow.utils.context.Context())
 
 
 class AirflowTask(AsyncAgentExecutorMixin, PythonTask[AirflowObj]):
@@ -134,7 +130,7 @@ class AirflowTask(AsyncAgentExecutorMixin, PythonTask[AirflowObj]):
         return {"task_config_pkl": jsonpickle.encode(self.task_config)}
 
 
-def _get_airflow_instance(airflow_obj: AirflowObj) -> typing.Union[BaseOperator, BaseSensorOperator, BaseTrigger]:
+def _get_airflow_instance(airflow_obj: AirflowObj) -> typing.Union[airflow.models.BaseOperator, airflow.sensors.base.BaseSensorOperator, airflow.triggers.base.BaseTrigger]:
     # Set the GET_ORIGINAL_TASK attribute to True so that obj_def will return the original
     # airflow task instead of the Flyte task.
     ctx = FlyteContextManager.current_context()
@@ -142,10 +138,10 @@ def _get_airflow_instance(airflow_obj: AirflowObj) -> typing.Union[BaseOperator,
 
     obj_module = importlib.import_module(name=airflow_obj.module)
     obj_def = getattr(obj_module, airflow_obj.name)
-    if issubclass(obj_def, BaseOperator) and not issubclass(obj_def, BaseSensorOperator) and _is_deferrable(obj_def):
+    if issubclass(obj_def, airflow.models.BaseOperator) and not issubclass(obj_def, airflow.sensors.base.BaseSensorOperator) and _is_deferrable(obj_def):
         try:
             return obj_def(**airflow_obj.parameters, deferrable=True)
-        except AirflowException as e:
+        except airflow.exceptions.AirflowException as e:
             logger.debug(f"Failed to create operator {airflow_obj.name} with err: {e}.")
             logger.debug(f"Airflow operator {airflow_obj.name} does not support deferring.")
 
@@ -212,9 +208,9 @@ params = FlyteContextManager.current_context().user_space_params
 params.builder().add_attr("GET_ORIGINAL_TASK", False).add_attr("XCOM_DATA", {}).build()
 
 # Monkey patch the Airflow operator. Instead of creating an airflow task, it returns a Flyte task.
-BaseOperator.__new__ = _flyte_operator
-BaseOperator.xcom_push = _flyte_xcom_push
+airflow.models.BaseOperator.__new__ = _flyte_operator
+airflow.models.BaseOperator.xcom_push = _flyte_xcom_push
 # Monkey patch the xcom_push method to store the data in the Flyte context.
 # Create a dummy DAG to avoid Airflow errors. This DAG is not used.
 # TODO: Add support using Airflow DAG in Flyte workflow. We can probably convert the Airflow DAG to a Flyte subworkflow.
-BaseSensorOperator.dag = DAG(dag_id="flyte_dag")
+airflow.sensors.base.BaseSensorOperator.dag = airflow.DAG(dag_id="flyte_dag")

--- a/plugins/flytekit-bigquery/flytekitplugins/bigquery/task.py
+++ b/plugins/flytekit-bigquery/flytekitplugins/bigquery/task.py
@@ -11,7 +11,6 @@ from flytekit.extend.backend.base_agent import AsyncAgentExecutorMixin
 from flytekit.models import task as _task_model
 from flytekit.types.structured import StructuredDataset
 
-
 bigquery = lazy_module("google.cloud.bigquery")
 
 

--- a/plugins/flytekit-bigquery/flytekitplugins/bigquery/task.py
+++ b/plugins/flytekit-bigquery/flytekitplugins/bigquery/task.py
@@ -1,15 +1,18 @@
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Type
 
-from google.cloud import bigquery
 from google.protobuf import json_format
 from google.protobuf.struct_pb2 import Struct
 
+from flytekit import lazy_module
 from flytekit.configuration import SerializationSettings
 from flytekit.extend import SQLTask
 from flytekit.extend.backend.base_agent import AsyncAgentExecutorMixin
 from flytekit.models import task as _task_model
 from flytekit.types.structured import StructuredDataset
+
+
+bigquery = lazy_module("google.cloud.bigquery")
 
 
 @dataclass

--- a/plugins/flytekit-dolt/flytekitplugins/dolt/schema.py
+++ b/plugins/flytekit-dolt/flytekitplugins/dolt/schema.py
@@ -3,6 +3,7 @@ import typing
 from dataclasses import dataclass
 from typing import Type
 
+import dolt_integrations.core as dolt_int
 from dataclasses_json import DataClassJsonMixin
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.struct_pb2 import Struct
@@ -13,8 +14,7 @@ from flytekit.models import types as _type_models
 from flytekit.models.literals import Literal, Scalar
 from flytekit.models.types import LiteralType
 
-
-dolt_int = lazy_module("dolt_integrations.core")
+# dolt_int = lazy_module("dolt_integrations")
 dolt = lazy_module("doltcli")
 pandas = lazy_module("pandas")
 

--- a/plugins/flytekit-dolt/flytekitplugins/dolt/schema.py
+++ b/plugins/flytekit-dolt/flytekitplugins/dolt/schema.py
@@ -3,18 +3,20 @@ import typing
 from dataclasses import dataclass
 from typing import Type
 
-import dolt_integrations.core as dolt_int
-import doltcli as dolt
-import pandas
 from dataclasses_json import DataClassJsonMixin
 from google.protobuf.json_format import MessageToDict
 from google.protobuf.struct_pb2 import Struct
 
-from flytekit import FlyteContext
+from flytekit import FlyteContext, lazy_module
 from flytekit.extend import TypeEngine, TypeTransformer
 from flytekit.models import types as _type_models
 from flytekit.models.literals import Literal, Scalar
 from flytekit.models.types import LiteralType
+
+
+dolt_int = lazy_module("dolt_integrations.core")
+dolt = lazy_module("doltcli")
+pandas = lazy_module("pandas")
 
 
 @dataclass

--- a/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
+++ b/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
@@ -5,7 +5,6 @@ from flytekit import PythonInstanceTask, lazy_module
 from flytekit.extend import Interface
 from flytekit.types.structured.structured_dataset import StructuredDataset
 
-
 duckdb = lazy_module("duckdb")
 pd = lazy_module("pandas")
 pa = lazy_module("pyarrow")

--- a/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
+++ b/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
@@ -1,13 +1,14 @@
 import json
 from typing import Dict, List, NamedTuple, Optional, Union
 
-import pandas as pd
-import pyarrow as pa
-
-import duckdb
-from flytekit import PythonInstanceTask
+from flytekit import PythonInstanceTask, lazy_module
 from flytekit.extend import Interface
 from flytekit.types.structured.structured_dataset import StructuredDataset
+
+
+duckdb = lazy_module("duckdb")
+pd = lazy_module("pandas")
+pa = lazy_module("pyarrow")
 
 
 class QueryOutput(NamedTuple):

--- a/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py
+++ b/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py
@@ -14,13 +14,8 @@ from flytekit.models.literals import Literal, Primitive, Scalar
 from flytekit.models.types import LiteralType
 from flytekit.types.file.file import FlyteFile, FlyteFilePathTransformer
 from flytekit.types.schema.types import FlyteSchema, FlyteSchemaTransformer
-from great_expectations.checkpoint import SimpleCheckpoint
-from great_expectations.core.run_identifier import RunIdentifier
-from great_expectations.core.util import convert_to_json_serializable
-from great_expectations.exceptions import ValidationError
 
 from .task import BatchRequestConfig
-
 
 ge = lazy_module("great_expectations")
 
@@ -292,7 +287,7 @@ class GreatExpectationsTypeTransformer(TypeTransformer[GreatExpectationsType]):
             checkpoint = ge.checkpoint.SimpleCheckpoint(f"_tmp_checkpoint_{ge_conf.expectation_suite_name}", context)
 
         # identify every run uniquely
-        run_id = ge.core.run_identifierRunIdentifier(
+        run_id = ge.core.run_identifier.RunIdentifier(
             **{
                 "run_name": ge_conf.datasource_name + "_run",
                 "run_time": datetime.datetime.utcnow(),

--- a/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py
+++ b/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py
@@ -6,8 +6,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from dataclasses_json import DataClassJsonMixin
 
-import great_expectations as ge
-from flytekit import FlyteContext
+from flytekit import FlyteContext, lazy_module
 from flytekit.extend import TypeEngine, TypeTransformer
 from flytekit.loggers import logger
 from flytekit.models import types as _type_models
@@ -21,6 +20,9 @@ from great_expectations.core.util import convert_to_json_serializable
 from great_expectations.exceptions import ValidationError
 
 from .task import BatchRequestConfig
+
+
+ge = lazy_module("great_expectations")
 
 
 @dataclass
@@ -281,16 +283,16 @@ class GreatExpectationsTypeTransformer(TypeTransformer[GreatExpectationsType]):
             )
 
         if ge_conf.checkpoint_params:
-            checkpoint = SimpleCheckpoint(
+            checkpoint = ge.checkpoint.SimpleCheckpoint(
                 f"_tmp_checkpoint_{ge_conf.expectation_suite_name}",
                 context,
                 **ge_conf.checkpoint_params,
             )
         else:
-            checkpoint = SimpleCheckpoint(f"_tmp_checkpoint_{ge_conf.expectation_suite_name}", context)
+            checkpoint = ge.checkpoint.SimpleCheckpoint(f"_tmp_checkpoint_{ge_conf.expectation_suite_name}", context)
 
         # identify every run uniquely
-        run_id = RunIdentifier(
+        run_id = ge.core.run_identifierRunIdentifier(
             **{
                 "run_name": ge_conf.datasource_name + "_run",
                 "run_time": datetime.datetime.utcnow(),
@@ -306,7 +308,7 @@ class GreatExpectationsTypeTransformer(TypeTransformer[GreatExpectationsType]):
                 }
             ],
         )
-        final_result = convert_to_json_serializable(checkpoint_result.list_validation_results())[0]
+        final_result = ge.core.util.convert_to_json_serializable(checkpoint_result.list_validation_results())[0]
 
         result_string = ""
         if final_result["success"] is False:
@@ -320,7 +322,7 @@ class GreatExpectationsTypeTransformer(TypeTransformer[GreatExpectationsType]):
                     )
 
             # raise a Great Expectations' exception
-            raise ValidationError("Validation failed!\nCOLUMN\t\tFAILED EXPECTATION\n" + result_string)
+            raise ge.exceptions.ValidationError("Validation failed!\nCOLUMN\t\tFAILED EXPECTATION\n" + result_string)
 
         logger.info("Validation succeeded!")
 

--- a/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/task.py
+++ b/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/task.py
@@ -6,17 +6,14 @@ from typing import Any, Dict, List, Optional, Type, Union
 
 from dataclasses_json import DataClassJsonMixin
 
-import great_expectations as ge
-from flytekit import PythonInstanceTask
+from flytekit import PythonInstanceTask, lazy_module
 from flytekit.core.context_manager import FlyteContext
 from flytekit.extend import Interface
 from flytekit.loggers import logger
 from flytekit.types.file.file import FlyteFile
 from flytekit.types.schema import FlyteSchema
-from great_expectations.checkpoint import SimpleCheckpoint
-from great_expectations.core.run_identifier import RunIdentifier
-from great_expectations.core.util import convert_to_json_serializable
-from great_expectations.exceptions import ValidationError
+
+ge = lazy_module("great_expectations")
 
 
 @dataclass
@@ -204,19 +201,19 @@ class GreatExpectationsTask(PythonInstanceTask[BatchRequestConfig]):
             )
 
         if self._checkpoint_params:
-            checkpoint = SimpleCheckpoint(
+            checkpoint = ge.checkpoint.SimpleCheckpoint(
                 f"_tmp_checkpoint_{self._expectation_suite_name}",
                 context,
                 **self._checkpoint_params,
             )
         else:
-            checkpoint = SimpleCheckpoint(
+            checkpoint = ge.checkpoint.SimpleCheckpoint(
                 f"_tmp_checkpoint_{self._expectation_suite_name}",
                 context,
             )
 
         # identify every run uniquely
-        run_id = RunIdentifier(
+        run_id = ge.core.run_identifier.RunIdentifier(
             **{
                 "run_name": self._datasource_name + "_run",
                 "run_time": datetime.datetime.utcnow(),
@@ -232,7 +229,7 @@ class GreatExpectationsTask(PythonInstanceTask[BatchRequestConfig]):
                 }
             ],
         )
-        final_result = convert_to_json_serializable(checkpoint_result.list_validation_results())[0]
+        final_result = ge.core.util.convert_to_json_serializable(checkpoint_result.list_validation_results())[0]
 
         result_string = ""
         if final_result["success"] is False:
@@ -246,7 +243,7 @@ class GreatExpectationsTask(PythonInstanceTask[BatchRequestConfig]):
                     )
 
             # raise a Great Expectations' exception
-            raise ValidationError("Validation failed!\nCOLUMN\t\tFAILED EXPECTATION\n" + result_string)
+            raise ge.exceptions.ValidationError("Validation failed!\nCOLUMN\t\tFAILED EXPECTATION\n" + result_string)
 
         logger.info("Validation succeeded!")
 

--- a/plugins/flytekit-huggingface/flytekitplugins/huggingface/sd_transformers.py
+++ b/plugins/flytekit-huggingface/flytekitplugins/huggingface/sd_transformers.py
@@ -1,9 +1,7 @@
 import os
 import typing
 
-import datasets
-
-from flytekit import FlyteContext
+from flytekit import FlyteContext, lazy_module
 from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
@@ -14,6 +12,9 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDatasetEncoder,
     StructuredDatasetTransformerEngine,
 )
+
+
+datasets = lazy_module("datasets")
 
 
 class HuggingFaceDatasetRenderer:

--- a/plugins/flytekit-huggingface/flytekitplugins/huggingface/sd_transformers.py
+++ b/plugins/flytekit-huggingface/flytekitplugins/huggingface/sd_transformers.py
@@ -13,7 +13,6 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDatasetTransformerEngine,
 )
 
-
 datasets = lazy_module("datasets")
 
 

--- a/plugins/flytekit-k8s-pod/flytekitplugins/pod/task.py
+++ b/plugins/flytekit-k8s-pod/flytekitplugins/pod/task.py
@@ -96,7 +96,7 @@ class PodFunctionTask(PythonFunctionTask[Pod]):
 
                 container.env = [
                     k8s_models.V1EnvVar(name=key, value=val) for key, val in sdk_default_container.env.items()
-                ] + container.env or []
+                ] + (container.env or [])
 
             final_containers.append(container)
 

--- a/plugins/flytekit-k8s-pod/flytekitplugins/pod/task.py
+++ b/plugins/flytekit-k8s-pod/flytekitplugins/pod/task.py
@@ -2,10 +2,8 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 from flyteidl.core import tasks_pb2 as _core_task
-from kubernetes.client import ApiClient
-from kubernetes.client.models import V1Container, V1EnvVar, V1PodSpec, V1ResourceRequirements
 
-from flytekit import FlyteContext, PythonFunctionTask
+from flytekit import FlyteContext, PythonFunctionTask, lazy_module
 from flytekit.configuration import SerializationSettings
 from flytekit.exceptions import user as _user_exceptions
 from flytekit.extend import Promise, TaskPlugins
@@ -14,6 +12,10 @@ from flytekit.models import task as _task_models
 
 _PRIMARY_CONTAINER_NAME_FIELD = "primary_container_name"
 PRIMARY_CONTAINER_DEFAULT_NAME = "primary"
+
+
+k8s_client = lazy_module("kubernetes.client")
+k8s_models = lazy_module("kubernetes.client.models")
 
 
 def _sanitize_resource_name(resource: _task_models.Resources.ResourceEntry) -> str:
@@ -35,7 +37,7 @@ class Pod(object):
     :param Optional[Dict[str, str]] annotations: Annotations are key/value pairs that are attached to arbitrary non-identifying metadata to pod spec.
     """
 
-    pod_spec: V1PodSpec
+    pod_spec: k8s_models.V1PodSpec
     primary_container_name: str = PRIMARY_CONTAINER_DEFAULT_NAME
     labels: Optional[Dict[str, str]] = None
     annotations: Optional[Dict[str, str]] = None
@@ -66,7 +68,7 @@ class PodFunctionTask(PythonFunctionTask[Pod]):
                 break
         if not primary_exists:
             # insert a placeholder primary container if it is not defined in the pod spec.
-            containers.append(V1Container(name=self.task_config.primary_container_name))
+            containers.append(k8s_models.V1Container(name=self.task_config.primary_container_name))
 
         final_containers = []
         for container in containers:
@@ -87,20 +89,20 @@ class PodFunctionTask(PythonFunctionTask[Pod]):
                 for resource in sdk_default_container.resources.requests:
                     requests[_sanitize_resource_name(resource)] = resource.value
 
-                resource_requirements = V1ResourceRequirements(limits=limits, requests=requests)
+                resource_requirements = k8s_models.V1ResourceRequirements(limits=limits, requests=requests)
                 if len(limits) > 0 or len(requests) > 0:
                     # Important! Only copy over resource requirements if they are non-empty.
                     container.resources = resource_requirements
 
-                container.env = [V1EnvVar(name=key, value=val) for key, val in sdk_default_container.env.items()] + (
-                    container.env or []
-                )
+                container.env = [
+                    k8s_models.V1EnvVar(name=key, value=val) for key, val in sdk_default_container.env.items()
+                ] + container.env or []
 
             final_containers.append(container)
 
         self.task_config.pod_spec.containers = final_containers
 
-        return ApiClient().sanitize_for_serialization(self.task_config.pod_spec)
+        return k8s_client.ApiClient().sanitize_for_serialization(self.task_config.pod_spec)
 
     def get_k8s_pod(self, settings: SerializationSettings) -> _task_models.K8sPod:
         return _task_models.K8sPod(

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -7,13 +7,12 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Union
 
-import cloudpickle
 from flyteidl.plugins.kubeflow import common_pb2 as kubeflow_common
 from flyteidl.plugins.kubeflow import pytorch_pb2 as pytorch_task
 from google.protobuf.json_format import MessageToDict
 
 import flytekit
-from flytekit import PythonFunctionTask, Resources
+from flytekit import PythonFunctionTask, Resources, lazy_module
 from flytekit.configuration import SerializationSettings
 from flytekit.core.resources import convert_resources_to_resource_model
 from flytekit.exceptions.user import FlyteRecoverableException
@@ -21,6 +20,9 @@ from flytekit.extend import IgnoreOutputs, TaskPlugins
 from flytekit.loggers import logger
 
 from .error_handling import create_recoverable_error_file, is_recoverable_worker_error
+
+
+cloudpickle = lazy_module("cloudpickle")
 
 TORCH_IMPORT_ERROR_MESSAGE = "PyTorch is not installed. Please install `flytekitplugins-kfpytorch['elastic']`."
 

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -21,7 +21,6 @@ from flytekit.loggers import logger
 
 from .error_handling import create_recoverable_error_file, is_recoverable_worker_error
 
-
 cloudpickle = lazy_module("cloudpickle")
 
 TORCH_IMPORT_ERROR_MESSAGE = "PyTorch is not installed. Please install `flytekitplugins-kfpytorch['elastic']`."

--- a/plugins/flytekit-mlflow/flytekitplugins/mlflow/tracking.py
+++ b/plugins/flytekit-mlflow/flytekitplugins/mlflow/tracking.py
@@ -6,7 +6,6 @@ from flytekit import FlyteContextManager, lazy_module
 from flytekit.bin.entrypoint import get_one_of
 from flytekit.deck.renderer import TopFrameRenderer
 
-
 go = lazy_module("plotly.graph_objects")
 plotly_subplots = lazy_module("plotly.subplots")
 pd = lazy_module("pandas")

--- a/plugins/flytekit-mlflow/flytekitplugins/mlflow/tracking.py
+++ b/plugins/flytekit-mlflow/flytekitplugins/mlflow/tracking.py
@@ -1,21 +1,19 @@
 import typing
 from functools import partial, wraps
 
-import pandas
-import pandas as pd
-import plotly.graph_objects as go
-from plotly.subplots import make_subplots
-
 import flytekit
-import mlflow
-from flytekit import FlyteContextManager
+from flytekit import FlyteContextManager, lazy_module
 from flytekit.bin.entrypoint import get_one_of
 from flytekit.deck.renderer import TopFrameRenderer
-from mlflow import MlflowClient
-from mlflow.entities.metric import Metric
 
 
-def metric_to_df(metrics: typing.List[Metric]) -> pd.DataFrame:
+go = lazy_module("plotly.graph_objects")
+plotly_subplots = lazy_module("plotly.subplots")
+pd = lazy_module("pandas")
+mlflow = lazy_module("mlflow")
+
+
+def metric_to_df(metrics: typing.List[mlflow.entities.metric.Metric]) -> pd.DataFrame:
     """
     Converts mlflow Metric object to a dataframe of 2 columns ['timestamp', 'value']
     """
@@ -27,7 +25,7 @@ def metric_to_df(metrics: typing.List[Metric]) -> pd.DataFrame:
     return pd.DataFrame(list(zip(t, v)), columns=["timestamp", "value"])
 
 
-def get_run_metrics(c: MlflowClient, run_id: str) -> typing.Dict[str, pandas.DataFrame]:
+def get_run_metrics(c: mlflow.MlflowClient, run_id: str) -> typing.Dict[str, pd.DataFrame]:
     """
     Extracts all metrics and returns a dictionary of metric name to the list of metric for the given run_id
     """
@@ -38,7 +36,7 @@ def get_run_metrics(c: MlflowClient, run_id: str) -> typing.Dict[str, pandas.Dat
     return metrics
 
 
-def get_run_params(c: MlflowClient, run_id: str) -> typing.Optional[pd.DataFrame]:
+def get_run_params(c: mlflow.MlflowClient, run_id: str) -> typing.Optional[pd.DataFrame]:
     """
     Extracts all parameters and returns a dictionary of metric name to the list of metric for the given run_id
     """
@@ -53,13 +51,13 @@ def get_run_params(c: MlflowClient, run_id: str) -> typing.Optional[pd.DataFrame
     return pd.DataFrame(list(zip(name, value)), columns=["name", "value"])
 
 
-def plot_metrics(metrics: typing.Dict[str, pandas.DataFrame]) -> typing.Optional[go.Figure]:
+def plot_metrics(metrics: typing.Dict[str, pd.DataFrame]) -> typing.Optional[go.Figure]:
     v = len(metrics)
     if v == 0:
         return None
 
     # Initialize figure with subplots
-    fig = make_subplots(rows=v, cols=1, subplot_titles=list(metrics.keys()))
+    fig = plotly_subplots.make_subplots(rows=v, cols=1, subplot_titles=list(metrics.keys()))
 
     # Add traces
     row = 1
@@ -122,7 +120,7 @@ def mlflow_autolog(fn=None, *, framework=mlflow.sklearn, experiment_name: typing
             out = fn(*args, **kwargs)
             run = mlflow.active_run()
             if run is not None:
-                client = MlflowClient()
+                client = mlflow.MlflowClient()
                 run_id = run.info.run_id
                 metrics = get_run_metrics(client, run_id)
                 figure = plot_metrics(metrics)

--- a/plugins/flytekit-modin/flytekitplugins/modin/schema.py
+++ b/plugins/flytekit-modin/flytekitplugins/modin/schema.py
@@ -2,14 +2,17 @@ import os
 import typing
 from typing import Type
 
-import modin
-from flytekit import FlyteContext
+from flytekit import FlyteContext, lazy_module
 from flytekit.extend import T, TypeEngine, TypeTransformer
 from flytekit.models.literals import Literal, Scalar, Schema
 from flytekit.models.types import LiteralType, SchemaType
 from flytekit.types.schema import LocalIOSchemaReader, LocalIOSchemaWriter, SchemaEngine, SchemaFormat, SchemaHandler
 from flytekit.types.schema.types import FlyteSchemaTransformer
 from modin import pandas
+
+
+modin = lazy_module("modin")
+pandas = lazy_module("modin.pandas")
 
 
 class ModinPandasSchemaReader(LocalIOSchemaReader[modin.pandas.DataFrame]):

--- a/plugins/flytekit-modin/flytekitplugins/modin/schema.py
+++ b/plugins/flytekit-modin/flytekitplugins/modin/schema.py
@@ -8,8 +8,6 @@ from flytekit.models.literals import Literal, Scalar, Schema
 from flytekit.models.types import LiteralType, SchemaType
 from flytekit.types.schema import LocalIOSchemaReader, LocalIOSchemaWriter, SchemaEngine, SchemaFormat, SchemaHandler
 from flytekit.types.schema.types import FlyteSchemaTransformer
-from modin import pandas
-
 
 modin = lazy_module("modin")
 pandas = lazy_module("modin.pandas")

--- a/plugins/flytekit-modin/flytekitplugins/modin/schema.py
+++ b/plugins/flytekit-modin/flytekitplugins/modin/schema.py
@@ -13,7 +13,7 @@ modin = lazy_module("modin")
 pandas = lazy_module("modin.pandas")
 
 
-class ModinPandasSchemaReader(LocalIOSchemaReader[modin.pandas.DataFrame]):
+class ModinPandasSchemaReader(LocalIOSchemaReader[pandas.DataFrame]):
     """
     Implements how ModinPandasDataFrame should be read using the ``open`` method of FlyteSchema
     """
@@ -26,13 +26,13 @@ class ModinPandasSchemaReader(LocalIOSchemaReader[modin.pandas.DataFrame]):
     ):
         super().__init__(from_path, cols, fmt)
 
-    def all(self, **kwargs) -> modin.pandas.DataFrame:
+    def all(self, **kwargs) -> pandas.DataFrame:
         if self._fmt == SchemaFormat.PARQUET:
-            return modin.pandas.read_parquet(self.from_path + "/00000")
+            return pandas.read_parquet(self.from_path + "/00000")
         raise AssertionError("Only Parquet type files are supported for modin pandas dataframe currently")
 
 
-class ModinPandasSchemaWriter(LocalIOSchemaWriter[modin.pandas.DataFrame]):
+class ModinPandasSchemaWriter(LocalIOSchemaWriter[pandas.DataFrame]):
     """
     Implements how ModinPandasDataFrame should be written to using ``open`` method of FlyteSchema
     """
@@ -45,18 +45,18 @@ class ModinPandasSchemaWriter(LocalIOSchemaWriter[modin.pandas.DataFrame]):
     ):
         super().__init__(str(to_path), cols, fmt)
 
-    def write(self, *dfs: modin.pandas.DataFrame, **kwargs):
+    def write(self, *dfs: pandas.DataFrame, **kwargs):
         if dfs is None or len(dfs) == 0:
             return
         if len(dfs) > 1:
-            raise AssertionError("Only a single modin.pandas.DataFrame can be written per variable currently")
+            raise AssertionError("Only a single pandas.DataFrame can be written per variable currently")
         if self._fmt == SchemaFormat.PARQUET:
             dfs[0].to_parquet(self.to_path + "/00000")
             return
-        raise AssertionError("Only Parquet type files are supported for modin.pandas dataframe currently")
+        raise AssertionError("Only Parquet type files are supported for pandas dataframe currently")
 
 
-class ModinPandasDataFrameTransformer(TypeTransformer[modin.pandas.DataFrame]):
+class ModinPandasDataFrameTransformer(TypeTransformer[pandas.DataFrame]):
     """
     Transforms ModinPandas DataFrame's to and from a Schema (typed/untyped)
     """
@@ -66,20 +66,20 @@ class ModinPandasDataFrameTransformer(TypeTransformer[modin.pandas.DataFrame]):
     ] = FlyteSchemaTransformer._SUPPORTED_TYPES
 
     def __init__(self):
-        super().__init__("modin.pandas-df-transformer", pandas.DataFrame)
+        super().__init__("pandas-df-transformer", pandas.DataFrame)
 
     @staticmethod
     def _get_schema_type() -> SchemaType:
         return SchemaType(columns=[])
 
-    def get_literal_type(self, t: Type[modin.pandas.DataFrame]) -> LiteralType:
+    def get_literal_type(self, t: Type[pandas.DataFrame]) -> LiteralType:
         return LiteralType(schema=self._get_schema_type())
 
     def to_literal(
         self,
         ctx: FlyteContext,
-        python_val: modin.pandas.DataFrame,
-        python_type: Type[modin.pandas.DataFrame],
+        python_val: pandas.DataFrame,
+        python_type: Type[pandas.DataFrame],
         expected: LiteralType,
     ) -> Literal:
         local_dir = ctx.file_access.get_random_local_directory()
@@ -96,10 +96,10 @@ class ModinPandasDataFrameTransformer(TypeTransformer[modin.pandas.DataFrame]):
         self,
         ctx: FlyteContext,
         lv: Literal,
-        expected_python_type: Type[modin.pandas.DataFrame],
+        expected_python_type: Type[pandas.DataFrame],
     ) -> T:
         if not (lv and lv.scalar and lv.scalar.schema):
-            return modin.pandas.DataFrame()
+            return pandas.DataFrame()
         local_dir = ctx.file_access.get_random_local_directory()
         ctx.file_access.download_directory(lv.scalar.schema.uri, local_dir)
         r = ModinPandasSchemaReader(from_path=local_dir, cols=None, fmt=SchemaFormat.PARQUET)
@@ -108,8 +108,8 @@ class ModinPandasDataFrameTransformer(TypeTransformer[modin.pandas.DataFrame]):
 
 SchemaEngine.register_handler(
     SchemaHandler(
-        "modin.pandas.Dataframe-Schema",
-        modin.pandas.DataFrame,
+        "pandas.Dataframe-Schema",
+        pandas.DataFrame,
         ModinPandasSchemaReader,
         ModinPandasSchemaWriter,
     )

--- a/plugins/flytekit-onnx-pytorch/flytekitplugins/onnxpytorch/schema.py
+++ b/plugins/flytekit-onnx-pytorch/flytekitplugins/onnxpytorch/schema.py
@@ -3,17 +3,18 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple, Type, Union
 
-import torch
 from dataclasses_json import DataClassJsonMixin
-from torch.onnx import OperatorExportTypes, TrainingMode
 from typing_extensions import Annotated, get_args, get_origin
 
-from flytekit import FlyteContext
+from flytekit import FlyteContext, lazy_module
 from flytekit.core.type_engine import TypeEngine, TypeTransformer, TypeTransformerFailedError
 from flytekit.models.core.types import BlobType
 from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
 from flytekit.types.file import ONNXFile
+
+
+torch = lazy_module("torch")
 
 
 @dataclass
@@ -40,11 +41,11 @@ class PyTorch2ONNXConfig(DataClassJsonMixin):
     args: Union[Tuple, torch.Tensor]
     export_params: bool = True
     verbose: bool = False
-    training: TrainingMode = TrainingMode.EVAL
+    training: torch.onnx.TrainingMode = torch.onnx.TrainingMode.EVAL
     opset_version: int = 9
     input_names: List[str] = field(default_factory=list)
     output_names: List[str] = field(default_factory=list)
-    operator_export_type: Optional[OperatorExportTypes] = None
+    operator_export_type: Optional[torch.onnx.OperatorExportTypes] = None
     do_constant_folding: bool = False
     dynamic_axes: Union[Dict[str, Dict[int, str]], Dict[str, List[int]]] = field(default_factory=dict)
     keep_initializers_as_inputs: Optional[bool] = None

--- a/plugins/flytekit-onnx-pytorch/flytekitplugins/onnxpytorch/schema.py
+++ b/plugins/flytekit-onnx-pytorch/flytekitplugins/onnxpytorch/schema.py
@@ -13,7 +13,6 @@ from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
 from flytekit.types.file import ONNXFile
 
-
 torch = lazy_module("torch")
 
 

--- a/plugins/flytekit-onnx-scikitlearn/flytekitplugins/onnxscikitlearn/schema.py
+++ b/plugins/flytekit-onnx-scikitlearn/flytekitplugins/onnxscikitlearn/schema.py
@@ -14,9 +14,9 @@ from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
 from flytekit.types.file import ONNXFile
 
-
 sklearn = lazy_module("sklearn")
 skl2onnx = lazy_module("skl2onnx")
+skl2onnx_data_types = lazy_module("skl2onnx.common.data_types")
 
 
 @dataclass
@@ -58,14 +58,14 @@ class ScikitLearn2ONNXConfig(DataClassJsonMixin):
 
     def __post_init__(self):
         validate_initial_types = [
-            True for item in self.initial_types if item in inspect.getmembers(skl2onnx.common.data_types)
+            True for item in self.initial_types if item in inspect.getmembers(skl2onnx_data_types)
         ]
         if not all(validate_initial_types):
             raise ValueError("All types in initial_types must be in skl2onnx.common.data_types")
 
         if self.final_types:
             validate_final_types = [
-                True for item in self.final_types if item in inspect.getmembers(skl2onnx.common.data_types)
+                True for item in self.final_types if item in inspect.getmembers(skl2onnx_data_types)
             ]
             if not all(validate_final_types):
                 raise ValueError("All types in final_types must be in skl2onnx.common.data_types")

--- a/plugins/flytekit-onnx-scikitlearn/flytekitplugins/onnxscikitlearn/schema.py
+++ b/plugins/flytekit-onnx-scikitlearn/flytekitplugins/onnxscikitlearn/schema.py
@@ -4,18 +4,19 @@ import inspect
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
-import skl2onnx.common.data_types
 from dataclasses_json import DataClassJsonMixin
-from skl2onnx import convert_sklearn
-from sklearn.base import BaseEstimator
 from typing_extensions import Annotated, get_args, get_origin
 
-from flytekit import FlyteContext
+from flytekit import FlyteContext, lazy_module
 from flytekit.core.type_engine import TypeEngine, TypeTransformer, TypeTransformerFailedError
 from flytekit.models.core.types import BlobType
 from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
 from flytekit.types.file import ONNXFile
+
+
+sklearn = lazy_module("sklearn")
+skl2onnx = lazy_module("skl2onnx")
 
 
 @dataclass
@@ -72,7 +73,7 @@ class ScikitLearn2ONNXConfig(DataClassJsonMixin):
 
 @dataclass
 class ScikitLearn2ONNX(DataClassJsonMixin):
-    model: BaseEstimator = field(default=None)
+    model: sklearn.base.BaseEstimator = field(default=None)
 
 
 def extract_config(t: Type[ScikitLearn2ONNX]) -> Tuple[Type[ScikitLearn2ONNX], ScikitLearn2ONNXConfig]:
@@ -90,7 +91,7 @@ def extract_config(t: Type[ScikitLearn2ONNX]) -> Tuple[Type[ScikitLearn2ONNX], S
 def to_onnx(ctx, model, config):
     local_path = ctx.file_access.get_random_local_path()
 
-    onx = convert_sklearn(model, **config)
+    onx = skl2onnx.convert_sklearn(model, **config)
 
     with open(local_path, "wb") as f:
         f.write(onx.SerializeToString())

--- a/plugins/flytekit-onnx-tensorflow/flytekitplugins/onnxtensorflow/schema.py
+++ b/plugins/flytekit-onnx-tensorflow/flytekitplugins/onnxtensorflow/schema.py
@@ -1,18 +1,20 @@
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
-import numpy as np
-import tensorflow as tf
-import tf2onnx
 from dataclasses_json import DataClassJsonMixin
 from typing_extensions import Annotated, get_args, get_origin
 
-from flytekit import FlyteContext
+from flytekit import FlyteContext, lazy_module
 from flytekit.core.type_engine import TypeEngine, TypeTransformer, TypeTransformerFailedError
 from flytekit.models.core.types import BlobType
 from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
 from flytekit.types.file import ONNXFile
+
+
+np = lazy_module("numpy")
+tf = lazy_module("tensorflow")
+tf2onnx = lazy_module("tf2onnx")
 
 
 @dataclass

--- a/plugins/flytekit-onnx-tensorflow/flytekitplugins/onnxtensorflow/schema.py
+++ b/plugins/flytekit-onnx-tensorflow/flytekitplugins/onnxtensorflow/schema.py
@@ -11,7 +11,6 @@ from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
 from flytekit.types.file import ONNXFile
 
-
 np = lazy_module("numpy")
 tf = lazy_module("tensorflow")
 tf2onnx = lazy_module("tf2onnx")

--- a/plugins/flytekit-pandera/flytekitplugins/pandera/schema.py
+++ b/plugins/flytekit-pandera/flytekitplugins/pandera/schema.py
@@ -8,7 +8,6 @@ from flytekit.models.types import LiteralType, SchemaType
 from flytekit.types.schema import FlyteSchema, PandasSchemaWriter, SchemaFormat, SchemaOpenMode
 from flytekit.types.schema.types import FlyteSchemaTransformer
 
-
 pandas = lazy_module("pandas")
 pandera = lazy_module("pandera")
 

--- a/plugins/flytekit-pandera/flytekitplugins/pandera/schema.py
+++ b/plugins/flytekit-pandera/flytekitplugins/pandera/schema.py
@@ -1,15 +1,16 @@
 import typing
 from typing import Type
 
-import pandas
-
-import pandera
-from flytekit import FlyteContext
+from flytekit import FlyteContext, lazy_module
 from flytekit.extend import TypeEngine, TypeTransformer
 from flytekit.models.literals import Literal, Scalar, Schema
 from flytekit.models.types import LiteralType, SchemaType
 from flytekit.types.schema import FlyteSchema, PandasSchemaWriter, SchemaFormat, SchemaOpenMode
 from flytekit.types.schema.types import FlyteSchemaTransformer
+
+
+pandas = lazy_module("pandas")
+pandera = lazy_module("pandera")
 
 T = typing.TypeVar("T")
 

--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -6,14 +6,11 @@ import tempfile
 import typing
 from typing import Any
 
-import nbformat
 from flyteidl.core.literals_pb2 import Literal as _pb2_Literal
 from flyteidl.core.literals_pb2 import LiteralMap as _pb2_LiteralMap
 from google.protobuf import text_format as _text_format
-from nbconvert import HTMLExporter
 
-import papermill as pm
-from flytekit import FlyteContext, PythonInstanceTask, StructuredDataset
+from flytekit import FlyteContext, PythonInstanceTask, StructuredDataset, lazy_module
 from flytekit.configuration import SerializationSettings
 from flytekit.core import utils
 from flytekit.core.context_manager import ExecutionParameters
@@ -27,6 +24,10 @@ from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import FlyteFile, HTMLPage, PythonNotebook
 
 T = typing.TypeVar("T")
+
+nbformat = lazy_module("nbformat")
+pm = lazy_module("papermill")
+nbconvert = lazy_module("nbconvert")
 
 
 def _dummy_task_func():
@@ -245,7 +246,7 @@ class NotebookTask(PythonInstanceTask[T]):
         We are using nbconvert htmlexporter and its classic template
         later about how to customize the exporter further.
         """
-        html_exporter = HTMLExporter()
+        html_exporter = nbconvert.HTMLExporter()
         html_exporter.template_name = "classic"
         nb = nbformat.read(from_nb, as_version=4)
         (body, resources) = html_exporter.from_notebook_node(nb)

--- a/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
+++ b/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
@@ -14,7 +14,6 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDatasetTransformerEngine,
 )
 
-
 pd = lazy_module("pandas")
 pl = lazy_module("polars")
 fsspec_utils = lazy_module("fsspec.utils")

--- a/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
+++ b/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
@@ -1,11 +1,7 @@
 import io
 import typing
 
-import pandas as pd
-from fsspec.utils import get_protocol
-
-import polars as pl
-from flytekit import FlyteContext
+from flytekit import FlyteContext, lazy_module
 from flytekit.core.data_persistence import get_fsspec_storage_options
 from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
@@ -17,6 +13,11 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDatasetEncoder,
     StructuredDatasetTransformerEngine,
 )
+
+
+pd = lazy_module("pandas")
+pl = lazy_module("polars")
+fsspec_utils = lazy_module("fsspec.utils")
 
 
 class PolarsDataFrameRenderer:
@@ -72,7 +73,10 @@ class ParquetToPolarsDataFrameDecodingHandler(StructuredDatasetDecoder):
     ) -> pl.DataFrame:
         uri = flyte_value.uri
 
-        kwargs = get_fsspec_storage_options(protocol=get_protocol(uri), data_config=ctx.file_access.data_config)
+        kwargs = get_fsspec_storage_options(
+            protocol=fsspec_utils.get_protocol(uri),
+            data_config=ctx.file_access.data_config,
+        )
         if current_task_metadata.structured_dataset_type and current_task_metadata.structured_dataset_type.columns:
             columns = [c.name for c in current_task_metadata.structured_dataset_type.columns]
             return pl.read_parquet(uri, columns=columns, use_pyarrow=True, storage_options=kwargs)

--- a/plugins/flytekit-pydantic/flytekitplugins/pydantic/basemodel_transformer.py
+++ b/plugins/flytekit-pydantic/flytekitplugins/pydantic/basemodel_transformer.py
@@ -5,12 +5,14 @@ from typing import Dict, Type
 from google.protobuf import json_format
 from typing_extensions import Annotated
 
-import pydantic
-from flytekit import FlyteContext
+from flytekit import FlyteContext, lazy_module
 from flytekit.core import type_engine
 from flytekit.models import literals, types
 
 from . import deserialization, serialization
+
+
+pydantic = lazy_module("pydantic")
 
 BaseModelLiterals = Annotated[
     Dict[str, literals.Literal],

--- a/plugins/flytekit-pydantic/flytekitplugins/pydantic/basemodel_transformer.py
+++ b/plugins/flytekit-pydantic/flytekitplugins/pydantic/basemodel_transformer.py
@@ -11,7 +11,6 @@ from flytekit.models import literals, types
 
 from . import deserialization, serialization
 
-
 pydantic = lazy_module("pydantic")
 
 BaseModelLiterals = Annotated[

--- a/plugins/flytekit-pydantic/flytekitplugins/pydantic/commons.py
+++ b/plugins/flytekit-pydantic/flytekitplugins/pydantic/commons.py
@@ -3,11 +3,14 @@ import datetime
 import typing
 from typing import Set
 
-import numpy
-import pyarrow
 from typing_extensions import Annotated
 
+from flytekit import lazy_module
 from flytekit.core import type_engine
+
+
+numpy = lazy_module("numpy")
+pyarrow = lazy_module("pyarrow")
 
 MODULES_TO_EXCLUDE_FROM_FLYTE_TYPES: Set[str] = {m.__name__ for m in [builtins, typing, datetime, pyarrow, numpy]}
 

--- a/plugins/flytekit-pydantic/flytekitplugins/pydantic/commons.py
+++ b/plugins/flytekit-pydantic/flytekitplugins/pydantic/commons.py
@@ -8,7 +8,6 @@ from typing_extensions import Annotated
 from flytekit import lazy_module
 from flytekit.core import type_engine
 
-
 numpy = lazy_module("numpy")
 pyarrow = lazy_module("pyarrow")
 

--- a/plugins/flytekit-pydantic/flytekitplugins/pydantic/deserialization.py
+++ b/plugins/flytekit-pydantic/flytekitplugins/pydantic/deserialization.py
@@ -8,7 +8,6 @@ from flytekit.core import context_manager, type_engine
 from flytekit.models import literals
 from flytekit.types import directory, file
 
-
 pydantic = lazy_module("pydantic")
 
 # this field is used by pydantic to get the validator method

--- a/plugins/flytekit-pydantic/flytekitplugins/pydantic/deserialization.py
+++ b/plugins/flytekit-pydantic/flytekitplugins/pydantic/deserialization.py
@@ -3,10 +3,13 @@ from typing import Any, Callable, Dict, Generator, Iterator, List, Optional, Typ
 
 from flytekitplugins.pydantic import commons, serialization
 
-import pydantic
+from flytekit import lazy_module
 from flytekit.core import context_manager, type_engine
 from flytekit.models import literals
 from flytekit.types import directory, file
+
+
+pydantic = lazy_module("pydantic")
 
 # this field is used by pydantic to get the validator method
 PYDANTIC_VALIDATOR_METHOD_NAME = pydantic.BaseModel.__get_validators__.__name__

--- a/plugins/flytekit-pydantic/flytekitplugins/pydantic/serialization.py
+++ b/plugins/flytekit-pydantic/flytekitplugins/pydantic/serialization.py
@@ -20,7 +20,6 @@ from flytekit.models import literals
 
 from . import commons
 
-
 pydantic = lazy_module("pydantic")
 
 BASEMODEL_JSON_KEY = "BaseModel JSON"

--- a/plugins/flytekit-pydantic/flytekitplugins/pydantic/serialization.py
+++ b/plugins/flytekit-pydantic/flytekitplugins/pydantic/serialization.py
@@ -14,11 +14,14 @@ from typing import Any, Dict, Union, cast
 from google.protobuf import json_format, struct_pb2
 from typing_extensions import Annotated
 
-import pydantic
+from flytekit import lazy_module
 from flytekit.core import context_manager, type_engine
 from flytekit.models import literals
 
 from . import commons
+
+
+pydantic = lazy_module("pydantic")
 
 BASEMODEL_JSON_KEY = "BaseModel JSON"
 OBJECTS_KEY = "Serialized Flyte Objects"

--- a/plugins/flytekit-ray/flytekitplugins/ray/task.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/task.py
@@ -7,11 +7,14 @@ from typing import Any, Callable, Dict, Optional
 from flytekitplugins.ray.models import HeadGroupSpec, RayCluster, RayJob, WorkerGroupSpec
 from google.protobuf.json_format import MessageToDict
 
-import ray
+from flytekit import lazy_module
 from flytekit.configuration import SerializationSettings
 from flytekit.core.context_manager import ExecutionParameters
 from flytekit.core.python_function_task import PythonFunctionTask
 from flytekit.extend import TaskPlugins
+
+
+ray = lazy_module("ray")
 
 
 @dataclass

--- a/plugins/flytekit-ray/flytekitplugins/ray/task.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/task.py
@@ -13,7 +13,6 @@ from flytekit.core.context_manager import ExecutionParameters
 from flytekit.core.python_function_task import PythonFunctionTask
 from flytekit.extend import TaskPlugins
 
-
 ray = lazy_module("ray")
 
 

--- a/plugins/flytekit-snowflake/flytekitplugins/snowflake/agent.py
+++ b/plugins/flytekit-snowflake/flytekitplugins/snowflake/agent.py
@@ -12,14 +12,13 @@ from flyteidl.admin.agent_pb2 import (
     Resource,
 )
 
-from flytekit import FlyteContextManager, StructuredDataset, logger, lazy_module
+from flytekit import FlyteContextManager, StructuredDataset, lazy_module, logger
 from flytekit.core.type_engine import TypeEngine
 from flytekit.extend.backend.base_agent import AgentBase, AgentRegistry, convert_to_flyte_state
 from flytekit.models import literals
 from flytekit.models.literals import LiteralMap
 from flytekit.models.task import TaskTemplate
 from flytekit.models.types import LiteralType, StructuredDatasetType
-
 
 snowflake_connector = lazy_module("snowflake.connector")
 

--- a/plugins/flytekit-snowflake/tests/test_agent.py
+++ b/plugins/flytekit-snowflake/tests/test_agent.py
@@ -10,6 +10,7 @@ from flyteidl.admin.agent_pb2 import SUCCEEDED, DeleteTaskResponse
 from flytekitplugins.snowflake.agent import Metadata
 
 import flytekit.models.interface as interface_models
+from flytekit import lazy_module
 from flytekit.extend.backend.base_agent import AgentRegistry
 from flytekit.interfaces.cli_identifiers import Identifier
 from flytekit.models import literals, task, types
@@ -18,14 +19,15 @@ from flytekit.models.task import Sql, TaskTemplate
 
 
 @mock.patch("flytekitplugins.snowflake.agent.SnowflakeAgent.get_private_key", return_value="pb")
-@mock.patch("snowflake.connector.connect")
 @pytest.mark.asyncio
-async def test_snowflake_agent(mock_conn, mock_get_private_key):
+async def test_snowflake_agent(mock_get_private_key):
     query_status_mock = MagicMock()
     query_status_mock.name = "SUCCEEDED"
 
     # Configure the mock connection to return the mock status object
-    mock_conn_instance = mock_conn.return_value
+    snowflake_connector = lazy_module("snowflake.connector")
+    snowflake_connector.connect = MagicMock()
+    mock_conn_instance = snowflake_connector.connect.return_value
     mock_conn_instance.get_query_status_throw_if_error.return_value = query_status_mock
 
     ctx = MagicMock(spec=grpc.ServicerContext)

--- a/plugins/flytekit-spark/flytekitplugins/spark/agent.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/agent.py
@@ -14,7 +14,6 @@ from flytekit.models.core.execution import TaskLog
 from flytekit.models.literals import LiteralMap
 from flytekit.models.task import TaskTemplate
 
-
 aiohttp = lazy_module("aiohttp")
 
 DATABRICKS_API_ENDPOINT = "/api/2.1/jobs"

--- a/plugins/flytekit-spark/flytekitplugins/spark/agent.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/agent.py
@@ -5,14 +5,17 @@ import typing
 from dataclasses import dataclass
 from typing import Optional
 
-import aiohttp
 import grpc
 from flyteidl.admin.agent_pb2 import PENDING, CreateTaskResponse, DeleteTaskResponse, GetTaskResponse, Resource
 
+from flytekit import lazy_module
 from flytekit.extend.backend.base_agent import AgentBase, AgentRegistry, convert_to_flyte_state, get_agent_secret
 from flytekit.models.core.execution import TaskLog
 from flytekit.models.literals import LiteralMap
 from flytekit.models.task import TaskTemplate
+
+
+aiohttp = lazy_module("aiohttp")
 
 DATABRICKS_API_ENDPOINT = "/api/2.1/jobs"
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/pyspark_transformers.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/pyspark_transformers.py
@@ -4,7 +4,6 @@ from flytekit import Blob, BlobMetadata, BlobType, FlyteContext, Literal, Litera
 from flytekit.core.type_engine import TypeEngine
 from flytekit.extend import TypeTransformer
 
-
 pyspark_ml = lazy_module("pyspark.ml")
 PipelineModel = pyspark_ml.PipelineModel
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/pyspark_transformers.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/pyspark_transformers.py
@@ -1,10 +1,12 @@
 from typing import Type
 
-from pyspark.ml import PipelineModel
-
-from flytekit import Blob, BlobMetadata, BlobType, FlyteContext, Literal, LiteralType, Scalar
+from flytekit import Blob, BlobMetadata, BlobType, FlyteContext, Literal, LiteralType, Scalar, lazy_module
 from flytekit.core.type_engine import TypeEngine
 from flytekit.extend import TypeTransformer
+
+
+pyspark_ml = lazy_module("pyspark.ml")
+PipelineModel = pyspark_ml.PipelineModel
 
 
 class PySparkPipelineModelTransformer(TypeTransformer[PipelineModel]):

--- a/plugins/flytekit-spark/flytekitplugins/spark/schema.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/schema.py
@@ -7,7 +7,6 @@ from flytekit.models.literals import Literal, Scalar, Schema
 from flytekit.models.types import LiteralType, SchemaType
 from flytekit.types.schema import SchemaEngine, SchemaFormat, SchemaHandler, SchemaReader, SchemaWriter
 
-
 pyspark = lazy_module("pyspark")
 
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/schema.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/schema.py
@@ -1,13 +1,14 @@
 import typing
 from typing import Type
 
-import pyspark
-
-from flytekit import FlyteContext
+from flytekit import FlyteContext, lazy_module
 from flytekit.extend import T, TypeEngine, TypeTransformer
 from flytekit.models.literals import Literal, Scalar, Schema
 from flytekit.models.types import LiteralType, SchemaType
 from flytekit.types.schema import SchemaEngine, SchemaFormat, SchemaHandler, SchemaReader, SchemaWriter
+
+
+pyspark = lazy_module("pyspark")
 
 
 class SparkDataFrameSchemaReader(SchemaReader[pyspark.sql.DataFrame]):

--- a/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
@@ -1,10 +1,6 @@
 import typing
 
-import pandas as pd
-import pyspark
-from pyspark.sql.dataframe import DataFrame
-
-from flytekit import FlyteContext
+from flytekit import FlyteContext, lazy_module
 from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import StructuredDatasetType
@@ -15,6 +11,11 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDatasetEncoder,
     StructuredDatasetTransformerEngine,
 )
+
+pd = lazy_module("pandas")
+pyspark = lazy_module("pyspark")
+ps_dataframe = lazy_module("pyspark.sql.dataframe")
+DataFrame = ps_dataframe.DataFrame
 
 
 class SparkDataFrameRenderer:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, Optional, Union, cast
 
 from google.protobuf.json_format import MessageToDict
 
-from flytekit import FlyteContextManager, PythonFunctionTask, logger, lazy_module
+from flytekit import FlyteContextManager, PythonFunctionTask, lazy_module, logger
 from flytekit.configuration import DefaultImages, SerializationSettings
 from flytekit.core.context_manager import ExecutionParameters
 from flytekit.extend import ExecutionState, TaskPlugins
@@ -12,7 +12,6 @@ from flytekit.extend.backend.base_agent import AsyncAgentExecutorMixin
 from flytekit.image_spec import ImageSpec
 
 from .models import SparkJob, SparkType
-
 
 pyspark_sql = lazy_module("pyspark.sql")
 SparkSession = pyspark_sql.SparkSession

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -3,9 +3,8 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Union, cast
 
 from google.protobuf.json_format import MessageToDict
-from pyspark.sql import SparkSession
 
-from flytekit import FlyteContextManager, PythonFunctionTask, logger
+from flytekit import FlyteContextManager, PythonFunctionTask, logger, lazy_module
 from flytekit.configuration import DefaultImages, SerializationSettings
 from flytekit.core.context_manager import ExecutionParameters
 from flytekit.extend import ExecutionState, TaskPlugins
@@ -13,6 +12,10 @@ from flytekit.extend.backend.base_agent import AsyncAgentExecutorMixin
 from flytekit.image_spec import ImageSpec
 
 from .models import SparkJob, SparkType
+
+
+pyspark_sql = lazy_module("pyspark.sql")
+SparkSession = pyspark_sql.SparkSession
 
 
 @dataclass

--- a/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
+++ b/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
@@ -11,8 +11,6 @@ from flytekit.loggers import logger
 from flytekit.models import task as task_models
 from flytekit.models.security import Secret
 from flytekit.types.schema import FlyteSchema
-from sqlalchemy import create_engine, text  # type: ignore
-
 
 pd = lazy_module("pandas")
 pandas_io_sql = lazy_module("pandas.io.sql")

--- a/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
+++ b/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
@@ -1,10 +1,7 @@
 import typing
 from dataclasses import dataclass
 
-import pandas as pd
-from pandas.io.sql import pandasSQL_builder
-
-from flytekit import current_context, kwtypes
+from flytekit import current_context, kwtypes, lazy_module
 from flytekit.configuration import SerializationSettings
 from flytekit.configuration.default_images import DefaultImages, PythonVersion
 from flytekit.core.base_sql_task import SQLTask
@@ -15,6 +12,11 @@ from flytekit.models import task as task_models
 from flytekit.models.security import Secret
 from flytekit.types.schema import FlyteSchema
 from sqlalchemy import create_engine, text  # type: ignore
+
+
+pd = lazy_module("pandas")
+pandas_io_sql = lazy_module("pandas.io.sql")
+sqlalchemy = lazy_module("sqlalchemy")
 
 
 class SQLAlchemyDefaultImages(DefaultImages):
@@ -126,7 +128,7 @@ class SQLAlchemyTaskExecutor(ShimTaskExecutor[SQLAlchemyTask]):
                 value = current_context().secrets.get(group=secret_dict["group"], key=secret_dict["key"])
                 tt.custom["connect_args"][key] = value
 
-        engine = create_engine(tt.custom["uri"], connect_args=tt.custom["connect_args"], echo=False)
+        engine = sqlalchemy.create_engine(tt.custom["uri"], connect_args=tt.custom["connect_args"], echo=False)
         logger.info(f"Connecting to db {tt.custom['uri']}")
 
         interpolated_query = SQLAlchemyTask.interpolate_query(tt.custom["query_template"], **kwargs)
@@ -134,7 +136,7 @@ class SQLAlchemyTaskExecutor(ShimTaskExecutor[SQLAlchemyTask]):
         with engine.begin() as connection:
             df = None
             if tt.interface.outputs:
-                df = pd.read_sql_query(text(interpolated_query), connection)
+                df = pd.read_sql_query(sqlalchemy.text(interpolated_query), connection)
             else:
-                pandasSQL_builder(connection).execute(text(interpolated_query))
+                pandas_io_sql.pandasSQL_builder(connection).execute(sqlalchemy.text(interpolated_query))
         return df

--- a/plugins/flytekit-vaex/flytekitplugins/vaex/sd_transformers.py
+++ b/plugins/flytekit-vaex/flytekitplugins/vaex/sd_transformers.py
@@ -1,10 +1,7 @@
 import os
 import typing
 
-import pandas as pd
-
-import vaex
-from flytekit import FlyteContext, StructuredDatasetType
+from flytekit import FlyteContext, StructuredDatasetType, lazy_module
 from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.types.structured.structured_dataset import (
@@ -14,6 +11,9 @@ from flytekit.types.structured.structured_dataset import (
     StructuredDatasetEncoder,
     StructuredDatasetTransformerEngine,
 )
+
+pd = lazy_module("pandas")
+vaex = lazy_module("vaex")
 
 
 class VaexDataFrameToParquetEncodingHandler(StructuredDatasetEncoder):

--- a/plugins/flytekit-vaex/setup.py
+++ b/plugins/flytekit-vaex/setup.py
@@ -9,6 +9,7 @@ plugin_requires = [
     "flytekit>=1.3.0b2,<2.0.0",
     "vaex-core>=4.13.0,<4.14; python_version < '3.10'",
     "vaex-core>=4.16.0; python_version >= '3.10'",
+    "pandas",
     "pydantic<2.0",
 ]
 

--- a/plugins/flytekit-whylogs/flytekitplugins/whylogs/renderer.py
+++ b/plugins/flytekit-whylogs/flytekitplugins/whylogs/renderer.py
@@ -1,7 +1,7 @@
 from flytekit import lazy_module
 
-
 why = lazy_module("whylogs")
+constaints = lazy_module("whylogs.core.constraints")
 pd = lazy_module("pandas")
 
 
@@ -60,7 +60,7 @@ class WhylogsConstraintsRenderer:
     """
 
     @staticmethod
-    def to_html(constraints: why.core.constraints.Constraints) -> str:
+    def to_html(constraints: constaints.Constraints) -> str:
         viz = why.viz.NotebookProfileVisualizer()
         report = viz.constraints_report(constraints=constraints)
         return report.data

--- a/plugins/flytekit-whylogs/flytekitplugins/whylogs/renderer.py
+++ b/plugins/flytekit-whylogs/flytekitplugins/whylogs/renderer.py
@@ -1,8 +1,8 @@
-from pandas import DataFrame
+from flytekit import lazy_module
 
-import whylogs as why
-from whylogs.core.constraints import Constraints
-from whylogs.viz import NotebookProfileVisualizer
+
+why = lazy_module("whylogs")
+pd = lazy_module("pandas")
 
 
 class WhylogsSummaryDriftRenderer:
@@ -13,7 +13,7 @@ class WhylogsSummaryDriftRenderer:
     """
 
     @staticmethod
-    def to_html(reference_data: DataFrame, target_data: DataFrame) -> str:
+    def to_html(reference_data: pd.DataFrame, target_data: pd.DataFrame) -> str:
         """
         This static method will profile the input data and then generate an HTML report
         with the Summary Drift calculations for all the dataframe's columns
@@ -27,7 +27,7 @@ class WhylogsSummaryDriftRenderer:
 
         target_view = why.log(target_data).view()
         reference_view = why.log(reference_data).view()
-        viz = NotebookProfileVisualizer()
+        viz = why.viz.NotebookProfileVisualizer()
         viz.set_profiles(target_profile_view=target_view, reference_profile_view=reference_view)
         return viz.summary_drift_report().data
 
@@ -60,7 +60,7 @@ class WhylogsConstraintsRenderer:
     """
 
     @staticmethod
-    def to_html(constraints: Constraints) -> str:
-        viz = NotebookProfileVisualizer()
+    def to_html(constraints: why.core.constraints.Constraints) -> str:
+        viz = why.viz.NotebookProfileVisualizer()
         report = viz.constraints_report(constraints=constraints)
         return report.data


### PR DESCRIPTION
## Tracking issue
Fixes https://github.com/flyteorg/flyte/issues/4401

## Why are the changes needed?

This change is primarily to simplify the dependencies needed for things like generating API reference documentation for flytekit. Before one needed all dependencies of all plugins to render API docs.

## What changes were proposed in this pull request?

Use `flytekit.lazy_module` to lazily load modules in the plugin packages.

## How was this patch tested?

Run tests locally with pytest