### PR TITLE
Create envd context for users

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -140,7 +140,7 @@ class ImageSpec:
 
     def with_commands(self, commands: Union[str, List[str]]) -> "ImageSpec":
         """
-        Builder that returns a new image spec with additional list of commands that will be executed during the building process.
+        Builder that returns a new image spec with an additional list of commands that will be executed during the building process.
         """
         new_image_spec = copy.deepcopy(self)
         if new_image_spec.commands is None:

--- a/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
+++ b/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
@@ -12,42 +12,62 @@ from flytekit.core import context_manager
 from flytekit.core.constants import REQUIREMENTS_FILE_NAME
 from flytekit.image_spec.image_spec import _F_IMG_ID, ImageBuildEngine, ImageSpec, ImageSpecBuilder
 
+FLYTE_LOCAL_REGISTRY = "localhost:30000"
+
 
 class EnvdImageSpecBuilder(ImageSpecBuilder):
     """
     This class is used to build a docker image using envd.
     """
 
-    def execute_command(self, command):
-        click.secho(f"Run command: {command} ", fg="blue")
-        p = subprocess.Popen(command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-        result = []
-        for line in iter(p.stdout.readline, ""):
-            if p.poll() is not None:
-                break
-            if line.decode().strip() != "":
-                output = line.decode().strip()
-                click.secho(output, fg="blue")
-                result.append(output)
-
-        if p.returncode != 0:
-            _, stderr = p.communicate()
-            raise Exception(f"failed to run command {command} with error {stderr}")
-
-        return result
-
     def build_image(self, image_spec: ImageSpec):
         cfg_path = create_envd_config(image_spec)
 
         if image_spec.registry_config:
             bootstrap_command = f"envd bootstrap --registry-config {image_spec.registry_config}"
-            self.execute_command(bootstrap_command)
+            execute_command(bootstrap_command)
 
         build_command = f"envd build --path {pathlib.Path(cfg_path).parent}  --platform {image_spec.platform}"
         if image_spec.registry:
             build_command += f" --output type=image,name={image_spec.image_name()},push=true"
-        self.execute_command(build_command)
+        envd_context_switch(image_spec.registry)
+        execute_command(build_command)
+
+
+def envd_context_switch(registry: str):
+    if registry == FLYTE_LOCAL_REGISTRY:
+        # Assume buildkit daemon is running within the sandbox and exposed on port 30003
+        command = "envd context create --name flyte-sandbox --builder tcp --builder-address localhost:30003 --use"
+        p = subprocess.run(command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if p.returncode != 0:
+            # Assume the context already exists
+            execute_command("envd context use --name flyte-sandbox")
+    else:
+        command = "envd context create --name flyte --builder docker-container --builder-address buildkitd-demo -use"
+        p = subprocess.run(command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if p.returncode != 0:
+            # Assume the context already exists
+            execute_command("envd context use --name flyte")
+
+
+def execute_command(command: str):
+    click.secho(f"Run command: {command} ", fg="blue")
+    p = subprocess.Popen(command.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    result = []
+    for line in iter(p.stdout.readline, ""):
+        if p.poll() is not None:
+            break
+        if line.decode().strip() != "":
+            output = line.decode().strip()
+            click.secho(output, fg="blue")
+            result.append(output)
+
+    if p.returncode != 0:
+        _, stderr = p.communicate()
+        raise Exception(f"failed to run command {command} with error {stderr}")
+
+    return result
 
 
 def _create_str_from_package_list(packages):


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
When pushing an image to the local registry, Users have to create a new envd context by themself.
if they terminate the sandbox, they must switch to another context.
```
envd context create --name flyte-sandbox --builder tcp --builder-address localhost:30003 --use
```

## What changes were proposed in this pull request?
Create a new context for users when they're trying to push an image to the local registry.

## How was this patch tested?
Local

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
