### PR TITLE
feat: Support pep604 union operator

### DIFF
--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -23,9 +23,9 @@ from flytekit.models import interface as _interface_models
 from flytekit.models.literals import Literal, Scalar, Void
 
 if sys.version_info >= (3, 10):
-    from types import UnionType as _UnionType
+    from types import UnionType as UnionTypePep604
 else:
-    _UnionType = typing.Union
+    UnionTypePep604 = typing.Union
 
 T = typing.TypeVar("T")
 
@@ -373,13 +373,13 @@ def transform_function_to_interface(fn: typing.Callable, docstring: Optional[Doc
 
     outputs = extract_return_annotation(return_annotation)
     for k, v in outputs.items():
-        if isinstance(v, _UnionType):
+        if isinstance(v, UnionTypePep604):
             annotation = convert_pep604_union_type(annotation)
         outputs[k] = v  # type: ignore
     inputs: Dict[str, Tuple[Type, Any]] = OrderedDict()
     for k, v in signature.parameters.items():  # type: ignore
         annotation = type_hints.get(k, None)
-        if isinstance(annotation, _UnionType):
+        if isinstance(annotation, UnionTypePep604):
             annotation = convert_pep604_union_type(annotation)
         default = v.default if v.default is not inspect.Parameter.empty else None
         # Inputs with default values are currently ignored, we may want to look into that in the future

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections
 import copy
 import inspect
+import sys
 import typing
 from collections import OrderedDict
 from typing import Any, Dict, Generator, List, Optional, Tuple, Type, TypeVar, Union, cast
@@ -15,10 +16,16 @@ from flytekit.core.artifact import Artifact, ArtifactIDSpecification, ArtifactQu
 from flytekit.core.docstring import Docstring
 from flytekit.core.sentinel import DYNAMIC_INPUT_BINDING
 from flytekit.core.type_engine import TypeEngine
+from flytekit.core.type_helpers import convert_pep604_union_type
 from flytekit.exceptions.user import FlyteValidationException
 from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
 from flytekit.models.literals import Literal, Scalar, Void
+
+if sys.version_info >= (3, 10):
+    from types import UnionType as _UnionType
+else:
+    _UnionType = typing.Union
 
 T = typing.TypeVar("T")
 
@@ -366,10 +373,14 @@ def transform_function_to_interface(fn: typing.Callable, docstring: Optional[Doc
 
     outputs = extract_return_annotation(return_annotation)
     for k, v in outputs.items():
+        if isinstance(v, _UnionType):
+            annotation = convert_pep604_union_type(annotation)
         outputs[k] = v  # type: ignore
     inputs: Dict[str, Tuple[Type, Any]] = OrderedDict()
     for k, v in signature.parameters.items():  # type: ignore
         annotation = type_hints.get(k, None)
+        if isinstance(annotation, _UnionType):
+            annotation = convert_pep604_union_type(annotation)
         default = v.default if v.default is not inspect.Parameter.empty else None
         # Inputs with default values are currently ignored, we may want to look into that in the future
         inputs[k] = (annotation, default)  # type: ignore

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -15,7 +15,6 @@ from flytekit.core.artifact import Artifact, ArtifactIDSpecification, ArtifactQu
 from flytekit.core.docstring import Docstring
 from flytekit.core.sentinel import DYNAMIC_INPUT_BINDING
 from flytekit.core.type_engine import TypeEngine
-from flytekit.core.type_helpers import convert_pep604_union_type, is_pep604_union_type
 from flytekit.exceptions.user import FlyteValidationException
 from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
@@ -367,14 +366,10 @@ def transform_function_to_interface(fn: typing.Callable, docstring: Optional[Doc
 
     outputs = extract_return_annotation(return_annotation)
     for k, v in outputs.items():
-        if is_pep604_union_type(v):
-            v = convert_pep604_union_type(v)
         outputs[k] = v  # type: ignore
     inputs: Dict[str, Tuple[Type, Any]] = OrderedDict()
     for k, v in signature.parameters.items():  # type: ignore
         annotation = type_hints.get(k, None)
-        if is_pep604_union_type(annotation):
-            annotation = convert_pep604_union_type(annotation)
         default = v.default if v.default is not inspect.Parameter.empty else None
         # Inputs with default values are currently ignored, we may want to look into that in the future
         inputs[k] = (annotation, default)  # type: ignore

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -15,6 +15,7 @@ from flytekit.core.artifact import Artifact, ArtifactIDSpecification, ArtifactQu
 from flytekit.core.docstring import Docstring
 from flytekit.core.sentinel import DYNAMIC_INPUT_BINDING
 from flytekit.core.type_engine import TypeEngine
+from flytekit.core.type_helpers import UnionTypePep604
 from flytekit.exceptions.user import FlyteValidationException
 from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
@@ -218,7 +219,7 @@ def transform_inputs_to_parameters(
     inputs_with_def = interface.inputs_with_defaults
     for k, v in inputs_vars.items():
         val, _default = inputs_with_def[k]
-        if _default is None and get_origin(val) is typing.Union and type(None) in get_args(val):
+        if _default is None and get_origin(val) in [typing.Union, UnionTypePep604] and type(None) in get_args(val):
             literal = Literal(scalar=Scalar(none_type=Void()))
             params[k] = _interface_models.Parameter(var=v, default=literal, required=False)
         else:

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -8,14 +8,14 @@ from collections import OrderedDict
 from typing import Any, Dict, Generator, List, Optional, Tuple, Type, TypeVar, Union, cast
 
 from flyteidl.core import artifact_id_pb2 as art_id
-from typing_extensions import get_args, get_origin, get_type_hints
+from typing_extensions import get_args, get_type_hints
+from typing_inspect import is_union_type
 
 from flytekit.core import context_manager
 from flytekit.core.artifact import Artifact, ArtifactIDSpecification, ArtifactQuery
 from flytekit.core.docstring import Docstring
 from flytekit.core.sentinel import DYNAMIC_INPUT_BINDING
 from flytekit.core.type_engine import TypeEngine
-from flytekit.core.type_helpers import UnionTypePep604
 from flytekit.exceptions.user import FlyteValidationException
 from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
@@ -219,7 +219,7 @@ def transform_inputs_to_parameters(
     inputs_with_def = interface.inputs_with_defaults
     for k, v in inputs_vars.items():
         val, _default = inputs_with_def[k]
-        if _default is None and get_origin(val) in [typing.Union, UnionTypePep604] and type(None) in get_args(val):
+        if _default is None and is_union_type(val) and type(None) in get_args(val):
             literal = Literal(scalar=Scalar(none_type=Void()))
             params[k] = _interface_models.Parameter(var=v, default=literal, required=False)
         else:

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -15,7 +15,7 @@ from flytekit.core import context_manager
 from flytekit.core.artifact import Artifact, ArtifactIDSpecification, ArtifactQuery
 from flytekit.core.docstring import Docstring
 from flytekit.core.sentinel import DYNAMIC_INPUT_BINDING
-from flytekit.core.type_engine import TypeEngine
+from flytekit.core.type_engine import TypeEngine, UnionTransformer
 from flytekit.exceptions.user import FlyteValidationException
 from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
@@ -219,7 +219,7 @@ def transform_inputs_to_parameters(
     inputs_with_def = interface.inputs_with_defaults
     for k, v in inputs_vars.items():
         val, _default = inputs_with_def[k]
-        if _default is None and is_union_type(val) and type(None) in get_args(val):
+        if _default is None and UnionTransformer.is_optional_type(val):
             literal = Literal(scalar=Scalar(none_type=Void()))
             params[k] = _interface_models.Parameter(var=v, default=literal, required=False)
         else:

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Generator, List, Optional, Tuple, Type, TypeVar, U
 
 from flyteidl.core import artifact_id_pb2 as art_id
 from typing_extensions import get_args, get_type_hints
-from typing_inspect import is_union_type
 
 from flytekit.core import context_manager
 from flytekit.core.artifact import Artifact, ArtifactIDSpecification, ArtifactQuery

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -9,7 +9,6 @@ import inspect
 import json
 import json as _json
 import mimetypes
-import sys
 import textwrap
 import typing
 from abc import ABC, abstractmethod
@@ -31,7 +30,12 @@ from typing_extensions import Annotated, get_args, get_origin
 from flytekit.core.annotation import FlyteAnnotation
 from flytekit.core.context_manager import FlyteContext
 from flytekit.core.hash import HashMethod
-from flytekit.core.type_helpers import convert_pep604_union_type, load_type_from_tag
+from flytekit.core.type_helpers import (
+    UnionTypePep604,
+    convert_pep604_union_type,
+    is_pep604_union_type,
+    load_type_from_tag,
+)
 from flytekit.core.utils import timeit
 from flytekit.exceptions import user as user_exceptions
 from flytekit.interaction.string_literals import literal_map_string_repr
@@ -59,11 +63,6 @@ from flytekit.models.types import LiteralType, SimpleType, StructuredDatasetType
 T = typing.TypeVar("T")
 DEFINITIONS = "definitions"
 TITLE = "title"
-
-if sys.version_info >= (3, 10):
-    from types import UnionType as UnionTypePep604
-else:
-    UnionTypePep604 = typing.Union
 
 
 class BatchSize:
@@ -983,7 +982,7 @@ class TypeEngine(typing.Generic[T]):
 
             python_type = args[0]
 
-        if isinstance(python_type, UnionTypePep604):
+        if is_pep604_union_type(python_type):
             python_type = convert_pep604_union_type(python_type)  # type: ignore
 
         # Step 2

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -971,9 +971,6 @@ class TypeEngine(typing.Generic[T]):
             if v is of type data class, use the dataclass transformer
 
         Step 6:
-            if v uses PEP604 style union, use UnionTranformer
-
-        Step 7:
             Pickle transformer is used
         """
         cls.lazy_import_transformers()
@@ -985,6 +982,9 @@ class TypeEngine(typing.Generic[T]):
                     return annotation
 
             python_type = args[0]
+
+        if isinstance(python_type, _UnionType):
+            python_type = convert_pep604_union_type(python_type)  # type: ignore
 
         # Step 2
         # this makes sure that if it's a list/dict of annotated types, we hit the unwrapping code in step 2

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1034,11 +1034,6 @@ class TypeEngine(typing.Generic[T]):
             return cls._DATACLASS_TRANSFORMER
 
         # Step 6
-        if isinstance(python_type, UnionTypePep604):
-            python_type = convert_pep604_union_type(python_type)  # type: ignore
-            return cls._REGISTRY[python_type]
-
-        # Step 7
         display_pickle_warning(str(python_type))
         from flytekit.types.pickle.pickle import FlytePickleTransformer
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -61,9 +61,9 @@ DEFINITIONS = "definitions"
 TITLE = "title"
 
 if sys.version_info >= (3, 10):
-    from types import UnionType as _UnionType
+    from types import UnionType as UnionTypePep604
 else:
-    _UnionType = typing.Union
+    UnionTypePep604 = typing.Union
 
 
 class BatchSize:
@@ -553,7 +553,7 @@ class DataclassTransformer(TypeTransformer[object]):
         from flytekit.types.structured.structured_dataset import StructuredDataset
 
         # Handle Optional
-        if get_origin(python_type) in [typing.Union, _UnionType] and type(None) in get_args(python_type):
+        if get_origin(python_type) in [typing.Union, UnionTypePep604] and type(None) in get_args(python_type):
             if python_val is None:
                 return None
             return self._serialize_flyte_type(python_val, get_args(python_type)[0])
@@ -606,7 +606,7 @@ class DataclassTransformer(TypeTransformer[object]):
         from flytekit.types.structured.structured_dataset import StructuredDataset, StructuredDatasetTransformerEngine
 
         # Handle Optional
-        if get_origin(expected_python_type) in [typing.Union, _UnionType] and type(None) in get_args(
+        if get_origin(expected_python_type) in [typing.Union, UnionTypePep604] and type(None) in get_args(
             expected_python_type
         ):
             if python_val is None:
@@ -702,7 +702,7 @@ class DataclassTransformer(TypeTransformer[object]):
         if val is None:
             return val
 
-        if get_origin(t) in [typing.Union, _UnionType] and type(None) in get_args(t):
+        if get_origin(t) in [typing.Union, UnionTypePep604] and type(None) in get_args(t):
             # Handle optional type. e.g. Optional[int], Optional[dataclass]
             # Marshmallow doesn't support union type, so the type here is always an optional type.
             # https://github.com/marshmallow-code/marshmallow/issues/1191#issuecomment-480831796
@@ -983,7 +983,7 @@ class TypeEngine(typing.Generic[T]):
 
             python_type = args[0]
 
-        if isinstance(python_type, _UnionType):
+        if isinstance(python_type, UnionTypePep604):
             python_type = convert_pep604_union_type(python_type)  # type: ignore
 
         # Step 2
@@ -1035,7 +1035,7 @@ class TypeEngine(typing.Generic[T]):
             return cls._DATACLASS_TRANSFORMER
 
         # Step 6
-        if isinstance(python_type, _UnionType):
+        if isinstance(python_type, UnionTypePep604):
             python_type = convert_pep604_union_type(python_type)  # type: ignore
             return cls._REGISTRY[python_type]
 
@@ -1515,7 +1515,7 @@ class UnionTransformer(TypeTransformer[T]):
 
     @staticmethod
     def is_optional_type(t: Type[T]) -> bool:
-        return get_origin(t) in [typing.Union, _UnionType] and type(None) in get_args(t)
+        return get_origin(t) in [typing.Union, UnionTypePep604] and type(None) in get_args(t)
 
     @staticmethod
     def get_sub_type_in_optional(t: Type[T]) -> Type[T]:

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -549,7 +549,7 @@ class DataclassTransformer(TypeTransformer[object]):
         from flytekit.types.structured.structured_dataset import StructuredDataset
 
         # Handle Optional
-        if is_union_type(python_type) and type(None) in get_args(python_type):
+        if UnionTransformer.is_optional_type(python_type):
             if python_val is None:
                 return None
             return self._serialize_flyte_type(python_val, get_args(python_type)[0])

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1975,6 +1975,7 @@ def _register_default_type_transformers():
     TypeEngine.register(ListTransformer())
     if sys.version_info >= (3, 10):
         from types import UnionType
+
         TypeEngine.register(UnionTransformer(), [UnionType])
     else:
         TypeEngine.register(UnionTransformer())

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -26,12 +26,12 @@ from google.protobuf.struct_pb2 import Struct
 from marshmallow_enum import EnumField, LoadDumpOptions
 from mashumaro.mixins.json import DataClassJSONMixin
 from typing_extensions import Annotated, get_args, get_origin
+from typing_inspect import is_union_type
 
 from flytekit.core.annotation import FlyteAnnotation
 from flytekit.core.context_manager import FlyteContext
 from flytekit.core.hash import HashMethod
 from flytekit.core.type_helpers import (
-    UnionTypePep604,
     convert_pep604_union_type,
     is_pep604_union_type,
     load_type_from_tag,
@@ -552,7 +552,7 @@ class DataclassTransformer(TypeTransformer[object]):
         from flytekit.types.structured.structured_dataset import StructuredDataset
 
         # Handle Optional
-        if get_origin(python_type) in [typing.Union, UnionTypePep604] and type(None) in get_args(python_type):
+        if is_union_type(python_type) and type(None) in get_args(python_type):
             if python_val is None:
                 return None
             return self._serialize_flyte_type(python_val, get_args(python_type)[0])
@@ -605,9 +605,7 @@ class DataclassTransformer(TypeTransformer[object]):
         from flytekit.types.structured.structured_dataset import StructuredDataset, StructuredDatasetTransformerEngine
 
         # Handle Optional
-        if get_origin(expected_python_type) in [typing.Union, UnionTypePep604] and type(None) in get_args(
-            expected_python_type
-        ):
+        if is_union_type(expected_python_type) and type(None) in get_args(expected_python_type):
             if python_val is None:
                 return None
             return self._deserialize_flyte_type(python_val, get_args(expected_python_type)[0])
@@ -701,7 +699,7 @@ class DataclassTransformer(TypeTransformer[object]):
         if val is None:
             return val
 
-        if get_origin(t) in [typing.Union, UnionTypePep604] and type(None) in get_args(t):
+        if is_union_type(t) and type(None) in get_args(t):
             # Handle optional type. e.g. Optional[int], Optional[dataclass]
             # Marshmallow doesn't support union type, so the type here is always an optional type.
             # https://github.com/marshmallow-code/marshmallow/issues/1191#issuecomment-480831796
@@ -1509,7 +1507,7 @@ class UnionTransformer(TypeTransformer[T]):
 
     @staticmethod
     def is_optional_type(t: Type[T]) -> bool:
-        return get_origin(t) in [typing.Union, UnionTypePep604] and type(None) in get_args(t)
+        return is_union_type(t) and type(None) in get_args(t)
 
     @staticmethod
     def get_sub_type_in_optional(t: Type[T]) -> Type[T]:

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -602,7 +602,7 @@ class DataclassTransformer(TypeTransformer[object]):
         from flytekit.types.structured.structured_dataset import StructuredDataset, StructuredDatasetTransformerEngine
 
         # Handle Optional
-        if is_union_type(expected_python_type) and type(None) in get_args(expected_python_type):
+        if UnionTransformer.is_optional_type(expected_python_type):
             if python_val is None:
                 return None
             return self._deserialize_flyte_type(python_val, get_args(expected_python_type)[0])
@@ -696,7 +696,7 @@ class DataclassTransformer(TypeTransformer[object]):
         if val is None:
             return val
 
-        if is_union_type(t) and type(None) in get_args(t):
+        if UnionTransformer.is_optional_type(t):
             # Handle optional type. e.g. Optional[int], Optional[dataclass]
             # Marshmallow doesn't support union type, so the type here is always an optional type.
             # https://github.com/marshmallow-code/marshmallow/issues/1191#issuecomment-480831796

--- a/flytekit/core/type_helpers.py
+++ b/flytekit/core/type_helpers.py
@@ -1,7 +1,13 @@
 import importlib
+import sys
 import typing
 
 T = typing.TypeVar("T")
+
+if sys.version_info >= (3, 10):
+    from types import UnionType as UnionTypePep604
+else:
+    UnionTypePep604 = typing.Union
 
 
 def load_type_from_tag(tag: str) -> typing.Type[T]:
@@ -24,6 +30,12 @@ def load_type_from_tag(tag: str) -> typing.Type[T]:
         raise ValueError(f"Could not find the protobuf named: {name} @ {module}.")
 
     return getattr(pb_module, name)
+
+
+def is_pep604_union_type(type_: typing.Any) -> bool:
+    origin = typing.get_origin(type_)
+    args = typing.get_args(type_)
+    return origin is UnionTypePep604 and len(args) > 1
 
 
 def convert_pep604_union_type(type_: typing.Any) -> typing.Any:

--- a/flytekit/core/type_helpers.py
+++ b/flytekit/core/type_helpers.py
@@ -24,3 +24,8 @@ def load_type_from_tag(tag: str) -> typing.Type[T]:
         raise ValueError(f"Could not find the protobuf named: {name} @ {module}.")
 
     return getattr(pb_module, name)
+
+
+def convert_pep604_union_type(type_: typing.Any) -> typing.Any:
+    """Convert PEP604 UnionType to a typing.Union type."""
+    return typing.Union[type_.__args__]  # type: ignore

--- a/flytekit/core/type_helpers.py
+++ b/flytekit/core/type_helpers.py
@@ -39,6 +39,7 @@ def is_pep604_union_type(type_: typing.Any) -> bool:
     if not is_union_type(origin) or origin is typing.Union:
         # PEP604 is types.UnionType which is different than typing.Union
         # See https://github.com/python/cpython/issues/105499
+        return False
     args = typing.get_args(type_)
     return origin is UnionTypePep604 and len(args) > 1
 

--- a/flytekit/core/type_helpers.py
+++ b/flytekit/core/type_helpers.py
@@ -36,13 +36,10 @@ def load_type_from_tag(tag: str) -> typing.Type[T]:
 
 def is_pep604_union_type(type_: typing.Any) -> bool:
     origin = typing.get_origin(type_)
-    if not is_union_type(origin):
-        return False
-    args = typing.get_args(type_)
-    if origin is typing.Union:
+    if not is_union_type(origin) or origin is typing.Union:
         # PEP604 is types.UnionType which is different than typing.Union
         # See https://github.com/python/cpython/issues/105499
-        return False
+    args = typing.get_args(type_)
     return origin is UnionTypePep604 and len(args) > 1
 
 

--- a/flytekit/core/type_helpers.py
+++ b/flytekit/core/type_helpers.py
@@ -1,7 +1,8 @@
-from typing_inspect import is_union_type
 import importlib
 import sys
 import typing
+
+from typing_inspect import is_union_type
 
 T = typing.TypeVar("T")
 

--- a/flytekit/core/type_helpers.py
+++ b/flytekit/core/type_helpers.py
@@ -1,3 +1,4 @@
+from typing_inspect import is_union_type
 import importlib
 import sys
 import typing
@@ -34,10 +35,16 @@ def load_type_from_tag(tag: str) -> typing.Type[T]:
 
 def is_pep604_union_type(type_: typing.Any) -> bool:
     origin = typing.get_origin(type_)
+    if not is_union_type(origin):
+        return False
     args = typing.get_args(type_)
+    if origin is typing.Union:
+        # PEP604 is types.UnionType which is different than typing.Union
+        # See https://github.com/python/cpython/issues/105499
+        return False
     return origin is UnionTypePep604 and len(args) > 1
 
 
 def convert_pep604_union_type(type_: typing.Any) -> typing.Any:
     """Convert PEP604 UnionType to a typing.Union type."""
-    return typing.Union[type_.__args__]  # type: ignore
+    return typing.Union[typing.get_args(type_)]  # type: ignore

--- a/flytekit/core/type_helpers.py
+++ b/flytekit/core/type_helpers.py
@@ -6,7 +6,7 @@ T = typing.TypeVar("T")
 
 if sys.version_info >= (3, 10):
     from types import UnionType as UnionTypePep604
-else:
+else:  # pragma: no cover
     UnionTypePep604 = typing.Union
 
 

--- a/flytekit/core/type_helpers.py
+++ b/flytekit/core/type_helpers.py
@@ -1,15 +1,7 @@
 import importlib
-import sys
 import typing
 
-from typing_inspect import is_union_type
-
 T = typing.TypeVar("T")
-
-if sys.version_info >= (3, 10):
-    from types import UnionType as UnionTypePep604
-else:  # pragma: no cover
-    UnionTypePep604 = typing.Union
 
 
 def load_type_from_tag(tag: str) -> typing.Type[T]:
@@ -32,18 +24,3 @@ def load_type_from_tag(tag: str) -> typing.Type[T]:
         raise ValueError(f"Could not find the protobuf named: {name} @ {module}.")
 
     return getattr(pb_module, name)
-
-
-def is_pep604_union_type(type_: typing.Any) -> bool:
-    origin = typing.get_origin(type_)
-    if not is_union_type(origin) or origin is typing.Union:
-        # PEP604 is types.UnionType which is different than typing.Union
-        # See https://github.com/python/cpython/issues/105499
-        return False
-    args = typing.get_args(type_)
-    return origin is UnionTypePep604 and len(args) > 1
-
-
-def convert_pep604_union_type(type_: typing.Any) -> typing.Any:
-    """Convert PEP604 UnionType to a typing.Union type."""
-    return typing.Union[typing.get_args(type_)]  # type: ignore

--- a/plugins/flytekit-pydantic/flytekitplugins/pydantic/commons.py
+++ b/plugins/flytekit-pydantic/flytekitplugins/pydantic/commons.py
@@ -1,5 +1,6 @@
 import builtins
 import datetime
+import types
 import typing
 from typing import Set
 
@@ -11,7 +12,9 @@ from flytekit.core import type_engine
 numpy = lazy_module("numpy")
 pyarrow = lazy_module("pyarrow")
 
-MODULES_TO_EXCLUDE_FROM_FLYTE_TYPES: Set[str] = {m.__name__ for m in [builtins, typing, datetime, pyarrow, numpy]}
+MODULES_TO_EXCLUDE_FROM_FLYTE_TYPES: Set[str] = {
+    m.__name__ for m in [builtins, types, typing, datetime, pyarrow, numpy]
+}
 
 
 def include_in_flyte_types(t: type) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "s3fs>=2023.3.0,!=2024.3.1",
     "statsd>=3.0.0,<4.0.0",
     "typing_extensions",
+    "typing-inspect",
     "urllib3>=1.22,<2.0.0",
 ]
 classifiers = [

--- a/tests/flytekit/unit/core/test_interface.py
+++ b/tests/flytekit/unit/core/test_interface.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import typing
 from typing import Dict, List
 
@@ -155,7 +156,7 @@ def test_file_types():
     return_type = extract_return_annotation(typing.get_type_hints(t1).get("return", None))
     assert return_type["o0"].extension() == FlyteFile[typing.TypeVar("svg")].extension()
 
-
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP604 requires >=3.10.")
 def test_parameters_and_defaults():
     ctx = context_manager.FlyteContext.current_context()
 

--- a/tests/flytekit/unit/core/test_interface.py
+++ b/tests/flytekit/unit/core/test_interface.py
@@ -156,6 +156,7 @@ def test_file_types():
     return_type = extract_return_annotation(typing.get_type_hints(t1).get("return", None))
     assert return_type["o0"].extension() == FlyteFile[typing.TypeVar("svg")].extension()
 
+
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP604 requires >=3.10.")
 def test_parameters_and_defaults():
     ctx = context_manager.FlyteContext.current_context()

--- a/tests/flytekit/unit/core/test_interface.py
+++ b/tests/flytekit/unit/core/test_interface.py
@@ -213,6 +213,18 @@ def test_parameters_and_defaults():
     assert not params.parameters["c"].required
     assert params.parameters["c"].default.scalar.none_type == Void()
 
+    def z(a: int | None = None, b: str | None = None, c: typing.List[int] | None = None) -> typing.Tuple[int, str]:
+        ...
+
+    our_interface = transform_function_to_interface(z)
+    params = transform_inputs_to_parameters(ctx, our_interface)
+    assert not params.parameters["a"].required
+    assert params.parameters["a"].default.scalar.none_type == Void()
+    assert not params.parameters["b"].required
+    assert params.parameters["b"].default.scalar.none_type == Void()
+    assert not params.parameters["c"].required
+    assert params.parameters["c"].default.scalar.none_type == Void()
+
 
 def test_parameters_with_docstring():
     ctx = context_manager.FlyteContext.current_context()

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -2579,9 +2579,9 @@ def test_union_file_directory():
 @pytest.mark.parametrize(
     "t,expected",
     [
-        (int | str, True),
-        (int | float | str, True),
-        (int | None, True),
+        (int | str, True),  # type: ignore
+        (int | float | str, True),  # type: ignore
+        (int | None, True),  # type: ignore
         (typing.Union[int, str], False),
         (typing.Union[int, None], False),
     ],

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1803,6 +1803,9 @@ def test_union_of_lists():
 def test_list_of_unions():
     pt = typing.List[typing.Union[str, int]]
     lt = TypeEngine.to_literal_type(pt)
+    pt_604 = typing.List[str | int]
+    lt_604 = TypeEngine.to_literal_type(pt_604)
+    assert lt == lt_604
     # todo(maximsmol): seems like the order here is non-deterministic
     assert lt.collection_type.union_type.variants == [
         LiteralType(simple=SimpleType.STRING, structure=TypeStructure(tag="str")),
@@ -1813,8 +1816,10 @@ def test_list_of_unions():
     ctx = FlyteContextManager.current_context()
     lv = TypeEngine.to_literal(ctx, ["hello", 123, "world"], pt, lt)
     v = TypeEngine.to_python_value(ctx, lv, pt)
+    lv_604 = TypeEngine.to_literal(ctx, ["hello", 123, "world"], pt_604, lt_604)
+    v_604 = TypeEngine.to_python_value(ctx, lv_604, pt_604)
     assert [x.scalar.union.stored_type.structure.tag for x in lv.collection.literals] == ["str", "int", "str"]
-    assert v == ["hello", 123, "world"]
+    assert v == v_604 == ["hello", 123, "world"]
 
 
 def test_pickle_type():

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1371,6 +1371,9 @@ def union_type_tags_unique(t: LiteralType):
 def test_union_type():
     pt = typing.Union[str, int]
     lt = TypeEngine.to_literal_type(pt)
+    pt_605 = str | int
+    lt_605 = TypeEngine.to_literal_type(pt_605)
+    assert lt == lt_605
     assert lt.union_type.variants == [
         LiteralType(simple=SimpleType.STRING, structure=TypeStructure(tag="str")),
         LiteralType(simple=SimpleType.INTEGER, structure=TypeStructure(tag="int")),
@@ -1528,8 +1531,10 @@ def test_assert_dataclassjsonmixin_type():
 
 def test_union_transformer():
     assert UnionTransformer.is_optional_type(typing.Optional[int])
+    assert UnionTransformer.is_optional_type(int | None)
     assert not UnionTransformer.is_optional_type(str)
     assert UnionTransformer.get_sub_type_in_optional(typing.Optional[int]) == int
+    assert UnionTransformer.get_sub_type_in_optional(int | None) == int
 
 
 def test_union_guess_type():
@@ -1600,6 +1605,9 @@ def test_annotated_union_type():
 def test_optional_type():
     pt = typing.Optional[int]
     lt = TypeEngine.to_literal_type(pt)
+    pt_605 = int | None
+    lt_605 = TypeEngine.to_literal_type(pt_605)
+    assert lt == lt_605
     assert lt.union_type.variants == [
         LiteralType(simple=SimpleType.INTEGER, structure=TypeStructure(tag="int")),
         LiteralType(simple=SimpleType.NONE, structure=TypeStructure(tag="none")),

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -2586,11 +2586,11 @@ def test_union_file_directory():
         (typing.Union[int, None], False),
     ],
 )
-def test_is_pep604_union_type(t: typing.Type, expected: bool) -> None:
+def test_is_pep604_union_type(t, expected):
     assert is_pep604_union_type(t) is expected
 
 
-def test_convert_pep604() -> None:
+def test_convert_pep604():
     assert convert_pep604_union_type(str | int) == typing.Union[str, int]
     assert convert_pep604_union_type(int | str) == typing.Union[int, str]
     assert convert_pep604_union_type(int | None) == typing.Optional[int]

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1372,9 +1372,9 @@ def union_type_tags_unique(t: LiteralType):
 def test_union_type():
     pt = typing.Union[str, int]
     lt = TypeEngine.to_literal_type(pt)
-    pt_605 = str | int
-    lt_605 = TypeEngine.to_literal_type(pt_605)
-    assert lt == lt_605
+    pt_604 = str | int
+    lt_604 = TypeEngine.to_literal_type(pt_604)
+    assert lt == lt_604
     assert lt.union_type.variants == [
         LiteralType(simple=SimpleType.STRING, structure=TypeStructure(tag="str")),
         LiteralType(simple=SimpleType.INTEGER, structure=TypeStructure(tag="int")),
@@ -1606,9 +1606,9 @@ def test_annotated_union_type():
 def test_optional_type():
     pt = typing.Optional[int]
     lt = TypeEngine.to_literal_type(pt)
-    pt_605 = int | None
-    lt_605 = TypeEngine.to_literal_type(pt_605)
-    assert lt == lt_605
+    pt_604 = int | None
+    lt_604 = TypeEngine.to_literal_type(pt_604)
+    assert lt == lt_604
     assert lt.union_type.variants == [
         LiteralType(simple=SimpleType.INTEGER, structure=TypeStructure(tag="int")),
         LiteralType(simple=SimpleType.NONE, structure=TypeStructure(tag="none")),

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1368,7 +1368,7 @@ def union_type_tags_unique(t: LiteralType):
     return True
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10))
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP604 requires >=3.10.")
 def test_union_type():
     pt = typing.Union[str, int]
     lt = TypeEngine.to_literal_type(pt)
@@ -1530,7 +1530,7 @@ def test_assert_dataclassjsonmixin_type():
         DataclassTransformer().assert_type(gt, pv)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10))
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP604 requires >=3.10.")
 def test_union_transformer():
     assert UnionTransformer.is_optional_type(typing.Optional[int])
     assert UnionTransformer.is_optional_type(int | None)
@@ -1604,7 +1604,7 @@ def test_annotated_union_type():
     assert v == "hello"
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10))
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP604 requires >=3.10.")
 def test_optional_type():
     pt = typing.Optional[int]
     lt = TypeEngine.to_literal_type(pt)
@@ -1802,7 +1802,7 @@ def test_union_of_lists():
     assert v == [1, 3]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10))
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP604 requires >=3.10.")
 def test_list_of_unions():
     pt = typing.List[typing.Union[str, int]]
     lt = TypeEngine.to_literal_type(pt)

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -49,7 +49,6 @@ from flytekit.core.type_engine import (
     get_underlying_type,
     is_annotated,
 )
-from flytekit.core.type_helpers import convert_pep604_union_type, is_pep604_union_type
 from flytekit.exceptions import user as user_exceptions
 from flytekit.models import types as model_types
 from flytekit.models.annotation import TypeAnnotation
@@ -2574,23 +2573,3 @@ def test_union_file_directory():
 
     pv = union_trans.to_python_value(ctx, lv, typing.Union[FlyteFile, FlyteDirectory])
     assert pv._remote_source == s3_dir
-
-
-@pytest.mark.parametrize(
-    "t,expected",
-    [
-        (int | str, True),  # type: ignore
-        (int | float | str, True),  # type: ignore
-        (int | None, True),  # type: ignore
-        (typing.Union[int, str], False),
-        (typing.Union[int, None], False),
-    ],
-)
-def test_is_pep604_union_type(t, expected):
-    assert is_pep604_union_type(t) is expected
-
-
-def test_convert_pep604():
-    assert convert_pep604_union_type(str | int) == typing.Union[str, int]
-    assert convert_pep604_union_type(int | str) == typing.Union[int, str]
-    assert convert_pep604_union_type(int | None) == typing.Optional[int]

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1368,6 +1368,7 @@ def union_type_tags_unique(t: LiteralType):
     return True
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10))
 def test_union_type():
     pt = typing.Union[str, int]
     lt = TypeEngine.to_literal_type(pt)
@@ -1529,6 +1530,7 @@ def test_assert_dataclassjsonmixin_type():
         DataclassTransformer().assert_type(gt, pv)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10))
 def test_union_transformer():
     assert UnionTransformer.is_optional_type(typing.Optional[int])
     assert UnionTransformer.is_optional_type(int | None)
@@ -1602,6 +1604,7 @@ def test_annotated_union_type():
     assert v == "hello"
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10))
 def test_optional_type():
     pt = typing.Optional[int]
     lt = TypeEngine.to_literal_type(pt)
@@ -1799,6 +1802,7 @@ def test_union_of_lists():
     assert v == [1, 3]
 
 
+@pytest.mark.skipif(sys.version_info < (3, 10))
 def test_list_of_unions():
     pt = typing.List[typing.Union[str, int]]
     lt = TypeEngine.to_literal_type(pt)


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/4706
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?
Python 3.10 introduced the ability to write union types using | rather than importing from typing (e.g., int | str instead of typing.Union[int, str]), and I believe this should be supported. See [PEP 604](https://peps.python.org/pep-0604/).

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Added unit tests and registered a large code base with the updated Flytekit and tested a workflow on remote. Ran a small test locally on Python 3.8 too to ensure correct error is bubbled up:
```console
│ ❱  5 def process(a: int | None) -> int:                                                                                                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
