### PR TITLE
Include exception type in error messages

### DIFF
--- a/flytekit/exceptions/scopes.py
+++ b/flytekit/exceptions/scopes.py
@@ -39,7 +39,7 @@ class FlyteScopedException(Exception):
         traceback_str = "\n    ".join([""] + lines)
 
         format_str = "Traceback (most recent call last):\n" "{traceback}\n" "\n" "Message:\n" "\n" "    {message}"
-        return format_str.format(traceback=traceback_str, message=str(self.value))
+        return format_str.format(traceback=traceback_str, message=f"{self.type}: {self.value}")
 
     def __str__(self):
         return str(self.value)

--- a/flytekit/exceptions/scopes.py
+++ b/flytekit/exceptions/scopes.py
@@ -39,7 +39,7 @@ class FlyteScopedException(Exception):
         traceback_str = "\n    ".join([""] + lines)
 
         format_str = "Traceback (most recent call last):\n" "{traceback}\n" "\n" "Message:\n" "\n" "    {message}"
-        return format_str.format(traceback=traceback_str, message=f"{self.type}: {self.value}")
+        return format_str.format(traceback=traceback_str, message=f"{self.type.__name__}: {self.value}")
 
     def __str__(self):
         return str(self.value)

--- a/tests/flytekit/unit/exceptions/test_scopes.py
+++ b/tests/flytekit/unit/exceptions/test_scopes.py
@@ -50,6 +50,7 @@ def test_intercepted_scope_non_flyte_exception():
     assert e.value == value_error
     assert "Bad value" in e.verbose_message
     assert "User error." in e.verbose_message
+    assert "ValueError" in e.verbose_message
     assert e.error_code == "USER:Unknown"
     assert e.kind == _error_models.ContainerError.Kind.NON_RECOVERABLE
 
@@ -60,6 +61,7 @@ def test_intercepted_scope_non_flyte_exception():
     assert e.value == value_error
     assert "Bad value" in e.verbose_message
     assert "SYSTEM ERROR!" in e.verbose_message
+    assert "ValueError" in e.verbose_message
     assert e.error_code == "SYSTEM:Unknown"
     assert e.kind == _error_models.ContainerError.Kind.RECOVERABLE
 
@@ -74,6 +76,7 @@ def test_intercepted_scope_flyte_user_exception():
     assert e.value == assertion_error
     assert "Bad assert" in e.verbose_message
     assert "User error." in e.verbose_message
+    assert "FlyteAssertion" in e.verbose_message
     assert e.error_code == "USER:AssertionError"
     assert e.kind == _error_models.ContainerError.Kind.NON_RECOVERABLE
 
@@ -84,6 +87,7 @@ def test_intercepted_scope_flyte_user_exception():
     assert e.value == assertion_error
     assert "Bad assert" in e.verbose_message
     assert "User error." in e.verbose_message
+    assert "FlyteAssertion" in e.verbose_message
     assert e.error_code == "USER:AssertionError"
     assert e.kind == _error_models.ContainerError.Kind.NON_RECOVERABLE
 
@@ -98,6 +102,7 @@ def test_intercepted_scope_flyte_system_exception():
     assert e.value == assertion_error
     assert "Bad assert" in e.verbose_message
     assert "SYSTEM ERROR!" in e.verbose_message
+    assert "FlyteSystemAssertion" in e.verbose_message
     assert e.kind == _error_models.ContainerError.Kind.RECOVERABLE
     assert e.error_code == "SYSTEM:AssertionError"
 
@@ -108,5 +113,6 @@ def test_intercepted_scope_flyte_system_exception():
     assert e.value == assertion_error
     assert "Bad assert" in e.verbose_message
     assert "SYSTEM ERROR!" in e.verbose_message
+    assert "FlyteSystemAssertion" in e.verbose_message
     assert e.error_code == "SYSTEM:AssertionError"
     assert e.kind == _error_models.ContainerError.Kind.RECOVERABLE

--- a/tests/flytekit/unit/exceptions/test_scopes.py
+++ b/tests/flytekit/unit/exceptions/test_scopes.py
@@ -50,7 +50,7 @@ def test_intercepted_scope_non_flyte_exception():
     assert e.value == value_error
     assert "Bad value" in e.verbose_message
     assert "User error." in e.verbose_message
-    assert "ValueError" in e.verbose_message
+    assert "ValueError:" in e.verbose_message
     assert e.error_code == "USER:Unknown"
     assert e.kind == _error_models.ContainerError.Kind.NON_RECOVERABLE
 
@@ -61,7 +61,7 @@ def test_intercepted_scope_non_flyte_exception():
     assert e.value == value_error
     assert "Bad value" in e.verbose_message
     assert "SYSTEM ERROR!" in e.verbose_message
-    assert "ValueError" in e.verbose_message
+    assert "ValueError:" in e.verbose_message
     assert e.error_code == "SYSTEM:Unknown"
     assert e.kind == _error_models.ContainerError.Kind.RECOVERABLE
 
@@ -76,7 +76,7 @@ def test_intercepted_scope_flyte_user_exception():
     assert e.value == assertion_error
     assert "Bad assert" in e.verbose_message
     assert "User error." in e.verbose_message
-    assert "FlyteAssertion" in e.verbose_message
+    assert "FlyteAssertion:" in e.verbose_message
     assert e.error_code == "USER:AssertionError"
     assert e.kind == _error_models.ContainerError.Kind.NON_RECOVERABLE
 
@@ -87,7 +87,7 @@ def test_intercepted_scope_flyte_user_exception():
     assert e.value == assertion_error
     assert "Bad assert" in e.verbose_message
     assert "User error." in e.verbose_message
-    assert "FlyteAssertion" in e.verbose_message
+    assert "FlyteAssertion:" in e.verbose_message
     assert e.error_code == "USER:AssertionError"
     assert e.kind == _error_models.ContainerError.Kind.NON_RECOVERABLE
 
@@ -102,7 +102,7 @@ def test_intercepted_scope_flyte_system_exception():
     assert e.value == assertion_error
     assert "Bad assert" in e.verbose_message
     assert "SYSTEM ERROR!" in e.verbose_message
-    assert "FlyteSystemAssertion" in e.verbose_message
+    assert "FlyteSystemAssertion:" in e.verbose_message
     assert e.kind == _error_models.ContainerError.Kind.RECOVERABLE
     assert e.error_code == "SYSTEM:AssertionError"
 
@@ -113,6 +113,6 @@ def test_intercepted_scope_flyte_system_exception():
     assert e.value == assertion_error
     assert "Bad assert" in e.verbose_message
     assert "SYSTEM ERROR!" in e.verbose_message
-    assert "FlyteSystemAssertion" in e.verbose_message
+    assert "FlyteSystemAssertion:" in e.verbose_message
     assert e.error_code == "SYSTEM:AssertionError"
     assert e.kind == _error_models.ContainerError.Kind.RECOVERABLE


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4777

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?
Makes it easier to debug failures. 

## What changes were proposed in this pull request?
Add the exception name to the error message that flytekit generates. This message gets displayed in the flyte UI. 

## How was this patch tested?
Updated unittests
Deployed on our flyte cluster

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly. - not applicable
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
