### PR TITLE
Enhance default image to check FLYTE_INTERNAL_IMAGE

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -285,7 +285,7 @@ class ImageConfig(DataClassJsonMixin):
                 images.append(img)
 
         if default_image is None:
-            default_image_str = os.environ.get("FLYTE_INTERNAL_IMAGE", DefaultImages.default_image())
+            default_image_str = DefaultImages.default_image()
             default_image = Image.look_up_image_info(DEFAULT_IMAGE_NAME, default_image_str, False)
         return ImageConfig.create_from(default_image=default_image, other_images=images)
 

--- a/flytekit/configuration/default_images.py
+++ b/flytekit/configuration/default_images.py
@@ -1,4 +1,5 @@
 import enum
+import os
 import sys
 import typing
 from contextlib import suppress
@@ -34,7 +35,8 @@ class DefaultImages(object):
             if default_image is not None:
                 return default_image
 
-        return cls.find_image_for()
+        default_image_str = os.environ.get("FLYTE_INTERNAL_IMAGE", cls.find_image_for())
+        return default_image_str
 
     @classmethod
     def find_image_for(


### PR DESCRIPTION
## Tracking issue

Provides context for https://flyte-org.slack.com/archives/CP2HDHKE1/p1709158841281599

## Why are the changes needed?

Some CLI paths like `pyflyte run, pyflyte register` do not use the image specified by the environment variable `FLYTE_INTERNAL_IMAGE` in the manner one might expect

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
