### PR TITLE
Add _literal_map_to_python_input to base task

### DIFF
--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -535,7 +535,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
     ) -> Dict[str, Any]:
         return TypeEngine.literal_map_to_kwargs(ctx, literal_map, self.python_interface.inputs)
 
-    def _output_to_literal_map(self, native_outputs: Dict[str, Any], ctx: FlyteContext):
+    def _output_to_literal_map(self, native_outputs: Dict[int, Any], ctx: FlyteContext):
         expected_output_names = list(self._outputs_interface.keys())
         if len(expected_output_names) == 1:
             # Here we have to handle the fact that the task could've been declared with a typing.NamedTuple of

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -531,7 +531,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
         return self.interface.outputs  # type: ignore
 
     def _literal_map_to_python_input(
-            self, literal_map: _literal_models.LiteralMap, ctx: FlyteContext
+        self, literal_map: _literal_models.LiteralMap, ctx: FlyteContext
     ) -> Dict[str, Any]:
         return TypeEngine.literal_map_to_kwargs(ctx, literal_map, self.python_interface.inputs)
 


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Add `_literal_map_to_python_input` base tasks. It allows people to override it, and preprocess the input before deserializing the literal map.

## What changes were proposed in this pull request?
Add `_literal_map_to_python_input` method the base tasks

## How was this patch tested?
Unit tests

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
