### PR TITLE
Add support for Union[FlyteFile, FlyteDirectory] as input

### DIFF
--- a/flytekit/extend/backend/base_agent.py
+++ b/flytekit/extend/backend/base_agent.py
@@ -146,7 +146,7 @@ class AsyncAgentBase(AgentBase):
 
     @abstractmethod
     def create(
-        self, task_template: TaskTemplate, output_prefix: str, inputs: Optional[LiteralMap], **kwargs
+        self, task_template: TaskTemplate, inputs: Optional[LiteralMap], **kwargs
     ) -> ResourceMeta:
         """
         Return a resource meta that can be used to get the status of the task.

--- a/flytekit/extend/backend/base_agent.py
+++ b/flytekit/extend/backend/base_agent.py
@@ -145,9 +145,7 @@ class AsyncAgentBase(AgentBase):
         return self._metadata_type
 
     @abstractmethod
-    def create(
-        self, task_template: TaskTemplate, inputs: Optional[LiteralMap], **kwargs
-    ) -> ResourceMeta:
+    def create(self, task_template: TaskTemplate, inputs: Optional[LiteralMap], **kwargs) -> ResourceMeta:
         """
         Return a resource meta that can be used to get the status of the task.
         """

--- a/flytekit/extend/backend/base_agent.py
+++ b/flytekit/extend/backend/base_agent.py
@@ -145,7 +145,7 @@ class AsyncAgentBase(AgentBase):
         return self._metadata_type
 
     @abstractmethod
-    def create(self, task_template: TaskTemplate, inputs: Optional[LiteralMap], **kwargs) -> ResourceMeta:
+    def create(self, task_template: TaskTemplate, output_prefix: str, inputs: Optional[LiteralMap], **kwargs) -> ResourceMeta:
         """
         Return a resource meta that can be used to get the status of the task.
         """

--- a/flytekit/extend/backend/base_agent.py
+++ b/flytekit/extend/backend/base_agent.py
@@ -145,7 +145,9 @@ class AsyncAgentBase(AgentBase):
         return self._metadata_type
 
     @abstractmethod
-    def create(self, task_template: TaskTemplate, output_prefix: str, inputs: Optional[LiteralMap], **kwargs) -> ResourceMeta:
+    def create(
+        self, task_template: TaskTemplate, output_prefix: str, inputs: Optional[LiteralMap], **kwargs
+    ) -> ResourceMeta:
         """
         Return a resource meta that can be used to get the status of the task.
         """

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -16,7 +16,7 @@ from marshmallow import fields
 
 from flytekit import BlobType
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
-from flytekit.core.type_engine import TypeEngine, TypeTransformer, get_batch_size, TypeTransformerFailedError
+from flytekit.core.type_engine import TypeEngine, TypeTransformer, TypeTransformerFailedError, get_batch_size
 from flytekit.exceptions.user import FlyteAssertion
 from flytekit.models import types as _type_models
 from flytekit.models.core import types as _core_types

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -14,8 +14,9 @@ from dataclasses_json import DataClassJsonMixin, config
 from fsspec.utils import get_protocol
 from marshmallow import fields
 
+from flytekit import BlobType
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
-from flytekit.core.type_engine import TypeEngine, TypeTransformer, get_batch_size
+from flytekit.core.type_engine import TypeEngine, TypeTransformer, get_batch_size, TypeTransformerFailedError
 from flytekit.exceptions.user import FlyteAssertion
 from flytekit.models import types as _type_models
 from flytekit.models.core import types as _core_types
@@ -441,6 +442,10 @@ class FlyteDirToMultipartBlobTransformer(TypeTransformer[FlyteDirectory]):
         self, ctx: FlyteContext, lv: Literal, expected_python_type: typing.Type[FlyteDirectory]
     ) -> FlyteDirectory:
         uri = lv.scalar.blob.uri
+
+        if lv.scalar.blob.metadata.type.dimensionality != BlobType.BlobDimensionality.MULTIPART:
+            raise TypeTransformerFailedError(f"{lv.scalar.blob.uri} is not a directory.")
+
         if not ctx.file_access.is_remote(uri) and not os.path.isdir(uri):
             raise FlyteAssertion(f"Expected a directory, but the given uri '{uri}' is not a directory.")
 

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -463,6 +463,9 @@ class FlyteFilePathTransformer(TypeTransformer[FlyteFile]):
         except AttributeError:
             raise TypeTransformerFailedError(f"Cannot convert from {lv} to {expected_python_type}")
 
+        if lv.scalar.blob.metadata.type.dimensionality != BlobType.BlobDimensionality.SINGLE:
+            raise TypeTransformerFailedError(f"{lv.scalar.blob.uri} is not a file.")
+
         if not ctx.file_access.is_remote(uri) and not os.path.isfile(uri):
             raise FlyteAssertion(
                 f"Cannot convert from {lv} to {expected_python_type}. " f"Expected a file, but {uri} is not a file."


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Can not use Union[FlyteFile, FlyteDirectory] as input

## What changes were proposed in this pull request?
Check the metadata in the literal before deserializing FlyteFile/FlyteDirectory

## How was this patch tested?
local/remote

### Setup process
```python
import os
import tempfile
from typing import Union

from flytekit import task, workflow, ImageSpec
from flytekit.types.directory import FlyteDirectory
from flytekit.types.file import FlyteFile

new_flytekit = "git+https://github.com/flyteorg/flytekit.git@d6ae58fb1ee6a7509d15fb1022d294bc2978e1dd"
image_spec = ImageSpec(packages=[new_flytekit], registry="pingsutw", apt_packages=["git"])


@task(container_image=image_spec)
def t1() -> FlyteFile:
    temp_dir = tempfile.mkdtemp(prefix='temp_example_')
    file1_path = os.path.join(temp_dir, 'file1.txt')
    with open(file1_path, 'w') as file1:
        file1.write('Content of file1.txt')
    return file1_path


@task(container_image=image_spec)
def t2() -> FlyteDirectory:
    temp_dir = tempfile.mkdtemp(prefix='temp_example_')
    return temp_dir


@task(container_image=image_spec)
def t3() -> Union[FlyteFile, FlyteDirectory]:
    temp_dir = tempfile.mkdtemp(prefix='temp_example_')
    return temp_dir


@task(container_image=image_spec)
def res(a: Union[FlyteFile, FlyteDirectory]):
    print(a)


@workflow
def wf():
    res(a=t1())
    res(a=t2())
    res(a=t3())


if __name__ == '__main__':
    wf()
```

### Screenshots
<img width="1890" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/4bb0b195-5eb6-4a36-8b82-21792456c277">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
