### PR TITLE
Preserve stacktrace

### DIFF
--- a/flytekit/clis/sdk_in_container/utils.py
+++ b/flytekit/clis/sdk_in_container/utils.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 import typing
 from dataclasses import Field, dataclass, field
 from types import MappingProxyType
@@ -81,6 +82,17 @@ def pretty_print_grpc_error(e: grpc.RpcError):
     return
 
 
+def pretty_print_traceback(e):
+    """
+    This method will print the Traceback of a error.
+    """
+    if e.__traceback__:
+        stack_list = traceback.format_list(traceback.extract_tb(e.__traceback__))
+        click.secho("Traceback:", fg="red")
+        for i in stack_list:
+            click.secho(f"{i}", fg="red")
+
+
 def pretty_print_exception(e: Exception):
     """
     This method will print the exception in a nice way. It will also check if the exception is a grpc.RpcError and
@@ -105,6 +117,7 @@ def pretty_print_exception(e: Exception):
                 pretty_print_grpc_error(cause)
             else:
                 click.secho(f"Underlying Exception: {cause}")
+                pretty_print_traceback(e)
         return
 
     if isinstance(e, grpc.RpcError):
@@ -112,6 +125,7 @@ def pretty_print_exception(e: Exception):
         return
 
     click.secho(f"Failed with Unknown Exception {type(e)} Reason: {e}", fg="red")  # noqa
+    pretty_print_traceback(e)
 
 
 class ErrorHandlingCommand(click.RichGroup):


### PR DESCRIPTION
# TL;DR
Giving a try on printing Traceback when errors are raised in `pyflyte`

Note:

Only included printing tracebacks when it's not `FlyteException` or `grpc` errors.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/4248

## Stacktrace error example
```pyflyte run workflow.py

 Usage: pyflyte run workflow.py [OPTIONS] COMMAND [ARGS]...

 Run a [workflow|task] from workflow.py

╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ --help      Show this message and exit.                                                                                                                                                                         │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Failed with Unknown Exception <class 'NameError'> Reason: Error encountered while executing 'my_workflow':
  name 'thiswillfail' is not defined
Traceback:
  File "/Users/rafaelraposo/development/oss/flytekit/flytekit/clis/sdk_in_container/utils.py", line 138, in invoke
    return super().invoke(ctx)

  File "/Users/rafaelraposo/.pyenv/versions/3.8.18/lib/python3.8/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))

  File "/Users/rafaelraposo/.pyenv/versions/3.8.18/lib/python3.8/site-packages/click/core.py", line 1686, in invoke
    sub_ctx = cmd.make_context(cmd_name, args, parent=ctx)

  File "/Users/rafaelraposo/.pyenv/versions/3.8.18/lib/python3.8/site-packages/click/core.py", line 943, in make_context
    self.parse_args(ctx, args)

  File "/Users/rafaelraposo/.pyenv/versions/3.8.18/lib/python3.8/site-packages/click/core.py", line 1641, in parse_args
    echo(ctx.get_help(), color=ctx.color)

  File "/Users/rafaelraposo/.pyenv/versions/3.8.18/lib/python3.8/site-packages/click/core.py", line 704, in get_help
    return self.command.get_help(self)

  File "/Users/rafaelraposo/.pyenv/versions/3.8.18/lib/python3.8/site-packages/click/core.py", line 1325, in get_help
    self.format_help(ctx, formatter)

  File "/Users/rafaelraposo/.pyenv/versions/3.8.18/lib/python3.8/site-packages/rich_click/rich_command.py", line 166, in format_help
    rich_format_help(self, ctx, formatter)

  File "/Users/rafaelraposo/.pyenv/versions/3.8.18/lib/python3.8/site-packages/rich_click/rich_click.py", line 653, in rich_format_help
    for command in obj.list_commands(ctx):

  File "/Users/rafaelraposo/development/oss/flytekit/flytekit/clis/sdk_in_container/run.py", line 652, in list_commands
    entities = get_entities_in_file(self._filename, self._should_delete)

  File "/Users/rafaelraposo/development/oss/flytekit/flytekit/clis/sdk_in_container/run.py", line 331, in get_entities_in_file
    importlib.import_module(module_name)

  File "/Users/rafaelraposo/.pyenv/versions/3.8.18/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)

  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import

  File "<frozen importlib._bootstrap>", line 991, in _find_and_load

  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked

  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked

  File "<frozen importlib._bootstrap_external>", line 843, in exec_module

  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed

  File "/Users/rafaelraposo/development/oss/playground/flytekit-play/workflow.py", line 16, in <module>
    print(f"my_workflow output: {my_workflow(x=1, y=2)}")

  File "/Users/rafaelraposo/development/oss/flytekit/flytekit/core/workflow.py", line 274, in __call__
    self.compile()

  File "/Users/rafaelraposo/development/oss/flytekit/flytekit/core/workflow.py", line 674, in compile
    workflow_outputs = exception_scopes.user_entry_point(self._workflow_function)(**input_kwargs)

  File "/Users/rafaelraposo/development/oss/flytekit/flytekit/exceptions/scopes.py", line 203, in user_entry_point
    raise type(exc)(f"Error encountered while executing '{fn_name}':\n  {exc}") from exc

Error encountered while executing 'my_workflow':
  name 'thiswillfail' is not defined
  ```
  
  A simple error were a variable is not defined.