### PR TITLE
Use disk-space-reclaimer only when running envd tests

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -282,6 +282,7 @@ jobs:
             plugin-names: "flytekit-whylogs"
     steps:
       - uses: insightsengineering/disk-space-reclaimer@v1
+        if: ${{ matrix.plugin-names == 'flytekit-envd' }}
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4


### PR DESCRIPTION
To make CI run faster, use disk-space-reclaimer only when running envd tests.