### PR TITLE
Feat: Allow overriding K8s pod template on workflow nodes

### DIFF
--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -30,10 +30,13 @@ def assert_no_promises_in_pod_template(pod_template: PodTemplate, location: str)
     """
     Raise an exception if any of the values in a PodTemplate are promises.
     """
-    try:
-        pod_template.pod_spec.to_dict()
-    except TypeError as e:
-        raise AssertionError(f"Cannot use a promise in the {location} value. Error: {e}")
+    from kubernetes.client import V1PodSpec
+
+    if pod_template.pod_spec and isinstance(pod_template.pod_spec, V1PodSpec):
+        try:
+            pod_template.pod_spec.to_dict()
+        except TypeError as e:
+            raise AssertionError(f"Cannot use a promise in the {location} value. Error: {e}")
 
     if pod_template.labels:
         assert_not_promise(pod_template.labels, location)

--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -6,6 +6,7 @@ from typing import Any, List
 
 from flyteidl.core import tasks_pb2
 
+from flytekit.core.pod_template import PodTemplate
 from flytekit.core.resources import Resources, convert_resources_to_resource_model
 from flytekit.core.utils import _dnsify
 from flytekit.loggers import logger
@@ -148,6 +149,13 @@ class Node(object):
             resources = convert_resources_to_resource_model(requests=requests, limits=limits)
             assert_no_promises_in_resources(resources)
             self._resources = resources
+
+        if "pod_template" in kwargs:
+            pod_template = kwargs["pod_template"]
+            if not isinstance(pod_template, PodTemplate):
+                raise AssertionError("pod_template should be specified as flytekit.core.pod_template.PodTemplate")
+            assert_not_promise(pod_template, "pod_template")
+            self.run_entity.pod_template = pod_template
 
         if "timeout" in kwargs:
             timeout = kwargs["timeout"]


### PR DESCRIPTION
## Why are the changes needed?

In a workflow, one can use [`.with_overrides()`](https://docs.flyte.org/projects/cookbook/en/stable/auto_examples/productionizing/customizing_resources.html#using-with-overrides) to modify e.g. resources, accelerators, images, ... of task nodes. This allows e.g. running *the same* task with different accelerators.

We make heavy use of pod templates to control on which node (pool) a certain task is scheduled. We would like to be able to schedule the same task dynamically on different types of nodes. For this, we would like to add the pod template as well to the list of task args that can be overriden.

## How was this patch tested?

* Added unit tests
* Executed the following test workflow in a cluster:

  ```py
  @task(
      pod_template=PodTemplate(
          pod_spec=V1PodSpec(
              containers=[],
              tolerations=[
                  V1Toleration(key="foo", operator="Equal", value="bar", effect="NoSchedule"),
              ],
          ),
          labels={"foo": "bar"},
      )
  )
  def train():
      ...
  
  
  @dynamic
  def override_pod_template(key: str, val: str):
      train().with_overrides(
          pod_template=PodTemplate(
              labels={key: val},
              pod_spec=V1PodSpec(
                  containers=[],
                  tolerations=[
                      V1Toleration(key=key, operator="Equal", value=val, effect="NoSchedule"),
                  ],
              ),
          )
      )
  
  @workflow
  def wf():
      override_pod_template(key="foo-override-dyn", val="bar-override-dyn")
  ```
  The resulting pod has the following manifest:
  
  ```yaml
  apiVersion: v1
  kind: Pod
  metadata:
    labels:
      foo-override-dyn: bar-override-dyn
      ...
    ...
  spec:
    ...
    tolerations:
      - effect: NoSchedule
        key: foo-override-dyn
        operator: Equal
        value: bar-override-dyn
  ```



- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

---

Note on limitations:

We do not serialize the pod template itself [as part of `TaskNodeOverrides`](https://github.com/flyteorg/flyte/blob/1bed29a93905f3745e2618f2f32cf77adea8c835/flyteidl/protos/flyteidl/core/workflow.proto#L280), send this overrides message to the backend, and apply it there. Instead, we register the task with a [`K8sPod` message](https://github.com/flyteorg/flyte/blob/1bed29a93905f3745e2618f2f32cf77adea8c835/flyteidl/protos/flyteidl/core/tasks.proto#L299C1-L299C1) which is constructed from the pod template (see also [here](https://github.com/flyteorg/flytekit/blob/061301fe3f5e1901394e564a3881f6a7788a2db8/flytekit/core/python_auto_container.py#L214-L215)).
`with_overrides(pod_template)` modifies this `K8sPod` message *before registration*. This means, overriding the pod template suffers from the same [limitations I documented here for e.g. `container_image`](https://github.com/flyteorg/flyte/issues/4543), [which is also not part of `TaskNodeOverrides`](https://github.com/flyteorg/flyte/blob/1bed29a93905f3745e2618f2f32cf77adea8c835/flyteidl/protos/flyteidl/core/workflow.proto#L280).

With the workaround leveraging `@dynamic` shown [here](https://github.com/flyteorg/flyte/issues/4543#issuecomment-1847327365) and in the code snippet above, the feature proposed in this PR will still be very useful for us though - just as  overriding `container_image` in a `@dynamic` already is for us.
