### PR TITLE
Support mashumaro DataClassORJSONMixin

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -45,3 +45,5 @@ pandas
 scikit-learn
 types-requests
 prometheus-client
+
+orjson

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -61,7 +61,7 @@ TITLE = "title"
 try:
     from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-    DataClassJSONMixin = DataClassJSONMixin | DataClassORJSONMixin
+    DataClassJSONMixin = typing.Union[DataClassJSONMixin, DataClassORJSONMixin]
 except ModuleNotFoundError:
     pass
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -325,11 +325,11 @@ class DataclassTransformer(TypeTransformer[object]):
 
     def __init__(self):
         super().__init__("Object-Dataclass-Transformer", object)
-        self.serializable_classes = [DataClassJSONMixin, DataClassJsonMixin]
+        self._serializable_classes = [DataClassJSONMixin, DataClassJsonMixin]
         try:
             from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-            self.serializable_classes.append(DataClassORJSONMixin)
+            self._serializable_classes.append(DataClassORJSONMixin)
         except ModuleNotFoundError:
             pass
 
@@ -473,7 +473,7 @@ class DataclassTransformer(TypeTransformer[object]):
         return _type_models.LiteralType(simple=_type_models.SimpleType.STRUCT, metadata=schema, structure=ts)
 
     def is_serializable_class(self, class_: Type[T]) -> bool:
-        return any(issubclass(class_, serializable_class) for serializable_class in self.serializable_classes)
+        return any(issubclass(class_, serializable_class) for serializable_class in self._serializable_classes)
 
     def to_literal(self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:
         if isinstance(python_val, dict):

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -58,13 +58,6 @@ T = typing.TypeVar("T")
 DEFINITIONS = "definitions"
 TITLE = "title"
 
-try:
-    from mashumaro.mixins.orjson import DataClassORJSONMixin
-
-    DataClassJSONMixin = typing.Union[DataClassJSONMixin, DataClassORJSONMixin]
-except ModuleNotFoundError:
-    pass
-
 
 class BatchSize:
     """
@@ -332,6 +325,13 @@ class DataclassTransformer(TypeTransformer[object]):
 
     def __init__(self):
         super().__init__("Object-Dataclass-Transformer", object)
+        self.serializable_classes = [DataClassJSONMixin, DataClassJsonMixin]
+        try:
+            from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+            self.serializable_classes.append(DataClassORJSONMixin)
+        except ModuleNotFoundError:
+            pass
 
     def assert_type(self, expected_type: Type[DataClassJsonMixin], v: T):
         # Skip iterating all attributes in the dataclass if the type of v already matches the expected_type
@@ -424,7 +424,7 @@ class DataclassTransformer(TypeTransformer[object]):
                 f"Type {t} cannot be parsed."
             )
 
-        if not issubclass(t, DataClassJsonMixin) and not issubclass(t, DataClassJSONMixin):
+        if not self.is_serializable_class(t):
             raise AssertionError(
                 f"Dataclass {t} should be decorated with @dataclass_json or mixin with DataClassJSONMixin to be "
                 f"serialized correctly"
@@ -472,6 +472,9 @@ class DataclassTransformer(TypeTransformer[object]):
 
         return _type_models.LiteralType(simple=_type_models.SimpleType.STRUCT, metadata=schema, structure=ts)
 
+    def is_serializable_class(self, class_: Type[T]) -> bool:
+        return any(issubclass(class_, serializable_class) for serializable_class in self.serializable_classes)
+
     def to_literal(self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:
         if isinstance(python_val, dict):
             json_str = json.dumps(python_val)
@@ -482,9 +485,7 @@ class DataclassTransformer(TypeTransformer[object]):
                 f"{type(python_val)} is not of type @dataclass, only Dataclasses are supported for "
                 f"user defined datatypes in Flytekit"
             )
-        if not issubclass(type(python_val), DataClassJsonMixin) and not issubclass(
-            type(python_val), DataClassJSONMixin
-        ):
+        if not self.is_serializable_class(type(python_val)):
             raise TypeTransformerFailedError(
                 f"Dataclass {python_type} should be decorated with @dataclass_json or inherit DataClassJSONMixin to be "
                 f"serialized correctly"
@@ -737,9 +738,7 @@ class DataclassTransformer(TypeTransformer[object]):
                 f"{expected_python_type} is not of type @dataclass, only Dataclasses are supported for "
                 "user defined datatypes in Flytekit"
             )
-        if not issubclass(expected_python_type, DataClassJsonMixin) and not issubclass(
-            expected_python_type, DataClassJSONMixin
-        ):
+        if not self.is_serializable_class(expected_python_type):
             raise TypeTransformerFailedError(
                 f"Dataclass {expected_python_type} should be decorated with @dataclass_json or mixin with DataClassJSONMixin to be "
                 f"serialized correctly"

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -58,6 +58,13 @@ T = typing.TypeVar("T")
 DEFINITIONS = "definitions"
 TITLE = "title"
 
+try:
+    from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+    DataClassJSONMixin = DataClassJSONMixin | DataClassORJSONMixin
+except ModuleNotFoundError:
+    pass
+
 
 class BatchSize:
     """

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -2505,6 +2505,7 @@ def test_DataclassTransformer_guess_python_type():
     pv = transformer.to_python_value(ctx, lv, expected_python_type=gt)
     assert datum_mashumaro_orjson.x == pv.x
     assert datum_mashumaro_orjson.y.value == pv.y
+    assert datum_mashumaro_orjson.z.isoformat() == pv.z
 
 
 def test_ListTransformer_get_sub_type():

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -22,6 +22,7 @@ from google.protobuf import struct_pb2 as _struct
 from marshmallow_enum import LoadDumpOptions
 from marshmallow_jsonschema import JSONSchema
 from mashumaro.mixins.json import DataClassJSONMixin
+from mashumaro.mixins.orjson import DataClassORJSONMixin
 from typing_extensions import Annotated, get_args, get_origin
 
 from flytekit import kwtypes
@@ -2366,6 +2367,10 @@ def test_DataclassTransformer_get_literal_type():
     class MyDataClassMashumaro(DataClassJsonMixin):
         x: int
 
+    @dataclass
+    class MyDataClassMashumaroORJSON(DataClassJsonMixin):
+        x: int
+
     @dataclass_json
     @dataclass
     class MyDataClass:
@@ -2379,6 +2384,9 @@ def test_DataclassTransformer_get_literal_type():
     literal_type = de.get_literal_type(MyDataClassMashumaro)
     assert literal_type is not None
 
+    literal_type = de.get_literal_type(MyDataClassMashumaroORJSON)
+    assert literal_type is not None
+
     invalid_json_str = "{ unbalanced_braces"
     with pytest.raises(Exception):
         Literal(scalar=Scalar(generic=_json_format.Parse(invalid_json_str, _struct.Struct())))
@@ -2387,6 +2395,10 @@ def test_DataclassTransformer_get_literal_type():
 def test_DataclassTransformer_to_literal():
     @dataclass
     class MyDataClassMashumaro(DataClassJsonMixin):
+        x: int
+
+    @dataclass
+    class MyDataClassMashumaroORJSON(DataClassORJSONMixin):
         x: int
 
     @dataclass_json
@@ -2398,11 +2410,18 @@ def test_DataclassTransformer_to_literal():
     ctx = FlyteContext.current_context()
 
     my_dat_class_mashumaro = MyDataClassMashumaro(5)
+    my_dat_class_mashumaro_orjson = MyDataClassMashumaroORJSON(5)
     my_data_class = MyDataClass(5)
 
     lv_mashumaro = transformer.to_literal(ctx, my_dat_class_mashumaro, MyDataClassMashumaro, MyDataClassMashumaro)
     assert lv_mashumaro is not None
     assert lv_mashumaro.scalar.generic["x"] == 5
+
+    lv_mashumaro_orjson = transformer.to_literal(
+        ctx, my_dat_class_mashumaro_orjson, MyDataClassMashumaroORJSON, MyDataClassMashumaroORJSON
+    )
+    assert lv_mashumaro_orjson is not None
+    assert lv_mashumaro_orjson.scalar.generic["x"] == 5
 
     lv = transformer.to_literal(ctx, my_data_class, MyDataClass, MyDataClass)
     assert lv is not None
@@ -2412,6 +2431,10 @@ def test_DataclassTransformer_to_literal():
 def test_DataclassTransformer_to_python_value():
     @dataclass
     class MyDataClassMashumaro(DataClassJsonMixin):
+        x: int
+
+    @dataclass
+    class MyDataClassMashumaroORJSON(DataClassORJSONMixin):
         x: int
 
     @dataclass_json
@@ -2432,8 +2455,17 @@ def test_DataclassTransformer_to_python_value():
     assert isinstance(result, MyDataClassMashumaro)
     assert result.x == 5
 
+    result = de.to_python_value(FlyteContext.current_context(), mock_literal, MyDataClassMashumaroORJSON)
+    assert isinstance(result, MyDataClassMashumaroORJSON)
+    assert result.x == 5
+
 
 def test_DataclassTransformer_guess_python_type():
+    @dataclass
+    class DatumMashumaroORJSON(DataClassORJSONMixin):
+        x: int
+        y: Color
+
     @dataclass
     class DatumMashumaro(DataClassJSONMixin):
         x: int
@@ -2463,6 +2495,14 @@ def test_DataclassTransformer_guess_python_type():
     pv = transformer.to_python_value(ctx, lv, expected_python_type=gt)
     assert datum_mashumaro.x == pv.x
     assert datum_mashumaro.y.value == pv.y
+
+    lt = TypeEngine.to_literal_type(DatumMashumaroORJSON)
+    datum_mashumaro_orjson = DatumMashumaroORJSON(5, Color.RED)
+    lv = transformer.to_literal(ctx, datum_mashumaro_orjson, DatumMashumaroORJSON, lt)
+    gt = transformer.guess_python_type(lt)
+    pv = transformer.to_python_value(ctx, lv, expected_python_type=gt)
+    assert datum_mashumaro_orjson.x == pv.x
+    assert datum_mashumaro_orjson.y.value == pv.y
 
 
 def test_ListTransformer_get_sub_type():

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -2465,6 +2465,7 @@ def test_DataclassTransformer_guess_python_type():
     class DatumMashumaroORJSON(DataClassORJSONMixin):
         x: int
         y: Color
+        z: datetime.datetime
 
     @dataclass
     class DatumMashumaro(DataClassJSONMixin):
@@ -2497,7 +2498,8 @@ def test_DataclassTransformer_guess_python_type():
     assert datum_mashumaro.y.value == pv.y
 
     lt = TypeEngine.to_literal_type(DatumMashumaroORJSON)
-    datum_mashumaro_orjson = DatumMashumaroORJSON(5, Color.RED)
+    now = datetime.datetime.now()
+    datum_mashumaro_orjson = DatumMashumaroORJSON(5, Color.RED, now)
     lv = transformer.to_literal(ctx, datum_mashumaro_orjson, DatumMashumaroORJSON, lt)
     gt = transformer.guess_python_type(lt)
     pv = transformer.to_python_value(ctx, lv, expected_python_type=gt)


### PR DESCRIPTION
## Why are the changes needed?

The mashumaro `DataClassORJSONMixin` class works like the mashumaro `DataClassJSONMixin` class. Additionally, it allows for serializing dataclasses with a wider variety of attributes types, including:
- [numpy](https://numpy.org/)
- [datetime](https://docs.python.org/3/library/datetime.html#datetime.datetime)
- [date](https://docs.python.org/3/library/datetime.html#datetime.date)
- [time](https://docs.python.org/3/library/datetime.html#datetime.time)
- [uuid.UUID](https://docs.python.org/3/library/uuid.html#uuid.UUID)

Currently, flytekit does not yet support the `DataClassJSONMixin` class and throws an error when classes derived from `DataClassORJSONMixin` are serialized.

## What changes were proposed in this pull request?

This PR introduces support for classes derived from the mashumaro `DataClassORJSONMixins` class.

## How was this patch tested?

Added DataClassORJSONMixin instances in `test_type_engine.py`

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
