### PR TITLE
set subnode and parent node timeout metadata for arraynode

### DIFF
--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -91,7 +91,7 @@ class ArrayNodeMapTask(PythonTask):
         self._min_successes: Optional[int] = min_successes
         self._min_success_ratio: Optional[float] = min_success_ratio
         self._collection_interface = collection_interface
-        self._timeout = timeout
+        self._timeout: Optional[timedelta] = timeout
 
         if "metadata" not in kwargs and actual_task.metadata:
             kwargs["metadata"] = actual_task.metadata

--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -361,8 +361,9 @@ def map_task(
         successfully before terminating this task and marking it successful.
     :param timeout: If specified, this determines the timeout for the parent ArrayNode
     """
-    return ArrayNodeMapTask(task_function, concurrency=concurrency, min_success_ratio=min_success_ratio,
-                            timeout=timeout, **kwargs)
+    return ArrayNodeMapTask(
+        task_function, concurrency=concurrency, min_success_ratio=min_success_ratio, timeout=timeout, **kwargs
+    )
 
 
 class ArrayNodeMapTaskResolver(tracker.TrackedInstance, TaskResolverMixin):

--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -20,7 +20,6 @@ from flytekit.loggers import logger
 from flytekit.models.array_job import ArrayJob
 from flytekit.models.core.workflow import NodeMetadata
 from flytekit.models.interface import Variable
-from flytekit.models.literals import RetryStrategy
 from flytekit.models.task import Container, K8sPod, Sql, Task
 from flytekit.tools.module_loader import load_object_from_module
 

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -458,7 +458,7 @@ def get_serializable_node(
     if isinstance(entity.flyte_entity, ArrayNodeMapTask):
         node_model = workflow_model.Node(
             id=_dnsify(entity.id),
-            metadata=entity.metadata,
+            metadata=entity.flyte_entity.get_parent_node_metadata(),
             inputs=entity.bindings,
             upstream_node_ids=[n.id for n in upstream_nodes],
             output_aliases=[],

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -1,6 +1,7 @@
 import functools
 import typing
 from collections import OrderedDict
+from datetime import timedelta
 from typing import List
 
 import pytest
@@ -60,10 +61,11 @@ def test_serialization(serialization_settings):
     def t1(a: int) -> int:
         return a + 1
 
-    arraynode_maptask = array_node_map_task(t1, metadata=TaskMetadata(retries=2))
+    arraynode_maptask = array_node_map_task(t1, metadata=TaskMetadata(retries=2, timeout=timedelta(hours=1)))
     task_spec = get_serializable(OrderedDict(), serialization_settings, arraynode_maptask)
 
     assert task_spec.template.metadata.retries.retries == 2
+    assert task_spec.template.metadata.timeout == timedelta(hours=1)
     assert task_spec.template.custom["minSuccessRatio"] == 1.0
     assert task_spec.template.type == "python-task"
     assert task_spec.template.task_type_version == 1


### PR DESCRIPTION
## Tracking issue
related to looking into this issue:

_https://github.com/flyteorg/flyte/issues/3875_

https://unionai.atlassian.net/browse/FLYTE-204

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?

Currently don't set metadata for either the parent ArrayNode or Subnodes

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

- enable timeouts to be defined for parent ArrayNodes. Set the timeout in the node's metadata
map_task(timeout= ...)

- set the underlying entity (only task for now) timeout in the target array_node's metadata

Note the subnode task timeouts are not supported yet.

Given:
```
@task(timeout="4h")
def foo(x: int) -> int:
    pass

@workflow
def bar(x: List[int]) -> List[int]:
    maptask(foo, timeout="6h")(x=x)
```

We want:
```
Node:
	NodeMetadata:
		timeout:"6h"
	Target
		ArrayNode
			Node
				NodeMetadata
					timeout: "4h"
				Target
					TaskNode
							"foo"
			Parallelism
			SuccessCriteria
```


<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

ran the map_task workflow in flytesnacks (updated to use array node map tasks) + set timeouts -> confirm appropriate timeout is set on NodeSpec and SubNodeSpec.

```
@task
def multi_input_task(quantity: int, price: float, shipping: float) -> float:
    return quantity * price * shipping


@workflow
def multiple_inputs_map_workflow(list_q: list[int] = [1, 2, 3, 4, 5], p: float = 6.0, s: float = 7.0) -> list[float]:
    partial_task = functools.partial(multi_input_task, price=p, shipping=s)
    return map_task(partial_task, timeout=timedelta(hours=1), metadata=TaskMetadata(timeout=timedelta(minutes=5)))(quantity=list_q)
```

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
