### PR TITLE
DeleteTask should return DeleteTaskResponse

### DIFF
--- a/flytekit/extend/backend/agent_service.py
+++ b/flytekit/extend/backend/agent_service.py
@@ -142,6 +142,7 @@ class AsyncAgentService(AsyncAgentServiceServicer):
 
     @record_agent_metrics
     async def DeleteTask(self, request: DeleteTaskRequest, context: grpc.ServicerContext) -> DeleteTaskResponse:
+        print("delete task", request)
         if request.task_category and request.task_category.name:
             agent = AgentRegistry.get_agent(request.task_category.name, request.task_category.version)
         else:

--- a/flytekit/extend/backend/agent_service.py
+++ b/flytekit/extend/backend/agent_service.py
@@ -148,7 +148,8 @@ class AsyncAgentService(AsyncAgentServiceServicer):
         else:
             agent = AgentRegistry.get_agent(request.task_type)
         logger.info(f"{agent.name} start deleting the job")
-        return await mirror_async_methods(agent.delete, resource_meta=agent.metadata_type.decode(request.resource_meta))
+        await mirror_async_methods(agent.delete, resource_meta=agent.metadata_type.decode(request.resource_meta))
+        return DeleteTaskResponse()
 
 
 class SyncAgentService(SyncAgentServiceServicer):

--- a/flytekit/extend/backend/agent_service.py
+++ b/flytekit/extend/backend/agent_service.py
@@ -142,7 +142,6 @@ class AsyncAgentService(AsyncAgentServiceServicer):
 
     @record_agent_metrics
     async def DeleteTask(self, request: DeleteTaskRequest, context: grpc.ServicerContext) -> DeleteTaskResponse:
-        print("delete task", request)
         if request.task_category and request.task_category.name:
             agent = AgentRegistry.get_agent(request.task_category.name, request.task_category.version)
         else:


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
`agent.delete` returns None for now and causes the gPRC server to fail to parse the response.
`DeleteTask` should return an empty `DeleteTaskResponse`

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
local / cloud

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
