### PR TITLE
Adds a FlyteDeck markdown renderer to core

### DIFF
--- a/flytekit/deck/__init__.py
+++ b/flytekit/deck/__init__.py
@@ -12,7 +12,8 @@ Contains deck renderers provided by flytekit.
 
    Deck
    TopFrameRenderer
+   MarkdownRenderer
 """
 
 from .deck import Deck
-from .renderer import TopFrameRenderer
+from .renderer import MarkdownRenderer, TopFrameRenderer

--- a/flytekit/deck/renderer.py
+++ b/flytekit/deck/renderer.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any
 
+from markdown_it import MarkdownIt
 from typing_extensions import Protocol, runtime_checkable
 
 from flytekit import lazy_module
@@ -48,3 +49,10 @@ class ArrowRenderer:
     def to_html(self, df: "pyarrow.Table") -> str:
         assert isinstance(df, pyarrow.Table)
         return df.to_string()
+
+
+class MarkdownRenderer:
+    """Convert a markdown string to HTML and return HTML as a unicode string."""
+
+    def to_html(self, text: str) -> str:
+        return MarkdownIt().render(text)

--- a/plugins/flytekit-deck-standard/flytekitplugins/deck/renderer.py
+++ b/plugins/flytekit-deck-standard/flytekitplugins/deck/renderer.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import TYPE_CHECKING, List, Optional, Union
 
 from flytekit import lazy_module
@@ -68,6 +69,10 @@ class MarkdownRenderer:
     basic use case.  It initializes an instance of Markdown, loads the
     necessary extensions and runs the parser on the given text.
     """
+
+    def __init__(self):
+        msg = "flytekitplugins.deck.MarkdownRenderer is deprecated. Please use flytekit.deck.MarkdownRenderer instead"
+        warnings.warn(msg, FutureWarning)
 
     def to_html(self, text: str) -> str:
         return markdown.markdown(text)

--- a/plugins/flytekit-deck-standard/tests/test_renderer.py
+++ b/plugins/flytekit-deck-standard/tests/test_renderer.py
@@ -38,7 +38,9 @@ def test_frame_profiling_renderer():
 
 def test_markdown_renderer():
     md_text = "#Hello Flyte\n##Hello Flyte\n###Hello Flyte"
-    renderer = MarkdownRenderer()
+
+    with pytest.warns(FutureWarning):
+        renderer = MarkdownRenderer()
     assert renderer.to_html(md_text) == markdown.markdown(md_text)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "joblib",
     "jsonpickle",
     "keyring>=18.0.1",
+    "markdown-it-py",
     "marshmallow-enum",
     "marshmallow-jsonschema>=0.12.0",
     "mashumaro>=3.9.1",

--- a/tests/flytekit/unit/deck/test_deck.py
+++ b/tests/flytekit/unit/deck/test_deck.py
@@ -2,11 +2,12 @@ import datetime
 import sys
 
 import pytest
+from markdown_it import MarkdownIt
 from mock import mock
 
 import flytekit
 from flytekit import Deck, FlyteContextManager, task
-from flytekit.deck import TopFrameRenderer
+from flytekit.deck import MarkdownRenderer, TopFrameRenderer
 from flytekit.deck.deck import _output_deck
 
 
@@ -153,3 +154,11 @@ def test_get_deck():
     ctx.user_space_params._decks = [ctx.user_space_params.default_deck]
     ctx.user_space_params._decks[0] = flytekit.Deck("test", html)
     _output_deck("test_task", ctx.user_space_params)
+
+
+def test_markdown_render():
+    renderer = MarkdownRenderer()
+    md_text = "#Hello Flyte\n##Hello Flyte\n###Hello Flyte"
+
+    md = MarkdownIt()
+    assert renderer.to_html(md_text) == md.render(md_text)


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
This PR introduces a `MarkdownRender` to core. This makes `FlyteDeck` more useful without needing to install a plugin. 

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
I added `markdown-it-py` as a direct dependency, but it does not increase our overall dependency count. `markdown-it-py` is a direct dependency of `rich`:

https://github.com/flyteorg/flytekit/blob/329aea8545aa9ea9f903acd7e006f3f12efb9cbb/dev-requirements.txt#L241-L242

And I do not think we will be removing the `rich` dependency.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

I added a unittest to check the renderer. I also ran this workflow built with this PR and the Flyte deck appears.

```python
from flytekit import task, workflow, current_context, Deck

@task(
    enable_deck=True,
    container_image="ghcr.io/thomasjpfan/flytekit:deck-markdown-0.0.1",
)
def write_to_deck():
    from flytekit.deck.renderer import MarkdownRenderer

    context = current_context()
    decks = context.decks

    decks.insert(0, Deck("My deck", MarkdownRenderer().to_html("# Hello world")))


@workflow
def main():
    write_to_deck()
```