### PR TITLE
Fix local overwrite cache

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -516,6 +516,8 @@ def run_command(ctx: click.Context, entity: typing.Union[PythonFunctionWorkflow,
                     if run_level_params.envvars:
                         for env_var, value in run_level_params.envvars.items():
                             os.environ[env_var] = value
+                    if run_level_params.overwrite_cache:
+                        os.environ["FLYTE_LOCAL_CACHE_OVERWRITE"] = "true"
                     output = entity(**inputs)
                     if inspect.iscoroutine(output):
                         # TODO: make eager mode workflows run with local-mode

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -618,12 +618,14 @@ class LocalConfig(object):
     """
 
     cache_enabled: bool = True
+    cache_overwrite: bool = False
 
     @classmethod
     def auto(cls, config_file: typing.Union[str, ConfigFile] = None) -> LocalConfig:
         config_file = get_config_file(config_file)
         kwargs = {}
         kwargs = set_if_exists(kwargs, "cache_enabled", _internal.Local.CACHE_ENABLED.read(config_file))
+        kwargs = set_if_exists(kwargs, "cache_overwrite", _internal.Local.CACHE_OVERWRITE.read(config_file))
         return LocalConfig(**kwargs)
 
 

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -69,6 +69,7 @@ class AZURE(object):
 class Local(object):
     SECTION = "local"
     CACHE_ENABLED = ConfigEntry(LegacyConfigEntry(SECTION, "cache_enabled", bool))
+    CACHE_OVERWRITE = ConfigEntry(LegacyConfigEntry(SECTION, "cache_overwrite", bool))
 
 
 class Credentials(object):

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -266,6 +266,7 @@ class Task(object):
 
         # if metadata.cache is set, check memoized version
         local_config = LocalConfig.auto()
+        print(local_config.cache_overwrite)
         if self.metadata.cache and local_config.cache_enabled:
             # TODO: how to get a nice `native_inputs` here?
             logger.info(
@@ -274,8 +275,11 @@ class Task(object):
             )
             outputs_literal_map = LocalTaskCache.get(self.name, self.metadata.cache_version, input_literal_map)
             # The cache returns None iff the key does not exist in the cache
-            if outputs_literal_map is None:
-                logger.info("Cache miss, task will be executed now")
+            if outputs_literal_map is None or local_config.cache_overwrite:
+                if outputs_literal_map is None:
+                    logger.info("Cache miss, task will be executed now")
+                else:
+                    logger.info("Cache overwrite, task will be executed now")
                 outputs_literal_map = self.sandbox_execute(ctx, input_literal_map)
                 # TODO: need `native_inputs`
                 LocalTaskCache.set(self.name, self.metadata.cache_version, input_literal_map, outputs_literal_map)

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -266,7 +266,6 @@ class Task(object):
 
         # if metadata.cache is set, check memoized version
         local_config = LocalConfig.auto()
-        print(local_config.cache_overwrite)
         if self.metadata.cache and local_config.cache_enabled:
             # TODO: how to get a nice `native_inputs` here?
             logger.info(

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -272,13 +272,17 @@ class Task(object):
                 f"Checking cache for task named {self.name}, cache version {self.metadata.cache_version} "
                 f"and inputs: {input_literal_map}"
             )
-            outputs_literal_map = LocalTaskCache.get(self.name, self.metadata.cache_version, input_literal_map)
-            # The cache returns None iff the key does not exist in the cache
-            if outputs_literal_map is None or local_config.cache_overwrite:
+            if local_config.cache_overwrite:
+                outputs_literal_map = None
+                logger.info("Cache overwrite, task will be executed now")
+            else:
+                outputs_literal_map = LocalTaskCache.get(self.name, self.metadata.cache_version, input_literal_map)
+                # The cache returns None iff the key does not exist in the cache
                 if outputs_literal_map is None:
                     logger.info("Cache miss, task will be executed now")
                 else:
-                    logger.info("Cache overwrite, task will be executed now")
+                    logger.info("Cache hit")
+            if outputs_literal_map is None:
                 outputs_literal_map = self.sandbox_execute(ctx, input_literal_map)
                 # TODO: need `native_inputs`
                 LocalTaskCache.set(self.name, self.metadata.cache_version, input_literal_map, outputs_literal_map)
@@ -286,8 +290,6 @@ class Task(object):
                     f"Cache set for task named {self.name}, cache version {self.metadata.cache_version} "
                     f"and inputs: {input_literal_map}"
                 )
-            else:
-                logger.info("Cache hit")
         else:
             # This code should mirror the call to `sandbox_execute` in the above cache case.
             # Code is simpler with duplication and less metaprogramming, but introduces regressions

--- a/flytekit/core/local_cache.py
+++ b/flytekit/core/local_cache.py
@@ -70,4 +70,4 @@ class LocalTaskCache(object):
     def set(task_name: str, cache_version: str, input_literal_map: LiteralMap, value: LiteralMap) -> None:
         if not LocalTaskCache._initialized:
             LocalTaskCache.initialize()
-        LocalTaskCache._cache.add(_calculate_cache_key(task_name, cache_version, input_literal_map), value)
+        LocalTaskCache._cache.set(_calculate_cache_key(task_name, cache_version, input_literal_map), value)


### PR DESCRIPTION
## Tracking issue
Closes _https://github.com/flyteorg/flyte/issues/4727_

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?

We can't overwrite the cache when using `pyflyte run --overwrite-cache` in local runs.

## What changes were proposed in this pull request?

* Once the argument `--overwrite-cache` is added, we get `run_level_params.overwrite_cache=True` and set the environment variable `FLYTE_LOCAL_CACHE_OVERWRITE=true` accordingly. 
* With `FLYTE_LOCAL_CACHE_OVERWRITE=true`, the task will be executed and overwrite the existing cache.
* The cache `add` function in `LocalTaskCache`  is changed to `set` as the previous one can't update the cache if there's already an existing one.


## How was this patch tested?

Added a test which confirms that setting `FLYTE_LOCAL_CACHE_OVERWRITE=true` can successfully overwrite the existing cache.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
