### PR TITLE
Agent Log Capture Feature

### DIFF
--- a/plugins/flytekit-airflow/flytekitplugins/airflow/agent.py
+++ b/plugins/flytekit-airflow/flytekitplugins/airflow/agent.py
@@ -1,9 +1,9 @@
 import asyncio
+import logging
 import typing
 from dataclasses import dataclass, field
-from typing import Optional
-import logging
 from io import StringIO
+from typing import Optional
 
 import cloudpickle
 import jsonpickle
@@ -21,7 +21,6 @@ from airflow.models import BaseOperator
 from airflow.sensors.base import BaseSensorOperator
 from airflow.triggers.base import TriggerEvent
 from airflow.utils.context import Context
-from flytekit import logger
 from flytekit.exceptions.user import FlyteUserException
 from flytekit.extend.backend.base_agent import AgentBase, AgentRegistry
 from flytekit.models.literals import LiteralMap
@@ -151,7 +150,7 @@ class AirflowAgent(AgentBase):
         logger.setLevel(original_level)
 
         if message:
-            message = message + "\n" +  log_capture_string.getvalue()
+            message = message + "\n" + log_capture_string.getvalue()
         else:
             message = log_capture_string.getvalue()
         print("message: ", message)

--- a/plugins/flytekit-airflow/flytekitplugins/airflow/agent.py
+++ b/plugins/flytekit-airflow/flytekitplugins/airflow/agent.py
@@ -153,7 +153,7 @@ class AirflowAgent(AgentBase):
             message = message + "\n" + log_capture_string.getvalue()
         else:
             message = log_capture_string.getvalue()
-        print("message: ", message)
+
         return GetTaskResponse(resource=Resource(phase=cur_phase, message=message))
 
     async def delete(self, resource_meta: bytes, **kwargs) -> DeleteTaskResponse:


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
Make every log in the agent server can be shown in flyte console instead of the agent server.

## What changes were proposed in this pull request?
In airflow agent, use `io.StringIO` and "logging" module to capture logging messages, and send them to flytepropeller.

TODO: we should split the feature into 2 functions, set log capture and unset it.
we can move it to `flytekit.extend.backend.utils`, to support all agents.

## How was this patch tested?
In local single binary.

<img width="760" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/37c68421-ee57-4e88-80ee-6f8617485ef9">


```python
if message:
    message = message + "\n" + log_capture_string.getvalue()
else:
    message = log_capture_string.getvalue()
print("message: ", message)
return GetTaskResponse(resource=Resource(phase=cur_phase, message=message))
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs


## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
