### PR TITLE
feat(resources): support serialization of Resources dataclasses

### DIFF
--- a/flytekit/core/resources.py
+++ b/flytekit/core/resources.py
@@ -1,11 +1,13 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
+from mashumaro.mixins.json import DataClassJSONMixin
+
 from flytekit.models import task as task_models
 
 
 @dataclass
-class Resources(object):
+class Resources(DataClassJSONMixin):
     """
     This class is used to specify both resource requests and resource limits.
 
@@ -45,7 +47,7 @@ class Resources(object):
 
 
 @dataclass
-class ResourceSpec(object):
+class ResourceSpec(DataClassJSONMixin):
     requests: Resources
     limits: Resources
 

--- a/tests/flytekit/unit/core/test_resources.py
+++ b/tests/flytekit/unit/core/test_resources.py
@@ -75,3 +75,29 @@ def test_incorrect_type_resources():
         Resources(gpu=1)  # type: ignore
     with pytest.raises(AssertionError):
         Resources(ephemeral_storage=1)  # type: ignore
+
+
+def test_resources_serialization():
+    resources = Resources(cpu="2", mem="1Gi", gpu="1", ephemeral_storage="10Gi")
+    json_str = resources.to_json()
+    assert isinstance(json_str, str)
+    assert '"cpu": "2"' in json_str
+    assert '"mem": "1Gi"' in json_str
+    assert '"gpu": "1"' in json_str
+    assert '"ephemeral_storage": "10Gi"' in json_str
+
+
+def test_resources_deserialization():
+    json_str = '{"cpu": "2", "mem": "1Gi", "gpu": "1", "ephemeral_storage": "10Gi"}'
+    resources = Resources.from_json(json_str)
+    assert resources.cpu == "2"
+    assert resources.mem == "1Gi"
+    assert resources.gpu == "1"
+    assert resources.ephemeral_storage == "10Gi"
+
+
+def test_resources_round_trip():
+    original = Resources(cpu="4", mem="2Gi", gpu="2", ephemeral_storage="20Gi")
+    json_str = original.to_json()
+    result = Resources.from_json(json_str)
+    assert original == result


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

If one would like to pass Resources instances as configuration to workflows, they need to be serializable.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

Following https://github.com/flyteorg/flytekit/pull/1735, declare Resources and ResourceSpec to inherit from DataClassJSONMixin

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

- Unit tests that (de)serialize Resources instances are added.
- Preliminary successful [CI execution on fork](https://github.com/cameronraysmith/flytekit/actions/runs/8208258128/job/22451306570).

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

- https://github.com/flyteorg/flytekit/pull/2196