### PR TITLE
install latest flyteidl with monodocs build

### DIFF
--- a/.github/workflows/monodocs_build.yml
+++ b/.github/workflows/monodocs_build.yml
@@ -35,8 +35,10 @@ jobs:
           conda install -c conda-forge conda-lock
           conda-lock install -n monodocs-env monodocs-environment.lock.yaml
       - shell: bash -el {0}
+        working-directory: ${{ github.workspace }}/flyte
         run: |
           conda activate monodocs-env
+          pip install -e ./flyteidl
           conda info
           conda list
           conda config --show-sources


### PR DESCRIPTION
This PR updates the monodocs ci build to install the latest development version of flyteidl so that changes in the protos can be picked up by the build process.