### PR TITLE
Fix: Limit grpcio version in flytekit-identity-aware-proxy due to regression

### DIFF
--- a/plugins/flytekit-identity-aware-proxy/setup.py
+++ b/plugins/flytekit-identity-aware-proxy/setup.py
@@ -9,6 +9,8 @@ plugin_requires = [
     "google-cloud-secret-manager",
     "google-auth",
     "flytekit>=1.10",
+    # https://github.com/grpc/grpc/issues/33935
+    # https://github.com/grpc/grpc/issues/35323
     "grpcio<1.55.0",
 ]
 

--- a/plugins/flytekit-identity-aware-proxy/setup.py
+++ b/plugins/flytekit-identity-aware-proxy/setup.py
@@ -4,7 +4,13 @@ PLUGIN_NAME = "identity_aware_proxy"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["click", "google-cloud-secret-manager", "google-auth", "flytekit>=1.10"]
+plugin_requires = [
+    "click",
+    "google-cloud-secret-manager",
+    "google-auth",
+    "flytekit>=1.10",
+    "grpcio<1.55.0",
+]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
## Why are the changes needed?

*This only affects Flyte users who protect flyteadmin with GCP Identity Aware Proxy.*

In this PR I limit the `grpcio` version required by `flytekit-identity-aware-proxy`.

There is a regression in `grpcio` where a channel breaks if the server doesn't respond with the content-type `application/grpc`.

The same problem was fixed for the nginx ingress recently by including the `accept=application/grpc` header in requests to flyteadmin from flytekit (see https://github.com/flyteorg/flytekit/pull/1841). (The grpc go client doesn't have this issue so flytectl is not affected.)

When flyteadmin is protected with GCP Identity Aware Proxy, this `accept` header doesn't help - unauthenticated requests still get a `text/html` response by the proxy.

[Lazy authentication](https://github.com/flyteorg/flytekit/blob/f721eef474bb04ec2df581a690fb703e7c2b7956/flytekit/clients/grpc_utils/auth_interceptor.py#L63) works with `grpcio<1.55` even if the first 401 response is of content type `text/html`. I described the details in [this issue](https://github.com/grpc/grpc/issues/35323) in the grpcio repository. This issue is closed because the grpcio maintainers [acknowledged the problem](https://github.com/grpc/grpc/issues/33935#issuecomment-1883843372) and reopened the [original issue](https://github.com/grpc/grpc/issues/33935).

---

For now, let's restrict the grpcio version users can use when protecting flyteadmin with GCP Identity Aware Proxy.

---

Prospect:

If this regression wouldn't be fixed in grpcio (despite the fact that the maintainers reopened the issue), the following would allow us to circumvent this problem for GCP Identity Aware Proxy Users:

* When [upgrading a channel to proxy authenticated](https://github.com/flyteorg/flytekit/blob/f721eef474bb04ec2df581a690fb703e7c2b7956/flytekit/clients/auth_helper.py#L127), not use the `AuthUnaryInterceptor` that is also used for flytekit's [normal authentication](https://github.com/flyteorg/flytekit/blob/f721eef474bb04ec2df581a690fb703e7c2b7956/flytekit/clients/auth_helper.py#L132) but introduce a new interceptor for proxy authentication.
* This new interceptor for proxy auth wouldn't do
    
    ```
    try rpc
    if 401:
       refresh creds
       retry rpc
    ```

    but

    ```
    if creds is None or creds is expired:  (via exp claim in jwt)
        refresh creds
    try rpc
    if 401:
        refresh creds
        retry-rpc
    ```

This is my backup plan in case the regression persists.