### PR TITLE
Fix Base Agent Input Bug

### DIFF
--- a/flytekit/extend/backend/base_agent.py
+++ b/flytekit/extend/backend/base_agent.py
@@ -220,7 +220,7 @@ class AsyncAgentExecutorMixin:
             self._agent.create,
             output_prefix=output_prefix,
             task_template=task_template,
-            inputs=inputs,
+            inputs=literal_map,
         )
 
         signal.signal(signal.SIGINT, partial(self.signal_handler, res.resource_meta))  # type: ignore


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

The input of `create` function in base_agent is wrong, we should fix it.

Before:
<img width="825" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/4868b012-fda3-4b13-ac2a-575f744209fd">

After:
<img width="554" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/22ae5b52-fb17-4c72-9d57-85e56cbabcd5">

