### PR TITLE
Disable rich logger in the default image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ LABEL org.opencontainers.image.source=https://github.com/flyteorg/flytekit
 
 WORKDIR /root
 ENV PYTHONPATH /root
+ENV FLYTE_SDK_RICH_TRACEBACKS 0
 
 ARG VERSION
 ARG DOCKER_IMAGE

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,9 +9,10 @@ ARG PYTHON_VERSION
 FROM python:${PYTHON_VERSION}-slim-bookworm
 
 MAINTAINER Flyte Team <users@flyte.org>
-LABEL org.opencontainers.image.source https://github.com/flyteorg/flytekit
+LABEL org.opencontainers.image.source=https://github.com/flyteorg/flytekit
 
 WORKDIR /root
+ENV FLYTE_SDK_RICH_TRACEBACKS 0
 
 ARG VERSION
 


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Rich is useful when running locally but not on remote cluster

## What changes were proposed in this pull request?
Disable rich logger by default in the default image.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
local & remote

```python
import os
from flytekit import task, workflow, ImageSpec
from airflow.sensors.time_sensor import TimeSensor

image = ImageSpec(apt_packages=["git"], packages=["pandas"], registry="pingsutw", env={"FLYTE_SDK_RICH_TRACEBACKS": "0"})


@task(container_image=image)
def get_env() -> str:
    return str(os.environ)


@workflow
def wf() -> str:
    return get_env()
```

### Setup process

### Screenshots
Before:
<img width="1548" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/b6a7f374-7336-40bb-837e-bb868adc1bda">

After:
<img width="1467" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/61330358-bb5f-48c8-953c-0d40fd99a6da">


- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
