### PR TITLE
Extends config plugin API to customize the default OAuth success html

### DIFF
--- a/flytekit/clients/auth/default_html.py
+++ b/flytekit/clients/auth/default_html.py
@@ -1,4 +1,14 @@
+from contextlib import suppress
+
+
 def get_default_success_html(endpoint: str) -> str:
+    from flytekit.configuration.plugin import get_plugin
+
+    with suppress(AttributeError):
+        success_html = get_plugin().get_auth_success_html(endpoint)
+        if success_html is not None:
+            return success_html
+
     return f"""
 <html>
     <head>

--- a/flytekit/configuration/plugin.py
+++ b/flytekit/configuration/plugin.py
@@ -47,6 +47,10 @@ class FlytekitPluginProtocol(Protocol):
     def get_default_image() -> Optional[str]:
         """Get default image. Return None to use the images from flytekit.configuration.DefaultImages"""
 
+    @staticmethod
+    def get_auth_success_html(endpoint: str) -> Optional[str]:
+        """Get default success html for auth. Return None to use flytekit's default success html."""
+
 
 class FlytekitPlugin:
     @staticmethod
@@ -78,6 +82,11 @@ class FlytekitPlugin:
     @staticmethod
     def get_default_image() -> Optional[str]:
         """Get default image. Return None to use the images from flytekit.configuration.DefaultImages"""
+        return None
+
+    @staticmethod
+    def get_auth_success_html(endpoint: str) -> Optional[str]:
+        """Get default success html. Return None to use flytekit's default success html."""
         return None
 
 

--- a/tests/flytekit/unit/clients/auth/test_default_html.py
+++ b/tests/flytekit/unit/clients/auth/test_default_html.py
@@ -1,3 +1,6 @@
+from unittest.mock import Mock
+
+import flytekit
 from flytekit.clients.auth.default_html import get_default_success_html
 
 
@@ -16,3 +19,15 @@ def test_default_html():
 </html>
 """
     )  # noqa
+
+
+def test_default_html_plugin(monkeypatch):
+    def get_auth_success_html(endpoint):
+        return f"<html><head><title>Successful Auth into {endpoint}!</title></head></html>"
+
+    plugin_mock = Mock()
+    plugin_mock.get_auth_success_html.side_effect = get_auth_success_html
+    mock_global_plugin = {"plugin": plugin_mock}
+    monkeypatch.setattr(flytekit.configuration.plugin, "_GLOBAL_CONFIG", mock_global_plugin)
+
+    assert get_default_success_html("flyte.org") == get_auth_success_html("flyte.org")


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
This PR allows configuration plugins to return a customized default OAuth success HTML page.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR extends the configuration plugin API to change the default OAuth success HTML.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests was added to check the behavior.