### PR TITLE
Fix: Handle overriding of container image in backend

### DIFF
--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -65,6 +65,7 @@ class Node(object):
         self._outputs = None
         self._resources: typing.Optional[_resources_model] = None
         self._extended_resources: typing.Optional[tasks_pb2.ExtendedResources] = None
+        self._container_image: typing.Optional[str] = None
 
     def runs_before(self, other: Node):
         """
@@ -193,7 +194,7 @@ class Node(object):
         if "container_image" in kwargs:
             v = kwargs["container_image"]
             assert_not_promise(v, "container_image")
-            self.run_entity._container_image = v
+            self._container_image = v
 
         if "accelerator" in kwargs:
             v = kwargs["accelerator"]

--- a/flytekit/models/core/workflow.py
+++ b/flytekit/models/core/workflow.py
@@ -595,10 +595,14 @@ class Node(_common.FlyteIdlEntity):
 
 class TaskNodeOverrides(_common.FlyteIdlEntity):
     def __init__(
-        self, resources: typing.Optional[Resources], extended_resources: typing.Optional[tasks_pb2.ExtendedResources]
+        self,
+        resources: typing.Optional[Resources],
+        extended_resources: typing.Optional[tasks_pb2.ExtendedResources],
+        container_image: typing.Optional[str],
     ):
         self._resources = resources
         self._extended_resources = extended_resources
+        self._container_image = container_image
 
     @property
     def resources(self) -> Resources:
@@ -608,19 +612,25 @@ class TaskNodeOverrides(_common.FlyteIdlEntity):
     def extended_resources(self) -> tasks_pb2.ExtendedResources:
         return self._extended_resources
 
+    @property
+    def container_image(self) -> str:
+        return self._container_image
+
     def to_flyte_idl(self):
         return _core_workflow.TaskNodeOverrides(
             resources=self.resources.to_flyte_idl() if self.resources is not None else None,
             extended_resources=self.extended_resources,
+            container_image=self.container_image,
         )
 
     @classmethod
     def from_flyte_idl(cls, pb2_object):
         resources = Resources.from_flyte_idl(pb2_object.resources)
         extended_resources = pb2_object.extended_resources if pb2_object.HasField("extended_resources") else None
+        container_image = pb2_object.container_image if len(pb2_object.container_image) > 0 else None
         if bool(resources.requests) or bool(resources.limits):
-            return cls(resources=resources, extended_resources=extended_resources)
-        return cls(resources=None, extended_resources=extended_resources)
+            return cls(resources=resources, extended_resources=extended_resources, container_image=container_image)
+        return cls(resources=None, extended_resources=extended_resources, container_image=container_image)
 
 
 class TaskNode(_common.FlyteIdlEntity):

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -477,7 +477,11 @@ def get_serializable_node(
             output_aliases=[],
             task_node=workflow_model.TaskNode(
                 reference_id=task_spec.template.id,
-                overrides=TaskNodeOverrides(resources=entity._resources, extended_resources=entity._extended_resources),
+                overrides=TaskNodeOverrides(
+                    resources=entity._resources,
+                    extended_resources=entity._extended_resources,
+                    container_image=entity._container_image,
+                ),
             ),
         )
         if entity._aliases:
@@ -554,7 +558,11 @@ def get_serializable_node(
             output_aliases=[],
             task_node=workflow_model.TaskNode(
                 reference_id=entity.flyte_entity.id,
-                overrides=TaskNodeOverrides(resources=entity._resources, extended_resources=entity._extended_resources),
+                overrides=TaskNodeOverrides(
+                    resources=entity._resources,
+                    extended_resources=entity._extended_resources,
+                    container_image=entity._container_image,
+                ),
             ),
         )
     elif isinstance(entity.flyte_entity, FlyteWorkflow):
@@ -603,7 +611,11 @@ def get_serializable_array_node(
     task_spec = get_serializable(entity_mapping, settings, entity, options)
     task_node = workflow_model.TaskNode(
         reference_id=task_spec.template.id,
-        overrides=TaskNodeOverrides(resources=node._resources, extended_resources=node._extended_resources),
+        overrides=TaskNodeOverrides(
+            resources=node._resources,
+            extended_resources=node._extended_resources,
+            container_image=node._container_image,
+        ),
     )
     node = workflow_model.Node(
         id=entity.name,

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -305,4 +305,4 @@ def test_map_task_override(serialization_settings):
     def wf(x: typing.List[int]):
         array_node_map_task(my_mappable_task)(a=x).with_overrides(container_image="random:image")
 
-    assert wf.nodes[0].run_entity.container_image == "random:image"
+    assert wf.nodes[0]._container_image == "random:image"

--- a/tests/flytekit/unit/core/test_map_task.py
+++ b/tests/flytekit/unit/core/test_map_task.py
@@ -352,7 +352,7 @@ def test_map_task_override(serialization_settings):
     def wf(x: typing.List[int]):
         map_task(my_mappable_task)(a=x).with_overrides(container_image="random:image")
 
-    assert wf.nodes[0].flyte_entity.run_task.container_image == "random:image"
+    assert wf.nodes[0]._container_image == "random:image"
 
 
 def test_bounded_inputs_vars_order(serialization_settings):

--- a/tests/flytekit/unit/core/test_node_creation.py
+++ b/tests/flytekit/unit/core/test_node_creation.py
@@ -465,7 +465,7 @@ def test_override_image():
         bar().with_overrides(container_image="hello/world")
         return "hi"
 
-    assert wf.nodes[0].flyte_entity.container_image == "hello/world"
+    assert wf.nodes[0]._container_image == "hello/world"
 
 
 def test_override_accelerator():


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4543

## Why are the changes needed?

The `container_image` task node override, among others, is currently broken (doesn't work with `pyflyte register` and only once with `pyflyte run`, see [tracking issue](https://github.com/flyteorg/flyte/issues/4543).

## What changes were proposed in this pull request?

Don't override container image of `run_entity` in `.with_overrides` but actually in flyteidl's `TaskNodeOverride` so that the container image is overridden in the backend.

## How was this patch tested?

In combination with https://github.com/flyteorg/flyte/pull/4858 I ensured that the resulting pod in the cluster has the correct image. I also adapted the unit tests.


- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flyte/pull/4858

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
