### PR TITLE
Adds get_default_image into configuration plugin

### DIFF
--- a/flytekit/configuration/default_images.py
+++ b/flytekit/configuration/default_images.py
@@ -1,6 +1,7 @@
 import enum
 import sys
 import typing
+from contextlib import suppress
 
 
 class PythonVersion(enum.Enum):
@@ -26,6 +27,13 @@ class DefaultImages(object):
 
     @classmethod
     def default_image(cls) -> str:
+        from flytekit.configuration.plugin import get_plugin
+
+        with suppress(AttributeError):
+            default_image = get_plugin().get_default_image()
+            if default_image is not None:
+                return default_image
+
         return cls.find_image_for()
 
     @classmethod

--- a/flytekit/configuration/plugin.py
+++ b/flytekit/configuration/plugin.py
@@ -43,6 +43,10 @@ class FlytekitPluginProtocol(Protocol):
     def secret_requires_group() -> bool:
         """Return True if secrets require group entry."""
 
+    @staticmethod
+    def get_default_image() -> Optional[str]:
+        """Get default image. Return None to use the images from flytekit.configuration.DefaultImages"""
+
 
 class FlytekitPlugin:
     @staticmethod
@@ -70,6 +74,11 @@ class FlytekitPlugin:
     def secret_requires_group() -> bool:
         """Return True if secrets require group entry."""
         return True
+
+    @staticmethod
+    def get_default_image() -> Optional[str]:
+        """Get default image. Return None to use the images from flytekit.configuration.DefaultImages"""
+        return None
 
 
 def _get_plugin_from_entrypoint():

--- a/tests/flytekit/unit/configuration/test_image_config.py
+++ b/tests/flytekit/unit/configuration/test_image_config.py
@@ -1,9 +1,11 @@
 import os
 import sys
+from unittest.mock import Mock
 
 import mock
 import pytest
 
+import flytekit
 from flytekit.configuration import ImageConfig
 from flytekit.configuration.default_images import DefaultImages, PythonVersion
 
@@ -63,3 +65,14 @@ def test_image_create():
 
 def test_get_version_suffix():
     assert DefaultImages.get_version_suffix() == "latest"
+
+
+def test_default_image_plugin(monkeypatch):
+    new_default_image = "registry/flytekit:py3.9-latest"
+
+    plugin_mock = Mock()
+    plugin_mock.get_default_image.return_value = new_default_image
+    mock_global_plugin = {"plugin": plugin_mock}
+    monkeypatch.setattr(flytekit.configuration.plugin, "_GLOBAL_CONFIG", mock_global_plugin)
+
+    assert DefaultImages.default_image() == new_default_image


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
This PR allows a third party plugin to override the default images.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR extends the configuration plugin API with a `get_default_image` method:

- If plugin returns `None`, then nothing changes and the images are pulled from flytekit's `DefaultImages`.
- If the plugin returns a string, then that string is used as the default image.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I added unit test to check the plugin's behavior with `DefaultImage`.