### PR TITLE
ChatGPT Agent

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -218,7 +218,6 @@ jobs:
           # TODO: uncomment this when the sagemaker agent is implemented: https://github.com/flyteorg/flyte/issues/4079
           # - flytekit-aws-sagemaker
           - flytekit-bigquery
-          - flytekit-chatgpt
           - flytekit-dask
           - flytekit-data-fsspec
           - flytekit-dbt
@@ -240,6 +239,7 @@ jobs:
           # onnx-tensorflow needs a version of tensorflow that does not work with protobuf>4.
           # The issue is being tracked on the tensorflow side in https://github.com/tensorflow/tensorflow/issues/53234#issuecomment-1330111693
           # flytekit-onnx-tensorflow
+          - flytekit-openai
           - flytekit-pandera
           - flytekit-papermill
           - flytekit-polars

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -218,6 +218,7 @@ jobs:
           # TODO: uncomment this when the sagemaker agent is implemented: https://github.com/flyteorg/flyte/issues/4079
           # - flytekit-aws-sagemaker
           - flytekit-bigquery
+          - flytekit-chatgpt
           - flytekit-dask
           - flytekit-data-fsspec
           - flytekit-dbt

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -11,7 +11,10 @@ RUN pip install prometheus-client grpcio-health-checking
 RUN pip install --no-cache-dir -U flytekit==$VERSION \
   flytekitplugins-airflow==$VERSION \
   flytekitplugins-bigquery==$VERSION \
+  flytekitplugins-chatgpt==$VERSION \
+  flytekitplugins-mmcloud==$VERSION \
   flytekitplugins-snowflake==$VERSION \
+  flytekitplugins-spark==$VERSION \
   && apt-get clean autoclean \
   && apt-get autoremove --yes \
   && rm -rf /var/lib/{apt,dpkg,cache,log}/ \

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -12,9 +12,7 @@ RUN pip install --no-cache-dir -U flytekit==$VERSION \
   flytekitplugins-airflow==$VERSION \
   flytekitplugins-bigquery==$VERSION \
   flytekitplugins-chatgpt==$VERSION \
-  flytekitplugins-mmcloud==$VERSION \
   flytekitplugins-snowflake==$VERSION \
-  flytekitplugins-spark==$VERSION \
   && apt-get clean autoclean \
   && apt-get autoremove --yes \
   && rm -rf /var/lib/{apt,dpkg,cache,log}/ \

--- a/flytekit/extend/backend/base_agent.py
+++ b/flytekit/extend/backend/base_agent.py
@@ -251,9 +251,12 @@ class SyncAgentExecutorMixin:
         return resource.outputs
 
     async def _do(self: T, agent: SyncAgentBase, template: TaskTemplate, inputs: Dict[str, Any] = None) -> Resource:
-        ctx = FlyteContext.current_context()
-        literal_map = TypeEngine.dict_to_literal_map(ctx, inputs or {}, self.get_input_types())
-        return await mirror_async_methods(agent.do, task_template=template, inputs=literal_map)
+        try:
+            ctx = FlyteContext.current_context()
+            literal_map = TypeEngine.dict_to_literal_map(ctx, inputs or {}, self.get_input_types())
+            return await mirror_async_methods(agent.do, task_template=template, inputs=literal_map)
+        except Exception as error_message:
+            raise FlyteUserException(f"Failed to run the task {self.name} with error: {error_message}")
 
 
 class AsyncAgentExecutorMixin:

--- a/plugins/flytekit-openai/README.md
+++ b/plugins/flytekit-openai/README.md
@@ -1,0 +1,44 @@
+# Flytekit ChatGPT Plugin
+ChatGPT plugin allows you to run ChatGPT tasks in the Flyte workflow without changing any code.
+
+## Example
+```python
+from flytekit import task, workflow
+from flytekitplugins.chatgpt import ChatGPTTask, ChatGPTConfig
+
+chatgpt_small_job = ChatGPTTask(
+    name="chatgpt gpt-3.5-turbo",
+    openai_organization="org-NayNG68kGnVXMJ8Ak4PMgQv7",
+    chatgpt_config={
+            "model": "gpt-3.5-turbo",
+            "temperature": 0.7,
+    },
+)
+
+chatgpt_big_job = ChatGPTTask(
+    name="chatgpt gpt-4",
+    openai_organization="org-NayNG68kGnVXMJ8Ak4PMgQv7",
+    chatgpt_config={
+            "model": "gpt-4",
+            "temperature": 0.7,
+    },
+)
+
+
+@workflow
+def wf(message: str) -> str:
+    message = chatgpt_small_job(message=message)
+    message = chatgpt_big_job(message=message)
+    return message
+
+
+if __name__ == "__main__":
+    print(wf(message="hi"))
+```
+
+
+To install the plugin, run the following command:
+
+```bash
+pip install flytekitplugins-chatgpt
+```

--- a/plugins/flytekit-openai/flytekitplugins/chatgpt/__init__.py
+++ b/plugins/flytekit-openai/flytekitplugins/chatgpt/__init__.py
@@ -1,0 +1,12 @@
+"""
+.. currentmodule:: flytekitplugins.chatgpt
+This package contains things that are useful when extending Flytekit.
+.. autosummary::
+   :template: custom.rst
+   :toctree: generated/
+   ChatGPTAgent
+   ChatGPTTask
+"""
+
+from .agent import ChatGPTAgent
+from .task import ChatGPTTask

--- a/plugins/flytekit-openai/flytekitplugins/chatgpt/agent.py
+++ b/plugins/flytekit-openai/flytekitplugins/chatgpt/agent.py
@@ -43,16 +43,13 @@ class ChatGPTAgent(SyncAgentBase):
         logger = logging.getLogger("httpx")
         logger.setLevel(logging.WARNING)
 
-        try:
-            completion = await asyncio.wait_for(
-                client.chat.completions.create(**custom["chatgpt_config"]), TIMEOUT_SECONDS
-            )
-            message = completion.choices[0].message.content
-            outputs = {"o0": message}
+        completion = await asyncio.wait_for(
+            client.chat.completions.create(**custom["chatgpt_config"]), TIMEOUT_SECONDS
+        )
+        message = completion.choices[0].message.content
+        outputs = {"o0": message}
 
-            return Resource(phase=TaskExecution.SUCCEEDED, outputs=outputs)
-        except Exception as error_message:
-            raise FlyteUserException(f"Failed to run the task {self.name} with error: {error_message}")
+        return Resource(phase=TaskExecution.SUCCEEDED, outputs=outputs)
 
 
 AgentRegistry.register(ChatGPTAgent())

--- a/plugins/flytekit-openai/flytekitplugins/chatgpt/agent.py
+++ b/plugins/flytekit-openai/flytekitplugins/chatgpt/agent.py
@@ -1,0 +1,57 @@
+import asyncio
+import logging
+from typing import Optional
+
+from flyteidl.core.execution_pb2 import TaskExecution
+
+from flytekit import FlyteContextManager, lazy_module
+from flytekit.core.type_engine import TypeEngine
+from flytekit.extend.backend.base_agent import AgentRegistry, Resource, SyncAgentBase
+from flytekit.extend.backend.utils import get_agent_secret
+from flytekit.models.literals import LiteralMap
+from flytekit.models.task import TaskTemplate
+
+openai = lazy_module("openai")
+
+TIMEOUT_SECONDS = 10
+OPENAI_API_KEY = "FLYTE_OPENAI_API_KEY"
+
+
+class ChatGPTAgent(SyncAgentBase):
+    name = "ChatGPT Agent"
+
+    def __init__(self):
+        super().__init__(task_type_name="chatgpt")
+
+    async def do(
+        self,
+        task_template: TaskTemplate,
+        inputs: Optional[LiteralMap] = None,
+    ) -> Resource:
+        ctx = FlyteContextManager.current_context()
+        input_python_value = TypeEngine.literal_map_to_kwargs(ctx, inputs, {"message": str})
+        message = input_python_value["message"]
+
+        custom = task_template.custom
+        custom["chatgpt_config"]["messages"] = [{"role": "user", "content": message}]
+        client = openai.AsyncOpenAI(
+            organization=custom["openai_organization"],
+            api_key=get_agent_secret(secret_key=OPENAI_API_KEY),
+        )
+
+        logger = logging.getLogger("httpx")
+        logger.setLevel(logging.WARNING)
+
+        try:
+            completion = await asyncio.wait_for(
+                client.chat.completions.create(**custom["chatgpt_config"]), TIMEOUT_SECONDS
+            )
+            message = completion.choices[0].message.content
+            outputs = {"o0": message}
+
+            return Resource(phase=TaskExecution.SUCCEEDED, outputs=outputs)
+        except Exception as error_message:
+            return Resource(phase=TaskExecution.FAILED, message=str(error_message))
+
+
+AgentRegistry.register(ChatGPTAgent())

--- a/plugins/flytekit-openai/flytekitplugins/chatgpt/agent.py
+++ b/plugins/flytekit-openai/flytekitplugins/chatgpt/agent.py
@@ -6,7 +6,6 @@ from flyteidl.core.execution_pb2 import TaskExecution
 
 from flytekit import FlyteContextManager, lazy_module
 from flytekit.core.type_engine import TypeEngine
-from flytekit.exceptions.user import FlyteUserException
 from flytekit.extend.backend.base_agent import AgentRegistry, Resource, SyncAgentBase
 from flytekit.extend.backend.utils import get_agent_secret
 from flytekit.models.literals import LiteralMap
@@ -43,9 +42,7 @@ class ChatGPTAgent(SyncAgentBase):
         logger = logging.getLogger("httpx")
         logger.setLevel(logging.WARNING)
 
-        completion = await asyncio.wait_for(
-            client.chat.completions.create(**custom["chatgpt_config"]), TIMEOUT_SECONDS
-        )
+        completion = await asyncio.wait_for(client.chat.completions.create(**custom["chatgpt_config"]), TIMEOUT_SECONDS)
         message = completion.choices[0].message.content
         outputs = {"o0": message}
 

--- a/plugins/flytekit-openai/flytekitplugins/chatgpt/agent.py
+++ b/plugins/flytekit-openai/flytekitplugins/chatgpt/agent.py
@@ -6,6 +6,7 @@ from flyteidl.core.execution_pb2 import TaskExecution
 
 from flytekit import FlyteContextManager, lazy_module
 from flytekit.core.type_engine import TypeEngine
+from flytekit.exceptions.user import FlyteUserException
 from flytekit.extend.backend.base_agent import AgentRegistry, Resource, SyncAgentBase
 from flytekit.extend.backend.utils import get_agent_secret
 from flytekit.models.literals import LiteralMap
@@ -51,7 +52,7 @@ class ChatGPTAgent(SyncAgentBase):
 
             return Resource(phase=TaskExecution.SUCCEEDED, outputs=outputs)
         except Exception as error_message:
-            return Resource(phase=TaskExecution.FAILED, message=str(error_message))
+            raise FlyteUserException(f"Failed to run the task {self.name} with error: {error_message}")
 
 
 AgentRegistry.register(ChatGPTAgent())

--- a/plugins/flytekit-openai/flytekitplugins/chatgpt/task.py
+++ b/plugins/flytekit-openai/flytekitplugins/chatgpt/task.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict
+
+from flytekit.configuration import SerializationSettings
+from flytekit.core.base_task import PythonTask
+from flytekit.core.interface import Interface
+from flytekit.extend.backend.base_agent import SyncAgentExecutorMixin
+
+
+class ChatGPTTask(SyncAgentExecutorMixin, PythonTask):
+    """
+    This is the simplest form of a ChatGPT Task, you can define the model and the input you want.
+    """
+
+    _TASK_TYPE = "chatgpt"
+
+    def __init__(self, name: str, openai_organization: str, chatgpt_config: Dict[str, Any], **kwargs):
+        """
+        Args:
+            name: Name of this task, should be unique in the project
+            openai_organization: OpenAI Organization. String can be found here. https://platform.openai.com/docs/api-reference/organization-optional
+            chatgpt_config: ChatGPT job configuration. Config structure can be found here. https://platform.openai.com/docs/api-reference/completions/create
+        """
+
+        if "model" not in chatgpt_config:
+            raise ValueError("The 'model' configuration variable is required in chatgpt_config")
+
+        task_config = {"openai_organization": openai_organization, "chatgpt_config": chatgpt_config}
+
+        inputs = {"message": str}
+        outputs = {"o0": str}
+
+        super().__init__(
+            task_type=self._TASK_TYPE,
+            name=name,
+            task_config=task_config,
+            interface=Interface(inputs=inputs, outputs=outputs),
+            **kwargs,
+        )
+
+    def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
+        return {
+            "openai_organization": self.task_config["openai_organization"],
+            "chatgpt_config": self.task_config["chatgpt_config"],
+        }

--- a/plugins/flytekit-openai/setup.py
+++ b/plugins/flytekit-openai/setup.py
@@ -1,0 +1,37 @@
+from setuptools import setup
+
+PLUGIN_NAME = "chatgpt"
+
+microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
+
+plugin_requires = ["flytekit>=1.10.7", "openai>=1.12.0", "flyteidl>=1.11.0b0"]
+
+__version__ = "0.0.0+develop"
+
+setup(
+    name=microlib_name,
+    version=__version__,
+    author="flyteorg",
+    author_email="admin@flyte.org",
+    description="This package holds the ChatGPT plugins for flytekit",
+    namespace_packages=["flytekitplugins"],
+    packages=[f"flytekitplugins.{PLUGIN_NAME}"],
+    install_requires=plugin_requires,
+    license="apache2",
+    python_requires=">=3.8",
+    classifiers=[
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Software Development",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+    entry_points={"flytekit.plugins": [f"{PLUGIN_NAME}=flytekitplugins.{PLUGIN_NAME}"]},
+)

--- a/plugins/flytekit-openai/setup.py
+++ b/plugins/flytekit-openai/setup.py
@@ -27,6 +27,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Software Development",

--- a/plugins/flytekit-openai/setup.py
+++ b/plugins/flytekit-openai/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "chatgpt"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.10.7", "openai>=1.12.0", "flyteidl>=1.11.0b0"]
+plugin_requires = ["flytekit>1.10.7", "openai>=1.12.0", "flyteidl>=1.11.0b0"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-openai/tests/test_agent.py
+++ b/plugins/flytekit-openai/tests/test_agent.py
@@ -1,0 +1,69 @@
+from datetime import timedelta
+from unittest import mock
+
+import pytest
+from flyteidl.core.execution_pb2 import TaskExecution
+
+from flytekit.extend.backend.base_agent import AgentRegistry
+from flytekit.interfaces.cli_identifiers import Identifier
+from flytekit.models import literals
+from flytekit.models.core.identifier import ResourceType
+from flytekit.models.literals import LiteralMap
+from flytekit.models.task import RuntimeMetadata, TaskMetadata, TaskTemplate
+
+
+async def mock_acreate(*args, **kwargs) -> str:
+    mock_response = mock.MagicMock()
+    mock_choice = mock.MagicMock()
+    mock_choice.message.content = "mocked_message"
+    mock_response.choices = [mock_choice]
+    return mock_response
+
+
+@pytest.mark.asyncio
+async def test_chatgpt_agent():
+    agent = AgentRegistry.get_agent("chatgpt")
+    task_id = Identifier(
+        resource_type=ResourceType.TASK, project="project", domain="domain", name="name", version="version"
+    )
+    task_config = {
+        "openai_organization": "test-openai-orgnization-id",
+        "chatgpt_config": {"model": "gpt-3.5-turbo", "temperature": 0.7},
+    }
+    task_metadata = TaskMetadata(
+        True,
+        RuntimeMetadata(RuntimeMetadata.RuntimeType.FLYTE_SDK, "1.0.0", "python"),
+        timedelta(days=1),
+        literals.RetryStrategy(3),
+        True,
+        "0.1.1b0",
+        "This is deprecated!",
+        True,
+        "A",
+    )
+    tmp = TaskTemplate(
+        id=task_id,
+        custom=task_config,
+        metadata=task_metadata,
+        interface=None,
+        type="chatgpt",
+    )
+
+    task_inputs = LiteralMap(
+        {
+            "message": literals.Literal(
+                scalar=literals.Scalar(primitive=literals.Primitive(string_value="Test ChatGPT Plugin"))
+            ),
+        },
+    )
+    message = "mocked_message"
+    mocked_token = "mocked_openai_api_key"
+    mocked_context = mock.patch("flytekit.current_context", autospec=True).start()
+    mocked_context.return_value.secrets.get.return_value = mocked_token
+
+    with mock.patch("openai.resources.chat.completions.AsyncCompletions.create", new=mock_acreate):
+        # Directly await the coroutine without using asyncio.run
+        response = await agent.do(tmp, task_inputs)
+
+    assert response.phase == TaskExecution.SUCCEEDED
+    assert response.outputs == {"o0": message}

--- a/plugins/flytekit-openai/tests/test_chatgpt.py
+++ b/plugins/flytekit-openai/tests/test_chatgpt.py
@@ -1,0 +1,43 @@
+from collections import OrderedDict
+
+from flytekitplugins.chatgpt import ChatGPTTask
+
+from flytekit.configuration import Image, ImageConfig, SerializationSettings
+from flytekit.extend import get_serializable
+from flytekit.models.types import SimpleType
+
+
+def test_chatgpt_task():
+    chatgpt_task = ChatGPTTask(
+        name="chatgpt",
+        openai_organization="TEST ORGANIZATION ID",
+        chatgpt_config={
+            "model": "gpt-3.5-turbo",
+            "temperature": 0.7,
+        },
+    )
+
+    assert len(chatgpt_task.interface.inputs) == 1
+    assert len(chatgpt_task.interface.outputs) == 1
+
+    default_img = Image(name="default", fqn="test", tag="tag")
+    serialization_settings = SerializationSettings(
+        project="proj",
+        domain="dom",
+        version="123",
+        image_config=ImageConfig(default_image=default_img, images=[default_img]),
+        env={},
+    )
+
+    chatgpt_task_spec = get_serializable(OrderedDict(), serialization_settings, chatgpt_task)
+    custom = chatgpt_task_spec.template.custom
+    assert custom["openai_organization"] == "TEST ORGANIZATION ID"
+    assert custom["chatgpt_config"]["model"] == "gpt-3.5-turbo"
+    assert custom["chatgpt_config"]["temperature"] == 0.7
+
+    assert len(chatgpt_task_spec.template.interface.inputs) == 1
+    assert len(chatgpt_task_spec.template.interface.outputs) == 1
+
+    assert chatgpt_task_spec.template.interface.inputs["message"].type.simple == SimpleType.STRING
+    assert chatgpt_task_spec.template.interface.outputs["o0"].type.simple == SimpleType.STRING
+ 

--- a/plugins/flytekit-openai/tests/test_chatgpt.py
+++ b/plugins/flytekit-openai/tests/test_chatgpt.py
@@ -40,4 +40,3 @@ def test_chatgpt_task():
 
     assert chatgpt_task_spec.template.interface.inputs["message"].type.simple == SimpleType.STRING
     assert chatgpt_task_spec.template.interface.outputs["o0"].type.simple == SimpleType.STRING
- 


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
We want to support chatgpt agent and provide example for users to develop sync agent.

## What changes were proposed in this pull request?
- add openai-chatgpt plugin

## How was this patch tested?
### Setup process
0. Set up my local single binary environment. (use `pyflyte serve agent`)
1. Build a docker image with sync agent proto and chatgpt agent's gitsha.
2. Test the chatgpt task in both local and remote scenarios.

```yaml
tasks:
  task-plugins:
    enabled-plugins:
      - container
      - sidecar
      - K8S-ARRAY
      - agent-service
      
    default-for-task-types:
      chatgpt: agent-service
      custom_task: agent-service
      container: container
      container_array: K8S-ARRAY

plugins:
  agent-service:
    supportedTaskTypes:
      - sensor
      - spark
      - default_task
      - custom_task
      - chatgpt
      - sensor
      - airflow
    defaultAgent:
      endpoint: "dns:///localhost:8000"
      insecure: true
      timeouts:
        GetTask: 100s
      defaultTimeout: 100s
```

```Dockerfile
FROM python:3.9-slim-buster
USER root
WORKDIR /root
ENV PYTHONPATH /root
RUN apt-get update && apt-get install build-essential -y
RUN apt-get install git -y

RUN pip install -U git+https://github.com/flyteorg/flytekit.git@c9972bf023d10bef3aefa9fa6763c6b35aec5693
RUN pip install -U git+https://github.com/flyteorg/flytekit.git@c9972bf023d10bef3aefa9fa6763c6b35aec5693#subdirectory=plugins/flytekit-openai
```
```python
from flytekit import task, workflow
from flytekitplugins.chatgpt import ChatGPTTask

chatgpt_new_job = ChatGPTTask(
            name="chatgpt",
            # openai_organization="org-NayNG68kGnVXMJ8Ak4PMgQv7",
            openai_organization="xxx",
            chatgpt_config={
                    "model": "gpt-3.5-turbo",
                    "temperature": 0.7,
            },
        )

@workflow
def wf() -> str:
    message = chatgpt_new_job(message="Hi")
    return t1(s=message)

@task
def t1(s: str) -> str:
    s = "Repsonse: " + s
    return s

if __name__ == "__main__":
    print(wf())
```
### Screenshots
#### Local Scenario
```bash
python chatgpt_chain.py
```
![image](https://github.com/flyteorg/flytekit/assets/76461262/da5d9265-30e1-4909-b29e-feaef4c282d8)
#### Remote Scenario
```bash
pyflyte run --remote --image futureoutlier/flytekit:chatgpt-0301 chatgpt_chain.py wf --message hi
```
![image](https://github.com/flyteorg/flytekit/assets/76461262/dd000e05-3ca9-473a-95d1-6743d592a130)
![image](https://github.com/flyteorg/flytekit/assets/76461262/b90a1914-e863-4105-8412-31918806647f)
![image](https://github.com/flyteorg/flytekit/assets/76461262/4338a912-3956-49d6-ac69-58bbdb0dcc7a)
![image](https://github.com/flyteorg/flytekit/assets/76461262/5aabac89-fe93-46cb-b156-a8fb99c3f895)



## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flytekit/pull/1822
https://github.com/flyteorg/flytekit/pull/2085

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
