### PR TITLE
Use logger in data_persistence.py

### DIFF
--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -247,7 +247,7 @@ class FileAccessProvider(object):
                 return shutil.copytree(
                     self.strip_file_header(from_path), self.strip_file_header(to_path), dirs_exist_ok=True
                 )
-            print(f"Getting {from_path} to {to_path}")
+            logger.info(f"Getting {from_path} to {to_path}")
             dst = file_system.get(from_path, to_path, recursive=recursive, **kwargs)
             if isinstance(dst, (str, pathlib.Path)):
                 return dst


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?

Flytekit logs could get confusing as it's possible that logs produced by calls to `print` might get buffered which will cause them to show up unformatted in a completely different place. 

## What changes were proposed in this pull request?

Change the log message in `get` in `data_persistence.py` to use the flytekit logger.

## How was this patch tested?

Built a local flytekit image and confirmed the log message shows up in the right place.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
