### PR TITLE
Raw Container Task Local Execution

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -2,7 +2,6 @@
 git+https://github.com/flyteorg/flyte.git@master#subdirectory=flyteidl
 
 coverage[toml]
-docker
 hypothesis
 joblib
 mock

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -51,3 +51,4 @@ prometheus-client
 
 orjson
 kubernetes>=12.0.1
+docker

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -2,6 +2,7 @@
 git+https://github.com/flyteorg/flyte.git@master#subdirectory=flyteidl
 
 coverage[toml]
+docker
 hypothesis
 joblib
 mock
@@ -51,4 +52,3 @@ prometheus-client
 
 orjson
 kubernetes>=12.0.1
-docker

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -143,8 +143,8 @@ class ContainerTask(PythonTask):
         if self._cmd:
             for cmd in self._cmd:
                 if cmd.startswith("{{.inputs.") and cmd.endswith("}}"):
-                    v = cmd[len("{{.inputs.") : -len("}}")]
-                    commands += str(native_inputs[v]) + " "
+                    k = cmd[len("{{.inputs.") : -len("}}")]
+                    commands += str(native_inputs[k]) + " "
                 elif cmd == self._output_data_dir:
                     commands += container_output_dir + " "
                 else:
@@ -152,8 +152,8 @@ class ContainerTask(PythonTask):
         if self._args:
             for arg in self._args:
                 if arg.startswith("{{.inputs.") and arg.endswith("}}"):
-                    v = arg[len("{{.inputs.") : -len("}}")]
-                    commands += str(native_inputs[v]) + " "
+                    k = arg[len("{{.inputs.") : -len("}}")]
+                    commands += str(native_inputs[k]) + " "
                 elif arg == self._output_data_dir:
                     commands += container_output_dir + " "
                 else:
@@ -186,7 +186,11 @@ class ContainerTask(PythonTask):
             for k, output_type in self._outputs.items():
                 with open(os.path.join(output_directory, k), "r") as f:
                     output_val = f.read()
-                output_dict[k] = output_type(output_val)
+                # bool('False') is True, so we need to handle this case
+                if output_type == bool:
+                    output_dict[k] = output_val == "True"
+                else:
+                    output_dict[k] = output_type(output_val)
         outputs_literal_map = TypeEngine.dict_to_literal_map(ctx, output_dict)
         outputs_literals = outputs_literal_map.literals
         output_names = list(self.interface.outputs.keys())

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -1,20 +1,24 @@
 import typing
 from enum import Enum
-from typing import Any, Dict, List, Optional, OrderedDict, Type
+from typing import Coroutine, Dict, List, Optional, OrderedDict, Tuple, Type, Union
 
 from flytekit.configuration import SerializationSettings
 from flytekit.core.base_task import PythonTask, TaskMetadata
 from flytekit.core.context_manager import FlyteContext
 from flytekit.core.interface import Interface
 from flytekit.core.pod_template import PodTemplate
+from flytekit.core.promise import Promise, VoidPromise, create_task_output
 from flytekit.core.python_auto_container import get_registerable_container_image
 from flytekit.core.resources import Resources, ResourceSpec
 from flytekit.core.utils import _get_container_definition, _serialize_pod_spec
 from flytekit.image_spec.image_spec import ImageSpec
+from flytekit.loggers import logger
+from flytekit.models import literals as _literal_models
 from flytekit.models import task as _task_model
 from flytekit.models.security import Secret, SecurityContext
 
 _PRIMARY_CONTAINER_NAME_FIELD = "primary_container_name"
+DOCKER_IMPORT_ERROR_MESSAGE = "Docker is not installed. Please install Docker by running `pip install docker`."
 
 
 class ContainerTask(PythonTask):
@@ -82,6 +86,7 @@ class ContainerTask(PythonTask):
         self._args = arguments
         self._input_data_dir = input_data_dir
         self._output_data_dir = output_data_dir
+        self._outputs = outputs
         self._md_format = metadata_format
         self._io_strategy = io_strategy
         self._resources = ResourceSpec(
@@ -93,12 +98,90 @@ class ContainerTask(PythonTask):
     def resources(self) -> ResourceSpec:
         return self._resources
 
-    def local_execute(self, ctx: FlyteContext, **kwargs) -> Any:
-        """
-        1. literals and promise generation. This can be easily done in local_execute.
-        2. use docker client api
-        """
-        raise RuntimeError("ContainerTask is not supported in local executions.")
+    def local_execute(
+        self, ctx: FlyteContext, **kwargs
+    ) -> Union[Tuple[Promise], Promise, VoidPromise, Coroutine, None]:
+        try:
+            import docker
+        except ImportError:
+            raise ImportError(DOCKER_IMPORT_ERROR_MESSAGE)
+        import os
+
+        from flytekit.core.promise import translate_inputs_to_literals
+        from flytekit.core.type_engine import TypeEngine, TypeTransformerFailedError
+
+        try:
+            kwargs = translate_inputs_to_literals(
+                ctx,
+                incoming_values=kwargs,
+                flyte_interface_types=self.interface.inputs,
+                native_types=self.get_input_types(),  # type: ignore
+            )
+        except TypeTransformerFailedError as exc:
+            msg = f"Failed to convert inputs of task '{self.name}':\n  {exc}"
+            logger.error(msg)
+            raise TypeError(msg) from exc
+        input_literal_map = _literal_models.LiteralMap(literals=kwargs)
+        try:
+            native_inputs = self._literal_map_to_python_input(input_literal_map, ctx)
+        except Exception as exc:
+            msg = f"Failed to convert inputs of task '{self.name}':\n  {exc}"
+            logger.error(msg)
+            raise type(exc)(msg) from exc
+
+        container_output_dir = "/flyte/raw-container-task/output"
+        output_directory = ctx.file_access.get_random_local_directory()
+        volume_bindings = {
+            output_directory: {
+                "bind": container_output_dir,
+                "mode": "rw",
+            },
+        }
+
+        commands = ""
+        if self._cmd:
+            for cmd in self._cmd:
+                if cmd.startswith("{{.inputs.") and cmd.endswith("}}"):
+                    v = cmd[len("{{.inputs.") : -len("}}")]
+                    commands += str(native_inputs[v]) + " "
+                elif cmd == self._output_data_dir:
+                    commands += container_output_dir + " "
+                else:
+                    commands += cmd + " "
+        if self._args:
+            for arg in self._args:
+                cmd += arg + " "
+
+        client = docker.from_env()
+        container = client.containers.run(
+            self._image,
+            command=[
+                "sh",
+                "-c",
+                commands,
+            ],
+            volumes=volume_bindings,
+            detach=True,
+        )
+        # Wait for the container to finish the task
+        container.wait()
+        container.stop()
+        container.remove()
+
+        output_dict = {}
+        if self._outputs:
+            for k, output_type in self._outputs.items():
+                with open(os.path.join(output_directory, k), "r") as f:
+                    output_val = f.read()
+                output_dict[k] = output_type(output_val)
+        outputs_literal_map = TypeEngine.dict_to_literal_map(ctx, output_dict)
+        outputs_literals = outputs_literal_map.literals
+        output_names = list(self.interface.outputs.keys())
+        # Tasks that don't return anything still return a VoidPromise
+        if len(output_names) == 0:
+            return VoidPromise(self.name)
+        vals = [Promise(var, outputs_literals[var]) for var in output_names]
+        return create_task_output(vals, self.python_interface)
 
     def get_container(self, settings: SerializationSettings) -> _task_model.Container:
         # if pod_template is specified, return None here but in get_k8s_pod, return pod_template merged with container

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -94,6 +94,10 @@ class ContainerTask(PythonTask):
         return self._resources
 
     def local_execute(self, ctx: FlyteContext, **kwargs) -> Any:
+        """
+        1. literals and promise generation. This can be easily done in local_execute.
+        2. use docker client api
+        """
         raise RuntimeError("ContainerTask is not supported in local executions.")
 
     def get_container(self, settings: SerializationSettings) -> _task_model.Container:

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -14,6 +14,7 @@ from flytekit.core.utils import _get_container_definition, _serialize_pod_spec
 from flytekit.image_spec.image_spec import ImageSpec
 from flytekit.loggers import logger
 from flytekit.models import task as _task_model
+from flytekit.models.literals import LiteralMap
 from flytekit.models.security import Secret, SecurityContext
 
 _PRIMARY_CONTAINER_NAME_FIELD = "primary_container_name"
@@ -221,7 +222,7 @@ class ContainerTask(PythonTask):
                     output_dict[k] = self._convert_output_val_to_correct_type(output_val, output_type)
         return output_dict
 
-    def execute(self, **kwargs) -> Any:
+    def execute(self, **kwargs) -> LiteralMap:
         try:
             import docker
         except ImportError:

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -116,7 +116,7 @@ class ContainerTask(PythonTask):
         Returns:
         - str or None: The extracted key if the command matches one of the supported formats, otherwise None.
         """
-        if cmd.startswith(self._input_data_dir):
+        if self._input_data_dir and cmd.startswith(self._input_data_dir):
             return os.path.relpath(cmd, self._input_data_dir)
 
         import re
@@ -136,18 +136,20 @@ class ContainerTask(PythonTask):
         parts = re.match(regex, s)
         if not parts:
             raise ValueError("Invalid timedelta string format")
-        
+
         days = int(parts.group(1)) if parts.group(1) else 0
         hours = int(parts.group(2)) if parts.group(2) else 0
         minutes = int(parts.group(3)) if parts.group(3) else 0
         seconds = int(parts.group(4)) if parts.group(4) else 0
         microseconds = int(parts.group(5)) if parts.group(5) else 0
 
-        return datetime.timedelta(days=days, 
-                                  hours=hours, 
-                                  minutes=minutes, 
-                                  seconds=seconds, 
-                                  microseconds=microseconds,)
+        return datetime.timedelta(
+            days=days,
+            hours=hours,
+            minutes=minutes,
+            seconds=seconds,
+            microseconds=microseconds,
+        )
 
     def local_execute(
         self, ctx: FlyteContext, **kwargs

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -250,9 +250,9 @@ class ContainerTask(PythonTask):
                     with open(os.path.join(output_directory, k), "r") as f:
                         output_val = f.read()
 
-                    # bool('False') is True, so we need to handle this case
+                    # bool('False') and bool('false') are True, so we need to handle this case
                     if output_type == bool:
-                        output_dict[k] = output_val == "True"
+                        output_dict[k] = False if output_val.lower() == "false" else True
                     elif output_type == datetime.datetime:
                         output_dict[k] = datetime.datetime.fromisoformat(output_val)  # type: ignore
                     elif output_type == datetime.timedelta:

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -200,7 +200,7 @@ class ContainerTask(PythonTask):
             },
         }
 
-        # Build the command string
+        # Build the command array
         commands = []
         cmd_and_args = []
         if self._cmd:

--- a/tests/flytekit/unit/core/Dockerfile.raw_container
+++ b/tests/flytekit/unit/core/Dockerfile.raw_container
@@ -1,12 +1,9 @@
-# Use the Alpine Linux version of Python 3.9 as the base image
 FROM python:3.9-alpine
 
-# Set the working directory in the container
 WORKDIR /root
 
-# You can use the docker copy command after building the image to copy test.py into the /app directory of the container
 COPY ./write_flytefile.py /root/write_flytefile.py
 COPY ./write_flytedir.py /root/write_flytedir.py
+COPY ./return_same_value.py /root/return_same_value.py
 
-# Specify the command to run when the container starts. Here, we use /bin/sh to start a shell.
 CMD ["/bin/sh"]

--- a/tests/flytekit/unit/core/Dockerfile.raw_container
+++ b/tests/flytekit/unit/core/Dockerfile.raw_container
@@ -1,0 +1,12 @@
+# Use the Alpine Linux version of Python 3.9 as the base image
+FROM python:3.9-alpine
+
+# Set the working directory in the container
+WORKDIR /root
+
+# You can use the docker copy command after building the image to copy test.py into the /app directory of the container
+COPY ./write_flytefile.py /root/write_flytefile.py
+COPY ./write_flytedir.py /root/write_flytedir.py
+
+# Specify the command to run when the container starts. Here, we use /bin/sh to start a shell.
+CMD ["/bin/sh"]

--- a/tests/flytekit/unit/core/return_same_value.py
+++ b/tests/flytekit/unit/core/return_same_value.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+def write_output(output_dir, output_file, v):
+    # Ensure the output directory exists
+    os.makedirs(output_dir, exist_ok=True)  # This will create the directory if it doesn't exist
+    with open(f"{output_dir}/{output_file}", "w") as f:
+        f.write(str(v))
+
+def main(*args, output_dir):
+    # Generate output files for each input argument
+    for i, arg in enumerate(args, start=1):
+        # Using i to generate filenames like 'a', 'b', 'c', ...
+        output_file = chr(ord('a') + i - 1)
+        write_output(output_dir, output_file, arg)
+
+if __name__ == "__main__":
+    *inputs, output_dir = sys.argv[1:]  # Unpack all inputs except for the last one for output_dir
+    main(*inputs, output_dir=output_dir)

--- a/tests/flytekit/unit/core/return_same_value.py
+++ b/tests/flytekit/unit/core/return_same_value.py
@@ -1,18 +1,21 @@
 import os
 import sys
 
+
 def write_output(output_dir, output_file, v):
     # Ensure the output directory exists
     os.makedirs(output_dir, exist_ok=True)  # This will create the directory if it doesn't exist
     with open(f"{output_dir}/{output_file}", "w") as f:
         f.write(str(v))
 
+
 def main(*args, output_dir):
     # Generate output files for each input argument
     for i, arg in enumerate(args, start=1):
         # Using i to generate filenames like 'a', 'b', 'c', ...
-        output_file = chr(ord('a') + i - 1)
+        output_file = chr(ord("a") + i - 1)
         write_output(output_dir, output_file, arg)
+
 
 if __name__ == "__main__":
     *inputs, output_dir = sys.argv[1:]  # Unpack all inputs except for the last one for output_dir

--- a/tests/flytekit/unit/core/test_container_task.py
+++ b/tests/flytekit/unit/core/test_container_task.py
@@ -24,7 +24,8 @@ from flytekit.tools.translator import get_serializable_task
 def test_local_execution():
     try:
         import docker
-        client = docker.from_env()
+
+        docker.from_env()
     except Exception as e:
         # Currently, Ubuntu will pass the test, but MacOS and Windows will not
         print(f"Skipping test due to Docker environment setup failure: {e}")

--- a/tests/flytekit/unit/core/test_container_task.py
+++ b/tests/flytekit/unit/core/test_container_task.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 
-import pytest
 from kubernetes.client.models import (
     V1Affinity,
     V1Container,
@@ -84,19 +83,6 @@ def test_pod_template():
         {"effect": "NoSchedule", "key": "nvidia.com/gpu", "operator": "Exists"}
     ]
     assert serialized_pod_spec["runtimeClassName"] == "nvidia"
-
-
-def test_local_execution():
-    ct = ContainerTask(
-        name="name",
-        input_data_dir="/var/inputs",
-        output_data_dir="/var/outputs",
-        image="inexistent-image:v42",
-        command=["some", "command"],
-    )
-
-    with pytest.raises(RuntimeError):
-        ct()
 
 
 def test_raw_container_with_image_spec(mock_image_spec_builder):

--- a/tests/flytekit/unit/core/test_container_task.py
+++ b/tests/flytekit/unit/core/test_container_task.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from typing import Tuple
 
 from kubernetes.client.models import (
     V1Affinity,
@@ -18,6 +19,31 @@ from flytekit.core.container_task import ContainerTask
 from flytekit.core.pod_template import PodTemplate
 from flytekit.image_spec.image_spec import ImageBuildEngine, ImageSpec
 from flytekit.tools.translator import get_serializable_task
+
+
+def test_local_execution():
+    calculate_ellipse_area_python = ContainerTask(
+        name="calculate_ellipse_area_python",
+        input_data_dir="/var/inputs",
+        output_data_dir="/var/outputs",
+        inputs=kwtypes(a=float, b=float),
+        outputs=kwtypes(area=float, metadata=str),
+        image="ghcr.io/flyteorg/rawcontainers-python:v2",
+        command=[
+            "python",
+            "calculate-ellipse-area.py",
+            "{{.inputs.a}}",
+            "{{.inputs.b}}",
+            "/var/outputs",
+        ],
+    )
+
+    def wf() -> Tuple[float, str]:
+        return calculate_ellipse_area_python(a=3.0, b=4.0)
+
+    area, metadata = wf()
+    assert area == 37.69911184307752
+    assert metadata == "[from python rawcontainer]"
 
 
 def test_pod_template():

--- a/tests/flytekit/unit/core/test_container_task.py
+++ b/tests/flytekit/unit/core/test_container_task.py
@@ -23,8 +23,8 @@ from flytekit.tools.translator import get_serializable_task
 
 def test_local_execution():
     try:
-        calculate_ellipse_area_python = ContainerTask(
-            name="calculate_ellipse_area_python",
+        calculate_ellipse_area_python_file_path = ContainerTask(
+            name="calculate_ellipse_area_python_file_path",
             input_data_dir="/var/inputs",
             output_data_dir="/var/outputs",
             inputs=kwtypes(a=float, b=float),
@@ -39,14 +39,39 @@ def test_local_execution():
             ],
         )
 
-        def wf() -> Tuple[float, str]:
-            return calculate_ellipse_area_python(a=3.0, b=4.0)
+        def wf_file_path() -> Tuple[float, str]:
+            return calculate_ellipse_area_python_file_path(a=3.0, b=4.0)
 
-        area, metadata = wf()
+        area, metadata = wf_file_path()
         assert area == 37.69911184307752
         assert metadata == "[from python rawcontainer]"
+
+        calculate_ellipse_area_python_template_style = ContainerTask(
+            name="calculate_ellipse_area_python_template_style",
+            input_data_dir="/var/inputs",
+            output_data_dir="/var/outputs",
+            inputs=kwtypes(a=float, b=float),
+            outputs=kwtypes(area=float, metadata=str),
+            image="ghcr.io/flyteorg/rawcontainers-python:v2",
+            command=[
+                "python",
+                "calculate-ellipse-area.py",
+                "/var/inputs/a",
+                "/var/inputs/b",
+                "/var/outputs",
+            ],
+        )
+
+        def wf_template_style() -> Tuple[float, str]:
+            return calculate_ellipse_area_python_template_style(a=3.0, b=4.0)
+
+        area, metadata = wf_template_style()
+        assert area == 37.69911184307752
+        assert metadata == "[from python rawcontainer]"
+
     except Exception as e:
         # Currently, Ubuntu will pass the test, but MacOS and Windows will not
+        # We need to add more actions in CI for MacOS and Windows to pass the test
         print(f"Skipping test due to Docker environment setup failure: {e}")
         return
 

--- a/tests/flytekit/unit/core/test_container_task.py
+++ b/tests/flytekit/unit/core/test_container_task.py
@@ -22,6 +22,14 @@ from flytekit.tools.translator import get_serializable_task
 
 
 def test_local_execution():
+    try:
+        import docker
+        client = docker.from_env()
+    except Exception as e:
+        # Currently, Ubuntu will pass the test, but MacOS and Windows will not
+        print(f"Skipping test due to Docker environment setup failure: {e}")
+        return
+
     calculate_ellipse_area_python = ContainerTask(
         name="calculate_ellipse_area_python",
         input_data_dir="/var/inputs",

--- a/tests/flytekit/unit/core/test_container_task.py
+++ b/tests/flytekit/unit/core/test_container_task.py
@@ -23,36 +23,32 @@ from flytekit.tools.translator import get_serializable_task
 
 def test_local_execution():
     try:
-        import docker
+        calculate_ellipse_area_python = ContainerTask(
+            name="calculate_ellipse_area_python",
+            input_data_dir="/var/inputs",
+            output_data_dir="/var/outputs",
+            inputs=kwtypes(a=float, b=float),
+            outputs=kwtypes(area=float, metadata=str),
+            image="ghcr.io/flyteorg/rawcontainers-python:v2",
+            command=[
+                "python",
+                "calculate-ellipse-area.py",
+                "{{.inputs.a}}",
+                "{{.inputs.b}}",
+                "/var/outputs",
+            ],
+        )
 
-        docker.from_env()
+        def wf() -> Tuple[float, str]:
+            return calculate_ellipse_area_python(a=3.0, b=4.0)
+
+        area, metadata = wf()
+        assert area == 37.69911184307752
+        assert metadata == "[from python rawcontainer]"
     except Exception as e:
         # Currently, Ubuntu will pass the test, but MacOS and Windows will not
         print(f"Skipping test due to Docker environment setup failure: {e}")
         return
-
-    calculate_ellipse_area_python = ContainerTask(
-        name="calculate_ellipse_area_python",
-        input_data_dir="/var/inputs",
-        output_data_dir="/var/outputs",
-        inputs=kwtypes(a=float, b=float),
-        outputs=kwtypes(area=float, metadata=str),
-        image="ghcr.io/flyteorg/rawcontainers-python:v2",
-        command=[
-            "python",
-            "calculate-ellipse-area.py",
-            "{{.inputs.a}}",
-            "{{.inputs.b}}",
-            "/var/outputs",
-        ],
-    )
-
-    def wf() -> Tuple[float, str]:
-        return calculate_ellipse_area_python(a=3.0, b=4.0)
-
-    area, metadata = wf()
-    assert area == 37.69911184307752
-    assert metadata == "[from python rawcontainer]"
 
 
 def test_pod_template():

--- a/tests/flytekit/unit/core/test_container_task.py
+++ b/tests/flytekit/unit/core/test_container_task.py
@@ -87,6 +87,10 @@ def test_local_execution():
     assert isinstance(metadata, str)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Skip if running on windows due to path error",
+)
 def test_local_execution_special_cases():
     # Boolean conversion from string checks
     assert all([bool(s) for s in ["False", "false", "True", "true"]])

--- a/tests/flytekit/unit/core/test_container_task.py
+++ b/tests/flytekit/unit/core/test_container_task.py
@@ -29,28 +29,6 @@ from flytekit.tools.translator import get_serializable_task
     reason="Skip if running on windows or macos due to CI Docker environment setup failure",
 )
 def test_local_execution():
-    # File path-based input execution
-    calculate_ellipse_area_python_file_path = ContainerTask(
-        name="calculate_ellipse_area_python_file_path",
-        input_data_dir="/var/inputs",
-        output_data_dir="/var/outputs",
-        inputs=kwtypes(a=float, b=float),
-        outputs=kwtypes(area=float, metadata=str),
-        image="ghcr.io/flyteorg/rawcontainers-python:v2",
-        command=[
-            "python",
-            "calculate-ellipse-area.py",
-            "/var/inputs/a",
-            "/var/inputs/b",
-            "/var/outputs",
-        ],
-    )
-
-    area, metadata = calculate_ellipse_area_python_file_path(a=3.0, b=4.0)
-    assert isinstance(area, float)
-    assert isinstance(metadata, str)
-
-    # Template-based input execution
     calculate_ellipse_area_python_template_style = ContainerTask(
         name="calculate_ellipse_area_python_template_style",
         input_data_dir="/var/inputs",
@@ -79,7 +57,7 @@ def test_local_execution():
     @workflow
     def wf(a: float, b: float) -> Tuple[float, str]:
         a, b = t1(a=a, b=b)
-        area, metadata = calculate_ellipse_area_python_file_path(a=a, b=b)
+        area, metadata = calculate_ellipse_area_python_template_style(a=a, b=b)
         return area, metadata
 
     area, metadata = wf(a=3.0, b=4.0)
@@ -99,10 +77,6 @@ def test_local_execution_special_cases():
     input_data_dir = "/var/inputs"
     assert os.path.normpath(input_data_dir) == "/var/inputs"
     assert os.path.normpath(input_data_dir + "/") == "/var/inputs"
-
-    # Retrieving key from input path
-    input_val = "/var/inputs/a"
-    assert os.path.relpath(input_val, input_data_dir) == "a"
 
     # Datetime and timedelta string conversions
     ct = ContainerTask(

--- a/tests/flytekit/unit/core/test_container_task.py
+++ b/tests/flytekit/unit/core/test_container_task.py
@@ -105,6 +105,12 @@ def test_local_execution_special_cases():
     assert os.path.relpath(input_val, input_data_dir) == "a"
 
     # Datetime and timedelta string conversions
+    ct = ContainerTask(
+        name="local-execution",
+        image="test-image",
+        command="echo",
+    )
+
     from datetime import datetime, timedelta
 
     now = datetime.now()

--- a/tests/flytekit/unit/core/test_container_task.py
+++ b/tests/flytekit/unit/core/test_container_task.py
@@ -104,16 +104,6 @@ def test_local_execution_special_cases():
     input_val = "/var/inputs/a"
     assert os.path.relpath(input_val, input_data_dir) == "a"
 
-    # Dynamic key path transformation
-    ct = ContainerTask(
-        name="local-execution",
-        image="test-image",
-        command="echo",
-    )
-    assert ct._get_key_from_cmd("{{.inputs.a}}") == "a"
-    nested_key = "{{.inputs.a.0.1}}"
-    assert ct._get_key_from_cmd(nested_key).replace(".", "/") == "a/0/1"
-
     # Datetime and timedelta string conversions
     from datetime import datetime, timedelta
 

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -126,7 +126,7 @@ def test_primitive_types_wf():
         output_data_dir="/var/outputs",
         inputs=kwtypes(a=int, b=bool, c=float, d=str, e=datetime.datetime, f=datetime.timedelta),
         outputs=kwtypes(a=int, b=bool, c=float, d=str, e=datetime.datetime, f=datetime.timedelta),
-        image="futureoutlier/rawcontainer:0320",
+        image="flytekit:rawcontainer",
         command=[
             "python",
             "return_same_value.py",
@@ -180,7 +180,7 @@ def test_input_output_dir_manipulation():
         output_data_dir="/outputs",
         inputs=kwtypes(a=int, b=bool, c=float, d=str, e=datetime.datetime, f=datetime.timedelta),
         outputs=kwtypes(a=int, b=bool, c=float, d=str, e=datetime.datetime, f=datetime.timedelta),
-        image="futureoutlier/rawcontainer:0320",
+        image="flytekit:rawcontainer",
         command=[
             "python",
             "return_same_value.py",

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -1,0 +1,109 @@
+from typing import Tuple, List
+import sys
+import pytest
+from flytekit import ContainerTask, kwtypes, workflow, task
+from flytekit.types.file import FlyteFile
+from flytekit.types.directory import FlyteDirectory
+import docker
+from pathlib import Path
+import flytekit
+import os
+
+@pytest.mark.skipif(
+    sys.platform in ["darwin", "win32"],
+    reason="Skip if running on windows or macos due to CI Docker environment setup failure",
+)
+def test_flytefile_wf():
+    client = docker.from_env()
+    path_to_dockerfile = "tests/flytekit/unit/core/"
+    dockerfile_name = "Dockerfile.raw_container"  
+    client.images.build(path=path_to_dockerfile, dockerfile=dockerfile_name, tag="flytekit:rawcontainer")
+
+    flyte_file_io = ContainerTask(
+            name="flyte_file_io",
+            input_data_dir="/var/inputs",
+            output_data_dir="/var/outputs",
+            inputs=kwtypes(inputs=FlyteFile),
+            outputs=kwtypes(out=FlyteFile),
+            image="flytekit:rawcontainer",
+            command=[
+                "python",
+                "write_flytefile.py",
+                "{{.inputs.inputs}}",
+                "/var/outputs/out",
+            ],
+    )
+
+    @task
+    def flyte_file_task() -> FlyteFile:
+        working_dir = flytekit.current_context().working_directory
+        write_file = os.path.join(working_dir, "flyte_file.txt")
+        with open(write_file, "w") as file:
+            file.write("This is flyte_file.txt file.")
+        return FlyteFile(path=write_file)
+
+    @workflow
+    def flyte_file_io_wf() -> FlyteFile:
+        ff = flyte_file_task()
+        return flyte_file_io(inputs=ff)
+
+    flytefile = flyte_file_io_wf()
+    assert isinstance(flytefile, FlyteFile)
+
+    with open(flytefile.path, 'r') as file:
+        content = file.read()
+    
+    assert content == "This is flyte_file.txt file."
+    
+
+@pytest.mark.skipif(
+    sys.platform in ["darwin", "win32"],
+    reason="Skip if running on windows or macos due to CI Docker environment setup failure",
+)
+def test_flytedir_wf():
+    client = docker.from_env()
+    path_to_dockerfile = "tests/flytekit/unit/core/"
+    dockerfile_name = "Dockerfile.raw_container"  
+    client.images.build(path=path_to_dockerfile, dockerfile=dockerfile_name, tag="flytekit:rawcontainer")
+
+    flyte_dir_io = ContainerTask(
+        name="flyte_dir_io",
+        input_data_dir="/var/inputs",
+        output_data_dir="/var/outputs",
+        inputs=kwtypes(inputs=FlyteDirectory),
+        outputs=kwtypes(out=FlyteDirectory),
+        # image="futureoutlier/rawcontainer:0320",
+        image="flytekit:rawcontainer",
+        command=[
+            "python",
+            "write_flytedir.py",
+            "{{.inputs.inputs}}",
+            # "/var/inputs/inputs",
+            "/var/outputs/out",
+        ],
+    )
+
+    @task
+    def flyte_dir_task() -> FlyteDirectory:
+        working_dir = flytekit.current_context().working_directory
+        local_dir = Path(os.path.join(working_dir, "csv_files"))
+        local_dir.mkdir(exist_ok=True)
+        write_file = os.path.join(local_dir, "flyte_dir.txt")
+        with open(write_file, "w") as file:
+            file.write("This is for flyte dir.")
+
+        return FlyteDirectory(path=str(local_dir))
+
+
+    @workflow
+    def flyte_dir_io_wf() -> FlyteDirectory:
+        fd = flyte_dir_task()
+        return flyte_dir_io(inputs=fd)
+    
+    flytyedir = flyte_dir_io_wf()
+    assert isinstance(flytyedir, FlyteDirectory)
+
+    with open(os.path.join(flytyedir.path, "flyte_dir.txt"), 'r') as file:
+        content = file.read()
+    
+    assert content == "This is for flyte dir."

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -187,9 +187,9 @@ def test_input_output_dir_manipulation():
             "{{.inputs.a}}",
             "{{.inputs.b}}",
             "{{.inputs.c}}",
-            "/inputs/d",
-            "/inputs/e",
-            "/inputs/f",
+            "{{.inputs.d}}",
+            "{{.inputs.e}}",
+            "{{.inputs.f}}",
             "/outputs",
         ],
     )

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -1,13 +1,15 @@
-from typing import Tuple, List
-import sys
-import pytest
-from flytekit import ContainerTask, kwtypes, workflow, task
-from flytekit.types.file import FlyteFile
-from flytekit.types.directory import FlyteDirectory
-import docker
-from pathlib import Path
-import flytekit
 import os
+import sys
+from pathlib import Path
+
+import docker
+import pytest
+
+import flytekit
+from flytekit import ContainerTask, kwtypes, task, workflow
+from flytekit.types.directory import FlyteDirectory
+from flytekit.types.file import FlyteFile
+
 
 @pytest.mark.skipif(
     sys.platform in ["darwin", "win32"],
@@ -16,22 +18,22 @@ import os
 def test_flytefile_wf():
     client = docker.from_env()
     path_to_dockerfile = "tests/flytekit/unit/core/"
-    dockerfile_name = "Dockerfile.raw_container"  
+    dockerfile_name = "Dockerfile.raw_container"
     client.images.build(path=path_to_dockerfile, dockerfile=dockerfile_name, tag="flytekit:rawcontainer")
 
     flyte_file_io = ContainerTask(
-            name="flyte_file_io",
-            input_data_dir="/var/inputs",
-            output_data_dir="/var/outputs",
-            inputs=kwtypes(inputs=FlyteFile),
-            outputs=kwtypes(out=FlyteFile),
-            image="flytekit:rawcontainer",
-            command=[
-                "python",
-                "write_flytefile.py",
-                "{{.inputs.inputs}}",
-                "/var/outputs/out",
-            ],
+        name="flyte_file_io",
+        input_data_dir="/var/inputs",
+        output_data_dir="/var/outputs",
+        inputs=kwtypes(inputs=FlyteFile),
+        outputs=kwtypes(out=FlyteFile),
+        image="flytekit:rawcontainer",
+        command=[
+            "python",
+            "write_flytefile.py",
+            "{{.inputs.inputs}}",
+            "/var/outputs/out",
+        ],
     )
 
     @task
@@ -50,11 +52,11 @@ def test_flytefile_wf():
     flytefile = flyte_file_io_wf()
     assert isinstance(flytefile, FlyteFile)
 
-    with open(flytefile.path, 'r') as file:
+    with open(flytefile.path, "r") as file:
         content = file.read()
-    
+
     assert content == "This is flyte_file.txt file."
-    
+
 
 @pytest.mark.skipif(
     sys.platform in ["darwin", "win32"],
@@ -63,7 +65,7 @@ def test_flytefile_wf():
 def test_flytedir_wf():
     client = docker.from_env()
     path_to_dockerfile = "tests/flytekit/unit/core/"
-    dockerfile_name = "Dockerfile.raw_container"  
+    dockerfile_name = "Dockerfile.raw_container"
     client.images.build(path=path_to_dockerfile, dockerfile=dockerfile_name, tag="flytekit:rawcontainer")
 
     flyte_dir_io = ContainerTask(
@@ -94,16 +96,15 @@ def test_flytedir_wf():
 
         return FlyteDirectory(path=str(local_dir))
 
-
     @workflow
     def flyte_dir_io_wf() -> FlyteDirectory:
         fd = flyte_dir_task()
         return flyte_dir_io(inputs=fd)
-    
+
     flytyedir = flyte_dir_io_wf()
     assert isinstance(flytyedir, FlyteDirectory)
 
-    with open(os.path.join(flytyedir.path, "flyte_dir.txt"), 'r') as file:
+    with open(os.path.join(flytyedir.path, "flyte_dir.txt"), "r") as file:
         content = file.read()
-    
+
     assert content == "This is for flyte dir."

--- a/tests/flytekit/unit/core/write_flytedir.py
+++ b/tests/flytekit/unit/core/write_flytedir.py
@@ -1,6 +1,7 @@
+import shutil
 import sys
 from pathlib import Path
-import shutil
+
 
 def copy_directory(input_path: Path, output_path: Path):
     if not input_path.exists() or not input_path.is_dir():
@@ -12,6 +13,7 @@ def copy_directory(input_path: Path, output_path: Path):
         print(f"Directory {input_path} was successfully copied to {output_path}")
     except Exception as e:
         print(f"Error copying {input_path} to {output_path}: {e}")
+
 
 if __name__ == "__main__":
     if len(sys.argv) > 2:

--- a/tests/flytekit/unit/core/write_flytedir.py
+++ b/tests/flytekit/unit/core/write_flytedir.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import shutil
+
+def copy_directory(input_path: Path, output_path: Path):
+    if not input_path.exists() or not input_path.is_dir():
+        print(f"Error: {input_path} does not exist or is not a directory.")
+        return
+
+    try:
+        shutil.copytree(input_path, output_path)
+        print(f"Directory {input_path} was successfully copied to {output_path}")
+    except Exception as e:
+        print(f"Error copying {input_path} to {output_path}: {e}")
+
+if __name__ == "__main__":
+    if len(sys.argv) > 2:
+        input_path = Path(sys.argv[1])
+        output_path = Path(sys.argv[2])
+        copy_directory(input_path, output_path)
+    else:
+        print("Usage: script.py <input_directory_path> <output_directory_path>")

--- a/tests/flytekit/unit/core/write_flytefile.py
+++ b/tests/flytekit/unit/core/write_flytefile.py
@@ -1,11 +1,12 @@
 import sys
 from pathlib import Path
 
-def copy_content_to_output(input_path: Path, output_path: Path):
 
+def copy_content_to_output(input_path: Path, output_path: Path):
     content = input_path.read_text()
 
     output_path.write_text(content)
+
 
 if __name__ == "__main__":
     if len(sys.argv) > 2:

--- a/tests/flytekit/unit/core/write_flytefile.py
+++ b/tests/flytekit/unit/core/write_flytefile.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+def copy_content_to_output(input_path: Path, output_path: Path):
+
+    content = input_path.read_text()
+
+    output_path.write_text(content)
+
+if __name__ == "__main__":
+    if len(sys.argv) > 2:
+        input_path = Path(sys.argv[1])
+        output_path = Path(sys.argv[2])
+        copy_content_to_output(input_path, output_path)
+    else:
+        print("Usage: script.py <input_path> <output_path>")


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3876

## Why are the changes needed?
We want to support users to run `raw-container` task locally.

Note: I didn't support ~~`datetime.timedelta`~~, `List` and `Dict`.
Since I found that copilot has bug to deal with that, so I will support them until those bugs are fixed.
(This implies that we have to fix flytecopilot for nested types and collections types first)

## What changes were proposed in this pull request?
1.  override `local_execute` function in `class ContainerTask(PythonTask)`
2. use `docker` python library to execute docker command
3. support int, str, float, bool, datetime.datetime, FlyteDirectory and FlyteFile
~~4. I will strip white space because it will be too complicated to support string with white space.~~
~~(datetime.datetime will be affected)~~
5. I've supported FlyteDirectroy and FlyteFile as input, ~~however, in remote cases, flytecopilot will fail, so I think I can support it locally first, and create an issue to support remote cases.~~
6. Support `direct file paths`  and `template-style references` as inputs.
For example, `{{.inputs.infile}}` and `/var/inputs/infile` both are valid inputs.

## How was this patch tested?
1. local execution with 4 examples.
Reference: https://docs.flyte.org/en/latest/user_guide/customizing_dependencies/raw_containers.html#raw-container
Note: `julia` image has error when using arm64, I've tested it by `docker run -it` into the container and found this error.
<img width="951" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/7868342b-915b-4810-b6b2-694376f58365">

2. local execution with 5 prmitive types as input and output.
3. `FlyteFile` task with input and output
4. `FlyteFile` task with output only
5. `FlyteDirectory` task with input and output
7. `FlyteDirectory` task with output only

Note: I've provided an image on docker hub, you can switch to this branch and test it directly.
image: `futureoutlier/rawcontainer:0320`

### Setup process
```bash
git clone https://github.com/flyteorg/flytekit
gh pr checkout 2258
make setup
pip install -e .
```
```
python raw_container_local_execution.py
```
python example:
```python
import logging
from typing import Tuple, List
import datetime
from flytekit import ContainerTask, kwtypes, workflow, task
from flytekit.types.file import FlyteFile
from flytekit.types.directory import FlyteDirectory


logger = logging.getLogger(__file__)

@workflow
def primitive_types(a: int, b: bool, c: float, d: str, e: datetime.datetime, f: datetime.timedelta) \
                            -> Tuple[int, bool, float, str, datetime.datetime, datetime.timedelta]:
    return python_return_same_values(a=a, b=b, c=c, d=d, e=e, f=f)

python_return_same_values = ContainerTask(
    name="python_return_same_values",
    input_data_dir="/var/inputs",
    output_data_dir="/var/outputs",
    inputs=kwtypes(a=int, b=bool, c=float, d=str, e=datetime.datetime, f=datetime.timedelta),
    outputs=kwtypes(a=int, b=bool, c=float, d=str, e=datetime.datetime, f=datetime.timedelta),
    image="futureoutlier/rawcontainer:0320",
    command=[
        "python",
        "return_same_value.py",
        "{{.inputs.a}}",
        "{{.inputs.b}}",
        "{{.inputs.c}}",
        "{{.inputs.d}}",
        "{{.inputs.e}}",
        "{{.inputs.f}}",
        "/var/outputs",
    ],
)
 

flyte_file_io = ContainerTask(
    name="flyte_file_io",
    input_data_dir="/var/inputs",
    output_data_dir="/var/outputs",
    inputs=kwtypes(inputs=FlyteFile),
    outputs=kwtypes(out=FlyteFile),
    image="futureoutlier/rawcontainer:0320",
    command=[
        "python",
        "write_flytefile.py",
        "{{.inputs.inputs}}",
        # "/var/inputs/inputs",
        "/var/outputs/out",
    ],
)

flyte_dir_io = ContainerTask(
    name="flyte_dir_io",
    input_data_dir="/var/inputs",
    output_data_dir="/var/outputs",
    inputs=kwtypes(inputs=FlyteDirectory),
    outputs=kwtypes(out=FlyteDirectory),
    image="futureoutlier/rawcontainer:0320",
    command=[
        "python",
        "write_flytedir.py",
        "{{.inputs.inputs}}",
        # "/var/inputs/inputs",
        "/var/outputs/out",
    ],
)

flyte_dir_out_only = ContainerTask(
    name="flyte_dir_out_only",
    input_data_dir="/var/inputs",
    output_data_dir="/var/outputs",
    # inputs=kwtypes(inputs=FlyteDirectory),
    outputs=kwtypes(out=FlyteDirectory),
    image="futureoutlier/rawcontainer:0320",
    command=[
        "python",
        "return_flytedir.py",
        "/var/outputs/out",
    ],
)

flyte_file_out_only = ContainerTask(
    name="flyte_file_out_only",
    input_data_dir="/var/inputs",
    output_data_dir="/var/outputs",
    # inputs=kwtypes(inputs=FlyteDirectory),
    outputs=kwtypes(out=FlyteFile),
    image="futureoutlier/rawcontainer:0320",
    command=[
        "python",
        "return_flytefile.py",
        "/var/outputs/out",
    ],
)

@task
def flyte_file_task() -> FlyteFile:
    with open("./a.txt", "w") as file:
        file.write("This is a.txt file.")
    return FlyteFile(path="./a.txt")

@workflow
def flyte_file_io_wf() -> FlyteFile:
    ff = flyte_file_task()
    return flyte_file_io(inputs=ff)

@task
def flyte_dir_task() -> FlyteDirectory:
    from pathlib import Path
    import flytekit
    import os

    working_dir = flytekit.current_context().working_directory
    local_dir = Path(os.path.join(working_dir, "csv_files"))
    local_dir.mkdir(exist_ok=True)
    write_file = local_dir / "a.txt"
    with open(write_file, "w") as file:
        file.write("This is for flyte dir.")

    return FlyteDirectory(path=str(local_dir))

@workflow
def flyte_dir_io_wf() -> FlyteDirectory:
    fd = flyte_dir_task()
    return flyte_dir_io(inputs=fd)

if __name__ == "__main__":
    print(flyte_dir_io_wf())
    print(flyte_file_io_wf())
    print(primitive_types(a=0, b=False, c=3.0, d="hello", e=datetime.datetime.now(), 
                          f=datetime.timedelta(days=1, hours=3, minutes=2, seconds=3, microseconds=5)))
    print(flyte_dir_out_only())
    print(flyte_file_out_only())
```

Dockerfile
```Dockerfile
# Use the Alpine Linux version of Python 3.9 as the base image
FROM python:3.9-alpine

# Set the working directory in the container
WORKDIR /root

# You can use the docker copy command after building the image to copy test.py into the /app directory of the container
COPY ./write_flytefile.py /root/write_flytefile.py
COPY ./write_flytedir.py /root/write_flytedir.py
COPY ./return_same_value.py /root/return_same_value.py
COPY ./return_flytefile.py /root/return_flytefile.py
COPY ./return_flytedir.py /root/return_flytedir.py


# Specify the command to run when the container starts. Here, we use /bin/sh to start a shell.
CMD ["/bin/sh"]
```

`write_flytefile.py`
```python
import sys
from pathlib import Path

def copy_content_to_output(input_path: Path, output_path: Path):

    content = input_path.read_text()

    output_path.write_text(content)

if __name__ == "__main__":
    if len(sys.argv) > 2:
        input_path = Path(sys.argv[1])
        output_path = Path(sys.argv[2])
        copy_content_to_output(input_path, output_path)
    else:
        print("Usage: script.py <input_path> <output_path>")
```

`write_flytedir.py`
```python
import sys
from pathlib import Path
import shutil

def copy_directory(input_path: Path, output_path: Path):
    if not input_path.exists() or not input_path.is_dir():
        print(f"Error: {input_path} does not exist or is not a directory.")
        return

    try:
        shutil.copytree(input_path, output_path)
        print(f"Directory {input_path} was successfully copied to {output_path}")
    except Exception as e:
        print(f"Error copying {input_path} to {output_path}: {e}")

if __name__ == "__main__":
    if len(sys.argv) > 2:
        input_path = Path(sys.argv[1])
        output_path = Path(sys.argv[2])
        copy_directory(input_path, output_path)
    else:
        print("Usage: script.py <input_directory_path> <output_directory_path>")
```

`return_same_value.py`
```python
import sys

def write_output(output_dir, output_file, v):
    with open(f"{output_dir}/{output_file}", "w") as f:
            f.write(str(v))

def main(*args, output_dir):
    # Generate output files for each input argument
    for i, arg in enumerate(args, start=1):
        # Using i to generate filenames like 'a', 'b', 'c', ...
        output_file = chr(ord('a') + i - 1)
        write_output(output_dir, output_file, arg)

if __name__ == "__main__":
    *inputs, output_dir = sys.argv[1:]  # Unpack all inputs except for the last one for output_dir

    main(*inputs, output_dir=output_dir)
```

`return_flytefile.py`
```python
import sys
from pathlib import Path


def write_output(out_path: Path):
    out_path.write_text("return flyte file content")


if __name__ == "__main__":
    write_output(Path(sys.argv[1]))
```

`return_flytedir.py`
```python
import sys
from pathlib import Path

def write_output(directory_path: Path):
    directory_path.mkdir(parents=True, exist_ok=True)
    
    file_path = directory_path / "test_flyte_dir_file"
    
    file_path.write_text("prove flytedir works")

if __name__ == "__main__":
    if len(sys.argv) > 1:
        write_output(Path(sys.argv[1]))
    else:
        print("Usage: script.py <output_directory_path>")
```


### Screenshots
Support documentation example
<img width="958" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/5242cd52-8914-4277-87ec-7ea95c71a6d2">

All examples above
<img width="1094" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/785150b6-e7d2-48f2-82d8-9af242cbbf0f">




## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flytekit/pull/1745
