### PR TITLE
Fix: Improve error handling in workflow compilation when output binding fails

### DIFF
--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -756,7 +756,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
                 )
                 bindings.append(b)
             except Exception as e:
-                raise AssertionError(f"Failed to bind output {output_names[0]} for function {self.name}.") from e
+                raise AssertionError(f"Failed to bind output {output_names[0]} for function {self.name}: {e}") from e
         elif len(output_names) > 1:
             if not isinstance(workflow_outputs, tuple):
                 raise AssertionError("The Workflow specification indicates multiple return values, received only one")
@@ -776,7 +776,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
                     )
                     bindings.append(b)
                 except Exception as e:
-                    raise AssertionError(f"Failed to bind output {out} for function {self.name}.") from e
+                    raise AssertionError(f"Failed to bind output {out} for function {self.name}: {e}") from e
 
         # Save all the things necessary to create an WorkflowTemplate, except for the missing project and domain
         self._nodes = all_nodes

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -756,7 +756,9 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
                 )
                 bindings.append(b)
             except Exception as e:
-                raise FlyteValidationException(f"Failed to bind output {output_names[0]} for function {self.name}: {e}") from e
+                raise FlyteValidationException(
+                    f"Failed to bind output {output_names[0]} for function {self.name}: {e}"
+                ) from e
         elif len(output_names) > 1:
             if not isinstance(workflow_outputs, tuple):
                 raise AssertionError("The Workflow specification indicates multiple return values, received only one")

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -746,14 +746,17 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
                     )
                 workflow_outputs = workflow_outputs[0]
             t = self.python_interface.outputs[output_names[0]]
-            b, _ = binding_from_python_std(
-                ctx,
-                output_names[0],
-                self.interface.outputs[output_names[0]].type,
-                workflow_outputs,
-                t,
-            )
-            bindings.append(b)
+            try:
+                b, _ = binding_from_python_std(
+                    ctx,
+                    output_names[0],
+                    self.interface.outputs[output_names[0]].type,
+                    workflow_outputs,
+                    t,
+                )
+                bindings.append(b)
+            except Exception as e:
+                raise AssertionError(f"Failed to bind output {output_names[0]} for function {self.name}.") from e
         elif len(output_names) > 1:
             if not isinstance(workflow_outputs, tuple):
                 raise AssertionError("The Workflow specification indicates multiple return values, received only one")
@@ -763,14 +766,17 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
                 if isinstance(workflow_outputs[i], ConditionalSection):
                     raise AssertionError("A Conditional block (if-else) should always end with an `else_()` clause")
                 t = self.python_interface.outputs[out]
-                b, _ = binding_from_python_std(
-                    ctx,
-                    out,
-                    self.interface.outputs[out].type,
-                    workflow_outputs[i],
-                    t,
-                )
-                bindings.append(b)
+                try:
+                    b, _ = binding_from_python_std(
+                        ctx,
+                        out,
+                        self.interface.outputs[out].type,
+                        workflow_outputs[i],
+                        t,
+                    )
+                    bindings.append(b)
+                except Exception as e:
+                    raise AssertionError(f"Failed to bind output {out} for function {self.name}.") from e
 
         # Save all the things necessary to create an WorkflowTemplate, except for the missing project and domain
         self._nodes = all_nodes

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -756,7 +756,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
                 )
                 bindings.append(b)
             except Exception as e:
-                raise AssertionError(f"Failed to bind output {output_names[0]} for function {self.name}: {e}") from e
+                raise FlyteValidationException(f"Failed to bind output {output_names[0]} for function {self.name}: {e}") from e
         elif len(output_names) > 1:
             if not isinstance(workflow_outputs, tuple):
                 raise AssertionError("The Workflow specification indicates multiple return values, received only one")
@@ -776,7 +776,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
                     )
                     bindings.append(b)
                 except Exception as e:
-                    raise AssertionError(f"Failed to bind output {out} for function {self.name}: {e}") from e
+                    raise FlyteValidationException(f"Failed to bind output {out} for function {self.name}: {e}") from e
 
         # Save all the things necessary to create an WorkflowTemplate, except for the missing project and domain
         self._nodes = all_nodes

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -34,6 +34,7 @@ from flytekit.core.task import TaskMetadata, task
 from flytekit.core.testing import patch, task_mock
 from flytekit.core.type_engine import RestrictedTypeError, SimpleTransformer, TypeEngine
 from flytekit.core.workflow import workflow
+from flytekit.exceptions.user import FlyteValidationException
 from flytekit.models import literals as _literal_models
 from flytekit.models.core import types as _core_types
 from flytekit.models.interface import Parameter
@@ -138,7 +139,7 @@ def test_missing_output():
     def wf() -> str:
         return None  # type: ignore
 
-    with pytest.raises(AssertionError, match="Failed to bind output"):
+    with pytest.raises(FlyteValidationException, match="Failed to bind output"):
         wf.compile()
 
 

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -804,7 +804,7 @@ def test_wf1_branches_no_else_malformed_but_no_error():
     def t2(a: str) -> str:
         return a
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(FlyteValidationException):
 
         @workflow
         def my_wf(a: int, b: str) -> (int, str):

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -133,6 +133,15 @@ def test_single_output():
     assert context_manager.FlyteContextManager.size() == 1
 
 
+def test_missing_output():
+    @workflow
+    def wf() -> str:
+        return None
+
+    with pytest.raises(AssertionError, match="Failed to bind output"):
+        wf.compile()
+
+
 def test_engine_file_output():
     basic_blob_type = _core_types.BlobType(
         format="",

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -136,7 +136,7 @@ def test_single_output():
 def test_missing_output():
     @workflow
     def wf() -> str:
-        return None
+        return None  # type: ignore
 
     with pytest.raises(AssertionError, match="Failed to bind output"):
         wf.compile()

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -794,7 +794,7 @@ def test_wf1_branches_no_else_malformed_but_no_error():
     def t2(a: str) -> str:
         return a
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AssertionError):
 
         @workflow
         def my_wf(a: int, b: str) -> (int, str):

--- a/tests/flytekit/unit/experimental/test_eager_workflows.py
+++ b/tests/flytekit/unit/experimental/test_eager_workflows.py
@@ -9,7 +9,6 @@ import pytest
 from hypothesis import given, settings
 
 from flytekit import dynamic, task, workflow
-from flytekit.core.type_engine import TypeTransformerFailedError
 from flytekit.experimental import EagerException, eager
 from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import FlyteFile
@@ -213,7 +212,7 @@ def test_local_workflow_within_eager_workflow_exception(x_input: int):
         out = await local_wf(x=x)
         return await double(x=out)
 
-    with pytest.raises(TypeTransformerFailedError):
+    with pytest.raises(AssertionError):
         asyncio.run(eager_wf(x=x_input))
 
 

--- a/tests/flytekit/unit/experimental/test_eager_workflows.py
+++ b/tests/flytekit/unit/experimental/test_eager_workflows.py
@@ -9,6 +9,7 @@ import pytest
 from hypothesis import given, settings
 
 from flytekit import dynamic, task, workflow
+from flytekit.exceptions.user import FlyteValidationException
 from flytekit.experimental import EagerException, eager
 from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import FlyteFile
@@ -212,7 +213,7 @@ def test_local_workflow_within_eager_workflow_exception(x_input: int):
         out = await local_wf(x=x)
         return await double(x=out)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(FlyteValidationException):
         asyncio.run(eager_wf(x=x_input))
 
 


### PR DESCRIPTION
## Why are the changes needed?

```py
@workflow
def wf() -> tuple[str, str, str]:
    return "foo", "bar", None
```

When registering this workflow, one gets the following obvious error:

```console
~ pyflyte register test_wf.py
...
Python value cannot be None, expected <class 'str'>/<FlyteLiteral simple: STRING>
```

However, the exception does not hint which workflow/output is causing the error. In a large workflow with numerous sub workflows and dozens of tasks, it took one of our ML engineers quite some time to figure out where exactly the `return` was missing. They asked whether we could make this simpler.

## What changes were proposed in this pull request?

I propose to catch errors raised by `binding_from_python_std` in the `PythonFunctionWorkflow`'s `compile` function just as is done e.g. [here](https://github.com/flyteorg/flytekit/blob/c559e2649f9ed0de02e9fe0151d491bb7dde664e/flytekit/core/promise.py#L1089).
This way, finding the error would have been a no-brainer.

## How was this patch tested?

For the example workflow above, the error message now is:

```console
~ pyflyte register test_wf.py
...
Failed to bind output o2 for function test_wf.wf: Python value cannot be None, expected <class 'str'>/<FlyteLiteral simple: STRING>
```

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

