### PR TITLE
Improve error message for pyflyte run

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -792,6 +792,8 @@ class WorkflowCommand(click.RichGroup):
         is_workflow = False
         if self._entities:
             is_workflow = exe_entity in self._entities.workflows
+        if not os.path.exists(self._filename):
+            raise ValueError(f"File {self._filename} does not exist")
         rel_path = os.path.relpath(self._filename)
         if rel_path.startswith(".."):
             raise ValueError(


### PR DESCRIPTION
## Why are the changes needed?
Improve error message

## What changes were proposed in this pull request?
raise an error if file not found

## How was this patch tested?
Before:
```bash
(flytekit-3.10) ➜  plugins git:(improve-error-message-1) ✗ pyflyte run --remote flyte-example/airflow_example/time_sensor.py wf
Failed with Unknown Exception <class 'ModuleNotFoundError'> Reason: No module named 'time_sensor'
Traceback:
  File "/Users/kevin/git/flytekit/flytekit/clis/sdk_in_container/utils.py", line 139, in invoke
    return super().invoke(ctx)

  File "/Users/kevin/anaconda3/envs/flytekit-3.10/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))

  File "/Users/kevin/anaconda3/envs/flytekit-3.10/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))

  File "/Users/kevin/anaconda3/envs/flytekit-3.10/lib/python3.10/site-packages/click/core.py", line 1682, in invoke
    cmd_name, cmd, args = self.resolve_command(ctx, args)

  File "/Users/kevin/anaconda3/envs/flytekit-3.10/lib/python3.10/site-packages/click/core.py", line 1729, in resolve_command
    cmd = self.get_command(ctx, cmd_name)

  File "/Users/kevin/git/flytekit/flytekit/clis/sdk_in_container/run.py", line 818, in get_command
    entity = load_naive_entity(module, exe_entity, project_root)

  File "/Users/kevin/git/flytekit/flytekit/clis/sdk_in_container/run.py", line 294, in load_naive_entity
    importlib.import_module(module_name)

  File "/Users/kevin/anaconda3/envs/flytekit-3.10/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)

  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import

  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load

  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked

No module named 'time_sensor'

```
After:
```bash
(flytekit-3.10) ➜  plugins git:(improve-error-message-1) ✗ pyflyte run --remote flyte-example/airflow_example/time_sensor.py wf 
Failed with Unknown Exception <class 'ValueError'> Reason: File /Users/kevin/git/flytekit/plugins/flyte-example/airflow_example/time_sensor.py does not exist
Traceback:
  File "/Users/kevin/git/flytekit/flytekit/clis/sdk_in_container/utils.py", line 139, in invoke
    return super().invoke(ctx)

  File "/Users/kevin/anaconda3/envs/flytekit-3.10/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))

  File "/Users/kevin/anaconda3/envs/flytekit-3.10/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))

  File "/Users/kevin/anaconda3/envs/flytekit-3.10/lib/python3.10/site-packages/click/core.py", line 1682, in invoke
    cmd_name, cmd, args = self.resolve_command(ctx, args)

  File "/Users/kevin/anaconda3/envs/flytekit-3.10/lib/python3.10/site-packages/click/core.py", line 1729, in resolve_command
    cmd = self.get_command(ctx, cmd_name)

  File "/Users/kevin/git/flytekit/flytekit/clis/sdk_in_container/run.py", line 796, in get_command
    raise ValueError(f"File {self._filename} does not exist")

File /Users/kevin/git/flytekit/plugins/flyte-example/airflow_example/time_sensor.py does not exist

```

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
