### PR TITLE
Add @lru_cache to ImageBuildEngine.build

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -197,6 +197,7 @@ class ImageBuildEngine:
         cls._REGISTRY[builder_type] = image_spec_builder
 
     @classmethod
+    @lru_cache
     def build(cls, image_spec: ImageSpec):
         img_name = image_spec.image_name()
         if img_name in cls._BUILT_IMAGES or image_spec.exist():


### PR DESCRIPTION
## Why are the changes needed?
Remove duplicate logs

## What changes were proposed in this pull request?
Add `@lru_cache` to ImageBuildEngine.build

## How was this patch tested?
```bash
pyflyte run --remote flyte-example/wf.py wf
```

### Screenshots

Before:
<img width="924" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/7cad6749-0c36-467d-9061-ece71d53ab36">

After:
<img width="732" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/0241a634-5c30-4165-94ea-a7e8dc892709">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

