### PR TITLE
entrypoint.py: Explicitly import exit from sys

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -8,6 +8,7 @@ import signal
 import subprocess
 import tempfile
 import traceback as _traceback
+from sys import exit
 from typing import List, Optional
 
 import click as _click


### PR DESCRIPTION
## Why are the changes needed?
[entrypoint.py calls exit(1) when the env var "FLYTE_FAIL_ON_ERROR" is set](https://github.com/flyteorg/flytekit/blob/d7c60296cf4fd75f608f950361f35b2d90310114/flytekit/bin/entrypoint.py#L180).
When using the Spark plugin for Databricks jobs,
this results in `NameError: name 'exit' is not defined` exception,
where a successful exit with return code 1 was expected.

Behavior confirmed for both Databricks Runtime 13.3 LTS (Apache Spark 3.4.1, python 3.10)
and Databricks Runtime 10.4 LTS (Apache Spark 3.2.1, python 3.8)
## What changes were proposed in this pull request?
Explicitly importing the `exit` function from the `sys` module should fix this.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->