### PR TITLE
Logger improvements

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -32,8 +32,7 @@ from flytekit.deck.deck import _output_deck
 from flytekit.exceptions import scopes as _scoped_exceptions
 from flytekit.exceptions import scopes as _scopes
 from flytekit.interfaces.stats.taggable import get_stats as _get_stats
-from flytekit.loggers import entrypoint_logger as logger
-from flytekit.loggers import user_space_logger
+from flytekit.loggers import logger, user_space_logger
 from flytekit.models import dynamic_job as _dynamic_job
 from flytekit.models import literals as _literal_models
 from flytekit.models.core import errors as _error_models

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -18,7 +18,7 @@ from flytekit.clients.auth_helper import (
     wrap_exceptions_channel,
 )
 from flytekit.configuration import PlatformConfig
-from flytekit.loggers import cli_logger
+from flytekit.loggers import logger
 
 
 class RawSynchronousFlyteClient(object):
@@ -53,7 +53,7 @@ class RawSynchronousFlyteClient(object):
         self._signal = signal_service.SignalServiceStub(self._channel)
         self._dataproxy_stub = dataproxy_service.DataProxyServiceStub(self._channel)
 
-        cli_logger.info(
+        logger.info(
             f"Flyte Client configured -> {self._cfg.endpoint} in {'insecure' if self._cfg.insecure else 'secure'} mode."
         )
         # metadata will hold the value of the token to send to the various endpoints.

--- a/flytekit/clis/sdk_in_container/helpers.py
+++ b/flytekit/clis/sdk_in_container/helpers.py
@@ -6,7 +6,7 @@ import rich_click as click
 
 from flytekit.clis.sdk_in_container.constants import CTX_CONFIG_FILE
 from flytekit.configuration import Config, ImageConfig, get_config_file
-from flytekit.loggers import cli_logger
+from flytekit.loggers import logger
 from flytekit.remote.remote import FlyteRemote
 
 FLYTE_REMOTE_INSTANCE_KEY = "flyte_remote"
@@ -18,12 +18,10 @@ def get_remote(
     cfg_file = get_config_file(cfg_file_path)
     if cfg_file is None:
         cfg_obj = Config.for_sandbox()
-        cli_logger.info("No config files found, creating remote with sandbox config")
+        logger.info("No config files found, creating remote with sandbox config")
     else:
         cfg_obj = Config.auto(cfg_file_path)
-        cli_logger.info(
-            f"Creating remote with config {cfg_obj}" + (f" with file {cfg_file_path}" if cfg_file_path else "")
-        )
+        logger.info(f"Creating remote with config {cfg_obj}" + (f" with file {cfg_file_path}" if cfg_file_path else ""))
     return FlyteRemote(
         cfg_obj, default_project=project, default_domain=domain, data_upload_location=data_upload_location
     )

--- a/flytekit/clis/sdk_in_container/pyflyte.py
+++ b/flytekit/clis/sdk_in_container/pyflyte.py
@@ -22,12 +22,18 @@ from flytekit.clis.sdk_in_container.utils import ErrorHandlingCommand, validate_
 from flytekit.clis.version import info
 from flytekit.configuration.file import FLYTECTL_CONFIG_ENV_VAR, FLYTECTL_CONFIG_ENV_VAR_OVERRIDE
 from flytekit.configuration.internal import LocalSDK
-from flytekit.loggers import cli_logger
+from flytekit.loggers import logger
 
 
 @click.group("pyflyte", invoke_without_command=True, cls=ErrorHandlingCommand)
 @click.option(
-    "--verbose", required=False, default=False, is_flag=True, help="Show verbose messages and exception traces"
+    "-v",
+    "--verbose",
+    required=False,
+    help="Show verbose messages and exception traces",
+    count=True,
+    default=0,
+    type=int,
 )
 @click.option(
     "-k",
@@ -47,7 +53,7 @@ from flytekit.loggers import cli_logger
     help="Path to config file for use within container",
 )
 @click.pass_context
-def main(ctx, pkgs: typing.List[str], config: str, verbose: bool):
+def main(ctx, pkgs: typing.List[str], config: str, verbose: int):
     """
     Entrypoint for all the user commands.
     """
@@ -60,7 +66,7 @@ def main(ctx, pkgs: typing.List[str], config: str, verbose: bool):
         cfg = configuration.ConfigFile(config)
         # Set here so that if someone has Config.auto() in their user code, the config here will get used.
         if FLYTECTL_CONFIG_ENV_VAR in os.environ:
-            cli_logger.info(
+            logger.info(
                 f"Config file arg {config} will override env var {FLYTECTL_CONFIG_ENV_VAR}: {os.environ[FLYTECTL_CONFIG_ENV_VAR]}"
             )
         os.environ[FLYTECTL_CONFIG_ENV_VAR_OVERRIDE] = config
@@ -68,6 +74,7 @@ def main(ctx, pkgs: typing.List[str], config: str, verbose: bool):
             pkgs = LocalSDK.WORKFLOW_PACKAGES.read(cfg)
             if pkgs is None:
                 pkgs = []
+
     ctx.obj[CTX_PACKAGES] = pkgs
     ctx.obj[CTX_VERBOSE] = verbose
 

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -10,7 +10,7 @@ from flytekit.clis.sdk_in_container.utils import domain_option_dec, project_opti
 from flytekit.configuration import ImageConfig
 from flytekit.configuration.default_images import DefaultImages
 from flytekit.interaction.click_types import key_value_callback
-from flytekit.loggers import cli_logger
+from flytekit.loggers import logger
 from flytekit.tools import repo
 
 _register_help = """
@@ -141,7 +141,7 @@ def register(
     """
     pkgs = ctx.obj[constants.CTX_PACKAGES]
     if not pkgs:
-        cli_logger.debug("No pkgs")
+        logger.debug("No pkgs")
     if pkgs:
         raise ValueError("Unimplemented, just specify pkgs like folder/files as args at the end of the command")
 

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -31,6 +31,7 @@ from flytekit.core.type_engine import TypeEngine
 from flytekit.core.workflow import PythonFunctionWorkflow, WorkflowBase
 from flytekit.exceptions.system import FlyteSystemException
 from flytekit.interaction.click_types import FlyteLiteralConverter, key_value_callback
+from flytekit.loggers import logger
 from flytekit.models import security
 from flytekit.models.common import RawOutputDataConfig
 from flytekit.models.interface import Parameter, Variable
@@ -500,8 +501,7 @@ def run_command(ctx: click.Context, entity: typing.Union[PythonFunctionWorkflow,
         # By the time we get to this function, all the loading has already happened
 
         run_level_params: RunLevelParams = ctx.obj
-        if run_level_params.verbose:
-            click.echo(f"Running {entity.name} with {kwargs} and run_level_params {run_level_params}")
+        logger.info(f"Running {entity.name} with {kwargs} and run_level_params {run_level_params}")
 
         click.secho(f"Running Execution on {'Remote' if run_level_params.is_remote else 'local'}.", fg="cyan")
         try:

--- a/flytekit/clis/sdk_in_container/utils.py
+++ b/flytekit/clis/sdk_in_container/utils.py
@@ -7,10 +7,9 @@ import grpc
 import rich_click as click
 from google.protobuf.json_format import MessageToJson
 
-from flytekit.clis.sdk_in_container.constants import CTX_VERBOSE
 from flytekit.exceptions.base import FlyteException
 from flytekit.exceptions.user import FlyteInvalidInputException
-from flytekit.loggers import cli_logger
+from flytekit.loggers import get_level_from_cli_verbosity, logger, upgrade_to_rich_logging
 
 project_option = click.Option(
     param_decls=["-p", "--project"],
@@ -66,7 +65,7 @@ def validate_package(ctx, param, values):
             pkgs.extend(val.split(","))
         else:
             pkgs.append(val)
-    cli_logger.debug(f"Using packages: {pkgs}")
+    logger.debug(f"Using packages: {pkgs}")
     return pkgs
 
 
@@ -120,10 +119,13 @@ class ErrorHandlingCommand(click.RichGroup):
     """
 
     def invoke(self, ctx: click.Context) -> typing.Any:
+        verbose = ctx.params["verbose"]
+        log_level = get_level_from_cli_verbosity(verbose)
+        upgrade_to_rich_logging(log_level=log_level)
         try:
             return super().invoke(ctx)
         except Exception as e:
-            if CTX_VERBOSE in ctx.obj and ctx.obj[CTX_VERBOSE]:
+            if verbose > 0:
                 click.secho("Verbose mode on")
                 raise e
             pretty_print_exception(e)

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -97,7 +97,7 @@ def initialize_global_loggers():
 def upgrade_to_rich_logging(
     console: typing.Optional["rich.console.Console"] = None, log_level: typing.Optional[int] = None
 ):
-    formatter = logging.Formatter(fmt="[%(name)s] %(message)s")
+    formatter = logging.Formatter(fmt="%(message)s")
     handler = logging.StreamHandler()
     if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0":
         try:
@@ -111,8 +111,7 @@ def upgrade_to_rich_logging(
                 tracebacks_suppress=[click, flytekit],
                 rich_tracebacks=True,
                 omit_repeated_times=False,
-                keywords=["[flytekit]"],
-                log_time_format="%Y-%m-%d %H:%M:%S,%f",
+                log_time_format="%H:%M:%S.%f",
                 console=Console(width=os.get_terminal_size().columns),
             )
         except OSError:

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -114,8 +114,9 @@ def upgrade_to_rich_logging(
                 log_time_format="%H:%M:%S.%f",
                 console=Console(width=os.get_terminal_size().columns),
             )
-        except OSError:
-            print("Failed to initialize rich logging, falling back to default logging")
+        except OSError as e:
+            logger.debug(f"Failed to initialize rich logging: {e}")
+            pass
     handler.setFormatter(formatter)
     set_flytekit_log_properties(handler, None, level=log_level or _get_env_logging_level())
     set_user_logger_properties(handler, None, logging.INFO)

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -1,9 +1,10 @@
 import logging
 import os
+import typing
 
 from pythonjsonlogger import jsonlogger
-from rich.console import Console
-from rich.logging import RichHandler
+
+from .tools import interactive
 
 # Note:
 # The environment variable controls exposed to affect the individual loggers should be considered to be beta.
@@ -17,77 +18,129 @@ LOGGING_RICH_FMT_ENV_VAR = "FLYTE_SDK_RICH_TRACEBACKS"
 
 # By default, the root flytekit logger to debug so everything is logged, but enable fine-tuning
 logger = logging.getLogger("flytekit")
+user_space_logger = logging.getLogger("user_space")
 
 # Stop propagation so that configuration is isolated to this file (so that it doesn't matter what the
 # global Python root logger is set to).
 logger.propagate = False
 
-# Child loggers
-child_loggers = {
-    "auth": logger.getChild("auth"),
-    "cli": logger.getChild("cli"),
-    "remote": logger.getChild("remote"),
-    "entrypoint": logger.getChild("entrypoint"),
-    "user_space": logger.getChild("user_space"),
-}
-auth_logger = child_loggers["auth"]
-cli_logger = child_loggers["cli"]
-remote_logger = child_loggers["remote"]
-entrypoint_logger = child_loggers["entrypoint"]
-user_space_logger = child_loggers["user_space"]
 
-# create console handler
-if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0":
-    try:
-        handler = RichHandler(
-            rich_tracebacks=True,
-            omit_repeated_times=False,
-            keywords=["[flytekit]"],
-            log_time_format="%Y-%m-%d %H:%M:%S,%f",
-            console=Console(width=os.get_terminal_size().columns),
-        )
-    except OSError:
-        handler = logging.StreamHandler()
-else:
+def set_flytekit_log_properties(
+    handler: typing.Optional[logging.Handler] = None,
+    filter: typing.Optional[logging.Filter] = None,
+    level: typing.Optional[int] = None,
+):
+    """
+    flytekit logger, refers to the framework logger. It is possible to selectively tune the logging for flytekit.
+
+    Sets the flytekit logger to the specified handler, filter, and level. If any of the parameters are None, then
+    the corresponding property on the flytekit logger will not be set.
+
+    :param handler: logging.Handler to add to the flytekit logger
+    :param filter: logging.Filter to add to the flytekit logger
+    :param level: logging level to set the flytekit logger to
+    """
+    global logger
+    if handler is not None:
+        logger.handlers.clear()
+        logger.addHandler(handler)
+    if filter is not None:
+        logger.addFilter(filter)
+    if level is not None:
+        logger.setLevel(level)
+
+
+def set_user_logger_properties(
+    handler: typing.Optional[logging.Handler] = None,
+    filter: typing.Optional[logging.Filter] = None,
+    level: typing.Optional[int] = None,
+):
+    """
+    user_space logger, refers to the user's logger. It is possible to selectively tune the logging for the user.
+
+    :param handler: logging.Handler to add to the user_space_logger
+    :param filter: logging.Filter to add to the user_space_logger
+    :param level: logging level to set the user_space_logger to
+    """
+    global user_space_logger
+    if handler is not None:
+        user_space_logger.addHandler(handler)
+    if filter is not None:
+        user_space_logger.addFilter(filter)
+    if level is not None:
+        user_space_logger.setLevel(level)
+
+
+def _get_env_logging_level() -> int:
+    """
+    Returns the logging level set in the environment variable, or logging.WARNING if the environment variable is not
+    set.
+    """
+    return int(os.getenv(LOGGING_ENV_VAR, logging.WARNING))
+
+
+def initialize_global_loggers():
+    """
+    Initializes the global loggers to the default configuration.
+    """
     handler = logging.StreamHandler()
-
-handler.setLevel(logging.DEBUG)
-
-# Root logger control
-# Don't want to import the configuration library since that will cause all sorts of circular imports, let's
-# just use the environment variable if it's defined. Decide in the future when we implement better controls
-# if we should control with the channel or with the logger level.
-# The handler log level controls whether log statements will actually print to the screen
-flytekit_root_env_var = f"{LOGGING_ENV_VAR}_ROOT"
-level_from_env = os.getenv(LOGGING_ENV_VAR)
-root_level_from_env = os.getenv(flytekit_root_env_var)
-if root_level_from_env is not None:
-    logger.setLevel(int(root_level_from_env))
-elif level_from_env is not None:
-    logger.setLevel(int(level_from_env))
-else:
-    logger.setLevel(logging.WARNING)
-
-for log_name, child_logger in child_loggers.items():
-    env_var = f"{LOGGING_ENV_VAR}_{log_name.upper()}"
-    level_from_env = os.getenv(env_var)
-    if level_from_env is not None:
-        child_logger.setLevel(int(level_from_env))
-    else:
-        if child_logger is user_space_logger:
-            child_logger.setLevel(logging.INFO)
-        else:
-            child_logger.setLevel(logging.WARNING)
-
-# create formatter
-logging_fmt = os.environ.get(LOGGING_FMT_ENV_VAR, "json")
-if logging_fmt == "json":
-    formatter = jsonlogger.JsonFormatter(fmt="%(asctime)s %(name)s %(levelname)s %(message)s")
-else:
+    handler.setLevel(logging.DEBUG)
     formatter = logging.Formatter(fmt="[%(name)s] %(message)s")
+    if os.environ.get(LOGGING_FMT_ENV_VAR, "json") == "json":
+        formatter = jsonlogger.JsonFormatter(fmt="%(asctime)s %(name)s %(levelname)s %(message)s")
+    handler.setFormatter(formatter)
 
-# add formatter to the handler
-handler.setFormatter(formatter)
+    set_flytekit_log_properties(handler, None, _get_env_logging_level())
+    set_user_logger_properties(handler, None, logging.INFO)
 
-# add ch to logger
-logger.addHandler(handler)
+
+def upgrade_to_rich_logging(
+    console: typing.Optional["rich.console.Console"] = None, log_level: typing.Optional[int] = None
+):
+    formatter = logging.Formatter(fmt="[%(name)s] %(message)s")
+    handler = logging.StreamHandler()
+    if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0":
+        try:
+            import click
+            from rich.console import Console
+            from rich.logging import RichHandler
+
+            import flytekit
+
+            handler = RichHandler(
+                tracebacks_suppress=[click, flytekit],
+                rich_tracebacks=True,
+                omit_repeated_times=False,
+                keywords=["[flytekit]"],
+                log_time_format="%Y-%m-%d %H:%M:%S,%f",
+                console=Console(width=os.get_terminal_size().columns),
+            )
+        except OSError:
+            print("Failed to initialize rich logging, falling back to default logging")
+    handler.setFormatter(formatter)
+    set_flytekit_log_properties(handler, None, level=log_level or _get_env_logging_level())
+    set_user_logger_properties(handler, None, logging.INFO)
+
+
+def get_level_from_cli_verbosity(verbosity: int) -> int:
+    """
+    Converts a verbosity level from the CLI to a logging level.
+
+    :param verbosity: verbosity level from the CLI
+    :return: logging level
+    """
+    if verbosity == 0:
+        return logging.CRITICAL
+    elif verbosity == 1:
+        return logging.WARNING
+    elif verbosity == 2:
+        return logging.INFO
+    else:
+        return logging.DEBUG
+
+
+if interactive.ipython_check():
+    upgrade_to_rich_logging()
+else:
+    # Default initialization
+    initialize_global_loggers()

--- a/flytekit/remote/entities.py
+++ b/flytekit/remote/entities.py
@@ -13,7 +13,7 @@ from flytekit.core import hash as hash_mixin
 from flytekit.core.promise import create_and_link_node_from_remote
 from flytekit.exceptions import system as _system_exceptions
 from flytekit.exceptions import user as _user_exceptions
-from flytekit.loggers import remote_logger
+from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
 from flytekit.models import launch_plan as _launch_plan_model
 from flytekit.models import launch_plan as _launch_plan_models
@@ -436,7 +436,7 @@ class FlyteNode(_hash_mixin.HashOnReferenceMixin, _workflow_model.Node):
         node_model_id = model.id
         # TODO: Consider removing
         if id in {_constants.START_NODE_ID, _constants.END_NODE_ID}:
-            remote_logger.warning(f"Should not call promote from model on a start node or end node {model}")
+            logger.warning(f"Should not call promote from model on a start node or end node {model}")
             return None, converted_sub_workflows
 
         flyte_task_node, flyte_workflow_node, flyte_branch_node, flyte_gate_node, flyte_array_node = (

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -44,7 +44,7 @@ from flytekit.exceptions.user import (
     FlyteEntityNotExistException,
     FlyteValueException,
 )
-from flytekit.loggers import remote_logger
+from flytekit.loggers import logger
 from flytekit.models import common as common_models
 from flytekit.models import filters as filter_models
 from flytekit.models import launch_plan as launch_plan_models
@@ -172,7 +172,7 @@ def _get_git_repo_url(source_path):
             raise ValueError("Unable to parse url")
 
     except Exception as e:
-        remote_logger.debug(str(e))
+        logger.debug(str(e))
         return ""
 
 
@@ -278,26 +278,26 @@ class FlyteRemote(object):
                 if len(data_response.pre_signed_urls.signed_url) == 0:
                     raise ValueError(f"Flyte url {flyte_uri} resolved to empty download link")
                 d = data_response.pre_signed_urls.signed_url[0]
-                remote_logger.debug(f"Download link is {d}")
+                logger.debug(f"Download link is {d}")
                 fs = ctx.file_access.get_filesystem_for_path(d)
 
                 # If the venv has IPython, then return IPython's HTML
                 if ipython_check():
                     from IPython.core.display import HTML
 
-                    remote_logger.debug(f"IPython found, returning HTML from {flyte_uri}")
+                    logger.debug(f"IPython found, returning HTML from {flyte_uri}")
                     with fs.open(d, "rb") as r:
                         html = HTML(str(r.read()))
                         return html
                 # If not return bytes
                 else:
-                    remote_logger.debug(f"IPython not found, returning HTML as bytes from {flyte_uri}")
+                    logger.debug(f"IPython not found, returning HTML as bytes from {flyte_uri}")
                     return fs.open(d, "rb").read()
 
         except user_exceptions.FlyteUserException as e:
-            remote_logger.info(f"Error from Flyte backend when trying to fetch data: {e.__cause__}")
+            logger.info(f"Error from Flyte backend when trying to fetch data: {e.__cause__}")
 
-        remote_logger.info(f"Nothing found from {flyte_uri}")
+        logger.info(f"Nothing found from {flyte_uri}")
 
     def remote_context(self):
         """Context manager with remote-specific configuration."""
@@ -508,14 +508,14 @@ class FlyteRemote(object):
             project=project or self.default_project, domain=domain or self.default_domain, name=execution_name
         )
         if isinstance(value, Literal):
-            remote_logger.debug(f"Using provided {value} as existing Literal value")
+            logger.debug(f"Using provided {value} as existing Literal value")
             lit = value
         else:
             lt = literal_type or (
                 TypeEngine.to_literal_type(python_type) if python_type else TypeEngine.to_literal_type(type(value))
             )
             lit = TypeEngine.to_literal(self.context, value, python_type or type(value), lt)
-            remote_logger.debug(f"Converted {value} to literal {lit} using literal type {lt}")
+            logger.debug(f"Converted {value} to literal {lit} using literal type {lt}")
 
         req = SignalSetRequest(id=SignalIdentifier(signal_id, wf_exec_id).to_flyte_idl(), value=lit.to_flyte_idl())
 
@@ -603,10 +603,10 @@ class FlyteRemote(object):
         if isinstance(cp_entity, RemoteEntity):
             if isinstance(cp_entity, (FlyteWorkflow, FlyteTask)):
                 if not cp_entity.should_register:
-                    remote_logger.debug(f"Skipping registration of remote entity: {cp_entity.name}")
+                    logger.debug(f"Skipping registration of remote entity: {cp_entity.name}")
                     raise RegistrationSkipped(f"Remote task/Workflow {cp_entity.name} is not registrable.")
             else:
-                remote_logger.debug(f"Skipping registration of remote entity: {cp_entity.name}")
+                logger.debug(f"Skipping registration of remote entity: {cp_entity.name}")
                 raise RegistrationSkipped(f"Remote task/Workflow {cp_entity.name} is not registrable.")
 
         if isinstance(
@@ -618,11 +618,11 @@ class FlyteRemote(object):
                 workflow_model.TaskNode,
             ),
         ):
-            remote_logger.debug("Ignoring nodes for registration.")
+            logger.debug("Ignoring nodes for registration.")
             return None
 
         elif isinstance(cp_entity, ReferenceSpec):
-            remote_logger.debug(f"Skipping registration of Reference entity, name: {cp_entity.template.id.name}")
+            logger.debug(f"Skipping registration of Reference entity, name: {cp_entity.template.id.name}")
             return None
 
         if isinstance(cp_entity, task_models.TaskSpec):
@@ -632,7 +632,7 @@ class FlyteRemote(object):
             try:
                 self.client.create_task(task_identifer=ident, task_spec=cp_entity)
             except FlyteEntityAlreadyExistsException:
-                remote_logger.info(f" {ident} Already Exists!")
+                logger.info(f" {ident} Already Exists!")
             return ident
 
         if isinstance(cp_entity, admin_workflow_models.WorkflowSpec):
@@ -642,7 +642,7 @@ class FlyteRemote(object):
             try:
                 self.client.create_workflow(workflow_identifier=ident, workflow_spec=cp_entity)
             except FlyteEntityAlreadyExistsException:
-                remote_logger.info(f" {ident} Already Exists!")
+                logger.info(f" {ident} Already Exists!")
 
             if create_default_launchplan:
                 if not og_entity:
@@ -666,7 +666,7 @@ class FlyteRemote(object):
                 try:
                     self.client.create_launch_plan(lp_entity.id, lp_entity.spec)
                 except FlyteEntityAlreadyExistsException:
-                    remote_logger.info(f" {lp_entity.id} Already Exists!")
+                    logger.info(f" {lp_entity.id} Already Exists!")
             return ident
 
         if isinstance(cp_entity, launch_plan_models.LaunchPlan):
@@ -674,7 +674,7 @@ class FlyteRemote(object):
             try:
                 self.client.create_launch_plan(launch_plan_identifer=ident, launch_plan_spec=cp_entity.spec)
             except FlyteEntityAlreadyExistsException:
-                remote_logger.info(f" {ident} Already Exists!")
+                logger.info(f" {ident} Already Exists!")
             return ident
 
         raise AssertionError(f"Unknown entity of type {type(cp_entity)}")
@@ -813,7 +813,7 @@ class FlyteRemote(object):
         if not to_upload.is_file():
             raise ValueError(f"{to_upload} is not a single file, upload arg must be a single file.")
         md5_bytes, str_digest, _ = hash_file(to_upload)
-        remote_logger.debug(f"Text hash of file to upload is {str_digest}")
+        logger.debug(f"Text hash of file to upload is {str_digest}")
 
         upload_location = self.client.get_upload_signed_url(
             project=project or self.default_project,
@@ -845,9 +845,7 @@ class FlyteRemote(object):
                     f"Request to send data {upload_location.signed_url} failed.",
                 )
 
-        remote_logger.debug(
-            f"Uploading {to_upload} to {upload_location.signed_url} native url {upload_location.native_url}"
-        )
+        logger.debug(f"Uploading {to_upload} to {upload_location.signed_url} native url {upload_location.native_url}")
 
         return md5_bytes, upload_location.native_url
 
@@ -970,7 +968,7 @@ class FlyteRemote(object):
         try:
             self.client.create_launch_plan(ident, idl_lp.spec)
         except FlyteEntityAlreadyExistsException:
-            remote_logger.debug("Launchplan already exists, ignoring")
+            logger.debug("Launchplan already exists, ignoring")
         flp = self.fetch_launch_plan(ident.project, ident.domain, ident.name, ident.version)
         flp._python_interface = entity.python_interface
         return flp
@@ -1044,7 +1042,7 @@ class FlyteRemote(object):
                         try:
                             type_hints[k] = TypeEngine.guess_python_type(input_flyte_type_map[k].type)
                         except ValueError:
-                            remote_logger.debug(f"Could not guess type for {input_flyte_type_map[k].type}, skipping...")
+                            logger.debug(f"Could not guess type for {input_flyte_type_map[k].type}, skipping...")
                     variable = entity.interface.inputs.get(k)
                     hint = type_hints[k]
                     self.file_access._get_upload_signed_url_fn = functools.partial(
@@ -1090,7 +1088,7 @@ class FlyteRemote(object):
                 literal_inputs,
             )
         except user_exceptions.FlyteEntityAlreadyExistsException:
-            remote_logger.warning(
+            logger.warning(
                 f"Execution with Execution ID {execution_name} already exists. "
                 f"Assuming this is the same execution, returning!"
             )
@@ -1473,7 +1471,7 @@ class FlyteRemote(object):
             # todo: Add logic to check that the fetched workflow is functionally equivalent.
             self.fetch_workflow(**resolved_identifiers_dict)
         except FlyteEntityNotExistException:
-            remote_logger.info("Registering workflow because it wasn't found in Flyte Admin.")
+            logger.info("Registering workflow because it wasn't found in Flyte Admin.")
             if not image_config:
                 raise ValueError("Need image config since we are registering")
             self.register_workflow(entity, ss, version=version, options=options)
@@ -1481,7 +1479,7 @@ class FlyteRemote(object):
         try:
             flyte_lp = self.fetch_launch_plan(**resolved_identifiers_dict)
         except FlyteEntityNotExistException:
-            remote_logger.info("Try to register default launch plan because it wasn't found in Flyte Admin!")
+            logger.info("Try to register default launch plan because it wasn't found in Flyte Admin!")
             default_lp = LaunchPlan.get_default_launch_plan(self.context, entity)
             self.register_launch_plan(
                 default_lp,
@@ -1720,14 +1718,14 @@ class FlyteRemote(object):
         # This case supports single-task execution compiled workflows.
         if node_id and node_id not in node_mapping and execution.id.node_id in node_mapping:
             node_id = execution.id.node_id
-            remote_logger.debug(
+            logger.debug(
                 f"Using node execution ID {node_id} instead of spec node id "
                 f"{execution.metadata.spec_node_id}, single-task execution likely."
             )
         # This case supports single-task execution compiled workflows with older versions of admin/propeller
         if not node_id:
             node_id = execution.id.node_id
-            remote_logger.debug(f"No metadata spec_node_id found, using {node_id}")
+            logger.debug(f"No metadata spec_node_id found, using {node_id}")
 
         # First see if it's a dummy node, if it is, we just skip it.
         if constants.START_NODE_ID in node_id or constants.END_NODE_ID in node_id:
@@ -1812,20 +1810,18 @@ class FlyteRemote(object):
 
             # Handle the case where it's a branch node
             elif execution._node.branch_node is not None:
-                remote_logger.info(
+                logger.info(
                     "Skipping branch node execution for now - branch nodes will "
                     "not have inputs and outputs filled in"
                 )
                 return execution
             else:
-                remote_logger.error(f"NE {execution} undeterminable, {type(execution._node)}, {execution._node}")
+                logger.error(f"NE {execution} undeterminable, {type(execution._node)}, {execution._node}")
                 raise Exception(f"Node execution undeterminable, entity has type {type(execution._node)}")
 
         # Handle the case for gate nodes
         elif execution._node.gate_node is not None:
-            remote_logger.info(
-                "Skipping gate node execution for now - gate nodes don't have inputs and outputs filled in"
-            )
+            logger.info("Skipping gate node execution for now - gate nodes don't have inputs and outputs filled in")
             return execution
 
         # This is the plain ol' task execution case
@@ -2002,7 +1998,7 @@ class FlyteRemote(object):
             start_date=from_date, end_date=to_date, for_lp=lp, parallel=parallel, failure_policy=failure_policy
         )
         if dry_run:
-            remote_logger.warning("Dry Run enabled. Workflow will not be registered and or executed.")
+            logger.warning("Dry Run enabled. Workflow will not be registered and or executed.")
             return wf
 
         unique_fingerprint = f"{start}-{end}-{launchplan}-{launchplan_version}"

--- a/flytekit/remote/remote_callable.py
+++ b/flytekit/remote/remote_callable.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional, Tuple, Type, Union
 from flytekit.core.context_manager import BranchEvalMode, ExecutionState, FlyteContext
 from flytekit.core.promise import Promise, VoidPromise, create_and_link_node_from_remote, extract_obj_name
 from flytekit.exceptions import user as user_exceptions
-from flytekit.loggers import remote_logger as logger
+from flytekit.loggers import logger
 from flytekit.models.core.workflow import NodeMetadata
 
 

--- a/flytekit/tools/ignore.py
+++ b/flytekit/tools/ignore.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional, Type
 
 from docker.utils.build import PatternMatcher
 
-from flytekit.loggers import cli_logger
+from flytekit.loggers import logger
 
 STANDARD_IGNORE_PATTERNS = ["*.pyc", ".cache", ".cache/*", "__pycache__", "**/__pycache__"]
 
@@ -48,9 +48,9 @@ class GitIgnore(Ignore):
             out = subprocess.run(["git", "ls-files", "-io", "--exclude-standard"], cwd=self.root, capture_output=True)
             if out.returncode == 0:
                 return dict.fromkeys(out.stdout.decode("utf-8").split("\n")[:-1])
-            cli_logger.warning(f"Could not determine ignored files due to:\n{out.stderr}\nNot applying any filters")
+            logger.warning(f"Could not determine ignored files due to:\n{out.stderr}\nNot applying any filters")
             return {}
-        cli_logger.info("No git executable found, not applying any filters")
+        logger.info("No git executable found, not applying any filters")
         return {}
 
     def _is_ignored(self, path: str) -> bool:
@@ -79,7 +79,7 @@ class DockerIgnore(Ignore):
         if os.path.isfile(dockerignore):
             with open(dockerignore, "r") as f:
                 patterns = [l.strip() for l in f.readlines() if l and not l.startswith("#")]
-        cli_logger.info(f"No .dockerignore found in {self.root}, not applying any filters")
+        logger.info(f"No .dockerignore found in {self.root}, not applying any filters")
         return PatternMatcher(patterns)
 
     def _is_ignored(self, path: str) -> bool:


### PR DESCRIPTION
## Tracking issue

With this change, flytekit now has 2 loggers, one for framework and one for user code.
Logger is default initialized based on environment. This logger is usually a json logger.

But, when a user runs any pyflyte command, the logger is switched (upgraded) to a rich logger. this can be turned off, but the logging is way more readable. the format is also adjusted

using `pyflyte -vvv` or `pyflyte -v` changes verbosity level of the log

```
 pyflyte -vv run test2.py wf --n 10
```

<img width="1706" alt="Screenshot 2023-12-14 at 1 03 54 PM" src="https://github.com/flyteorg/flytekit/assets/16888709/8a996390-628d-4d6b-baed-1d2ff60a00d9">

The PR also simplifies the logging setup. Now, everywhere in the framework, `logger` should be used. There is work to be done to make the logging less verbose and more meaningful, that will be done as a follow up


## Why are the changes needed?
Better logging when using the CLI

## What changes were proposed in this pull request?
Logger setup for flytekit

## How was this patch tested?
locally and remotely


