### PR TITLE
feat: Add retry mechanism to file access methods

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -38,6 +38,7 @@ python-magic; (platform_system=='Darwin' or platform_system=='Linux')
 
 types-protobuf
 types-croniter
+types-decorator
 types-mock
 autoflake
 

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -111,6 +111,7 @@ def retry_request(func, retries=5, *args, **kwargs):
                 sleep(min(random.random() + 2 ** (retry - 1), 32))
             return func(*args, **kwargs)
         except OSError as e:
+            # Catch the specific error message from S3 since S3FS doesn't catch it and retry the request.
             if "Please reduce your request rate" in str(e):
                 if retry == retries - 1:
                     raise e

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -105,6 +105,7 @@ def get_fsspec_storage_options(
 
 @decorator
 def retry_request(func, *args, **kwargs):
+    # TODO: Remove this method once this PR is merged. https://github.com/fsspec/s3fs/pull/865
     retries = kwargs.pop("retries", 5)
     for retry in range(retries):
         try:

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -22,10 +22,12 @@ import os
 import pathlib
 import tempfile
 import typing
+from time import sleep
 from typing import Any, Dict, Optional, Union, cast
 from uuid import UUID
 
 import fsspec
+from decorator import decorator
 from fsspec.utils import get_protocol
 from typing_extensions import Unpack
 
@@ -99,6 +101,21 @@ def get_fsspec_storage_options(
     if protocol in ("abfs", "abfss"):
         return {**azure_setup_args(data_config.azure, anonymous=anonymous), **kwargs}
     return {}
+
+
+@decorator
+def retry_request(func, retries=5, *args, **kwargs):
+    for retry in range(retries):
+        try:
+            if retry > 0:
+                sleep(min(random.random() + 2 ** (retry - 1), 32))
+            return func(*args, **kwargs)
+        except OSError as e:
+            if "Please reduce your request rate" in str(e):
+                if retry == retries - 1:
+                    raise e
+            else:
+                raise e
 
 
 class FileAccessProvider(object):
@@ -246,6 +263,7 @@ class FileAccessProvider(object):
                 return anon_fs.exists(path)
             raise oe
 
+    @retry_request
     def get(self, from_path: str, to_path: str, recursive: bool = False, **kwargs):
         file_system = self.get_filesystem_for_path(from_path)
         if recursive:
@@ -272,6 +290,7 @@ class FileAccessProvider(object):
                 return file_system.get(from_path, to_path, recursive=recursive, **kwargs)
             raise oe
 
+    @retry_request
     def put(self, from_path: str, to_path: str, recursive: bool = False, **kwargs):
         file_system = self.get_filesystem_for_path(to_path)
         from_path = self.strip_file_header(from_path)

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -110,8 +110,8 @@ def retry_request(func, retries=5, *args, **kwargs):
             if retry > 0:
                 sleep(min(random.random() + 2 ** (retry - 1), 32))
             return func(*args, **kwargs)
-        except OSError as e:
-            # Catch the specific error message from S3 since S3FS doesn't catch it and retry the request.
+        except Exception as e:
+            # Catch this specific error message from S3 since S3FS doesn't catch it and retry the request.
             if "Please reduce your request rate" in str(e):
                 if retry == retries - 1:
                     raise e

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -105,7 +105,7 @@ def get_fsspec_storage_options(
 
 @decorator
 def retry_request(func, *args, **kwargs):
-    # TODO: Remove this method once this PR is merged. https://github.com/fsspec/s3fs/pull/865
+    # TODO: Remove this method once s3fs has a new release. https://github.com/fsspec/s3fs/pull/865
     retries = kwargs.pop("retries", 5)
     for retry in range(retries):
         try:

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -110,7 +110,7 @@ def retry_request(func, *args, **kwargs):
     for retry in range(retries):
         try:
             if retry > 0:
-                sleep(min(random.random() + 2 ** (retry - 1), 32))
+                sleep(random.randint(0, min(2**retry, 32)))
             return func(*args, **kwargs)
         except Exception as e:
             # Catch this specific error message from S3 since S3FS doesn't catch it and retry the request.

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -104,7 +104,8 @@ def get_fsspec_storage_options(
 
 
 @decorator
-def retry_request(func, retries=5, *args, **kwargs):
+def retry_request(func, *args, **kwargs):
+    retries = kwargs.pop("retries", 5)
     for retry in range(retries):
         try:
             if retry > 0:

--- a/tests/flytekit/unit/core/test_data.py
+++ b/tests/flytekit/unit/core/test_data.py
@@ -7,7 +7,6 @@ from uuid import UUID
 import fsspec
 import mock
 import pytest
-from mock import Mock
 from s3fs import S3FileSystem
 
 from flytekit.configuration import Config, DataConfig, S3Config

--- a/tests/flytekit/unit/core/test_data.py
+++ b/tests/flytekit/unit/core/test_data.py
@@ -421,7 +421,7 @@ def test_walk_local_copy_to_s3(source_folder):
         assert len(new_suffixes) == 2  # should have written two files
 
 
-@mock.patch("fsspec.spec.AbstractFileSystem.put")
+@mock.patch("fsspec.AbstractFileSystem.put")
 def test_fsspec_retry(mock_put):
     mock_put.side_effect = Mock(side_effect=OSError("Please reduce your request rate"))
     dc = Config.for_sandbox().data_config

--- a/tests/flytekit/unit/core/test_data.py
+++ b/tests/flytekit/unit/core/test_data.py
@@ -7,6 +7,7 @@ from uuid import UUID
 import fsspec
 import mock
 import pytest
+from mock import Mock
 from s3fs import S3FileSystem
 
 from flytekit.configuration import Config, DataConfig, S3Config
@@ -418,3 +419,17 @@ def test_walk_local_copy_to_s3(source_folder):
         new_crawl = fd.crawl()
         new_suffixes = [y for x, y in new_crawl]
         assert len(new_suffixes) == 2  # should have written two files
+
+
+@mock.patch("fsspec.spec.AbstractFileSystem.put")
+def test_fsspec_retry(mock_put):
+    mock_put.side_effect = Mock(side_effect=OSError("Please reduce your request rate"))
+    dc = Config.for_sandbox().data_config
+    explicit_empty_folder = UUID(int=random.getrandbits(128)).hex
+    raw_output_path = f"s3://my-s3-bucket/testdata/{explicit_empty_folder}"
+    provider = FileAccessProvider(local_sandbox_dir="/tmp/unittest", raw_output_prefix=raw_output_path, data_config=dc)
+
+    ctx = FlyteContextManager.current_context()
+    with FlyteContextManager.with_context(ctx.with_file_access(provider)):
+        with pytest.raises(OSError):
+            ctx.file_access.put("/tmp/123", "s3://my-s3-bucket/testdata/dest", retries=2)


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Failed to upload a file to s3
```bash
      File "/usr/local/lib/python3.11/site-packages/s3fs/core.py", line 719, in _lsdir
        raise translate_boto_error(e)

Message:

    OSError: [Errno 16] Please reduce your request rate.

User error.
```

<img width="1911" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/75f7b36f-7058-4e59-b694-6b1f87580969">


## What changes were proposed in this pull request?
Catch the error `Please reduce your request rate`, and retry the request.

## How was this patch tested?
Remote cluster

### Setup process
```python
import asyncio
import os
from typing import List, Dict, Any, Coroutine
import s3fs

from flytekit import ImageSpec, task, workflow, Resources, FlyteContextManager

# Constants
NUMBER_OF_REQUESTS: int = 100000
BUCKET_NAME: str = 's3://xxx/load-test/'
OBJECT_KEY: str = 'your_object_key'
DATA: str = 'abcsfsdfsdfsfdsdf'
s3fs = s3fs.S3FileSystem()


def write_data(source_file: str, object_key: str):
    ctx = FlyteContextManager.current_context()
    ctx.file_access.put(source_file, f"{BUCKET_NAME}{object_key}")


def make_file_if_not_exists(file_path: str, data: str) -> None:
    if not os.path.exists(file_path):
        with open(file_path, "w") as f:
            f.write(data)


async def make_s3_request(object_key: str, data: str, idx: int) -> Dict[str, Any]:
    if idx % 10 == 0:
        print(f"Making request for object_key: {idx}")
    source_file = f"/root/source_{idx % 10000}.txt"
    make_file_if_not_exists(source_file, data)
    response: Dict[str, Any] = await asyncio.to_thread(write_data, source_file, object_key)
    if idx % 10 == 0:
        print(f"Done with request {idx}")
    # response = await s3fs._put("/tmp/test/file.txt", f"s3://union-cloud-oc-staging-dogfood/load-test/{object_key}")
    return response


async def send_requests() -> List[Coroutine]:
    tasks: List[Coroutine] = [make_s3_request(f"{OBJECT_KEY}_{i}", DATA, i) for i in range(NUMBER_OF_REQUESTS)]
    print("Sending requests")
    return await asyncio.gather(*tasks)


async def main() -> None:
    responses: List[Dict[str, Any]] = await send_requests()
    # Do something with the responses


new_flytekit = "git+https://github.com/flyteorg/flytekit@0db9079b6e11767aac61c5dafc1c025ba04ef31e"
image = ImageSpec(registry="pingsutw", packages=[new_flytekit], apt_packages=["git"])


@task(
    requests=Resources(cpu="1", mem="3000Mi"),
    limits=Resources(cpu="1", mem="5000Mi"),
    interruptible=False,
    # container_image=image,
)
def s3_load_task():
    asyncio.run(main())


@workflow
def wf():
    for i in range(100):
        s3_load_task()


if __name__ == "__main__":
    asyncio.run(main())

```

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
