### PR TITLE
feat: Support ImageSpec as base image

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -60,7 +60,7 @@ class ImageSpec:
     apt_packages: Optional[List[str]] = None
     cuda: Optional[str] = None
     cudnn: Optional[str] = None
-    base_image: Optional[str] = None
+    base_image: Optional[Union[str, "ImageSpec"]] = None
     platform: str = "linux/amd64"
     pip_index: Optional[str] = None
     registry_config: Optional[str] = None
@@ -226,6 +226,10 @@ class ImageBuildEngine:
     @classmethod
     @lru_cache
     def build(cls, image_spec: ImageSpec) -> str:
+        if isinstance(image_spec.base_image, ImageSpec):
+            cls.build(image_spec.base_image)
+            image_spec.base_image = image_spec.base_image.image_name()
+
         if image_spec.builder is None and cls._REGISTRY:
             builder = max(cls._REGISTRY, key=lambda name: cls._REGISTRY[name][1])
         else:
@@ -267,6 +271,8 @@ def calculate_hash_from_image_spec(image_spec: ImageSpec):
     """
     # copy the image spec to avoid modifying the original image spec. otherwise, the hash will be different.
     spec = copy.deepcopy(image_spec)
+    if isinstance(spec.base_image, ImageSpec):
+        spec.base_image = spec.base_image.image_name()
     spec.source_root = hash_directory(image_spec.source_root) if image_spec.source_root else b""
     if spec.requirements:
         spec.requirements = hashlib.sha1(pathlib.Path(spec.requirements).read_bytes()).hexdigest()

--- a/plugins/flytekit-envd/tests/test_image_spec.py
+++ b/plugins/flytekit-envd/tests/test_image_spec.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 import pytest
 from flytekitplugins.envd.image_builder import EnvdImageSpecBuilder, create_envd_config
 
-from flytekit.image_spec.image_spec import ImageBuildEngine, ImageSpec, ImageSpecBuilder
+from flytekit.image_spec.image_spec import ImageBuildEngine, ImageSpec
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -21,11 +21,6 @@ def register_envd_higher_priority():
 
 
 def test_image_spec():
-    class MockImageSpecBuilder(ImageSpecBuilder):
-        def build_image(self, img):
-            print("Building an image...")
-
-    ImageBuildEngine.register("dummy", MockImageSpecBuilder())
     base_image = ImageSpec(
         packages=["numpy"],
         python_version="3.8",


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
It enables users to easily reuse the ImageSpec and merge different ImageSpecs together.

## What changes were proposed in this pull request?
ImageBuildEngine will build the base image if the base image is an ImageSpec.

## How was this patch tested?
pyflyte run --remote ..

### Setup process

```python
from flytekit import task, workflow, ImageSpec, dynamic

new_flytekit = "git+https://github.com/flyteorg/flytekit@64730c8ffb4e76cb268817e30d31c6d209452e75"
image_sklearn = ImageSpec(packages=["scikit-learn", new_flytekit], apt_packages=["git"], registry="pingsutw")
image_tensorflow = ImageSpec(base_image=image_sklearn, packages=["tensorflow"], registry="pingsutw")


@task(container_image=image_sklearn)
def t1(a: int) -> int:
    return a + 2


@workflow
def wf(a: int = 3):
    t1(a=a)


if __name__ == "__main__":
    print(f"Running my_wf: {wf(a=50)}")
```

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
