### PR TITLE
Do not lazy-load pyspark.ml

### DIFF
--- a/plugins/flytekit-spark/flytekitplugins/spark/pyspark_transformers.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/pyspark_transformers.py
@@ -4,8 +4,7 @@ from flytekit import Blob, BlobMetadata, BlobType, FlyteContext, Literal, Litera
 from flytekit.core.type_engine import TypeEngine
 from flytekit.extend import TypeTransformer
 
-pyspark_ml = lazy_module("pyspark.ml")
-PipelineModel = pyspark_ml.PipelineModel
+from pyspark.ml import PipelineModel
 
 
 class PySparkPipelineModelTransformer(TypeTransformer[PipelineModel]):

--- a/plugins/flytekit-spark/flytekitplugins/spark/pyspark_transformers.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/pyspark_transformers.py
@@ -1,10 +1,10 @@
 from typing import Type
 
-from flytekit import Blob, BlobMetadata, BlobType, FlyteContext, Literal, LiteralType, Scalar, lazy_module
+from pyspark.ml import PipelineModel
+
+from flytekit import Blob, BlobMetadata, BlobType, FlyteContext, Literal, LiteralType, Scalar
 from flytekit.core.type_engine import TypeEngine
 from flytekit.extend import TypeTransformer
-
-from pyspark.ml import PipelineModel
 
 
 class PySparkPipelineModelTransformer(TypeTransformer[PipelineModel]):


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4877

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?
Spark tasks are currently broken on version 1.10.3 and 1.10.2 of the flytekit spark plugin.

## What changes were proposed in this pull request?
Do not lazy-load the `pyspark.ml` module.

## How was this patch tested?
Built an image that used that and tested on a real Flyte cluster using a slightly modified version of https://github.com/flyteorg/flytesnacks/blob/master/examples/k8s_spark_plugin/k8s_spark_plugin/pyspark_pi.py.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
