### PR TITLE
Fix warnings in package building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ script-files = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["flytekit", "flytekit_scripts"]
+include = ["flytekit*", "flytekit_scripts"]
 exclude = ["boilerplate", "docs", "plugins", "tests*"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Fixes warnings seen in https://github.com/flyteorg/flytekit/actions/runs/7187240991/job/19636434972 when building the wheel.