### PR TITLE
pyflyte run spark task

### DIFF
--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -273,7 +273,6 @@ def get_registerable_container_image(img: Optional[Union[str, ImageSpec]], cfg: 
 
     :param img: Configured image or image spec
     :param cfg: Registration configuration
-    :param settings: Serialization settings
     :return:
     """
     if isinstance(img, ImageSpec):

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -175,6 +175,13 @@ class PythonAutoContainerTask(PythonTask[T], ABC, metaclass=FlyteTrackedABC):
         """
         return self._get_command_fn(settings)
 
+    def get_image(self, settings: SerializationSettings) -> str:
+        if settings.fast_serialization_settings is None or not settings.fast_serialization_settings.enabled:
+            if isinstance(self.container_image, ImageSpec):
+                # Set the source root for the image spec if it's non-fast registration
+                self.container_image.source_root = settings.source_root
+        return get_registerable_container_image(self.container_image, settings.image_config)
+
     def get_container(self, settings: SerializationSettings) -> _task_model.Container:
         # if pod_template is not None, return None here but in get_k8s_pod, return pod_template merged with container
         if self.pod_template is not None:
@@ -187,11 +194,8 @@ class PythonAutoContainerTask(PythonTask[T], ABC, metaclass=FlyteTrackedABC):
         for elem in (settings.env, self.environment):
             if elem:
                 env.update(elem)
-        if settings.fast_serialization_settings is None or not settings.fast_serialization_settings.enabled:
-            if isinstance(self.container_image, ImageSpec):
-                self.container_image.source_root = settings.source_root
         return _get_container_definition(
-            image=get_registerable_container_image(self.container_image, settings.image_config),
+            image=self.get_image(settings),
             command=[],
             args=self.get_command(settings=settings),
             data_loading_config=None,
@@ -269,6 +273,7 @@ def get_registerable_container_image(img: Optional[Union[str, ImageSpec]], cfg: 
 
     :param img: Configured image or image spec
     :param cfg: Registration configuration
+    :param settings: Serialization settings
     :return:
     """
     if isinstance(img, ImageSpec):

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -986,6 +986,7 @@ class FlyteRemote(object):
                 destination_dir=destination_dir,
                 distribution_location=upload_native_url,
             ),
+            source_root=source_path,
         )
 
         if version is None:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -7,6 +7,7 @@ from google.protobuf.json_format import MessageToDict
 from flytekit import FlyteContextManager, PythonFunctionTask, lazy_module, logger
 from flytekit.configuration import DefaultImages, SerializationSettings
 from flytekit.core.context_manager import ExecutionParameters
+from flytekit.core.python_auto_container import get_registerable_container_image
 from flytekit.extend import ExecutionState, TaskPlugins
 from flytekit.extend.backend.base_agent import AsyncAgentExecutorMixin
 from flytekit.image_spec import ImageSpec
@@ -135,6 +136,14 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
             container_image=container_image,
             **kwargs,
         )
+
+    def get_image(self, settings: SerializationSettings) -> str:
+        print("test test test")
+        if isinstance(self.container_image, ImageSpec):
+            # Ensure that the code is always copied into the image, even during fast-registration.
+            self.container_image.source_root = settings.source_root
+
+        return get_registerable_container_image(self.container_image, settings.image_config)
 
     def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
         job = SparkJob(

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -138,7 +138,6 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         )
 
     def get_image(self, settings: SerializationSettings) -> str:
-        print("test test test")
         if isinstance(self.container_image, ImageSpec):
             # Ensure that the code is always copied into the image, even during fast-registration.
             self.container_image.source_root = settings.source_root


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Since only the Spark driver downloads the workflow code, pyflyte run doesn't work with Spark tasks as the Spark executors also need the workflow code.

## What changes were proposed in this pull request?
Always copy the code into the image if the task is a spark task.

## How was this patch tested?
remote cluster

```bash
pyflyte run --remote flyte-example/test2.py spark_wf
```

### Setup process
```python
import random

from click.testing import CliRunner

from flytekit.clis.sdk_in_container import pyflyte
from flytekitplugins.spark import Spark

import flytekit
from flytekit import ImageSpec, task, Resources, workflow
from operator import add

custom_image = ImageSpec(
    name="flytekit",
    registry="pingsutw",  # your docker registry
)


def f(_):
    x = random.random() * 2 - 1
    y = random.random() * 2 - 1
    return 1 if x**2 + y**2 <= 1 else 0


@task(
    task_config=Spark(
        spark_conf={
            "spark.driver.memory": "1000M",
            "spark.executor.memory": "1000M",
            "spark.executor.cores": "1",
            "spark.executor.instances": "2",
            "spark.driver.cores": "1",
            "spark.jars": "https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop3-latest.jar",
        },
    ),
    limits=Resources(mem="2000M"),
    container_image=custom_image,
)
def hello_spark(partitions: int) -> float:
    print("Starting Spark with Partitions: {}".format(partitions))

    n = 1 * partitions
    sess = flytekit.current_context().spark_session
    count = (
        sess.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)
    )

    pi_val = 4.0 * count / n
    return pi_val


@workflow
def spark_wf(partitions: int = 10) -> float:
    return hello_spark(partitions=partitions)


if __name__ == '__main__':
    runner = CliRunner()
    result = runner.invoke(pyflyte.main,
                           ["register",
                            "--non-fast",
                            "--version",
                            "v3",
                            "/Users/kevin/git/flytekit/flyte-example/test2.py",
                            ])
    print(result.output)
```

### Screenshots
<img width="1901" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/929c9950-a05e-42a5-821d-05ffc352e440">


- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA