### PR TITLE
Changes default destination dir to be "working dir"

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -70,7 +70,7 @@ class RunLevelParams(PyFlyteParams):
             param_decls=["--destination-dir", "destination_dir"],
             required=False,
             type=str,
-            default="/root",
+            default=".",
             show_default=True,
             help="Directory inside the image where the tar file containing the code will be copied to",
         )


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4638

## Why are the changes needed?
In the absence of this change `pyflyte run` configures the default destination directory - the path where the code should be installed within a container to be `/root`. This does not work for cases in which the user may want a directory other than `/root`. Though it is possible to pass in this directory, it fails in case you have a task with multiple tasks, each uses a different container and separate paths.

A propose solution by @vkaiser-mb is to set it on a per task basis
```
@task(working_dir="/home/user_a", container_image="a")
def do_a():
 ...

@task(working_dir="/home/user_b", container_image="a")
def do_b():
  ...

@workflow
def wf():
  do_a()
  do_b()
```
This complicates the process, as it is one more argument on the task and is not simple to change and hard to keep in sync with the container Dockerfile.

## What changes were proposed in this pull request?

The proposal is to instead simply set the WORKDIR in the Dockerfile and use that as the actual location of the installation. The code change then makes the current working dir as the default installation path.

## How was this patch tested?
Tested with `pyflyte run` using existing flytekit dockerfile as it sets the WORKDIR correctly https://github.com/flyteorg/flytekit/blob/892b4741d0c38bd61b9cdaf1defb002d729acba2/Dockerfile#L7 to `/root` We could easily change it to be non-root and this should continue to work.


