### PR TITLE
Fix Flyin VScode Server Timeout Shutdown Bug

### DIFF
--- a/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
+++ b/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
@@ -6,7 +6,6 @@ import platform
 import shutil
 import signal
 import subprocess
-import sys
 import tarfile
 import time
 from threading import Event

--- a/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
+++ b/plugins/flytekit-flyin/flytekitplugins/flyin/vscode_lib/decorator.py
@@ -92,13 +92,12 @@ def exit_handler(
         # If the time from last connection is longer than max idle seconds, terminate the vscode server.
         if delta > max_idle_seconds:
             logger.info(f"VSCode server is idle for more than {max_idle_seconds} seconds. Terminating...")
-            terminate_process()
-            sys.exit()
+            break
 
         # Wait for HEARTBEAT_CHECK_SECONDS seconds, but return immediately when resume_task is set.
         resume_task.wait(timeout=HEARTBEAT_CHECK_SECONDS)
 
-    # User has resumed the task.
+    # User has resumed the task or reached the max idle time.
     terminate_process()
 
     # Reload the task function since it may be modified.


### PR DESCRIPTION
## Tracking issue
Fixes https://github.com/flyteorg/flyte/issues/4284

## Why are the changes needed?
If we don't make those changes, the pod will exit without returning output to flytepropeller, and the task will fail.
I've tested this PR here 2 days ago.
https://github.com/flyteorg/flytekit/pull/1953
