### PR TITLE
Makes the deviceflow auth URL simplier

### DIFF
--- a/flytekit/clients/auth/authenticator.py
+++ b/flytekit/clients/auth/authenticator.py
@@ -302,7 +302,9 @@ class DeviceCodeAuthenticator(Authenticator):
             self._verify,
             self._session,
         )
-        text = f"To Authenticate, navigate in a browser to the following URL: {click.style(resp.verification_uri, fg='blue', underline=True)} and enter code: {click.style(resp.user_code, fg='blue')}"
+
+        full_uri = f"{resp.verification_uri}?user_code={resp.user_code}"
+        text = f"To Authenticate, navigate in a browser to the following URL: {click.style(full_uri, fg='blue', underline=True)}"
         click.secho(text)
         try:
             # Currently the refresh token is not retrieved. We may want to add support for refreshTokens so that


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, device flow requires one to copy over the user code:

```bash
To Authenticate, navigate in a browser to the following URL:
https://signin.mydomain/activate and enter code: THISISACODE
```

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This changes the URL one click with device-flow:

```bash
To Authenticate, navigate in a browser to the following URL:
https://signin.mydomain/activate?user_code=THISISACODE
```

My concern is if using `user_code=` is generic enough.