### PR TITLE
Migrate over to using datetime.now(timezone.utc)

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -249,7 +249,7 @@ def setup_execution(
             domain=exe_domain,
             name=exe_name,
         ),
-        execution_date=_datetime.datetime.utcnow(),
+        execution_date=_datetime.datetime.now(_datetime.timezone.utc),
         stats=_get_stats(
             cfg=StatsConfig.auto(),
             # Stats metric path will be:

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -937,7 +937,7 @@ class FlyteContextManager(object):
         default_user_space_params = ExecutionParameters(
             execution_id=WorkflowExecutionIdentifier.promote_from_model(default_execution_id),
             task_id=_identifier.Identifier(_identifier.ResourceType.TASK, "local", "local", "local", "local"),
-            execution_date=_datetime.datetime.utcnow(),
+            execution_date=_datetime.datetime.now(_datetime.timezone.utc),
             stats=mock_stats.MockStats(),
             logging=user_space_logger,
             tmp_dir=user_space_path,

--- a/flytekit/core/mock_stats.py
+++ b/flytekit/core/mock_stats.py
@@ -57,8 +57,10 @@ class _Timer(object):
         self._tags = tags
 
     def __enter__(self):
-        self._timer = _datetime.datetime.utcnow()
+        self._timer = _datetime.datetime.now(_datetime.timezone.utc)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self._mock_stats.gauge(self._metric, _datetime.datetime.utcnow() - self._timer, tags=self._tags)
+        self._mock_stats.gauge(
+            self._metric, _datetime.datetime.now(_datetime.timezone.utc) - self._timer, tags=self._tags
+        )
         self._timer = None

--- a/flytekit/core/utils.py
+++ b/flytekit/core/utils.py
@@ -311,7 +311,7 @@ class timeit:
         return wrapper
 
     def __enter__(self):
-        self.start_time = datetime.datetime.utcnow()
+        self.start_time = datetime.datetime.now(datetime.timezone.utc)
         self._start_wall_time = _time.perf_counter()
         self._start_process_time = _time.process_time()
         return self
@@ -323,7 +323,7 @@ class timeit:
         """
         from flytekit.core.context_manager import FlyteContextManager
 
-        end_time = datetime.datetime.utcnow()
+        end_time = datetime.datetime.now(datetime.timezone.utc)
         end_wall_time = _time.perf_counter()
         end_process_time = _time.process_time()
 

--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -2,7 +2,7 @@ import asyncio
 import inspect
 import signal
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import partial, wraps
 from typing import List, Optional
 
@@ -179,9 +179,9 @@ class AsyncEntity:
         self.async_stack.set_node(node)
 
         poll_interval = self._poll_interval or timedelta(seconds=30)
-        time_to_give_up = datetime.max if self._timeout is None else datetime.utcnow() + self._timeout
+        time_to_give_up = datetime.max if self._timeout is None else datetime.now(timezone.utc) + self._timeout
 
-        while datetime.utcnow() < time_to_give_up:
+        while datetime.now(timezone.utc) < time_to_give_up:
             execution = self.remote.sync(execution)
             if execution.closure.phase in {WorkflowExecutionPhase.FAILED}:
                 raise EagerException(f"Error executing {self.entity.name} with error: {execution.closure.error}")
@@ -208,9 +208,9 @@ class AsyncEntity:
             )
 
             poll_interval = self._poll_interval or timedelta(seconds=6)
-            time_to_give_up = datetime.max if self._timeout is None else datetime.utcnow() + self._timeout
+            time_to_give_up = datetime.max if self._timeout is None else datetime.now(timezone.utc) + self._timeout
 
-            while datetime.utcnow() < time_to_give_up:
+            while datetime.now(timezone.utc) < time_to_give_up:
                 execution = self.remote.sync(execution)
                 if execution.is_done:
                     break

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -18,7 +18,7 @@ import uuid
 from base64 import b64encode
 from collections import OrderedDict
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Dict
 
 import click
@@ -1661,9 +1661,9 @@ class FlyteRemote(object):
         :param sync_nodes: passed along to the sync call for the workflow execution
         """
         poll_interval = poll_interval or timedelta(seconds=30)
-        time_to_give_up = datetime.max if timeout is None else datetime.now(timezone.utc) + timeout
+        time_to_give_up = datetime.max if timeout is None else datetime.now() + timeout
 
-        while datetime.now(timezone.utc) < time_to_give_up:
+        while datetime.now() < time_to_give_up:
             execution = self.sync_execution(execution, sync_nodes=sync_nodes)
             if execution.is_done:
                 return execution

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -18,7 +18,7 @@ import uuid
 from base64 import b64encode
 from collections import OrderedDict
 from dataclasses import asdict, dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict
 
 import click
@@ -1661,9 +1661,9 @@ class FlyteRemote(object):
         :param sync_nodes: passed along to the sync call for the workflow execution
         """
         poll_interval = poll_interval or timedelta(seconds=30)
-        time_to_give_up = datetime.max if timeout is None else datetime.utcnow() + timeout
+        time_to_give_up = datetime.max if timeout is None else datetime.now(timezone.utc) + timeout
 
-        while datetime.utcnow() < time_to_give_up:
+        while datetime.now(timezone.utc) < time_to_give_up:
             execution = self.sync_execution(execution, sync_nodes=sync_nodes)
             if execution.is_done:
                 return execution

--- a/plugins/flytekit-deck-standard/tests/test_renderer.py
+++ b/plugins/flytekit-deck-standard/tests/test_renderer.py
@@ -22,8 +22,8 @@ time_info_df = pd.DataFrame(
     [
         dict(
             Name="foo",
-            Start=datetime.datetime.utcnow(),
-            Finish=datetime.datetime.utcnow() + datetime.timedelta(microseconds=1000),
+            Start=datetime.datetime.now(datetime.timezone.utc),
+            Finish=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(microseconds=1000),
             WallTime=1.0,
             ProcessTime=1.0,
         )

--- a/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py
+++ b/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/schema.py
@@ -290,7 +290,7 @@ class GreatExpectationsTypeTransformer(TypeTransformer[GreatExpectationsType]):
         run_id = ge.core.run_identifier.RunIdentifier(
             **{
                 "run_name": ge_conf.datasource_name + "_run",
-                "run_time": datetime.datetime.utcnow(),
+                "run_time": datetime.datetime.now(datetime.timezone.utc),
             }
         )
 

--- a/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/task.py
+++ b/plugins/flytekit-greatexpectations/flytekitplugins/great_expectations/task.py
@@ -216,7 +216,7 @@ class GreatExpectationsTask(PythonInstanceTask[BatchRequestConfig]):
         run_id = ge.core.run_identifier.RunIdentifier(
             **{
                 "run_name": self._datasource_name + "_run",
-                "run_time": datetime.datetime.utcnow(),
+                "run_time": datetime.datetime.now(datetime.timezone.utc),
             }
         )
 

--- a/plugins/flytekit-identity-aware-proxy/tests/test_flytekitplugins_iap.py
+++ b/plugins/flytekit-identity-aware-proxy/tests/test_flytekitplugins_iap.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import click
@@ -58,7 +58,7 @@ def test_get_gcp_secret_manager_secret_not_found():
 
 def create_mock_token(aud: str, expires_in: timedelta = None):
     """Create a mock JWT token with a certain audience, expiration time, and random JTI."""
-    exp = datetime.utcnow() + expires_in
+    exp = datetime.now(timezone.utc) + expires_in
     jti = "test_token" + str(uuid.uuid4())
     payload = {"exp": exp, "aud": aud, "jti": jti}
 

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -81,10 +81,10 @@ def test_monitor_workflow_execution(register):
     )
 
     poll_interval = datetime.timedelta(seconds=1)
-    time_to_give_up = datetime.datetime.utcnow() + datetime.timedelta(seconds=60)
+    time_to_give_up = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=60)
 
     execution = remote.sync_execution(execution, sync_nodes=True)
-    while datetime.datetime.utcnow() < time_to_give_up:
+    while datetime.datetime.now(datetime.timezone.utc) < time_to_give_up:
         if execution.is_done:
             break
 

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -1,6 +1,6 @@
 import base64
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -251,7 +251,7 @@ def test_exec_params():
     ep = ExecutionParameters(
         execution_id=id_models.WorkflowExecutionIdentifier("p", "d", "n"),
         task_id=id_models.Identifier(id_models.ResourceType.TASK, "local", "local", "local", "local"),
-        execution_date=datetime.utcnow(),
+        execution_date=datetime.now(timezone.utc),
         stats=mock_stats.MockStats(),
         logging=None,
         tmp_dir="/tmp",

--- a/tests/flytekit/unit/deck/test_deck.py
+++ b/tests/flytekit/unit/deck/test_deck.py
@@ -32,8 +32,8 @@ def test_deck():
 def test_timeline_deck():
     time_info = dict(
         Name="foo",
-        Start=datetime.datetime.utcnow(),
-        Finish=datetime.datetime.utcnow() + datetime.timedelta(microseconds=1000),
+        Start=datetime.datetime.now(datetime.timezone.utc),
+        Finish=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(microseconds=1000),
         WallTime=1.0,
         ProcessTime=1.0,
     )

--- a/tests/flytekit/unit/models/test_literals.py
+++ b/tests/flytekit/unit/models/test_literals.py
@@ -103,7 +103,7 @@ def test_boolean_primitive():
 
 
 def test_datetime_primitive():
-    dt = datetime.utcnow().replace(tzinfo=timezone.utc)
+    dt = datetime.now(timezone.utc)
     obj = literals.Primitive(datetime=dt)
     assert obj.integer is None
     assert obj.boolean is None


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

`datetime.utcnow()` is deprecated:

> DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR migrates over to using `datetime.now(timezone.utc)` everywhere. (We can not use `datetime.UTC` yet because it was introduced in requires Python >= 3.11.)

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
This PR does not change functionally, thus the existing test should cover the changes.