### PR TITLE
Error when multiple configuration plugins are installed

### DIFF
--- a/flytekit/configuration/plugin.py
+++ b/flytekit/configuration/plugin.py
@@ -74,7 +74,7 @@ def _get_plugin_from_entrypoint():
     if len(plugins) >= 2:
         plugin_names = [p.name for p in plugins]
         raise ValueError(
-            f"Multiple plugins installed {plugin_names}. flytekit only supports one installed plugin at a time."
+            f"Multiple plugins installed: {plugin_names}. flytekit only supports one installed plugin at a time."
         )
 
     plugin_to_load = plugins[0]

--- a/flytekit/configuration/plugin.py
+++ b/flytekit/configuration/plugin.py
@@ -73,7 +73,9 @@ def _get_plugin_from_entrypoint():
 
     if len(plugins) >= 2:
         plugin_names = [p.name for p in plugins]
-        logger.info(f"Multiple plugins seen for {group}: {plugin_names}")
+        raise ValueError(
+            f"Multiple plugins installed {plugin_names}. flytekit only supports one installed plugin at a time."
+        )
 
     plugin_to_load = plugins[0]
     logger.info(f"Loading plugin: {plugin_to_load.name}")

--- a/tests/flytekit/unit/cli/pyflyte/test_plugin.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_plugin.py
@@ -25,7 +25,7 @@ def test_get_plugin_errors_with_multiple_plugins(entry_points, caplog):
     entry_points.side_effect = lambda *args, **kwargs: [entry_1, entry_2]
 
     msg = re.escape(
-        "Multiple plugins installed ['entry_1', 'entry_2']. flytekit only supports one installed plugin at a time."
+        "Multiple plugins installed: ['entry_1', 'entry_2']. flytekit only supports one installed plugin at a time."
     )
     with pytest.raises(ValueError, match=msg):
         _get_plugin_from_entrypoint()

--- a/tests/flytekit/unit/cli/pyflyte/test_plugin.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_plugin.py
@@ -1,6 +1,8 @@
+import re
 from unittest.mock import Mock, patch
 
 import click
+import pytest
 
 from flytekit.configuration.plugin import FlytekitPlugin, FlytekitPluginProtocol, _get_plugin_from_entrypoint
 
@@ -14,20 +16,19 @@ def test_get_plugin_default(entry_points):
 
 
 @patch("flytekit.configuration.plugin.entry_points")
-def test_get_plugin_load_other_plugin(entry_points, caplog):
-    loaded_plugin_1 = Mock()
+def test_get_plugin_errors_with_multiple_plugins(entry_points, caplog):
     entry_1 = Mock()
     entry_1.name = "entry_1"
-    entry_1.load.side_effect = lambda: loaded_plugin_1
 
     entry_2 = Mock()
+    entry_2.name = "entry_2"
     entry_points.side_effect = lambda *args, **kwargs: [entry_1, entry_2]
 
-    plugin = _get_plugin_from_entrypoint()
-    assert plugin is loaded_plugin_1
-
-    assert entry_1.load.call_count == 1
-    assert entry_2.load.call_count == 0
+    msg = re.escape(
+        "Multiple plugins installed ['entry_1', 'entry_2']. flytekit only supports one installed plugin at a time."
+    )
+    with pytest.raises(ValueError, match=msg):
+        _get_plugin_from_entrypoint()
 
 
 class CustomPlugin(FlytekitPlugin):


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
For the initial release, I think it's better to be strict and disallow multiple plugin installed.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
I updated the code and tests to have the more restricted behavior.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I updated the unit test to check for the error when multiple multiples are installed.