### PR TITLE
Setting interruptible on ArrayNode sub node metadata

### DIFF
--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -113,9 +113,9 @@ class ArrayNodeMapTask(PythonTask):
 
     def construct_node_metadata(self) -> NodeMetadata:
         # TODO: add support for other Flyte entities
-        interruptible=None
+        interruptible = None
         if self._run_task.metadata:
-            interruptible=self._run_task.metadata.interruptible
+            interruptible = self._run_task.metadata.interruptible
 
         return NodeMetadata(
             name=self.name,

--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -113,14 +113,9 @@ class ArrayNodeMapTask(PythonTask):
 
     def construct_node_metadata(self) -> NodeMetadata:
         # TODO: add support for other Flyte entities
-        interruptible = None
-        if self._run_task.metadata:
-            interruptible = self._run_task.metadata.interruptible
-
-        return NodeMetadata(
-            name=self.name,
-            interruptible=interruptible,
-        )
+        nm = super().construct_node_metadata()
+        nm._name = self.name
+        return nm
 
     @property
     def min_success_ratio(self) -> Optional[float]:

--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -113,8 +113,13 @@ class ArrayNodeMapTask(PythonTask):
 
     def construct_node_metadata(self) -> NodeMetadata:
         # TODO: add support for other Flyte entities
+        interruptible=None
+        if self._run_task.metadata:
+            interruptible=self._run_task.metadata.interruptible
+
         return NodeMetadata(
             name=self.name,
+            interruptible=interruptible,
         )
 
     @property

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -303,3 +303,45 @@ def test_map_task_override(serialization_settings):
         map_task(my_mappable_task)(a=x).with_overrides(container_image="random:image")
 
     assert wf.nodes[0]._container_image == "random:image"
+
+
+def test_serialization_metadata(serialization_settings):
+    @task(interruptible=True)
+    def t1(a: int) -> int:
+        return a + 1
+
+    arraynode_maptask = map_task(t1, metadata=TaskMetadata(retries=2))
+    # since we manually override task metadata, the underlying task metadata will not be copied.
+    assert not arraynode_maptask.metadata.interruptible
+
+    @workflow
+    def wf(x: typing.List[int]):
+        return arraynode_maptask(a=x)
+
+    od = OrderedDict()
+    wf_spec = get_serializable(od, serialization_settings, wf)
+
+    assert not arraynode_maptask.construct_node_metadata().interruptible
+    assert not wf_spec.template.nodes[0].metadata.interruptible
+
+
+def test_serialization_metadata2(serialization_settings):
+    @task
+    def t1(a: int) -> int:
+        return a + 1
+
+    arraynode_maptask = map_task(t1, metadata=TaskMetadata(retries=2, interruptible=True))
+    assert arraynode_maptask.metadata.interruptible
+
+    @workflow
+    def wf(x: typing.List[int]):
+        return arraynode_maptask(a=x)
+
+    od = OrderedDict()
+    wf_spec = get_serializable(od, serialization_settings, wf)
+
+    assert arraynode_maptask.construct_node_metadata().interruptible
+    assert wf_spec.template.nodes[0].metadata.interruptible
+    task_spec = od[arraynode_maptask]
+    assert task_spec.template.metadata.retries.retries == 2
+    assert task_spec.template.metadata.interruptible


### PR DESCRIPTION
## Tracking issue
_NA_

## Why are the changes needed?
If a task is labeled as `interruptible` that attribute is not persisted when executing within an ArrayNode.

## What changes were proposed in this pull request?
Maintain the `interruptible` setting from the internal task in the sub node metadata.

## How was this patch tested?
locally

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
_NA_

## Docs link
_NA_