### PR TITLE
Extends ImageSpec to accept image names from plugin and have priority for plugins

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -198,19 +198,19 @@ class ImageBuildEngine:
     ImageBuildEngine contains a list of builders that can be used to build an ImageSpec.
     """
 
-    _REGISTRY: typing.Dict[str, Tuple[int, ImageSpecBuilder]] = {}
+    _REGISTRY: typing.Dict[str, Tuple[ImageSpecBuilder, int]] = {}
     _BUILT_IMAGES: typing.Set[str] = set()
     _IMAGE_NAME_TO_REAL_NAME: Dict[str, str] = {}
 
     @classmethod
     def register(cls, builder_type: str, image_spec_builder: ImageSpecBuilder, priority: int = 5):
-        cls._REGISTRY[builder_type] = (priority, image_spec_builder)
+        cls._REGISTRY[builder_type] = (image_spec_builder, priority)
 
     @classmethod
     @lru_cache
     def build(cls, image_spec: ImageSpec) -> str:
         if image_spec.builder is None and cls._REGISTRY:
-            builder = max(cls._REGISTRY, key=cls._REGISTRY.get)
+            builder = max(cls._REGISTRY, key=lambda name: cls._REGISTRY[name][1])
         else:
             builder = image_spec.builder
 
@@ -221,7 +221,7 @@ class ImageBuildEngine:
             click.secho(f"Image {img_name} not found. Building...", fg="blue")
             if builder not in cls._REGISTRY:
                 raise Exception(f"Builder {builder} is not registered.")
-            fully_qualified_image_name = cls._REGISTRY[builder][1].build_image(image_spec)
+            fully_qualified_image_name = cls._REGISTRY[builder][0].build_image(image_spec)
             if fully_qualified_image_name is not None:
                 cls._IMAGE_NAME_TO_REAL_NAME[img_name] = fully_qualified_image_name
                 img_name = fully_qualified_image_name

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -204,6 +204,9 @@ class ImageBuildEngine:
 
     _REGISTRY: typing.Dict[str, Tuple[ImageSpecBuilder, int]] = {}
     _BUILT_IMAGES: typing.Set[str] = set()
+    # _IMAGE_NAME_TO_REAL_NAME is used to keep track of the fully qualified image name
+    # returned by the image builder. This allows ImageSpec to map from `image_spc.image_name()`
+    # to the real qualified name.
     _IMAGE_NAME_TO_REAL_NAME: Dict[str, str] = {}
 
     @classmethod

--- a/plugins/flytekit-envd/tests/test_image_spec.py
+++ b/plugins/flytekit-envd/tests/test_image_spec.py
@@ -11,7 +11,7 @@ from flytekit.image_spec.image_spec import ImageBuildEngine, ImageSpec
 def register_envd_higher_priority():
     # Register a new envd platform with the highest priority so the test in this file uses envd
     highest_priority_builder = max(ImageBuildEngine._REGISTRY, key=ImageBuildEngine._REGISTRY.get)
-    highest_priority = ImageBuildEngine._REGISTRY[highest_priority_builder][0]
+    highest_priority = ImageBuildEngine._REGISTRY[highest_priority_builder][1]
     yield ImageBuildEngine.register(
         "envd_high_priority",
         EnvdImageSpecBuilder(),

--- a/plugins/flytekit-envd/tests/test_image_spec.py
+++ b/plugins/flytekit-envd/tests/test_image_spec.py
@@ -1,9 +1,23 @@
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
 from flytekitplugins.envd.image_builder import EnvdImageSpecBuilder, create_envd_config
 
-from flytekit.image_spec.image_spec import ImageSpec
+from flytekit.image_spec.image_spec import ImageBuildEngine, ImageSpec
+
+
+@pytest.fixture(scope="module", autouse=True)
+def register_envd_higher_priority():
+    # Register a new envd platform with the highest priority so the test in this file uses envd
+    highest_priority_builder = max(ImageBuildEngine._REGISTRY, key=ImageBuildEngine._REGISTRY.get)
+    highest_priority = ImageBuildEngine._REGISTRY[highest_priority_builder][0]
+    yield ImageBuildEngine.register(
+        "envd_high_priority",
+        EnvdImageSpecBuilder(),
+        priority=highest_priority + 1,
+    )
+    del ImageBuildEngine._REGISTRY["envd_high_priority"]
 
 
 def test_image_spec():


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
This PR:

- Extends the image spec plugin to allow `ImageSpecBuilder.build_image` to return an image name. This allows image spec plugins to point to images in it's own registry.
- Changes the default builder to `None` and introduce a priority. This allows the default builder to be the one with the higher priority.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
The changes are backward compatible since returning an image name in `ImageSpecBuilder.build_image` is optional. If an plugin returns a name, it will be used by `ImageSpec.image_name()` when referencing the same image.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I added unit tests to check the expected behavior.