### PR TITLE
[Bug] Map task caching failures

### DIFF
--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -77,8 +77,9 @@ class ArrayNodeMapTask(PythonTask):
             f = actual_task.lhs
         else:
             _, mod, f, _ = tracker.extract_task_module(cast(PythonFunctionTask, actual_task).task_function)
+        sorted_bounded_inputs = ','.join(sorted(self._bound_inputs))
         h = hashlib.md5(
-            f"{collection_interface.__str__()}{concurrency}{min_successes}{min_success_ratio}".encode("utf-8")
+            f"{sorted_bounded_inputs}{concurrency}{min_successes}{min_success_ratio}".encode("utf-8")
         ).hexdigest()
         self._name = f"{mod}.map_{f}_{h}-arraynode"
 

--- a/flytekit/core/map_task.py
+++ b/flytekit/core/map_task.py
@@ -92,7 +92,9 @@ class MapPythonTask(PythonTask):
             f = actual_task.lhs
         else:
             _, mod, f, _ = tracker.extract_task_module(typing.cast(PythonFunctionTask, actual_task).task_function)
-        h = hashlib.md5(collection_interface.__str__().encode("utf-8")).hexdigest()
+
+        sorted_bounded_inputs = ','.join(sorted(self._bound_inputs))
+        h = hashlib.md5(sorted_bounded_inputs.encode("utf-8")).hexdigest()
         name = f"{mod}.map_{f}_{h}"
 
         self._cmd_prefix: typing.Optional[typing.List[str]] = None

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -187,7 +187,7 @@ def test_inputs_outputs_length():
     assert m.python_interface.inputs == {"a": List[int], "b": List[str], "c": List[float]}
     assert (
         m.name
-        == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_4ee240ef5cf979dbc133fb30035cb874-arraynode"
+        == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_bf51001578d0ae197a52c0af0a99dd89-arraynode"
     )
     r_m = ArrayNodeMapTask(many_inputs)
     assert str(r_m.python_interface) == str(m.python_interface)
@@ -197,7 +197,7 @@ def test_inputs_outputs_length():
     assert m.python_interface.inputs == {"a": List[int], "b": List[str], "c": float}
     assert (
         m.name
-        == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_352fcdea8523a83134b51bbf5793f14e-arraynode"
+        == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_cb470e880fabd6265ec80e29fe60250d-arraynode"
     )
     r_m = ArrayNodeMapTask(many_inputs, bound_inputs=set("c"))
     assert str(r_m.python_interface) == str(m.python_interface)
@@ -207,7 +207,7 @@ def test_inputs_outputs_length():
     assert m.python_interface.inputs == {"a": List[int], "b": str, "c": float}
     assert (
         m.name
-        == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_e224ba3a5b00e08083d541a6ca99b179-arraynode"
+        == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_316e10eb97f5d2abd585951048b807b9-arraynode"
     )
     r_m = ArrayNodeMapTask(many_inputs, bound_inputs={"c", "b"})
     assert str(r_m.python_interface) == str(m.python_interface)
@@ -217,7 +217,7 @@ def test_inputs_outputs_length():
     assert m.python_interface.inputs == {"a": int, "b": str, "c": float}
     assert (
         m.name
-        == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_f080e60be9d6faedeef0c74834d6812a-arraynode"
+        == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_758022acd59ad1c8b81670378d4de4f6-arraynode"
     )
     r_m = ArrayNodeMapTask(many_inputs, bound_inputs={"a", "c", "b"})
     assert str(r_m.python_interface) == str(m.python_interface)

--- a/tests/flytekit/unit/core/test_map_task.py
+++ b/tests/flytekit/unit/core/test_map_task.py
@@ -192,28 +192,28 @@ def test_inputs_outputs_length():
 
     m = map_task(many_inputs)
     assert m.python_interface.inputs == {"a": typing.List[int], "b": typing.List[str], "c": typing.List[float]}
-    assert m.name == "tests.flytekit.unit.core.test_map_task.map_many_inputs_24c08b3a2f9c2e389ad9fc6a03482cf9"
+    assert m.name == "tests.flytekit.unit.core.test_map_task.map_many_inputs_d41d8cd98f00b204e9800998ecf8427e"
     r_m = MapPythonTask(many_inputs)
     assert str(r_m.python_interface) == str(m.python_interface)
 
     p1 = functools.partial(many_inputs, c=1.0)
     m = map_task(p1)
     assert m.python_interface.inputs == {"a": typing.List[int], "b": typing.List[str], "c": float}
-    assert m.name == "tests.flytekit.unit.core.test_map_task.map_many_inputs_697aa7389996041183cf6cfd102be4f7"
+    assert m.name == "tests.flytekit.unit.core.test_map_task.map_many_inputs_4a8a08f09d37b73795649038408b5f33"
     r_m = MapPythonTask(many_inputs, bound_inputs=set("c"))
     assert str(r_m.python_interface) == str(m.python_interface)
 
     p2 = functools.partial(p1, b="hello")
     m = map_task(p2)
     assert m.python_interface.inputs == {"a": typing.List[int], "b": str, "c": float}
-    assert m.name == "tests.flytekit.unit.core.test_map_task.map_many_inputs_cc18607da7494024a402a5fa4b3ea5c6"
+    assert m.name == "tests.flytekit.unit.core.test_map_task.map_many_inputs_74aefa13d6ab8e4bfbd241583749dfe8"
     r_m = MapPythonTask(many_inputs, bound_inputs={"c", "b"})
     assert str(r_m.python_interface) == str(m.python_interface)
 
     p3 = functools.partial(p2, a=1)
     m = map_task(p3)
     assert m.python_interface.inputs == {"a": int, "b": str, "c": float}
-    assert m.name == "tests.flytekit.unit.core.test_map_task.map_many_inputs_52fe80b04781ea77ef6f025f4b49abef"
+    assert m.name == "tests.flytekit.unit.core.test_map_task.map_many_inputs_a44c56c8177e32d3613988f4dba7962e"
     r_m = MapPythonTask(many_inputs, bound_inputs={"a", "c", "b"})
     assert str(r_m.python_interface) == str(m.python_interface)
 


### PR DESCRIPTION
## Tracking issue
_https://github.com/flyteorg/flyte/issues/4731_

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?

[Legacy map tasks](https://github.com/flyteorg/flytekit/blob/7996c2ebb6892341d31e6efbd7c7f0f8ca2c9b34/flytekit/core/map_task.py#L95) and [new map tasks](https://github.com/flyteorg/flytekit/blob/7996c2ebb6892341d31e6efbd7c7f0f8ca2c9b34/flytekit/core/array_node_map_task.py#L79) include the collection interface as part of task names to support partially binding different parameters of the same mappable task. This introduces issues when collection interface includes types that produces non-deterministic outputs such as guaranteed cache misses. 

Example where the output contains a memory address causing for guaranteed cache misses:
```
@task()
def process_data(index: int) -> Annotated[pd.DataFrame, Annotated[pd.DataFrame, HashMethod(hash_pandas_dataframe)]]:
    ...
```

The same can be done for inputs.


<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

Utilize an ordered list of the bounded input names in favor of the entire interface. This is similar to [this](https://github.com/flyteorg/flytekit/blob/7996c2ebb6892341d31e6efbd7c7f0f8ca2c9b34/flytekit/core/interface.py#L278) but disregards any Typed values, opting to only keep the keys/names.

Note, this will cause for all cache enabled map tasks to have cache misses on first runs as task names will all change.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

Confirmed that intputs/outputs w/ memory address don't impact caching
```
def hash_pandas_dataframe(df: pd.DataFrame) -> str:
    return str(pd.util.hash_pandas_object(df))


@task()
def mem_output(index: int) -> Annotated[pd.DataFrame, HashMethod(hash_pandas_dataframe)]:
    target = [index] * 3
    df = pd.DataFrame({"target": target})
    return df


@task()
def mem_input(df: Annotated[pd.DataFrame, HashMethod(hash_pandas_dataframe)]) -> int:
    return df["target"].tolist()[0]


@workflow
def caching_df(
    l: List[int] = [1, 2, 3, 4],
) -> None:
    from flytekit.experimental import map_task
    partial_task = functools.partial(mem_output)
    outputs = map_task(partial_task, metadata=TaskMetadata(cache=True, cache_version="2"))(index=l)
    partial_task2 = functools.partial(mem_input)
    map_task(partial_task2, metadata=TaskMetadata(cache=True, cache_version="2"))(df=outputs)
```


Confirmed if partially binding different parameters for the same mapped task still worked:
```
@task
def square_add(i: int, j: int) -> List[int]:
   return [i*i + j]


@workflow
def wf(xs: List[int] = [1, 1, 1], ys: List[int] = [2, 2, 2]):
   square_fixed = functools.partial(square_add, j=10)
   add_fixed = functools.partial(square_add, i=2)
   map_task(square_fixed, metadata=TaskMetadata(cache=True, cache_version="1.0.0"))(i=xs)
   map_task(add_fixed, metadata=TaskMetadata(cache=True, cache_version="1.0.0"))(j=ys)
```


### Screenshots
![Screenshot 2024-01-17 at 5 57 40 PM](https://github.com/flyteorg/flytekit/assets/37558497/febee9a5-22bb-41f7-8a3a-897e932c4077)


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
