### PR TITLE
Fix: Allow both '*_test.py' and '*test_.py' test module naming convention for nested tasks

### DIFF
--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -246,7 +246,7 @@ def istestfunction(func) -> bool:
         mod_name = mod.__name__
         if "." in mod_name:
             mod_name = mod_name.split(".")[-1]
-        return mod_name.startswith("test_")
+        return mod_name.startswith("test_") or mod_name.endswith("_test")
     return False
 
 

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -238,8 +238,10 @@ def is_functools_wrapped_module_level(func: Callable) -> bool:
 
 def istestfunction(func) -> bool:
     """
-    Returns true if the function is defined in a test module. A test module has to have `test_` as the prefix.
-    False in all other cases
+    Return true if the function is defined in a test module.
+
+    A test module has to have `test_` as the prefix or `_test` as the suffix.
+    False in all other cases.
     """
     mod = inspect.getmodule(func)
     if mod:


### PR DESCRIPTION
## Why are the changes needed?

Flyte tasks have to be importable from the module level so that the so-called task resolver can import them when executing a task in a K8s pod. This means they cannot be inner or nested functions.

One exemption from this rule is testing.

```py
from flytekit import task

def test_foo():
    @task
    def foo():
        ...

    foo()
```

When the file is called `test_*.py`, inner test functions are allowed by flytekit.


## What changes were proposed in this pull request?

The above test works with `pytest test_foo.py` but fails with `pytest foo_test.py`:

```console
ValueError: TaskFunction cannot be a nested/inner or local function. It should be accessible at a module level for Flyte to execute it. Test modules with names beginning with `test_` are allowed to have nested tasks. If you're decorating your task function with custom decorators, use functools.wraps or functools.update_wrapper on the function wrapper. Alternatively if you want to create your own tasks with custom behavior use the TaskResolverMixin
```

This goes against the naming convention for test modules employed by pytest ([docs](https://docs.pytest.org/en/7.2.x/explanation/goodpractices.html#conventions-for-python-test-discovery)):

> search for test_*.py or *_test.py files

Of course it's a no-brainer to rename test to make it pass but this requires users to understand why a task needs to be importable from the module/what a task resolver is.

Let's adopt pytest's convention so that users never notice these details.