### PR TITLE
Force tests in a module to be run by the same worker

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -10,7 +10,7 @@ env:
   FLYTE_SDK_LOGGING_LEVEL: 10 # debug
   # --dist loadscope guarantees that tests in the same module are picked up by the same worker (i.e. run serially in a worker),
   # as per https://pytest-xdist.readthedocs.io/en/stable/distribution.html.
-  PYTEST_OPTS: -n2 --dist loadscope
+  # PYTEST_OPTS: -n2 --dist loadscope
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -10,7 +10,7 @@ env:
   FLYTE_SDK_LOGGING_LEVEL: 10 # debug
   # --dist loadscope guarantees that tests in the same module are picked up by the same worker (i.e. run serially in a worker),
   # as per https://pytest-xdist.readthedocs.io/en/stable/distribution.html.
-  # PYTEST_OPTS: -n2 --dist loadscope
+  PYTEST_OPTS: -n2 --dist loadscope
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -8,6 +8,8 @@ on:
 
 env:
   FLYTE_SDK_LOGGING_LEVEL: 10 # debug
+  # --dist loadscope guarantees that tests in the same module are picked up by the same worker (i.e. run serially in a worker)
+  PYTEST_OPTS: -n2 --dist loadscope
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -44,13 +46,9 @@ jobs:
         # Skip this step if running on python 3.12 due to https://github.com/tensorflow/tensorflow/issues/62003
         # and https://github.com/pytorch/pytorch/issues/110436
         if: ${{ matrix.python-version != '3.12' }}
-        env:
-          PYTEST_OPTS: -n2
         run: |
           make unit_test_extras_codecov
       - name: Test with coverage
-        env:
-          PYTEST_OPTS: -n2
         run: |
           make unit_test_codecov
       - name: Codecov
@@ -87,8 +85,6 @@ jobs:
           pip install --force-reinstall "${{ matrix.pandas }}"
           pip freeze
       - name: Test with coverage
-        env:
-          PYTEST_OPTS: -n2
         run: |
           make unit_test_codecov
       - name: Codecov
@@ -120,8 +116,6 @@ jobs:
       - name: Install dependencies
         run: make setup && pip freeze
       - name: Test with coverage
-        env:
-          PYTEST_OPTS: -n2
         run: |
           make test_serialization_codecov
       - name: Codecov

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -8,7 +8,8 @@ on:
 
 env:
   FLYTE_SDK_LOGGING_LEVEL: 10 # debug
-  # --dist loadscope guarantees that tests in the same module are picked up by the same worker (i.e. run serially in a worker)
+  # --dist loadscope guarantees that tests in the same module are picked up by the same worker (i.e. run serially in a worker),
+  # as per https://pytest-xdist.readthedocs.io/en/stable/distribution.html.
   PYTEST_OPTS: -n2 --dist loadscope
 
 concurrency:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export REPOSITORY=flytekit
 
 PIP_COMPILE = pip-compile --upgrade --verbose --resolver=backtracking
 MOCK_FLYTE_REPO=tests/flytekit/integration/remote/mock_flyte_repo/workflows
-PYTEST_OPTS ?=
+PYTEST_OPTS ?= -n auto --dist=loadscope
 PYTEST = pytest ${PYTEST_OPTS}
 
 .SILENT: help

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ update_boilerplate:
 .PHONY: setup
 setup: install-piptools ## Install requirements
 	pip install --pre -r dev-requirements.in
-	pip install git+https://github.com/flyteorg/flyte.git@7711df2cebaaa6a2dc8d7de2149859eed5ba0cc2#subdirectory=flyteidl
 
 
 .PHONY: fmt

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export REPOSITORY=flytekit
 
 PIP_COMPILE = pip-compile --upgrade --verbose --resolver=backtracking
 MOCK_FLYTE_REPO=tests/flytekit/integration/remote/mock_flyte_repo/workflows
-PYTEST_OPTS ?= -n auto --dist=loadscope
+PYTEST_OPTS ?=
 PYTEST = pytest ${PYTEST_OPTS}
 
 .SILENT: help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "diskcache>=5.2.1",
     "docker>=4.0.0,<7.0.0",
     "docstring-parser>=0.9.0",
-    "flyteidl>1.10.6",
+    "flyteidl>=1.10.7b4",
     "fsspec>=2023.3.0",
     "gcsfs>=2023.3.0",
     "googleapis-common-protos>=1.57",

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -109,7 +109,6 @@ def test_dispatch_execute_exception(mock_write_to_file, mock_upload_dir, mock_ge
         assert mock_write_to_file.call_count == 1
 
 
-@mock.patch.dict(os.environ, {"FLYTE_FAIL_ON_ERROR": "True"})
 @mock.patch("flytekit.core.utils.load_proto_from_file")
 @mock.patch("flytekit.core.data_persistence.FileAccessProvider.get_data")
 @mock.patch("flytekit.core.data_persistence.FileAccessProvider.put_data")
@@ -135,8 +134,9 @@ def test_dispatch_execute_return_error_code(mock_write_to_file, mock_upload_dir,
 
         mock_write_to_file.side_effect = verify_output
 
-        with pytest.raises(SystemExit, match="1"):
-            _dispatch_execute(ctx, python_task, "inputs path", "outputs prefix")
+        with mock.patch.dict(os.environ, {"FLYTE_FAIL_ON_ERROR": "True"}):
+            with pytest.raises(SystemExit):
+                _dispatch_execute(ctx, python_task, "inputs path", "outputs prefix")
 
 
 # This function collects outputs instead of writing them to a file.

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -135,9 +135,8 @@ def test_dispatch_execute_return_error_code(mock_write_to_file, mock_upload_dir,
 
         mock_write_to_file.side_effect = verify_output
 
-        with pytest.raises(SystemExit) as cm:
+        with pytest.raises(SystemExit, match="1"):
             _dispatch_execute(ctx, python_task, "inputs path", "outputs prefix")
-            pytest.assertEqual(cm.value.code, 1)
 
 
 # This function collects outputs instead of writing them to a file.

--- a/tests/flytekit/unit/configuration/test_internal.py
+++ b/tests/flytekit/unit/configuration/test_internal.py
@@ -48,7 +48,6 @@ def test_client_secret_location():
     assert platform_cfg.auth_mode == AuthType.CLIENTSECRET.value
 
 
-@mock.patch.dict("os.environ")
 def test_client_secret_env_var():
     cfg = get_config_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/sample.yaml"))
     secret_env_var = Credentials.CLIENT_CREDENTIALS_SECRET_ENV_VAR.read(cfg)
@@ -60,10 +59,10 @@ def test_client_secret_env_var():
     secret_env_var = Credentials.CLIENT_CREDENTIALS_SECRET_ENV_VAR.read(cfg)
     assert secret_env_var == "FAKE_SECRET_NAME"
 
-    os.environ["FAKE_SECRET_NAME"] = "fake_secret_value"
-    platform_cfg = PlatformConfig.auto(cfg)
-    assert platform_cfg.client_credentials_secret == "fake_secret_value"
-    assert platform_cfg.auth_mode == AuthType.CLIENTSECRET.value
+    with mock.patch.dict(os.environ, {"FAKE_SECRET_NAME": "fake_secret_value"}):
+        platform_cfg = PlatformConfig.auto(cfg)
+        assert platform_cfg.client_credentials_secret == "fake_secret_value"
+        assert platform_cfg.auth_mode == AuthType.CLIENTSECRET.value
 
 
 def test_read_file_if_exists():

--- a/tests/flytekit/unit/core/test_checkpoint.py
+++ b/tests/flytekit/unit/core/test_checkpoint.py
@@ -154,23 +154,5 @@ def t1(n: int) -> int:
     return n + 1
 
 
-@flytekit.task(cache=True, cache_version="v0")
-def t2(n: int) -> int:
-    ctx = flytekit.current_context()
-    cp = ctx.checkpoint
-    cp.write(bytes(n + 1))
-    return n + 1
-
-
-@pytest.fixture(scope="function", autouse=True)
-def setup():
-    LocalTaskCache.initialize()
-    LocalTaskCache.clear()
-
-
 def test_checkpoint_task():
     assert t1(n=5) == 6
-
-
-def test_checkpoint_cached_task():
-    assert t2(n=5) == 6

--- a/tests/flytekit/unit/core/test_checkpoint.py
+++ b/tests/flytekit/unit/core/test_checkpoint.py
@@ -5,7 +5,6 @@ import pytest
 
 import flytekit
 from flytekit.core.checkpointer import SyncCheckpoint
-from flytekit.core.local_cache import LocalTaskCache
 from flytekit.exceptions.user import FlyteAssertion
 
 

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -114,10 +114,10 @@ def test_validate_image(mock_image):
 def test_secrets_manager_default():
     with pytest.raises(ValueError):
         sec = SecretsManager()
-        sec.get("group", "key")
+        sec.get("group", "key2")
 
     with pytest.raises(ValueError):
-        _ = sec.group.key
+        _ = sec.group.key2
 
 
 def test_secrets_manager_get_envvar():

--- a/tests/flytekit/unit/core/test_local_cache.py
+++ b/tests/flytekit/unit/core/test_local_cache.py
@@ -9,6 +9,7 @@ from dataclasses_json import DataClassJsonMixin
 from pytest import fixture
 from typing_extensions import Annotated
 
+import flytekit
 from flytekit.core.base_sql_task import SQLTask
 from flytekit.core.base_task import kwtypes
 from flytekit.core.context_manager import FlyteContextManager
@@ -529,3 +530,15 @@ def test_literal_hash_placement():
 
     assert litmap.hash == _recursive_hash_placement(litmap).hash
     assert litcoll.hash == _recursive_hash_placement(litcoll).hash
+
+
+@task(cache=True, cache_version="v0")
+def t2(n: int) -> int:
+    ctx = flytekit.current_context()
+    cp = ctx.checkpoint
+    cp.write(bytes(n + 1))
+    return n + 1
+
+
+def test_checkpoint_cached_task():
+    assert t2(n=5) == 6

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -1,3 +1,4 @@
+import mock
 import os
 import typing
 from collections import OrderedDict
@@ -270,32 +271,32 @@ def test_serialization_images():
     def t6(a: int) -> int:
         return a
 
-    os.environ["FLYTE_INTERNAL_IMAGE"] = "docker.io/default:version"
-    imgs = ImageConfig.auto(
-        config_file=os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/images.config")
-    )
-    rs = flytekit.configuration.SerializationSettings(
-        project="project",
-        domain="domain",
-        version="version",
-        env=None,
-        image_config=imgs,
-    )
-    t1_spec = get_serializable(OrderedDict(), rs, t1)
-    assert t1_spec.template.container.image == "docker.io/xyz:latest"
-    t1_spec.to_flyte_idl()
+    with mock.patch.dict(os.environ, {"FLYTE_INTERNAL_IMAGE": "docker.io/default:version"}):
+        imgs = ImageConfig.auto(
+            config_file=os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/images.config")
+        )
+        rs = flytekit.configuration.SerializationSettings(
+            project="project",
+            domain="domain",
+            version="version",
+            env=None,
+            image_config=imgs,
+        )
+        t1_spec = get_serializable(OrderedDict(), rs, t1)
+        assert t1_spec.template.container.image == "docker.io/xyz:latest"
+        t1_spec.to_flyte_idl()
 
-    t2_spec = get_serializable(OrderedDict(), rs, t2)
-    assert t2_spec.template.container.image == "docker.io/abc:latest"
+        t2_spec = get_serializable(OrderedDict(), rs, t2)
+        assert t2_spec.template.container.image == "docker.io/abc:latest"
 
-    t4_spec = get_serializable(OrderedDict(), rs, t4)
-    assert t4_spec.template.container.image == "docker.io/org/myimage:latest"
+        t4_spec = get_serializable(OrderedDict(), rs, t4)
+        assert t4_spec.template.container.image == "docker.io/org/myimage:latest"
 
-    t5_spec = get_serializable(OrderedDict(), rs, t5)
-    assert t5_spec.template.container.image == "docker.io/org/myimage:latest"
+        t5_spec = get_serializable(OrderedDict(), rs, t5)
+        assert t5_spec.template.container.image == "docker.io/org/myimage:latest"
 
-    t5_spec = get_serializable(OrderedDict(), rs, t6)
-    assert t5_spec.template.container.image == "docker.io/xyz_123:v1"
+        t5_spec = get_serializable(OrderedDict(), rs, t6)
+        assert t5_spec.template.container.image == "docker.io/xyz_123:v1"
 
 
 def test_serialization_command1():

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -1,8 +1,8 @@
-import mock
 import os
 import typing
 from collections import OrderedDict
 
+import mock
 import pytest
 
 import flytekit.configuration


### PR DESCRIPTION
## Tracking issue
NA

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?
flytekit unit tests started failing in the last couple of days due to the use of global shared state in `test_local_cache.py`. Tests are run using `pytest-xdist` and this PR makes it so that we run all tests in the same module in the same worker

## What changes were proposed in this pull request?

We specify `--dist loadscope` to force tests in the same module to be picked by the same pytest worker.

I'm also:
1. removing the pinned version of flyteidl from the `setup` make target.
2. setting defaults for PYTEST_OPTS in the makefile
3. fixing a bunch of assumptions in the unit tests that didn't play well with pytest-xdist

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
