### PR TITLE
Fix: Handle SIGTERM in kubeflow pytorch elastic training plugin

### DIFF
--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -386,6 +386,7 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
         else:
             raise Exception("Bad start method")
 
+        from torch.distributed.elastic.multiprocessing.api import SignalException
         from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
 
         try:
@@ -399,6 +400,9 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
                 raise FlyteRecoverableException(e.format_msg())
             else:
                 raise RuntimeError(e.format_msg())
+        except SignalException as e:
+            logger.exception(f"Elastic launch agent process terminating: {e}")
+            raise IgnoreOutputs()
 
         # `out` is a dictionary of rank (not local rank) -> result
         # Rank 0 returns the result of the task function


### PR DESCRIPTION
## Why are the changes needed?

We recently observed many pytorch elastic training jobs failing with the following "user error":

```console
      File ".../flytekitplugins/kfpytorch/task.py", line 391, in _execute
        out = elastic_launch(
      ...
      File ".../torch/distributed/elastic/multiprocessing/api.py", line 62, in _terminate_process_handler
        raise SignalException(f"Process {os.getpid()} got signal: {sigval}", sigval=sigval)

Message:

    Process 107 got signal: 15

User error.
```

This `SignalException` [is raised by pytorch when the elastic launch agent process (which launches the worker processes within a Pod) receives SIGTERM etc](https://github.com/pytorch/pytorch/blob/f170d6665ca7dea844d20b06bd4dcb82d28f2879/torch/distributed/elastic/multiprocessing/api.py#L62). This in turn happens for instance when a multi pod distributed training job fails in one pod and the Kubeflow training operator deletes the other pods.

---

There haven't been any changes in the pytorch elastic training plugin that would explain this sudden change of behaviour and we also didn't upgrade torch.

I noticed in google cloud logging, that we started to see these `SignalException`s on the day we upgraded from `flytekit==1.9.0` to `flytekit==1.10.1`.
I traced the cause down to [this](https://github.com/flyteorg/flytekit/commit/b072130a6edbf80cf5406d35c6f8a3a7a60fefbe) commit in which the following change was made to the task pods' entrypoint/command `pyflyte-fast-execute`:


```py
@_pass_through.command("pyflyte-fast-execute")
def fast_execute_task_cmd(...):

   # Before
    p = subprocess.run(cmd, check=False)
    exit(p.returncode)

    # After
    p = subprocess.Popen(cmd)

    def handle_sigterm(signum, frame):
        logger.info(f"passing signum {signum} [frame={frame}] to subprocess")
        p.send_signal(signum)

    signal.signal(signal.SIGTERM, handle_sigterm)
    returncode = p.wait()
    exit(returncode)
```

With this change, it makes sense that starting with `flytekit==1.9.1`, the pytorch elastic training agent process in the elastic plugin starts to receive SIGTERM signals, causing it to raise the `SignalException`.


## What changes were proposed in this pull request?

The `SignalException` raised by the pytorch elastic launch agent process happens in the user scope, causing it to be shown in the UI as a user error:

<img width="755" alt="Screenshot 2023-12-21 at 14 10 47" src="https://github.com/flyteorg/flytekit/assets/36511035/c5a53c6a-e098-48e7-b51c-ddcc10d052ef">

This is confusing for users as it suggests that the `SignalException` was the root cause of the failure while it actually is a side-effect of the shutdown. Treating the `SignalException` as a user error also influences the retry behaviour in an unintended way as this error is not recoverable.

Because of this, we need to catch and ignore this error.

---

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
