### PR TITLE
Pass in env vars in FlyteRemote register_script

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -907,6 +907,7 @@ class FlyteRemote(object):
         :param options: Additional execution options that can be configured for the default launchplan
         :param source_path: The root of the project path
         :param module_name: the name of the module
+        :param envs: Environment variables to be passed to the serialization
         :return:
         """
         if image_config is None:

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -892,6 +892,7 @@ class FlyteRemote(object):
         options: typing.Optional[Options] = None,
         source_path: typing.Optional[str] = None,
         module_name: typing.Optional[str] = None,
+        envs: typing.Optional[typing.Dict[str, str]] = None,
     ) -> typing.Union[FlyteWorkflow, FlyteTask]:
         """
         Use this method to register a workflow via script mode.
@@ -926,6 +927,7 @@ class FlyteRemote(object):
             domain=domain,
             image_config=image_config,
             git_repo=_get_git_repo_url(source_path),
+            env=envs,
             fast_serialization_settings=FastSerializationSettings(
                 enabled=True,
                 destination_dir=destination_dir,


### PR DESCRIPTION
## Why are the changes needed?

The `FlyteRemote.register_script` function is useful for registering local code to remote during integration tests of workflows. It does not allow the user to pass in environment variables to the serialization though, even though it should be easy to support this.

## What changes were proposed in this pull request?

Make it possible to pass in environment variables using a `dict[str,str]` which can be passed directly to `SerializationSettings`.

## How was this patch tested?

Don't think `register_script` is covered by unit tests at the moment.
