### PR TITLE
Improve Rich Logger

### DIFF
--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -4,9 +4,9 @@ import typing
 
 from pythonjsonlogger import jsonlogger
 
-from .tools import interactive
-
 from flytekit.core.context_manager import FlyteContextManager
+
+from .tools import interactive
 
 # Note:
 # The environment variable controls exposed to affect the individual loggers should be considered to be beta.

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -106,6 +106,7 @@ def upgrade_to_rich_logging(
     if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0" or (
         ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION
     ):
+        print("@@@ use rich handler!")
         try:
             import click
             from rich.console import Console

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -98,7 +98,7 @@ def upgrade_to_rich_logging(
     console: typing.Optional["rich.console.Console"] = None, log_level: typing.Optional[int] = None
 ):
     from flytekit.core.context_manager import ExecutionState, FlyteContextManager
-
+    print("@@@ come to upgrade rich loggin function")
     formatter = logging.Formatter(fmt="%(message)s")
     handler = logging.StreamHandler()
     ctx = FlyteContextManager.current_context()

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -4,8 +4,6 @@ import typing
 
 from pythonjsonlogger import jsonlogger
 
-from flytekit.core.context_manager import FlyteContextManager
-
 from .tools import interactive
 
 # Note:
@@ -99,6 +97,8 @@ def initialize_global_loggers():
 def upgrade_to_rich_logging(
     console: typing.Optional["rich.console.Console"] = None, log_level: typing.Optional[int] = None
 ):
+    from flytekit.core.context_manager import FlyteContextManager
+
     formatter = logging.Formatter(fmt="%(message)s")
     handler = logging.StreamHandler()
     ctx = FlyteContextManager.current_context()

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -103,7 +103,7 @@ def upgrade_to_rich_logging(
     handler = logging.StreamHandler()
     ctx = FlyteContextManager.current_context()
 
-    if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0" and not ctx.execution_state:
+    if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0" and ctx.execution_state:
         try:
             import click
             from rich.console import Console

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -97,13 +97,15 @@ def initialize_global_loggers():
 def upgrade_to_rich_logging(
     console: typing.Optional["rich.console.Console"] = None, log_level: typing.Optional[int] = None
 ):
-    from flytekit.core.context_manager import FlyteContextManager
+    from flytekit.core.context_manager import ExecutionState, FlyteContextManager
 
     formatter = logging.Formatter(fmt="%(message)s")
     handler = logging.StreamHandler()
     ctx = FlyteContextManager.current_context()
 
-    if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0" and ctx.execution_state:
+    if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0" or (
+        ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION
+    ):
         try:
             import click
             from rich.console import Console

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -6,6 +6,8 @@ from pythonjsonlogger import jsonlogger
 
 from .tools import interactive
 
+from flytekit.core.context_manager import FlyteContextManager
+
 # Note:
 # The environment variable controls exposed to affect the individual loggers should be considered to be beta.
 # The ux/api may change in the future.
@@ -99,7 +101,9 @@ def upgrade_to_rich_logging(
 ):
     formatter = logging.Formatter(fmt="%(message)s")
     handler = logging.StreamHandler()
-    if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0":
+    ctx = FlyteContextManager.current_context()
+
+    if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0" and not ctx.execution_state:
         try:
             import click
             from rich.console import Console

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -106,24 +106,25 @@ def upgrade_to_rich_logging(
     if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0" or (
         ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION
     ):
-        print("@@@ use rich handler!")
-        try:
-            import click
-            from rich.console import Console
-            from rich.logging import RichHandler
+        pass
+        # print("@@@ use rich handler!")
+        # try:
+        #     import click
+        #     from rich.console import Console
+        #     from rich.logging import RichHandler
 
-            import flytekit
+        #     import flytekit
 
-            handler = RichHandler(
-                tracebacks_suppress=[click, flytekit],
-                rich_tracebacks=True,
-                omit_repeated_times=False,
-                log_time_format="%H:%M:%S.%f",
-                console=Console(width=os.get_terminal_size().columns),
-            )
-        except OSError as e:
-            logger.debug(f"Failed to initialize rich logging: {e}")
-            pass
+        #     handler = RichHandler(
+        #         tracebacks_suppress=[click, flytekit],
+        #         rich_tracebacks=True,
+        #         omit_repeated_times=False,
+        #         log_time_format="%H:%M:%S.%f",
+        #         console=Console(width=os.get_terminal_size().columns),
+        #     )
+        # except OSError as e:
+        #     logger.debug(f"Failed to initialize rich logging: {e}")
+        #     pass
     handler.setFormatter(formatter)
     set_flytekit_log_properties(handler, None, level=log_level or _get_env_logging_level())
     set_user_logger_properties(handler, None, logging.INFO)

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -98,7 +98,7 @@ def upgrade_to_rich_logging(
     console: typing.Optional["rich.console.Console"] = None, log_level: typing.Optional[int] = None
 ):
     from flytekit.core.context_manager import ExecutionState, FlyteContextManager
-    print("@@@ come to upgrade rich loggin function")
+
     formatter = logging.Formatter(fmt="%(message)s")
     handler = logging.StreamHandler()
     ctx = FlyteContextManager.current_context()
@@ -106,25 +106,23 @@ def upgrade_to_rich_logging(
     if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0" or (
         ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION
     ):
-        pass
-        # print("@@@ use rich handler!")
-        # try:
-        #     import click
-        #     from rich.console import Console
-        #     from rich.logging import RichHandler
+        try:
+            import click
+            from rich.console import Console
+            from rich.logging import RichHandler
 
-        #     import flytekit
+            import flytekit
 
-        #     handler = RichHandler(
-        #         tracebacks_suppress=[click, flytekit],
-        #         rich_tracebacks=True,
-        #         omit_repeated_times=False,
-        #         log_time_format="%H:%M:%S.%f",
-        #         console=Console(width=os.get_terminal_size().columns),
-        #     )
-        # except OSError as e:
-        #     logger.debug(f"Failed to initialize rich logging: {e}")
-        #     pass
+            handler = RichHandler(
+                tracebacks_suppress=[click, flytekit],
+                rich_tracebacks=True,
+                omit_repeated_times=False,
+                log_time_format="%H:%M:%S.%f",
+                console=Console(width=os.get_terminal_size().columns),
+            )
+        except OSError as e:
+            logger.debug(f"Failed to initialize rich logging: {e}")
+            pass
     handler.setFormatter(formatter)
     set_flytekit_log_properties(handler, None, level=log_level or _get_env_logging_level())
     set_user_logger_properties(handler, None, logging.INFO)


### PR DESCRIPTION
## Why are the changes needed?
When executing flyekit pod task, we will have context in the container, and we don't want to use the rich logger to print them.

## What changes were proposed in this pull request?

## How was this patch tested?
```python
@task
def say_hello() -> None:
    raise ValueError("This is a test error")
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
