### PR TITLE
Add s3 server_side_encryption and sse_kms_id config

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -530,6 +530,7 @@ class S3Config(object):
     backoff: datetime.timedelta = datetime.timedelta(seconds=5)
     access_key_id: typing.Optional[str] = None
     secret_access_key: typing.Optional[str] = None
+    server_side_encryption: typing.Optional[str] = None
 
     @classmethod
     def auto(cls, config_file: typing.Union[str, ConfigFile] = None) -> S3Config:
@@ -546,6 +547,9 @@ class S3Config(object):
         kwargs = set_if_exists(kwargs, "backoff", _internal.AWS.BACKOFF_SECONDS.read(config_file))
         kwargs = set_if_exists(kwargs, "access_key_id", _internal.AWS.S3_ACCESS_KEY_ID.read(config_file))
         kwargs = set_if_exists(kwargs, "secret_access_key", _internal.AWS.S3_SECRET_ACCESS_KEY.read(config_file))
+        kwargs = set_if_exists(
+            kwargs, "server_side_encryption", _internal.AWS.S3_SERVER_SIDE_ENCRYPTION.read(config_file)
+        )
         return S3Config(**kwargs)
 
 

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -531,6 +531,7 @@ class S3Config(object):
     access_key_id: typing.Optional[str] = None
     secret_access_key: typing.Optional[str] = None
     server_side_encryption: typing.Optional[str] = None
+    sse_kms_key_id: typing.Optional[str] = None
 
     @classmethod
     def auto(cls, config_file: typing.Union[str, ConfigFile] = None) -> S3Config:
@@ -550,6 +551,7 @@ class S3Config(object):
         kwargs = set_if_exists(
             kwargs, "server_side_encryption", _internal.AWS.S3_SERVER_SIDE_ENCRYPTION.read(config_file)
         )
+        kwargs = set_if_exists(kwargs, "sse_kms_key_id", _internal.AWS.S3_SSE_KMS_ID.read(config_file))
         return S3Config(**kwargs)
 
 

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -44,6 +44,10 @@ class AWS(object):
     S3_SECRET_ACCESS_KEY = ConfigEntry(
         LegacyConfigEntry(SECTION, "secret_access_key"), YamlConfigEntry("storage.connection.secret-key")
     )
+    S3_SERVER_SIDE_ENCRYPTION = ConfigEntry(
+        LegacyConfigEntry(SECTION, "server_side_encryption"),
+        YamlConfigEntry("storage.connection.server_side_encryption"),
+    )
     ENABLE_DEBUG = ConfigEntry(LegacyConfigEntry(SECTION, "enable_debug", bool))
     RETRIES = ConfigEntry(LegacyConfigEntry(SECTION, "retries", int))
     BACKOFF_SECONDS = ConfigEntry(

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -48,6 +48,10 @@ class AWS(object):
         LegacyConfigEntry(SECTION, "server_side_encryption"),
         YamlConfigEntry("storage.connection.server_side_encryption"),
     )
+    S3_SSE_KMS_ID = ConfigEntry(
+        LegacyConfigEntry(SECTION, "sse_kms_key_id"),
+        YamlConfigEntry("storage.connection.sse_kms_key_id"),
+    )
     ENABLE_DEBUG = ConfigEntry(LegacyConfigEntry(SECTION, "enable_debug", bool))
     RETRIES = ConfigEntry(LegacyConfigEntry(SECTION, "retries", int))
     BACKOFF_SECONDS = ConfigEntry(

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -38,6 +38,7 @@ from flytekit.loggers import logger
 # for key and secret
 _FSSPEC_S3_KEY_ID = "key"
 _FSSPEC_S3_SECRET = "secret"
+
 _ANON = "anon"
 
 
@@ -57,6 +58,9 @@ def s3_setup_args(s3_cfg: configuration.S3Config, anonymous: bool = False) -> Di
 
     if anonymous:
         kwargs[_ANON] = True
+
+    if s3_cfg.server_side_encryption:
+        kwargs["s3_additional_kwargs"] = {"ServerSideEncryption": s3_cfg.server_side_encryption}
 
     return kwargs
 

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -60,7 +60,10 @@ def s3_setup_args(s3_cfg: configuration.S3Config, anonymous: bool = False) -> Di
         kwargs[_ANON] = True
 
     if s3_cfg.server_side_encryption:
-        kwargs["s3_additional_kwargs"] = {"ServerSideEncryption": s3_cfg.server_side_encryption}
+        kwargs["s3_additional_kwargs"] = {
+            "ServerSideEncryption": s3_cfg.server_side_encryption,
+            "SSEKMSKeyId": s3_cfg.sse_kms_key_id,
+        }
 
     return kwargs
 

--- a/tests/flytekit/unit/core/test_data.py
+++ b/tests/flytekit/unit/core/test_data.py
@@ -207,6 +207,7 @@ def test_s3_setup_args_env_flyte(mock_os, mock_get_config_file):
         "FLYTE_AWS_ACCESS_KEY_ID": "flyte",
         "FLYTE_AWS_SECRET_ACCESS_KEY": "flyte-secret",
         "FLYTE_AWS_SERVER_SIDE_ENCRYPTION": "AES256",
+        "FLYTE_AWS_SSE_KMS_ID": "arn:1234",
     }
     mock_os.get.side_effect = lambda x, y: ee.get(x)
     kwargs = s3_setup_args(S3Config.auto())
@@ -214,7 +215,10 @@ def test_s3_setup_args_env_flyte(mock_os, mock_get_config_file):
         "key": "flyte",
         "secret": "flyte-secret",
         "cache_regions": True,
-        "s3_additional_kwargs": {"ServerSideEncryption": "AES256"},
+        "s3_additional_kwargs": {
+            "ServerSideEncryption": "AES256",
+            "SSEKMSKeyId": "arn:1234",
+        },
     }
 
 

--- a/tests/flytekit/unit/core/test_data.py
+++ b/tests/flytekit/unit/core/test_data.py
@@ -206,10 +206,16 @@ def test_s3_setup_args_env_flyte(mock_os, mock_get_config_file):
     ee = {
         "FLYTE_AWS_ACCESS_KEY_ID": "flyte",
         "FLYTE_AWS_SECRET_ACCESS_KEY": "flyte-secret",
+        "FLYTE_AWS_SERVER_SIDE_ENCRYPTION": "AES256",
     }
     mock_os.get.side_effect = lambda x, y: ee.get(x)
     kwargs = s3_setup_args(S3Config.auto())
-    assert kwargs == {"key": "flyte", "secret": "flyte-secret", "cache_regions": True}
+    assert kwargs == {
+        "key": "flyte",
+        "secret": "flyte-secret",
+        "cache_regions": True,
+        "s3_additional_kwargs": {"ServerSideEncryption": "AES256"},
+    }
 
 
 @mock.patch("flytekit.configuration.get_config_file")


### PR DESCRIPTION
Based on https://github.com/flyteorg/flytekit/pull/1887

## Why are the changes needed?

Users failed to write the data to the bucket because they are enable Serverside Encryption

## What changes were proposed in this pull request?

https://github.com/fsspec/s3fs/pull/90/files
Add support passing server_side_encryption to s3fs

## How was this patch tested?

Tests added to tests/flytekit/unit/core/test_data.py

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

Based on https://github.com/flyteorg/flytekit/pull/1887

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
