### PR TITLE
Add S3 server-side-encryption headers for pre-signed URLs

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -530,6 +530,7 @@ class S3Config(object):
     backoff: datetime.timedelta = datetime.timedelta(seconds=5)
     access_key_id: typing.Optional[str] = None
     secret_access_key: typing.Optional[str] = None
+    s3_additional_kwargs: typing.Optional[str] = None
 
     @classmethod
     def auto(cls, config_file: typing.Union[str, ConfigFile] = None) -> S3Config:
@@ -546,6 +547,7 @@ class S3Config(object):
         kwargs = set_if_exists(kwargs, "backoff", _internal.AWS.BACKOFF_SECONDS.read(config_file))
         kwargs = set_if_exists(kwargs, "access_key_id", _internal.AWS.S3_ACCESS_KEY_ID.read(config_file))
         kwargs = set_if_exists(kwargs, "secret_access_key", _internal.AWS.S3_SECRET_ACCESS_KEY.read(config_file))
+        kwargs = set_if_exists(kwargs, "s3_additional_kwargs", _internal.AWS.S3_ADDITIONAL_KWARGS.read(config_file))
         return S3Config(**kwargs)
 
 

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -44,6 +44,9 @@ class AWS(object):
     S3_SECRET_ACCESS_KEY = ConfigEntry(
         LegacyConfigEntry(SECTION, "secret_access_key"), YamlConfigEntry("storage.connection.secret-key")
     )
+    S3_ADDITIONAL_KWARGS = ConfigEntry(
+        LegacyConfigEntry(SECTION, "s3_additional_kwargs"), YamlConfigEntry("storage.connection.extra-args")
+    )
     ENABLE_DEBUG = ConfigEntry(LegacyConfigEntry(SECTION, "enable_debug", bool))
     RETRIES = ConfigEntry(LegacyConfigEntry(SECTION, "retries", int))
     BACKOFF_SECONDS = ConfigEntry(

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -36,11 +36,13 @@ from flytekit.core.utils import timeit
 from flytekit.exceptions.user import FlyteAssertion, FlyteValueException
 from flytekit.interfaces.random import random
 from flytekit.loggers import logger
+import json
 
 # Refer to https://github.com/fsspec/s3fs/blob/50bafe4d8766c3b2a4e1fc09669cf02fb2d71454/s3fs/core.py#L198
 # for key and secret
 _FSSPEC_S3_KEY_ID = "key"
 _FSSPEC_S3_SECRET = "secret"
+_FSSPEC_S3_ADDITIONAL_KWARGS = "s3_additional_kwargs"
 _ANON = "anon"
 
 Uploadable = typing.Union[str, os.PathLike, pathlib.Path, bytes, io.BufferedReader, io.BytesIO, io.StringIO]
@@ -55,6 +57,9 @@ def s3_setup_args(s3_cfg: configuration.S3Config, anonymous: bool = False) -> Di
 
     if s3_cfg.secret_access_key:
         kwargs[_FSSPEC_S3_SECRET] = s3_cfg.secret_access_key
+
+    if s3_cfg.s3_additional_kwargs:
+        kwargs[_FSSPEC_S3_ADDITIONAL_KWARGS] = json.loads(s3_cfg.s3_additional_kwargs)
 
     # S3fs takes this as a special arg
     if s3_cfg.endpoint is not None:

--- a/flytekit/core/utils.py
+++ b/flytekit/core/utils.py
@@ -211,6 +211,29 @@ def write_proto_to_file(proto, path):
         writer.write(proto.SerializeToString())
 
 
+def get_extra_headers_for_signed_url(signed_url):
+    """
+    A limitation of S3 Bucket Policies is that when enforcing SSE, checks are
+    done on the headers of the request. Therefore, when using pre-signed urls
+    we should fill in the headers with the SSE information from the url itself.
+
+    This is possible since these self-contained pre-signed urls contain the SSE
+    information within its query string.
+    """
+    from urllib.parse import parse_qs
+    headers = dict()
+    query_params = parse_qs(signed_url)
+    if "x-amz-server-side-encryption" in query_params:
+        sse = query_params["x-amz-server-side-encryption"]
+        if len(sse) > 0:
+            headers["x-amz-server-side-encryption"] = sse[0]
+    if "x-amz-server-side-encryption-aws-kms-key-id" in query_params:
+        keyid = query_params["x-amz-server-side-encryption-aws-kms-key-id"]
+        if len(keyid) > 0:
+            headers["x-amz-server-side-encryption-aws-kms-key-id"] = keyid[0]
+    return headers
+
+
 class Directory(object):
     def __init__(self, path):
         """

--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -587,6 +587,7 @@ def _internal_demo_remote(remote: FlyteRemote) -> FlyteRemote:
                     endpoint=FLYTE_SANDBOX_MINIO_ENDPOINT,
                     access_key_id=remote.config.data_config.s3.access_key_id,
                     secret_access_key=remote.config.data_config.s3.secret_access_key,
+                    s3_additional_kwargs=remote.config.data_config.s3.s3_additional_kwargs,
                 ),
             ),
         ),

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -19,6 +19,7 @@ from base64 import b64encode
 from collections import OrderedDict
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
+from urllib.parse import parse_qs
 
 import click
 import fsspec
@@ -827,12 +828,14 @@ class FlyteRemote(object):
         )
 
         extra_headers = self.get_extra_headers_for_protocol(upload_location.native_url)
+        extra_sse_headers = self.get_extra_headers_for_signed_url(upload_location.signed_url)
         encoded_md5 = b64encode(md5_bytes)
         with open(str(to_upload), "+rb") as local_file:
             content = local_file.read()
             content_length = len(content)
             headers = {"Content-Length": str(content_length), "Content-MD5": encoded_md5}
             headers.update(extra_headers)
+            headers.update(extra_sse_headers)
             rsp = requests.put(
                 upload_location.signed_url,
                 data=content,
@@ -2036,6 +2039,28 @@ class FlyteRemote(object):
         if native_url.startswith("abfs://"):
             return {"x-ms-blob-type": "BlockBlob"}
         return {}
+
+    @staticmethod
+    def get_extra_headers_for_signed_url(signed_url):
+        """
+        A limitation of S3 Bucket Policies is that when enforcing SSE, checks are
+        done on the headers of the request. Therefore, when using pre-signed urls
+        we should fill in the headers with the SSE information from the url itself.
+
+        This is possible since these self-contained pre-signed urls contain the SSE
+        information within its query string.
+        """
+        headers = dict()
+        query_params = parse_qs(signed_url)
+        if "x-amz-server-side-encryption" in query_params:
+            sse = query_params["x-amz-server-side-encryption"]
+            if len(sse) > 0:
+                headers["x-amz-server-side-encryption"] = sse[0]
+        if "x-amz-server-side-encryption-aws-kms-key-id" in query_params:
+            keyid = query_params["x-amz-server-side-encryption-aws-kms-key-id"]
+            if len(keyid) > 0:
+                headers["x-amz-server-side-encryption-aws-kms-key-id"] = keyid[0]
+        return headers
 
     def activate_launchplan(self, ident: Identifier):
         """

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -19,7 +19,6 @@ from base64 import b64encode
 from collections import OrderedDict
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
-from urllib.parse import parse_qs
 
 import click
 import fsspec

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -828,7 +828,7 @@ class FlyteRemote(object):
         )
 
         extra_headers = self.get_extra_headers_for_protocol(upload_location.native_url)
-        extra_sse_headers = self.get_extra_headers_for_signed_url(upload_location.signed_url)
+        extra_sse_headers = utils.get_extra_headers_for_signed_url(upload_location.signed_url)
         encoded_md5 = b64encode(md5_bytes)
         with open(str(to_upload), "+rb") as local_file:
             content = local_file.read()
@@ -2039,28 +2039,6 @@ class FlyteRemote(object):
         if native_url.startswith("abfs://"):
             return {"x-ms-blob-type": "BlockBlob"}
         return {}
-
-    @staticmethod
-    def get_extra_headers_for_signed_url(signed_url):
-        """
-        A limitation of S3 Bucket Policies is that when enforcing SSE, checks are
-        done on the headers of the request. Therefore, when using pre-signed urls
-        we should fill in the headers with the SSE information from the url itself.
-
-        This is possible since these self-contained pre-signed urls contain the SSE
-        information within its query string.
-        """
-        headers = dict()
-        query_params = parse_qs(signed_url)
-        if "x-amz-server-side-encryption" in query_params:
-            sse = query_params["x-amz-server-side-encryption"]
-            if len(sse) > 0:
-                headers["x-amz-server-side-encryption"] = sse[0]
-        if "x-amz-server-side-encryption-aws-kms-key-id" in query_params:
-            keyid = query_params["x-amz-server-side-encryption-aws-kms-key-id"]
-            if len(keyid) > 0:
-                headers["x-amz-server-side-encryption-aws-kms-key-id"] = keyid[0]
-        return headers
 
     def activate_launchplan(self, ident: Identifier):
         """

--- a/flytekit/remote/remote_fs.py
+++ b/flytekit/remote/remote_fs.py
@@ -17,6 +17,7 @@ from fsspec.callbacks import NoOpCallback
 from fsspec.implementations.http import HTTPFileSystem
 from fsspec.utils import get_protocol
 
+from flytekit.core import utils
 from flytekit.loggers import logger
 from flytekit.tools.script_mode import hash_file
 
@@ -179,6 +180,9 @@ class FlyteFS(HTTPFileSystem):
         resp, content_length, md5_bytes = self.get_upload_link(lpath, rpath, p, hashes)
 
         headers = {"Content-Length": str(content_length), "Content-MD5": b64encode(md5_bytes).decode("utf-8")}
+        extra_sse_headers = utils.get_extra_headers_for_signed_url(resp.signed_url)
+        headers.update(extra_sse_headers)
+
         kwargs["headers"] = headers
         rpath = resp.signed_url
         FlytePathResolver.add_mapping(rpath, resp.native_url)

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -235,19 +235,6 @@ def test_get_extra_headers_s3():
     assert headers == {}
 
 
-def test_get_extra_sse_headers_azure_blob_storage():
-    signed_url = "https://storageaccount.blob.core.windows.net/flyte-demo/file"
-    headers = FlyteRemote.get_extra_headers_for_protocol(signed_url)
-    assert headers == {}
-
-
-def test_get_extra_sse_headers_s3():
-    signed_url = "https://flyte-demo.s3.us-west-2.amazonaws.com/file?X-Amz-SignedHeaders=content-md5%3Bhost%3Bx-amz-server-side-encryption%3Bx-amz-server-side-encryption-aws-kms-key-id&x-amz-server-side-encryption=aws%3Akms&x-amz-server-side-encryption-aws-kms-key-id=kmsId"
-    headers = FlyteRemote.get_extra_headers_for_protocol(signed_url)
-    assert headers["x-amz-server-side-encryption"] == "aws_kms"
-    assert headers["x-amz-server-side-encryption-aws-kms-key-id"] == "kmsId"
-
-
 @patch("flytekit.remote.remote.SynchronousFlyteClient")
 def test_generate_console_http_domain_sandbox_rewrite(mock_client):
     _, temp_filename = tempfile.mkstemp(suffix=".yaml")

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -235,6 +235,19 @@ def test_get_extra_headers_s3():
     assert headers == {}
 
 
+def test_get_extra_sse_headers_azure_blob_storage():
+    signed_url = "https://storageaccount.blob.core.windows.net/flyte-demo/file"
+    headers = FlyteRemote.get_extra_headers_for_protocol(signed_url)
+    assert headers == {}
+
+
+def test_get_extra_sse_headers_s3():
+    signed_url = "https://flyte-demo.s3.us-west-2.amazonaws.com/file?X-Amz-SignedHeaders=content-md5%3Bhost%3Bx-amz-server-side-encryption%3Bx-amz-server-side-encryption-aws-kms-key-id&x-amz-server-side-encryption=aws%3Akms&x-amz-server-side-encryption-aws-kms-key-id=kmsId"
+    headers = FlyteRemote.get_extra_headers_for_protocol(signed_url)
+    assert headers["x-amz-server-side-encryption"] == "aws_kms"
+    assert headers["x-amz-server-side-encryption-aws-kms-key-id"] == "kmsId"
+
+
 @patch("flytekit.remote.remote.SynchronousFlyteClient")
 def test_generate_console_http_domain_sandbox_rewrite(mock_client):
     _, temp_filename = tempfile.mkstemp(suffix=".yaml")


### PR DESCRIPTION
## Tracking issue
Part of a group:
1. https://github.com/flyteorg/stow/pull/11
2. https://github.com/flyteorg/flyte/pull/4897
3. https://github.com/flyteorg/flytekit/pull/2193

## Why are the changes needed?

Support S3 buckets encrypted with SSE

## What changes were proposed in this pull request?
When using pre-signed urls for PUTs to S3 buckets encrypted with SSE, fill in the headers with the SSE information from the url itself, if detected in the url.

Otherwise, the normal path (no SSE) is taken i.e. for backwards-compatability.

## How was this patch tested?

Tests added to `tests/flytekit/unit/remote/test_remote.py`

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
