### PR TITLE
[FIX] `image_builder()`: `shutil.copytree()` ignoring permission

### DIFF
--- a/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
+++ b/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
@@ -106,7 +106,7 @@ def build():
         envd_config += f'    install.cuda(version="{image_spec.cuda}", cudnn="{cudnn}")\n'
 
     if image_spec.source_root:
-        shutil.copytree(image_spec.source_root, pathlib.Path(cfg_path).parent, dirs_exist_ok=True)
+        shutil.copytree(image_spec.source_root, pathlib.Path(cfg_path).parent, dirs_exist_ok=True, copy_function=shutil.copy)
 
         envd_version = metadata.version("envd")
         # Indentation is required by envd


### PR DESCRIPTION
## Tracking issue

NA

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?

[python shutil.copytree - ignore permissions](https://stackoverflow.com/questions/1303413/python-shutil-copytree-ignore-permissions)

## What changes were proposed in this pull request?

In Python 3.2 and higher, there's now a built-in way to do this. `shutil.copytree()` accepts a custom file copy function as an argument. You can use that to change it from the default file copy function to one that doesn't copy permissions like `shutil.copy()`.

## How was this patch tested?

This will only work for files since directory permissions are not copied with the copy_function.
In the sense of `image_builer()` is fine.
They are mirrored explicitly with `shutil.copystat()` instead.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
