### PR TITLE
Omit '=' from auto-generated version

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -878,7 +878,7 @@ class FlyteRemote(object):
             h.update(bytes(s, "utf-8"))
 
         # Omit the character '=' from the version as that's essentially padding used by the base64 encoding
-        # and does not increase entropy of the hash while making it very incovenient to copy-and-paste.
+        # and does not increase entropy of the hash while making it very inconvenient to copy-and-paste.
         return base64.urlsafe_b64encode(h.digest()).decode("ascii").rstrip("=")
 
     def register_script(

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -877,7 +877,9 @@ class FlyteRemote(object):
         for s in additional_context:
             h.update(bytes(s, "utf-8"))
 
-        return base64.urlsafe_b64encode(h.digest()).decode("ascii")
+        # Omit the character '=' from the version as that's essentially padding used by the base64 encoding
+        # and does not increase entropy of the hash while making it very incovenient to copy-and-paste.
+        return base64.urlsafe_b64encode(h.digest()).decode("ascii").rstrip("=")
 
     def register_script(
         self,

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -207,6 +207,22 @@ def test_more_stuff(mock_client):
     assert computed_v2 != computed_v3
 
 
+@patch("flytekit.remote.remote.SynchronousFlyteClient")
+def test_version_hash_special_characters(mock_client):
+    r = FlyteRemote(config=Config.auto(), default_project="project", default_domain="domain")
+
+    serialization_settings = flytekit.configuration.SerializationSettings(
+        project="project",
+        domain="domain",
+        version="version",
+        env=None,
+        image_config=ImageConfig.auto(img_name=DefaultImages.default_image()),
+    )
+
+    computed_v = r._version_from_hash(b"", serialization_settings)
+    assert '=' not in computed_v
+
+
 def test_get_extra_headers_azure_blob_storage():
     native_url = "abfs://flyte@storageaccount/container/path/to/file"
     headers = FlyteRemote.get_extra_headers_for_protocol(native_url)

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -220,7 +220,7 @@ def test_version_hash_special_characters(mock_client):
     )
 
     computed_v = r._version_from_hash(b"", serialization_settings)
-    assert '=' not in computed_v
+    assert "=" not in computed_v
 
 
 def test_get_extra_headers_azure_blob_storage():


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?
We've received feedback that the auto-generated versions are difficult to copy due to the extra '=' that show at the end of each version.

## What changes were proposed in this pull request?
The '=' is a padding character used by the base64 algorithm to encode data, as per https://datatracker.ietf.org/doc/html/rfc4648#section-3.2. In this PR we omit those characters without loss of functionality, since those characters don't increase the entropy, while solving the original problem that a simple double-click wouldn't select those characters.

## How was this patch tested?
Added one test.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
