### PR TITLE
Support PodTemplate in ArrayNode

### DIFF
--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -150,6 +150,11 @@ class ArrayNodeMapTask(PythonTask):
     def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
         return ArrayJob(parallelism=self._concurrency, min_success_ratio=self._min_success_ratio).to_dict()
 
+    def get_config(self, settings: SerializationSettings) -> Optional[Dict[str, str]]:
+        if self.python_function_task.pod_template is None:
+            return {}
+        return {"primary_container_name": self.python_function_task.pod_template.primary_container_name}
+
     def get_container(self, settings: SerializationSettings) -> Container:
         with self.prepare_target():
             return self.python_function_task.get_container(settings)

--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -82,6 +82,7 @@ class ArrayNodeMapTask(PythonTask):
         ).hexdigest()
         self._name = f"{mod}.map_{f}_{h}-arraynode"
 
+        self._cmd_prefix: typing.Optional[typing.List[str]] = None
         self._concurrency: Optional[int] = concurrency
         self._min_successes: Optional[int] = min_successes
         self._min_success_ratio: Optional[float] = min_success_ratio
@@ -185,10 +186,12 @@ class ArrayNodeMapTask(PythonTask):
             *mt.loader_args(settings, self),
         ]
 
-        # TODO: add support for ContainerTask
-        # if self._cmd_prefix:
-        #     return self._cmd_prefix + container_args
+         if self._cmd_prefix:
+             return self._cmd_prefix + container_args
         return container_args
+
+    def set_command_prefix(self, cmd: typing.Optional[typing.List[str]]):
+        self._cmd_prefix = cmd
 
     def __call__(self, *args, **kwargs):
         """

--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -151,9 +151,7 @@ class ArrayNodeMapTask(PythonTask):
         return ArrayJob(parallelism=self._concurrency, min_success_ratio=self._min_success_ratio).to_dict()
 
     def get_config(self, settings: SerializationSettings) -> Optional[Dict[str, str]]:
-        if self.python_function_task.pod_template is None:
-            return {}
-        return {"primary_container_name": self.python_function_task.pod_template.primary_container_name}
+        return self.python_function_task.get_config(settings)
 
     def get_container(self, settings: SerializationSettings) -> Container:
         with self.prepare_target():

--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -82,7 +82,7 @@ class ArrayNodeMapTask(PythonTask):
         ).hexdigest()
         self._name = f"{mod}.map_{f}_{h}-arraynode"
 
-        self._cmd_prefix: typing.Optional[typing.List[str]] = None
+        self._cmd_prefix: Optional[List[str]] = None
         self._concurrency: Optional[int] = concurrency
         self._min_successes: Optional[int] = min_successes
         self._min_success_ratio: Optional[float] = min_success_ratio
@@ -186,11 +186,11 @@ class ArrayNodeMapTask(PythonTask):
             *mt.loader_args(settings, self),
         ]
 
-         if self._cmd_prefix:
-             return self._cmd_prefix + container_args
+        if self._cmd_prefix:
+            return self._cmd_prefix + container_args
         return container_args
 
-    def set_command_prefix(self, cmd: typing.Optional[typing.List[str]]):
+    def set_command_prefix(self, cmd: Optional[List[str]]):
         self._cmd_prefix = cmd
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
## Tracking issue
_NA_

## Why are the changes needed?
Currently, ArrayNode does not support operating over tasks that use PodTemplates. This is a very powerful resource that should be enabled.

## What changes were proposed in this pull request?
Updating the ArrayNode construct to use underlying function config.

## How was this patch tested?
locally / cloud / etc with many workflows, for example:

```
@task(pod_template=PodTemplate(
    primary_container_name="primary",
    labels={"mylabel": "myvalue"},
))
def echo_2(x: int) -> int:
    time.sleep(1)
    return x

@workflow
def gen_wf_2() -> typing.List[typing.Optional[int]]:
    return map_task(echo_2)(x=list(range(5)))

```

### Setup process
_NA_

### Screenshots
_NA_

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
_NA_

## Docs link
_NA_
