### PR TITLE
pyflyte `run`& `register` asynchronously

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1036,7 +1036,9 @@ class FlyteRemote(object):
 
         if isinstance(entity, PythonTask):
             return self.register_task(entity, serialization_settings, version)
-        return self.register_workflow(entity, serialization_settings, version, default_launch_plan, options)
+        fwf = self.register_workflow(entity, serialization_settings, version, default_launch_plan, options)
+        fwf._python_interface = entity.python_interface
+        return fwf
 
     def register_launch_plan(
         self,

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -304,8 +304,7 @@ def register(
         tasks = []
         for entity in entities:
             tasks.append(loop.run_in_executor(None, functools.partial(_raw_register, entity)))
-        if tasks:
-            await asyncio.wait(tasks)
+        await asyncio.gather(*tasks)
         return
 
     # concurrent register

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -299,7 +299,7 @@ def register(
         except RegistrationSkipped:
             secho(og_id, "failed")
 
-    async def _register(entities: typing.List[FlyteControlPlaneEntity]):
+    async def _register(entities: typing.List[task.TaskSpec]):
         loop = asyncio.get_event_loop()
         tasks = []
         for entity in entities:

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -48,7 +48,6 @@ FlyteLocalEntity = Union[
     ReferenceLaunchPlan,
     ReferenceEntity,
 ]
-
 FlyteControlPlaneEntity = Union[
     TaskSpec,
     _launch_plan_models.LaunchPlan,

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -48,13 +48,14 @@ FlyteLocalEntity = Union[
     ReferenceLaunchPlan,
     ReferenceEntity,
 ]
+
 FlyteControlPlaneEntity = Union[
     TaskSpec,
+    _launch_plan_models.LaunchPlan,
+    admin_workflow_models.WorkflowSpec,
+    workflow_model.Node,
     BranchNodeModel,
     ArrayNodeModel,
-    workflow_model.Node,
-    admin_workflow_models.WorkflowSpec,
-    _launch_plan_models.LaunchPlan,
 ]
 
 

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -50,11 +50,11 @@ FlyteLocalEntity = Union[
 ]
 FlyteControlPlaneEntity = Union[
     TaskSpec,
-    _launch_plan_models.LaunchPlan,
-    admin_workflow_models.WorkflowSpec,
-    workflow_model.Node,
     BranchNodeModel,
     ArrayNodeModel,
+    workflow_model.Node,
+    admin_workflow_models.WorkflowSpec,
+    _launch_plan_models.LaunchPlan,
 ]
 
 

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -50,6 +50,37 @@ def register():
     assert out.returncode == 0
 
 
+# only accept one arg for now.
+# be careful with different wf_name in each wf.
+def run(file_name, wf_name, arg_key, arg_value):
+    out = subprocess.run(
+        [
+            "pyflyte",
+            "--verbose",
+            "-c",
+            CONFIG,
+            "run",
+            "--remote",
+            "--image",
+            IMAGE,
+            "--project",
+            PROJECT,
+            "--domain",
+            DOMAIN,
+            MODULE_PATH / file_name,
+            wf_name,
+            arg_key,
+            arg_value,
+        ]
+    )
+    assert out.returncode == 0
+
+
+# test child_workflow.parent_wf asynchronously register a parent wf1 with child lp from another wf2.
+def test_remote_run():
+    run("child_workflow.py", "parent_wf", "--a", "3")
+
+
 def test_fetch_execute_launch_plan(register):
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
     flyte_launch_plan = remote.fetch_launch_plan(name="basic.hello_world.my_wf", version=VERSION)

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -50,9 +50,7 @@ def register():
     assert out.returncode == 0
 
 
-# only accept one arg for now.
-# be careful with different wf_name in each wf.
-def run(file_name, wf_name, arg_key, arg_value):
+def run(file_name, wf_name, *args):
     out = subprocess.run(
         [
             "pyflyte",
@@ -69,8 +67,7 @@ def run(file_name, wf_name, arg_key, arg_value):
             DOMAIN,
             MODULE_PATH / file_name,
             wf_name,
-            arg_key,
-            arg_value,
+            *args,
         ]
     )
     assert out.returncode == 0


### PR DESCRIPTION
## Tracking issue

NA

## Why are the changes needed?

To make register  `task`, `workflow`, and `launchplan` **x2.5 ~ x4 faster**  in `pyflyte run` and  `pyflyte register` by leveraging `asyncio`.

## What changes were proposed in this pull request?

- https://github.com/flyteorg/flytekit/pull/2267: A neat workaround by @pingsutw for sync grpc clients.
- Entities serialization is not enough in async approach.
    - It's necessary to separate registered entities into "task" and "non-task" categories in orders. This is because we can ensure flyteadmin returns a task registration response before registering workflows that depend on it.


## How was this patch tested?

### Setup process

After introducing localhost network latency to `1000ms` per request, we can simulate network IO-intensive operations to cloud services (e.g., object storage, Kubernetes cluster, FlyteAdmin) on your own desktop. This way, we can finally evaluate performance improvements through `asyncio` without setup a real cluster outside. Otherwise, the Flyte sandbox cluster residing in macOS is just too fast to measure.

Steps to reproduce network condition:

1. `sudo pfctl -f -`: packfilter out proto tcp from any to any pipe `1`.
2. `sudo dnctl pipe 1 config delay 1000`: Adding 1000ms latency to every dummynet requests.
3. `sudo pfctl -E`: Enabling the latency setup in packfilter.

> Don't forget set latency back to `0` to get your original network speed.



> <img width="955" alt="Screenshot 2024-03-18 at 3 15 17 PM" src="https://github.com/flyteorg/flytekit/assets/35886692/f7f63ee6-a636-4ae4-8ced-2d7d59f81305">
  
### Screenshots

- The registration elapsed time reduced from `34.1s` to `16.1s` after introducing asynchronous registration.
- Register, 9 `task`, 1 `wf`, 1 `lp`.

#### 1. Register in the `sync` manner: **`21.1s`**

  1. `python3 -m cProfile -o sync_requests_500ms.prof ./flytekit/clis/sdk_in_container/pyflyte.py register ./workflow.py`
  2. `snakeviz ./sync_requests_500ms.prof`

  - <img width="1280" alt="Screenshot 2024-03-23 at 7 43 15 AM" src="https://github.com/flyteorg/flytekit/assets/35886692/88df8d2f-161f-4e02-a9a1-ac8aaaecd612">


#### 2. Register in the `async` manner: **`6.05s`**
  1. `python3 -m cProfile -o async_requests_500ms.prof ./flytekit/clis/sdk_in_container/pyflyte.py register ./workflow.py`
  2. `snakeviz ./async_requests_500ms.prof`
  
  - <img width="1280" alt="Screenshot 2024-03-23 at 7 44 57 AM" src="https://github.com/flyteorg/flytekit/assets/35886692/3226a16c-deeb-42ba-8240-6fa3f4ab6413">

#### 3. Run in the `async` manner: **`5.95s`**
  1. `python3 -m cProfile -o async_requests_500ms_run.prof ./flytekit/clis/sdk_in_container/pyflyte.py run --remote ./workflow.py wf`
  2. `snakeviz ./async_requests_500ms_run.prof`
  
  - <img width="1280" alt="Screenshot 2024-03-26 at 2 19 59 PM" src="https://github.com/flyteorg/flytekit/assets/35886692/acf75d56-5752-4535-af8c-96464142803b">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
