### PR TITLE
Option to disable local caching

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -623,7 +623,7 @@ class LocalConfig(object):
     def auto(cls, config_file: typing.Union[str, ConfigFile] = None) -> LocalConfig:
         config_file = get_config_file(config_file)
         kwargs = {}
-        kwargs = set_if_exists(kwargs, "cache_enabled", _internal.LOCAL.CACHE_ENABLED.read(config_file))
+        kwargs = set_if_exists(kwargs, "cache_enabled", _internal.Local.CACHE_ENABLED.read(config_file))
         return LocalConfig(**kwargs)
 
 

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -612,6 +612,22 @@ class DataConfig(object):
 
 
 @dataclass(init=True, repr=True, eq=True, frozen=True)
+class LocalConfig(object):
+    """
+    Any configuration specific to local runs.
+    """
+
+    cache_enabled: bool = True
+
+    @classmethod
+    def auto(cls, config_file: typing.Union[str, ConfigFile] = None) -> LocalConfig:
+        config_file = get_config_file(config_file)
+        kwargs = {}
+        kwargs = set_if_exists(kwargs, "cache_enabled", _internal.LOCAL.CACHE_ENABLED.read(config_file))
+        return LocalConfig(**kwargs)
+
+
+@dataclass(init=True, repr=True, eq=True, frozen=True)
 class Config(object):
     """
     This the parent configuration object and holds all the underlying configuration object types. An instance of

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -66,7 +66,7 @@ class AZURE(object):
     CLIENT_SECRET = ConfigEntry(LegacyConfigEntry(SECTION, "client_secret"))
 
 
-class LOCAL(object):
+class Local(object):
     SECTION = "local"
     CACHE_ENABLED = ConfigEntry(LegacyConfigEntry(SECTION, "cache_enabled", bool))
 

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -66,6 +66,11 @@ class AZURE(object):
     CLIENT_SECRET = ConfigEntry(LegacyConfigEntry(SECTION, "client_secret"))
 
 
+class LOCAL(object):
+    SECTION = "local"
+    CACHE_ENABLED = ConfigEntry(LegacyConfigEntry(SECTION, "cache_enabled", bool))
+
+
 class Credentials(object):
     SECTION = "credentials"
     COMMAND = ConfigEntry(LegacyConfigEntry(SECTION, "command", list), YamlConfigEntry("admin.command", list))

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -27,7 +27,7 @@ from typing import Any, Coroutine, Dict, Generic, List, Optional, OrderedDict, T
 
 from flyteidl.core import tasks_pb2
 
-from flytekit.configuration import SerializationSettings
+from flytekit.configuration import LocalConfig, SerializationSettings
 from flytekit.core.context_manager import (
     ExecutionParameters,
     ExecutionState,
@@ -265,7 +265,8 @@ class Task(object):
         input_literal_map = _literal_models.LiteralMap(literals=kwargs)
 
         # if metadata.cache is set, check memoized version
-        if self.metadata.cache:
+        local_config = LocalConfig.auto()
+        if self.metadata.cache and local_config.cache_enabled:
             # TODO: how to get a nice `native_inputs` here?
             logger.info(
                 f"Checking cache for task named {self.name}, cache version {self.metadata.cache_version} "

--- a/tests/flytekit/unit/core/test_local_cache.py
+++ b/tests/flytekit/unit/core/test_local_cache.py
@@ -100,6 +100,25 @@ def test_single_task_workflow():
     assert n_cached_task_calls == 2
 
 
+def test_cache_can_be_disabled(monkeypatch):
+    monkeypatch.setenv("FLYTE_LOCAL_CACHE_ENABLED", "false")
+
+    @task(cache=True, cache_version="v1")
+    def is_even(n: int) -> bool:
+        global n_cached_task_calls
+        n_cached_task_calls += 1
+        return n % 2 == 0
+
+    assert n_cached_task_calls == 0
+    # Run once and check that the counter is increased
+    assert is_even(n=1) is False
+    assert n_cached_task_calls == 1
+
+    # Run again and check that the counter is increased again i.e. no caching
+    assert is_even(n=1) is False
+    assert n_cached_task_calls == 2
+
+
 def test_shared_tasks_in_two_separate_workflows():
     @task(cache=True, cache_version="0.0.1")
     def is_odd(n: int) -> bool:


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/4395

## Why are the changes needed?
While local caching is useful in some cases, it has often led to unexpected errors for users not being aware. Especially in large codebases this can lead to unexpected test failures, etc.

## What changes were proposed in this pull request?
This PR introduces a new config section `local` with one value `cachen_enabled` (which defaults to true):
```
[local]
cache_enabled = True
```

## How was this patch tested?
Added a test which confirms that setting `FLYTE_LOCAL_CACHE_ENABLED=false` prevents the local use of the cache.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Docs link
Changed in https://github.com/flyteorg/flytesnacks/pull/1425

https://flyte--1425.org.readthedocs.build/projects/cookbook/en/1425/auto_examples/development_lifecycle/task_cache.html#how-does-local-caching-work

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
