### PR TITLE
Add default_project in register_launch_plan

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -981,7 +981,7 @@ class FlyteRemote(object):
         :param options:
         :return:
         """
-        ss = SerializationSettings(image_config=ImageConfig(), project=project, domain=domain, version=version)
+        ss = SerializationSettings(image_config=ImageConfig(), project=project or self.default_project, domain=domain or self.default_domain, version=version)
 
         ident = self._resolve_identifier(ResourceType.LAUNCH_PLAN, entity.name, version, ss)
         m = OrderedDict()


### PR DESCRIPTION
## Tracking issue
Closes _https://github.com/flyteorg/flyte/issues/4889_

## Why are the changes needed?
Use `default_project` and `default_domain` when users don't setup `project` and `domain` in `register_launch_plan`

## What changes were proposed in this pull request?
Add `self.default_project` and `self.default_domain` in `SerializationSettings` initialization.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
