### PR TITLE
Download specific files in FlyteDirectory

### DIFF
--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -461,7 +461,7 @@ class ImperativeWorkflow(WorkflowBase):
             raise FlyteValidationException(f"Workflow not ready, wf is currently {self}")
 
         # Create a map that holds the outputs of each node.
-        intermediate_node_outputs: Dict[Node, Dict[str, Promise]] = {GLOBAL_START_NODE: {}}
+        intermediate_node_outputs: Dict[Node, Dict[str, Promise]] = {GLOBAL_START_NODE: {}}  # type: ignore
 
         # Start things off with the outputs of the global input node, i.e. the inputs to the workflow.
         # local_execute should've already ensured that all the values in kwargs are Promise objects

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -266,10 +266,10 @@ class FlyteDirectory(DataClassJsonMixin, os.PathLike, typing.Generic[T]):
         file_access = FlyteContextManager.current_context().file_access
         if not file_access.is_remote(final_path):
             for p in os.listdir(final_path):
-                if pathlib.Path(p).is_dir():
-                    paths.append(FlyteDirectory(p))
-                else:
+                if os.path.isfile(os.path.join(final_path, p)):
                     paths.append(FlyteFile(p))
+                else:
+                    paths.append(FlyteDirectory(p))
             return paths
 
         def create_downloader(_remote_path: str, _local_path: str, is_multipart: bool):

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -123,7 +123,7 @@ class FlyteDirectory(DataClassJsonMixin, os.PathLike, typing.Generic[T]):
         self,
         path: typing.Union[str, os.PathLike],
         downloader: typing.Optional[typing.Callable] = None,
-        remote_directory: typing.Optional[typing.Union[os.PathLike, typing.Literal[False]]] = None,
+        remote_directory: typing.Optional[typing.Union[os.PathLike, str, typing.Literal[False]]] = None,
     ):
         """
         :param path: The source path that users are expected to call open() on
@@ -138,7 +138,7 @@ class FlyteDirectory(DataClassJsonMixin, os.PathLike, typing.Generic[T]):
         self._downloader = downloader or noop
         self._downloaded = False
         self._remote_directory = remote_directory
-        self._remote_source = None
+        self._remote_source: typing.Optional[str] = None
 
     def __fspath__(self):
         """
@@ -192,7 +192,7 @@ class FlyteDirectory(DataClassJsonMixin, os.PathLike, typing.Generic[T]):
         return self._downloaded
 
     @property
-    def remote_directory(self) -> typing.Optional[typing.Union[os.PathLike, bool]]:
+    def remote_directory(self) -> typing.Optional[typing.Union[os.PathLike, bool, str]]:
         return self._remote_directory
 
     @property
@@ -235,6 +235,66 @@ class FlyteDirectory(DataClassJsonMixin, os.PathLike, typing.Generic[T]):
 
     def download(self) -> str:
         return self.__fspath__()
+
+    @classmethod
+    def listdir(cls, directory: FlyteDirectory) -> typing.List[typing.Union[FlyteDirectory, FlyteFile]]:
+        """
+        This function will list all files and folders in the given directory, but without downloading the contents.
+        In addition, it will return a list of FlyteFile and FlyteDirectory objects that have ability to lazily download the
+        contents of the file/folder. For example:
+
+        .. code-block:: python
+
+            entity = FlyteDirectory.listdir(directory)
+            for e in entity:
+                print("s3 object:", e.remote_source)
+                # s3 object: s3://test-flytedir/file1.txt
+                # s3 object: s3://test-flytedir/file2.txt
+                # s3 object: s3://test-flytedir/sub_dir
+
+            open(entity[0], "r")  # This will download the file to the local disk.
+            open(entity[0], "r")  # flytekit will read data from the local disk if you open it again.
+        """
+
+        final_path = directory.path
+        if directory.remote_source:
+            final_path = directory.remote_source
+        elif directory.remote_directory:
+            final_path = typing.cast(os.PathLike, directory.remote_directory)
+
+        paths: typing.List[typing.Union[FlyteDirectory, FlyteFile]] = []
+        file_access = FlyteContextManager.current_context().file_access
+        if not file_access.is_remote(final_path):
+            for p in os.listdir(final_path):
+                if pathlib.Path(p).is_dir():
+                    paths.append(FlyteDirectory(p))
+                else:
+                    paths.append(FlyteFile(p))
+            return paths
+
+        def create_downloader(_remote_path: str, _local_path: str, is_multipart: bool):
+            return lambda: file_access.get_data(_remote_path, _local_path, is_multipart=is_multipart)
+
+        fs = file_access.get_filesystem_for_path(final_path)
+        for key in fs.listdir(final_path):
+            remote_path = os.path.join(final_path, key["name"].split(os.sep)[-1])
+            if key["type"] == "file":
+                local_path = file_access.get_random_local_path()
+                os.makedirs(pathlib.Path(local_path).parent, exist_ok=True)
+                downloader = create_downloader(remote_path, local_path, is_multipart=False)
+
+                flyte_file: FlyteFile = FlyteFile(local_path, downloader=downloader)
+                flyte_file._remote_source = remote_path
+                paths.append(flyte_file)
+            else:
+                local_folder = file_access.get_random_local_directory()
+                downloader = create_downloader(remote_path, local_folder, is_multipart=True)
+
+                flyte_directory: FlyteDirectory = FlyteDirectory(path=local_folder, downloader=downloader)
+                flyte_directory._remote_source = remote_path
+                paths.append(flyte_directory)
+
+        return paths
 
     def crawl(
         self, maxdepth: typing.Optional[int] = None, topdown: bool = True, **kwargs

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -200,7 +200,7 @@ class FlyteFile(os.PathLike, typing.Generic[T], DataClassJSONMixin):
         self._downloader = downloader
         self._downloaded = False
         self._remote_path = remote_path
-        self._remote_source = None
+        self._remote_source: typing.Optional[str] = None
 
     def __fspath__(self):
         # This is where a delayed downloading of the file will happen

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -300,7 +300,7 @@ def convert_schema_type_to_structured_dataset_type(
 def get_supported_types():
     import numpy as _np
 
-    _SUPPORTED_TYPES: typing.Dict[Type, LiteralType] = {
+    _SUPPORTED_TYPES: typing.Dict[Type, LiteralType] = {  # type: ignore
         _np.int32: type_models.LiteralType(simple=type_models.SimpleType.INTEGER),
         _np.int64: type_models.LiteralType(simple=type_models.SimpleType.INTEGER),
         _np.uint32: type_models.LiteralType(simple=type_models.SimpleType.INTEGER),

--- a/tests/flytekit/unit/core/test_flyte_directory.py
+++ b/tests/flytekit/unit/core/test_flyte_directory.py
@@ -5,6 +5,7 @@ import tempfile
 import typing
 from unittest.mock import MagicMock
 
+import mock
 import pytest
 
 import flytekit.configuration
@@ -16,6 +17,7 @@ from flytekit.core.dynamic_workflow_task import dynamic
 from flytekit.core.task import task
 from flytekit.core.type_engine import TypeEngine
 from flytekit.core.workflow import workflow
+from flytekit.exceptions.user import FlyteAssertion
 from flytekit.models.core.types import BlobType
 from flytekit.models.literals import LiteralMap
 from flytekit.types.directory.types import FlyteDirectory, FlyteDirToMultipartBlobTransformer
@@ -89,25 +91,24 @@ def test_transformer_to_literal_local():
             TypeEngine.to_literal(ctx, 3, FlyteDirectory, lt)
 
 
-# def test_transformer_to_literal_localss():
-#     random_dir = context_manager.FlyteContext.current_context().file_access.get_random_local_directory()
-#     fs = FileAccessProvider(local_sandbox_dir=random_dir, raw_output_prefix=os.path.join(random_dir, "raw"))
-#     ctx = context_manager.FlyteContext.current_context()
-#     with context_manager.FlyteContextManager.with_context(ctx.with_file_access(fs)) as ctx:
-#
-#         tf = FlyteDirToMultipartBlobTransformer()
-#         lt = tf.get_literal_type(FlyteDirectory)
-#         # Can't use if it's not a directory
-#         with pytest.raises(FlyteAssertion):
-#             p = "/tmp/flyte/xyz"
-#             path = pathlib.Path(p)
-#             try:
-#                 path.unlink()
-#             except OSError:
-#                 ...
-#             with open(p, "w") as fh:
-#                 fh.write("hello world\n")
-#             tf.to_literal(ctx, FlyteDirectory(p), FlyteDirectory, lt)
+def test_transformer_to_literal_local_path():
+    random_dir = context_manager.FlyteContext.current_context().file_access.get_random_local_directory()
+    fs = FileAccessProvider(local_sandbox_dir=random_dir, raw_output_prefix=os.path.join(random_dir, "raw"))
+    ctx = context_manager.FlyteContext.current_context()
+    with context_manager.FlyteContextManager.with_context(ctx.with_file_access(fs)) as ctx:
+        tf = FlyteDirToMultipartBlobTransformer()
+        lt = tf.get_literal_type(FlyteDirectory)
+        # Can't use if it's not a directory
+        with pytest.raises(FlyteAssertion):
+            p = ctx.file_access.get_random_local_path()
+            path = pathlib.Path(p)
+            try:
+                path.unlink()
+            except OSError:
+                ...
+            with open(p, "w") as fh:
+                fh.write("hello world\n")
+            tf.to_literal(ctx, FlyteDirectory(p), FlyteDirectory, lt)
 
 
 def test_transformer_to_literal_remote():
@@ -279,3 +280,31 @@ def test_directory_guess():
     fft = transformer.guess_python_type(lt)
     assert issubclass(fft, FlyteDirectory)
     assert fft.extension() == ""
+
+
+@mock.patch("s3fs.core.S3FileSystem._lsdir")
+@mock.patch("flytekit.core.data_persistence.FileAccessProvider.get_data")
+def test_list_dir(mock_get_data, mock_lsdir):
+    mock_lsdir.return_value = [
+        {"name": "s3://test-flytedir/file1.txt", "type": "file"},
+        {"name": "s3://test-flytedir/file2.txt", "type": "file"},
+        {"name": "s3://test-flytedir/sub_dir", "type": "directory"},
+    ]
+
+    mock_get_data.side_effect = lambda: Exception("Should not be called")
+
+    temp_dir = tempfile.mkdtemp(prefix="temp_example_")
+    file1_path = os.path.join(temp_dir, "file1.txt")
+    with open(file1_path, "w") as file1:
+        file1.write("Content of file1.txt")
+
+    f = FlyteDirectory(temp_dir)
+    paths = FlyteDirectory.listdir(f)
+    assert len(paths) == 1
+
+    f = FlyteDirectory("s3://test-flytedir")
+    paths = FlyteDirectory.listdir(f)
+    assert len(paths) == 3
+
+    with pytest.raises(Exception):
+        open(paths[0], "r")

--- a/tests/flytekit/unit/core/test_flyte_directory.py
+++ b/tests/flytekit/unit/core/test_flyte_directory.py
@@ -311,6 +311,7 @@ def test_list_dir(mock_get_data, mock_lsdir):
 
     f = FlyteDirectory(path=temp_dir)
     f._remote_source = remote_dir
+    paths = FlyteDirectory.listdir(f)
     assert len(paths) == 3
 
     with pytest.raises(Exception):


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
flytekit downloads the entire directory when calling `os.listdir(FlyteDirectory(...))`. However, users may only want to download the specific files they will use when the task is running.

## What changes were proposed in this pull request?
Add a new method called listdir in `FlyteDirectory` that can list all the files and folders in the given directory. `listdir` only returns either `flytefile` or `FlyteDirectory`

## How was this patch tested?
```python
import os
import tempfile

from flytekit import workflow, task, ImageSpec
from flytekit.types.directory import FlyteDirectory

new_flytekit = "git+https://github.com/flyteorg/flytekit.git@a5171380ea8a1aa55e20647a06e4313cbc19bec4"
image_spec = ImageSpec(registry="pingsutw", apt_packages=["git"], packages=[new_flytekit])


@task(container_image=image_spec)
def t1() -> FlyteDirectory:
    temp_dir = tempfile.mkdtemp(prefix='temp_example_')

    # Create some sample files in the temporary directory
    file1_path = os.path.join(temp_dir, 'file1.txt')
    with open(file1_path, 'w') as file1:
        file1.write('Content of file1.txt')

    file2_path = os.path.join(temp_dir, 'file2.txt')
    with open(file2_path, 'w') as file2:
        file2.write('Content of file2.txt')

    sub_dir = os.path.join(temp_dir, 'sub_dir')
    os.mkdir(sub_dir)
    file3_path = os.path.join(sub_dir, 'file3.txt')
    with open(file3_path, 'w') as file3:
        file3.write('Content of file3.txt')

    remote_dir = FlyteContext.current_context().file_access.get_random_remote_directory()

    return FlyteDirectory(path=temp_dir, remote_directory=remote_dir)


@task(container_image=image_spec)
def t2(directory: FlyteDirectory):
    entity = FlyteDirectory.listdir(directory)
    for e in entity:
        print("s3 object:", e.remote_source)
        # s3 object: s3://test-flytedir/file1.txt
        # s3 object: s3://test-flytedir/file2.txt
        # s3 object: s3://test-flytedir/sub_dir

    f = open(entity[0], "r")
    print(f.read())
    # Download s3 file to local disk
    # Getting s3://test-flytedir/file1.txt to /var/folders/xp/_4ltv_bx3pb_r0bm00fk9z_00000gn/T/flyte-ed16jhdg/sandbox/local_flytekit/6efb309606124d7104991164a0503671
    # Content of file1.txt

    f = open(entity[0], "r")
    print(f.read())
    # Read from local disk
    # Content of file1.txt


@workflow
def wf():
    t2(directory=t1())


if __name__ == '__main__':
    wf()
```

### Screenshots
<img width="1886" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/41676165-8954-486e-9b0f-32b65db0458e">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed off.

## Related PRs
NA

## Docs link
NA
