### PR TITLE
Check envd version before building images

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -7,10 +7,14 @@ import typing
 from abc import abstractmethod
 from dataclasses import asdict, dataclass
 from functools import lru_cache
+from importlib import metadata
 from typing import List, Optional, Union
 
 import click
 import requests
+from packaging.version import Version
+
+from flytekit.exceptions.user import FlyteAssertion
 
 DOCKER_HUB = "docker.io"
 _F_IMG_ID = "_F_IMG_ID"
@@ -206,10 +210,14 @@ class ImageBuildEngine:
             click.secho(f"Image {img_name} not found. Building...", fg="blue")
             if image_spec.builder not in cls._REGISTRY:
                 raise Exception(f"Builder {image_spec.builder} is not registered.")
-            if image_spec.builder == "envd" :
-                from flytekitplugins.envd.image_builder import EnvdImageSpecBuilder
+            if image_spec.builder == "envd":
+                envd_version = metadata.version("envd")
+                if Version(envd_version) < Version("0.3.39"):
+                    raise FlyteAssertion(
+                        f"envd version {envd_version} is not compatible with flytekit>v1.10.2."
+                        f" Please upgrade envd to v0.3.39+."
+                    )
 
-                cls._REGISTRY[image_spec.builder] = EnvdImageSpecBuilder()
             cls._REGISTRY[image_spec.builder].build_image(image_spec)
             cls._BUILT_IMAGES.add(img_name)
 

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -212,6 +212,8 @@ class ImageBuildEngine:
                 raise Exception(f"Builder {image_spec.builder} is not registered.")
             if image_spec.builder == "envd":
                 envd_version = metadata.version("envd")
+                # flytekit v1.10.2+ copies the workflow code to the WorkDir specified in the Dockerfile. However, envd<0.3.39
+                # overwrites the WorkDir when building the image, resulting in a permission issue when flytekit downloads the file.
                 if Version(envd_version) < Version("0.3.39"):
                     raise FlyteAssertion(
                         f"envd version {envd_version} is not compatible with flytekit>v1.10.2."

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -206,6 +206,10 @@ class ImageBuildEngine:
             click.secho(f"Image {img_name} not found. Building...", fg="blue")
             if image_spec.builder not in cls._REGISTRY:
                 raise Exception(f"Builder {image_spec.builder} is not registered.")
+            if image_spec.builder == "envd" :
+                from flytekitplugins.envd.image_builder import EnvdImageSpecBuilder
+
+                cls._REGISTRY[image_spec.builder] = EnvdImageSpecBuilder()
             cls._REGISTRY[image_spec.builder].build_image(image_spec)
             cls._BUILT_IMAGES.add(img_name)
 

--- a/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
+++ b/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
@@ -11,7 +11,8 @@ from flytekit.configuration import DefaultImages
 from flytekit.core import context_manager
 from flytekit.core.constants import REQUIREMENTS_FILE_NAME
 from flytekit.image_spec.image_spec import _F_IMG_ID, ImageBuildEngine, ImageSpec, ImageSpecBuilder
-
+from importlib.metadata import version
+from packaging import version
 
 class EnvdImageSpecBuilder(ImageSpecBuilder):
     """
@@ -108,11 +109,8 @@ def build():
     if image_spec.source_root:
         shutil.copytree(image_spec.source_root, pathlib.Path(cfg_path).parent, dirs_exist_ok=True)
 
-        version_command = "envd version -s -f json"
-        envd_version = json.loads(EnvdImageSpecBuilder().execute_command(version_command)[0])["envd"].replace("v", "")
-
         # Indentation is required by envd
-        if Version(envd_version) <= Version("0.3.37"):
+        if version("envd") <= Version("0.3.37"):
             envd_config += '    io.copy(host_path="./", envd_path="/root")'
         else:
             envd_config += '    io.copy(source="./", target="/root")'

--- a/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
+++ b/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
@@ -1,8 +1,8 @@
-import json
 import os
 import pathlib
 import shutil
 import subprocess
+from importlib import metadata
 
 import click
 from packaging.version import Version
@@ -11,8 +11,7 @@ from flytekit.configuration import DefaultImages
 from flytekit.core import context_manager
 from flytekit.core.constants import REQUIREMENTS_FILE_NAME
 from flytekit.image_spec.image_spec import _F_IMG_ID, ImageBuildEngine, ImageSpec, ImageSpecBuilder
-from importlib.metadata import version
-from packaging import version
+
 
 class EnvdImageSpecBuilder(ImageSpecBuilder):
     """
@@ -109,8 +108,9 @@ def build():
     if image_spec.source_root:
         shutil.copytree(image_spec.source_root, pathlib.Path(cfg_path).parent, dirs_exist_ok=True)
 
+        envd_version = metadata.version("envd")
         # Indentation is required by envd
-        if version("envd") <= Version("0.3.37"):
+        if Version(envd_version) <= Version("0.3.37"):
             envd_config += '    io.copy(host_path="./", envd_path="/root")'
         else:
             envd_config += '    io.copy(source="./", target="/root")'


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
This [PR](https://github.com/flyteorg/flytekit/pull/2108) changes the default `destination-dir` to `.`, so flytekit will download the code to the `workdir` specified in the Dockerfile. However, envd<0.3.39 replace the `workdir` to /, and flytekit may not have permission to download a file to `/`. Therefore, we should force people to use envd>0.3.39 to build the image.

<img width="966" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/f71f5417-4c24-4796-ab9f-80bc813fcee8">


## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

Check `envd` version before building images. Raise an error if it is lower than 0.3.39.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

```python
from flytekit import task, workflow, ImageSpec

image_spec = ImageSpec(
    base_image="ghcr.io/flyteorg/flytekit:py3.11-1.10.2",
    packages=["flytekit>=1.6.0", "numpy", "mypy"],
    registry="pingsutw",
    python_version="3.11"
)


@task(container_image=image_spec, cache_version="1.0", cache=True)
def get_data() -> str:
    return "hello dgx.."


@task(
    container_image=dgx_image_spec
)
def train(data: str) -> str:
    print(data)

    return f"gpu is available: 123"


@workflow
def wf() -> str:
    data = get_data()
    return train(data=data)
```

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

