### PR TITLE
Skip errors when running pyflyte register

### DIFF
--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -117,6 +117,14 @@ the root of your project, it finds the first folder that does not have a ``__ini
     callback=key_value_callback,
     help="Environment variables to set in the container, of the format `ENV_NAME=ENV_VALUE`",
 )
+@click.option(
+    "--skip-errors",
+    "--skip-error",
+    default=False,
+    is_flag=True,
+    help="Skip errors during registration. This is useful when registering multiple packages and you want to skip "
+    "errors for some packages.",
+)
 @click.argument("package-or-module", type=click.Path(exists=True, readable=True, resolve_path=True), nargs=-1)
 @click.pass_context
 def register(
@@ -135,6 +143,7 @@ def register(
     dry_run: bool,
     activate_launchplans: bool,
     env: typing.Optional[typing.Dict[str, str]],
+    skip_errors: bool,
 ):
     """
     see help
@@ -187,6 +196,7 @@ def register(
             env=env,
             dry_run=dry_run,
             activate_launchplans=activate_launchplans,
+            skip_errors=skip_errors,
         )
     except Exception as e:
         raise e


### PR DESCRIPTION
## Why are the changes needed?
Failed to register certain workflows due to the below errors
```bash
       "task-module",
          "basics.workflow",
          "task-name",
          "slope"
        ],
        "resources": {}
      }
    },
    "description": {
      "longDescription": {
        "format": "DESCRIPTION_FORMAT_RST"
      }
    }
  }
}
RPC Failed, with Status: StatusCode.INVALID_ARGUMENT
        details: task with different structure already exists with id resource_type:TASK project:"flytesnacks" domain:"development" name:"basics.workflow.slope" version:"v0.3.257" 
        Debug string UNKNOWN:Error received from peer  {grpc_message:"task with different structure already exists with id resource_type:TASK project:\"flytesnacks\" domain:\"development\" name:\"basics.workflow.slope\" version:\"v0.3.257\" ", grpc_status:3, created_time:"2024-01-17T00:21:33.186053-08:00"}


```

## What changes were proposed in this pull request?
Skip errors and continue resisting the workflows

## How was this patch tested?
```bash
 pyflyte register --skip-errors --version v0.3.257  basics
```

### Screenshots
<img width="946" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/694a457b-5d95-4260-8ed4-3baeb15deefc">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

