### PR TITLE
Raises envd specific error in envd plugin instead of image_spec builder itself

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -7,14 +7,10 @@ import typing
 from abc import abstractmethod
 from dataclasses import asdict, dataclass
 from functools import lru_cache
-from importlib import metadata
 from typing import Dict, List, Optional, Tuple, Union
 
 import click
 import requests
-from packaging.version import Version
-
-from flytekit.exceptions.user import FlyteAssertion
 
 DOCKER_HUB = "docker.io"
 _F_IMG_ID = "_F_IMG_ID"
@@ -228,16 +224,6 @@ class ImageBuildEngine:
             click.secho(f"Image {img_name} not found. Building...", fg="blue")
             if builder not in cls._REGISTRY:
                 raise Exception(f"Builder {builder} is not registered.")
-            if builder == "envd":
-                envd_version = metadata.version("envd")
-                # flytekit v1.10.2+ copies the workflow code to the WorkDir specified in the Dockerfile. However, envd<0.3.39
-                # overwrites the WorkDir when building the image, resulting in a permission issue when flytekit downloads the file.
-                if Version(envd_version) < Version("0.3.39"):
-                    raise FlyteAssertion(
-                        f"envd version {envd_version} is not compatible with flytekit>v1.10.2."
-                        f" Please upgrade envd to v0.3.39+."
-                    )
-
             fully_qualified_image_name = cls._REGISTRY[builder][0].build_image(image_spec)
             if fully_qualified_image_name is not None:
                 cls._IMAGE_NAME_TO_REAL_NAME[img_name] = fully_qualified_image_name

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -1,4 +1,5 @@
 import base64
+import contextlib
 import copy
 import hashlib
 import os
@@ -7,10 +8,15 @@ import typing
 from abc import abstractmethod
 from dataclasses import asdict, dataclass
 from functools import lru_cache
+from importlib import metadata
+from importlib.metadata import PackageNotFoundError
 from typing import Dict, List, Optional, Tuple, Union
 
 import click
 import requests
+from packaging.version import Version
+
+from flytekit.exceptions.user import FlyteAssertion
 
 DOCKER_HUB = "docker.io"
 _F_IMG_ID = "_F_IMG_ID"
@@ -224,6 +230,17 @@ class ImageBuildEngine:
             click.secho(f"Image {img_name} not found. Building...", fg="blue")
             if builder not in cls._REGISTRY:
                 raise Exception(f"Builder {builder} is not registered.")
+            with contextlib.suppress(PackageNotFoundError):
+                if builder == "envd":
+                    envd_version = metadata.version("envd")
+                    # flytekit v1.10.2+ copies the workflow code to the WorkDir specified in the Dockerfile. However, envd<0.3.39
+                    # overwrites the WorkDir when building the image, resulting in a permission issue when flytekit downloads the file.
+                    if Version(envd_version) < Version("0.3.39"):
+                        raise FlyteAssertion(
+                            f"envd version {envd_version} is not compatible with flytekit>v1.10.2."
+                            f" Please upgrade envd to v0.3.39+."
+                        )
+
             fully_qualified_image_name = cls._REGISTRY[builder][0].build_image(image_spec)
             if fully_qualified_image_name is not None:
                 cls._IMAGE_NAME_TO_REAL_NAME[img_name] = fully_qualified_image_name

--- a/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
+++ b/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
@@ -10,7 +10,6 @@ from packaging.version import Version
 from flytekit.configuration import DefaultImages
 from flytekit.core import context_manager
 from flytekit.core.constants import REQUIREMENTS_FILE_NAME
-from flytekit.exceptions.user import FlyteAssertion
 from flytekit.image_spec.image_spec import _F_IMG_ID, ImageBuildEngine, ImageSpec, ImageSpecBuilder
 
 
@@ -39,15 +38,6 @@ class EnvdImageSpecBuilder(ImageSpecBuilder):
         return result
 
     def build_image(self, image_spec: ImageSpec):
-        envd_version = metadata.version("envd")
-        # flytekit v1.10.2+ copies the workflow code to the WorkDir specified in the Dockerfile. However, envd<0.3.39
-        # overwrites the WorkDir when building the image, resulting in a permission issue when flytekit downloads the file.
-        if Version(envd_version) < Version("0.3.39"):
-            raise FlyteAssertion(
-                f"envd version {envd_version} is not compatible with flytekit>v1.10.2."
-                f" Please upgrade envd to v0.3.39+."
-            )
-
         cfg_path = create_envd_config(image_spec)
 
         if image_spec.registry_config:


### PR DESCRIPTION
This PR raises envd specific error in envd plugin instead of image_spec builder itself.

Currently, `ImageSpecBuilder` requires `envd` to be installed for the version check. This forces non-envd based image builders to have `envd` installed as well.