### PR TITLE
ShellTask: stores process return code, stdout and stderr for later use.

### DIFF
--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -284,18 +284,6 @@ class ShellTask(PythonInstanceTask[T]):
         return self._process_result
 
     @property
-    def returncode(self) -> typing.Optional[int]:
-        return self._process_result.returncode
-
-    @property
-    def stdout(self) -> typing.Optional[str]:
-        return self._process_result.output
-
-    @property
-    def stderr(self) -> typing.Optional[str]:
-        return self._process_result.error
-
-    @property
     def script(self) -> typing.Optional[str]:
         return self._script
 

--- a/tests/flytekit/unit/extras/tasks/test_shell.py
+++ b/tests/flytekit/unit/extras/tasks/test_shell.py
@@ -32,6 +32,21 @@ else:
     script_sh_2 = os.path.join(testdata, "script_args_env.sh")
 
 
+def test_shell_task_access_to_result():
+    t = ShellTask(
+        name="test",
+        script="""
+        echo "Hello World!"
+        """,
+        shell="/bin/bash",
+    )
+    t()
+
+    assert t.result.returncode == 0
+    assert t.result.output == "Hello World!"  # ShellTask strips carriage returns
+    assert t.result.error == ""
+
+
 def test_shell_task_no_io():
     t = ShellTask(
         name="test",
@@ -342,9 +357,10 @@ def test_long_run_script():
 
 def test_subproc_execute():
     cmd = ["echo", "hello"]
-    o, e = subproc_execute(cmd)
-    assert o == "hello\n"
-    assert e == ""
+    result = subproc_execute(cmd)
+    assert result.returncode == 0
+    assert result.output == "hello\n"
+    assert result.error == ""
 
 
 def test_subproc_execute_with_shell():


### PR DESCRIPTION
Fixes #4888.

## Tracking issue
_https://github.com/flyteorg/flyte/issues/4888_
followed by @eapolinario 

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

- Creation of a structure named `ProcessResult` to store a subprocess return code, stdout and stderr
- Functions now return an instance of `ProcessResult` instead of `Tuple[str, str]`
- `ShellTask` stores an instance of `ProcessResult`

## How was this patch tested?

- `./tests/flytekit/unit/extras/tasks/test_shell.py`:
    - `test_shell_task_access_to_result` added
    - `test_subproc_execute()` adapted to accommodate `subproc_execute` new return type


- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
