### PR TITLE
CI Uses GITHUB_OUTPUT in github actions

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           # from refs/tags/v1.2.3 get 1.2.3
           VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
-          echo "::set-output name=version::$VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
         shell: bash
       - name: Build and publish
         env:


### PR DESCRIPTION
`::set-output` has been deprecated a while back: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR switches over the CI to use the new API: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs