### PR TITLE
Flyin - VSCode default directory

### DIFF
--- a/flytekit/models/literals.py
+++ b/flytekit/models/literals.py
@@ -8,10 +8,11 @@ from google.protobuf.struct_pb2 import Struct
 from flytekit.exceptions import user as _user_exceptions
 from flytekit.models import common as _common
 from flytekit.models.core import types as _core_types
-from flytekit.models.types import Error, StructuredDatasetType
+from flytekit.models.types import Error
 from flytekit.models.types import LiteralType as _LiteralType
 from flytekit.models.types import OutputReference as _OutputReference
 from flytekit.models.types import SchemaType as _SchemaType
+from flytekit.models.types import StructuredDatasetType
 
 
 class RetryStrategy(_common.FlyteIdlEntity):

--- a/flytekit/models/literals.py
+++ b/flytekit/models/literals.py
@@ -8,11 +8,10 @@ from google.protobuf.struct_pb2 import Struct
 from flytekit.exceptions import user as _user_exceptions
 from flytekit.models import common as _common
 from flytekit.models.core import types as _core_types
-from flytekit.models.types import Error
+from flytekit.models.types import Error, StructuredDatasetType
 from flytekit.models.types import LiteralType as _LiteralType
 from flytekit.models.types import OutputReference as _OutputReference
 from flytekit.models.types import SchemaType as _SchemaType
-from flytekit.models.types import StructuredDatasetType
 
 
 class RetryStrategy(_common.FlyteIdlEntity):

--- a/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
+++ b/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
@@ -435,10 +435,14 @@ class vscode(ClassDecorator):
         prepare_launch_json()
 
         # 5. Launches and monitors the VSCode server.
-        # Run the function in the background
+        #    Run the function in the background.
+        #    Make the task function's source file directory the default directory.
+        task_function_source_dir = os.path.dirname(
+            FlyteContextManager.current_context().user_space_params.TASK_FUNCTION_SOURCE_PATH
+        )
         child_process = multiprocessing.Process(
             target=execute_command,
-            kwargs={"cmd": f"code-server --bind-addr 0.0.0.0:{self.port} --auth none"},
+            kwargs={"cmd": f"code-server --bind-addr 0.0.0.0:{self.port} --auth none {task_function_source_dir}"},
         )
         child_process.start()
 


### PR DESCRIPTION
## Tracking issue
_https://github.com/flyteorg/flyte/issues/4284_

## Why are the changes needed?
Previously, when users accessed the VSCode server by navigating to `http://localhost:8080` in their web browser, they were not directed to a specific directory. This could be confusing, especially for those who are not familiar with VSCode, as they might not see their code files immediately.


## What changes were proposed in this pull request?
The proposed change sets a default directory for the VSCode server. Now, when users connect to the server without setting the folder argument such as `http://localhost:8080`, VSCode server will automatically open the directory where the task function's source files are located, which is `http://localhost:8080/?folder=/root`.
<img width="1624" alt="截圖 2023-12-14 上午12 07 45" src="https://github.com/flyteorg/flytekit/assets/114708546/0e08d3b6-2368-4036-af5f-aa0733c7b297">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

