### PR TITLE
Agent uploads input.pb even if task input is None

### DIFF
--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -128,7 +128,6 @@ class FileAccessProvider(object):
         self._local = fsspec.filesystem(None)
 
         self._data_config = data_config if data_config else DataConfig.auto()
-        print(type(raw_output_prefix))
         self._default_protocol = get_protocol(str(raw_output_prefix))
         self._default_remote = cast(fsspec.AbstractFileSystem, self.get_filesystem(self._default_protocol))
         if os.name == "nt" and raw_output_prefix.startswith("file://"):

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -128,7 +128,8 @@ class FileAccessProvider(object):
         self._local = fsspec.filesystem(None)
 
         self._data_config = data_config if data_config else DataConfig.auto()
-        self._default_protocol = get_protocol(raw_output_prefix)
+        print(type(raw_output_prefix))
+        self._default_protocol = get_protocol(str(raw_output_prefix))
         self._default_remote = cast(fsspec.AbstractFileSystem, self.get_filesystem(self._default_protocol))
         if os.name == "nt" and raw_output_prefix.startswith("file://"):
             raise FlyteAssertion("Cannot use the file:// prefix on Windows.")

--- a/flytekit/extend/backend/base_agent.py
+++ b/flytekit/extend/backend/base_agent.py
@@ -204,13 +204,12 @@ class AsyncAgentExecutorMixin:
         literals = inputs or {}
         for k, v in inputs.items():
             literals[k] = TypeEngine.to_literal(ctx, v, type(v), self._entity.interface.inputs[k].type)
-        literal_map = LiteralMap(literals) if literals else None
-        if literal_map and isinstance(self, PythonFunctionTask):
+        if isinstance(self, PythonFunctionTask):
             # Write the inputs to a remote file, so that the remote task can read the inputs from this file.
             path = ctx.file_access.get_random_local_path()
-            utils.write_proto_to_file(literal_map.to_flyte_idl(), path)
+            utils.write_proto_to_file(LiteralMap(literals).to_flyte_idl(), path)
             ctx.file_access.put_data(path, f"{output_prefix}/inputs.pb")
-            task_template = render_task_template(task_template, output_prefix)
+        task_template = render_task_template(task_template, output_prefix)
 
         if self._agent.asynchronous:
             res = await self._agent.async_create(grpc_ctx, output_prefix, task_template, inputs)

--- a/flytekit/extend/backend/base_agent.py
+++ b/flytekit/extend/backend/base_agent.py
@@ -209,7 +209,7 @@ class AsyncAgentExecutorMixin:
             path = ctx.file_access.get_random_local_path()
             utils.write_proto_to_file(LiteralMap(literals).to_flyte_idl(), path)
             ctx.file_access.put_data(path, f"{output_prefix}/inputs.pb")
-        task_template = render_task_template(task_template, output_prefix)
+            task_template = render_task_template(task_template, output_prefix)
 
         if self._agent.asynchronous:
             res = await self._agent.async_create(grpc_ctx, output_prefix, task_template, inputs)


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
Agent failed to run a `PythonFunctionTask` remotely since `input.pb` was not found. 

## What changes were proposed in this pull request?
Upload empty input.pb even if the input is None since `--inputs` is required by the `pyflyte-execute` command
https://github.com/flyteorg/flytekit/blob/47e15b607c67aee2274190cf90877c4cead859b3/flytekit/bin/entrypoint.py#L454

## How was this patch tested?
Run an agent task locally

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
