### PR TITLE
Fix Get the Secret Bug from OS Environment Variable

### DIFF
--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -365,7 +365,7 @@ class SecretsManager(object):
         fpath = self.get_secrets_file(group, key, group_version)
         v = os.environ.get(env_var)
         if v is not None:
-            return v
+            return v.strip()
         if os.path.exists(fpath):
             with open(fpath, encode_mode) as f:
                 return f.read().strip()


### PR DESCRIPTION
## Why are the changes needed?
In the current design of flytekit, we have two ways to retrieve secrets:

1. Get the secret from the OS's environment variables.
2. Get the secret from a specified file path. (Usually use kubectl to create secret value)

If you choose the first method, you will encounter an issue: the retrieved secret value needs to have `whitespace characters` removed.

This update aims to fix errors that occur when using `flytekit.current_context().secrets.get` along with the first method above, especially in `Single Binary Mode`.

## What changes were proposed in this pull request?
Call `strip` method to remove whitespace characters in `context manager` get secret function.
Note: The type of variable from os environment is python pickle object, maybe that's why we have this error.
I've tried to return `type` of the secret value.
Use code like below.
```python
token = flytekit.current_context().secrets.get
return type(token)
```
```json
{
   "o0":{
      "type":"single (PythonPickle) blob",
      "uri":"s3://my-s3-bucket/data/81/f4d0ab375012340e7942-fjfcm5iy-0/004422d2313077a075ec20a2e765bcb9/e5d6226b55aa2670cc70e14f7ec76bda"
   }
}
```

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
0. Start flyte cluster using latest single binary mode.
1. Add a secret value in your local cluster.
![image](https://github.com/flyteorg/flytekit/assets/76461262/b9d0f229-5e6d-49c4-ab36-51204f34c43a)
2. Use pyflyte run remote to run the task.
3. Copy the Output value to clipboard.
![image](https://github.com/flyteorg/flytekit/assets/76461262/bfce61e1-de59-432e-a27d-6a8f93ed50cc)
#### Use Default Flytekit Image
```
pyflyte run --remote secret.py github_secret_task
```
Return Value
```json
{"o0":"abc_jDDmlkadf8ASSD8DSDA5F66ds6saADSFFdas\n"}
```
#### Use Flytekit Image Built by this branch
```bash
pyflyte run --remote --image futureoutlier/flytekit-secret:0145 secret.py github_secret_task
```
Return Value
```json
{"o0":"abc_jDDmlkadf8ASSD8DSDA5F66ds6saADSFFdas"}
```

#### Dockerfile (Use this branch)
```Dockerfile
FROM python:3.9-slim-buster
USER root
WORKDIR /root
ENV PYTHONPATH /root
RUN apt-get update && apt-get install build-essential -y
RUN apt-get install git -y

RUN pip install -U git+https://github.com/Future-Outlier/flytekit.git@6d194c6a18754c6b8d825d0bf3d347db97be56d2
```

#### Python File
```python
import flytekit
from flytekit import Secret, task

@task(secret_requests=[Secret(key="token", group="github-api")])
def github_secret_task() -> str:
    return flytekit.current_context().secrets.get("github-api", "token")
```

### Screenshots
#### Use Default Flytekit Image
![image](https://github.com/flyteorg/flytekit/assets/76461262/aa553807-639a-4a46-aaa7-8352057965e7)
This image shows the output from the `default Flytekit image`, which includes a trailing blank space at the end of the output string.
#### Use Built Image By This branch
![image](https://github.com/flyteorg/flytekit/assets/76461262/f7ece301-49bf-49b9-a41f-6487ba45a272)
This image displays the output using the `new Flytekit image` from this branch, where the trailing blank space at the end of the output string is removed.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

