### PR TITLE
Envvars local execution

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -513,6 +513,9 @@ def run_command(ctx: click.Context, entity: typing.Union[PythonFunctionWorkflow,
 
             if not run_level_params.is_remote:
                 with FlyteContextManager.with_context(_update_flyte_context(run_level_params)):
+                    if run_level_params.envvars:
+                        for env_var, value in run_level_params.envvars.items():
+                            os.environ[env_var] = value
                     output = entity(**inputs)
                     if inspect.iscoroutine(output):
                         # TODO: make eager mode workflows run with local-mode

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -199,7 +199,15 @@ def test_union_type_with_invalid_input():
 def test_get_entities_in_file():
     e = get_entities_in_file(WORKFLOW_FILE, False)
     assert e.workflows == ["my_wf", "wf_with_env_vars", "wf_with_none"]
-    assert e.tasks == ["get_subset_df", "print_all", "show_sd", "task_with_env_vars", "task_with_optional", "test_union1", "test_union2"]
+    assert e.tasks == [
+        "get_subset_df",
+        "print_all",
+        "show_sd",
+        "task_with_env_vars",
+        "task_with_optional",
+        "test_union1",
+        "test_union2",
+    ]
     assert e.all() == [
         "my_wf",
         "wf_with_env_vars",

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -392,19 +392,27 @@ def test_pyflyte_run_with_none(a_val):
     assert result.exit_code == 0
 
 
-@pytest.mark.parametrize("envs, envs_argument, expected_output", [
-    (["--env", "MY_ENV_VAR=hello"], '["MY_ENV_VAR"]', "hello"),
-    (["--env", "MY_ENV_VAR=hello", "--env", "ABC=42"], '["MY_ENV_VAR","ABC"]', "hello,42"),
-])
+@pytest.mark.parametrize(
+    "envs, envs_argument, expected_output",
+    [
+        (["--env", "MY_ENV_VAR=hello"], '["MY_ENV_VAR"]', "hello"),
+        (["--env", "MY_ENV_VAR=hello", "--env", "ABC=42"], '["MY_ENV_VAR","ABC"]', "hello,42"),
+    ],
+)
 def test_envvar_local_execution(envs, envs_argument, expected_output):
     runner = CliRunner()
-    args = [
-        "run",
-    ] + envs + [
-        WORKFLOW_FILE,
-        "wf_with_env_vars",
-        "--env_vars",
-    ] + [envs_argument]
+    args = (
+        [
+            "run",
+        ]
+        + envs
+        + [
+            WORKFLOW_FILE,
+            "wf_with_env_vars",
+            "--env_vars",
+        ]
+        + [envs_argument]
+    )
     result = runner.invoke(
         pyflyte.main,
         args,

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -390,3 +390,25 @@ def test_pyflyte_run_with_none(a_val):
     else:
         assert output == a_val
     assert result.exit_code == 0
+
+
+@pytest.mark.parametrize("envs, envs_argument, expected_output", [
+    (["--env", "MY_ENV_VAR=hello"], '["MY_ENV_VAR"]', "hello"),
+    (["--env", "MY_ENV_VAR=hello", "--env", "ABC=42"], '["MY_ENV_VAR","ABC"]', "hello,42"),
+])
+def test_envvar_local_execution(envs, envs_argument, expected_output):
+    runner = CliRunner()
+    args = [
+        "run",
+    ] + envs + [
+        WORKFLOW_FILE,
+        "wf_with_env_vars",
+        "--env_vars",
+    ] + [envs_argument]
+    result = runner.invoke(
+        pyflyte.main,
+        args,
+        catch_exceptions=False,
+    )
+    output = result.stdout.strip().split("\n")[-1].strip()
+    assert output == expected_output

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -198,14 +198,16 @@ def test_union_type_with_invalid_input():
 
 def test_get_entities_in_file():
     e = get_entities_in_file(WORKFLOW_FILE, False)
-    assert e.workflows == ["my_wf", "wf_with_none"]
-    assert e.tasks == ["get_subset_df", "print_all", "show_sd", "task_with_optional", "test_union1", "test_union2"]
+    assert e.workflows == ["my_wf", "wf_with_env_vars", "wf_with_none"]
+    assert e.tasks == ["get_subset_df", "print_all", "show_sd", "task_with_env_vars", "task_with_optional", "test_union1", "test_union2"]
     assert e.all() == [
         "my_wf",
+        "wf_with_env_vars",
         "wf_with_none",
         "get_subset_df",
         "print_all",
         "show_sd",
+        "task_with_env_vars",
         "task_with_optional",
         "test_union1",
         "test_union2",

--- a/tests/flytekit/unit/cli/pyflyte/workflow.py
+++ b/tests/flytekit/unit/cli/pyflyte/workflow.py
@@ -113,12 +113,14 @@ def task_with_optional(a: typing.Optional[str]) -> str:
 def wf_with_none(a: typing.Optional[str] = None) -> str:
     return task_with_optional(a=a)
 
+
 @task
 def task_with_env_vars(env_vars: typing.List[str]) -> str:
     collated_env_vars = []
     for env_var in env_vars:
         collated_env_vars.append(os.environ[env_var])
     return ",".join(collated_env_vars)
+
 
 @workflow
 def wf_with_env_vars(env_vars: typing.List[str]) -> str:

--- a/tests/flytekit/unit/cli/pyflyte/workflow.py
+++ b/tests/flytekit/unit/cli/pyflyte/workflow.py
@@ -1,5 +1,6 @@
 import datetime
 import enum
+import os
 import typing
 from dataclasses import dataclass
 
@@ -111,3 +112,14 @@ def task_with_optional(a: typing.Optional[str]) -> str:
 @workflow
 def wf_with_none(a: typing.Optional[str] = None) -> str:
     return task_with_optional(a=a)
+
+@task
+def task_with_env_vars(env_vars: typing.List[str]) -> str:
+    collated_env_vars = []
+    for env_var in env_vars:
+        collated_env_vars.append(os.environ[env_var])
+    return ",".join(collated_env_vars)
+
+@workflow
+def wf_with_env_vars(env_vars: typing.List[str]) -> str:
+    return task_with_env_vars(env_vars=env_vars)


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/4503

## Why are the changes needed?

We introduced the ability to pass environment variables from the command line when using `pyflyte run` in https://github.com/flyteorg/flytekit/pull/1617, however that only works for remote executions. This PR enables this for local executions as well.

## What changes were proposed in this pull request?

Set environment variables prior to executing Flyte entities locally.

## How was this patch tested?

Unit tests and local.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
