### PR TITLE
Core/fix register remote

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -51,7 +51,7 @@ RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLYTEKIT=$PSEUDO_VERSION \
     && :
 
 
-ENV PYTHONPATH="/flytekit:/flytekit/plugins/flytekit-k8s-pod:/flytekit/plugins/flytekit-deck-standard:"
+ENV PYTHONPATH="/flytekit:/flytekit/tests/flytekit/integration/remote:/flytekit/plugins/flytekit-k8s-pod:/flytekit/plugins/flytekit-deck-standard:"
 
 # Switch to the 'flytekit' user for better security.
 USER flytekit

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -50,6 +50,7 @@ RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLYTEKIT=$PSEUDO_VERSION \
     && :
 
 
-ENV PYTHONPATH="/flytekit:/flytekit/tests/flytekit/integration/remote:/flytekit/plugins/flytekit-k8s-pod:/flytekit/plugins/flytekit-deck-standard:"
+ENV PYTHONPATH="/flytekit:/flytekit/tests/flytekit/integration/remote"
+
 # Switch to the 'flytekit' user for better security.
 USER flytekit

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -33,16 +33,14 @@ class InstanceTrackingMeta(type):
 
     @staticmethod
     def _get_module_from_main(globals) -> Optional[str]:
-        curdir = Path.cwd()
         file = globals.get("__file__")
         if file is None:
             return None
 
         file = Path(file)
         try:
-            root_dir = os.path.commonpath([file.resolve(), curdir.resolve()])
+            root_dir = os.path.commonpath([file.resolve(), Path.cwd()])
             file_relative = Path(os.path.relpath(file.resolve(), root_dir))
-            curdir = Path(root_dir)
         except ValueError:
             return None
 
@@ -51,8 +49,8 @@ class InstanceTrackingMeta(type):
         if len(module_components) == 0:
             return None
 
-        # make sure current directory is in the PYTHONPATH.
-        sys.path.insert(0, str(curdir))
+        # make sure /root directory is in the PYTHONPATH.
+        sys.path.insert(0, root_dir)
         try:
             return import_module_from_file(module_name, file)
         except ModuleNotFoundError:

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -40,8 +40,6 @@ class InstanceTrackingMeta(type):
 
         file = Path(file)
         try:
-            # import pdb
-            # pdb.set_trace()
             _root_dir = os.path.commonpath([file.resolve(), curdir.resolve()])
             file_relative = Path(os.path.relpath(file.resolve(), _root_dir))
             curdir = Path(_root_dir)

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -40,9 +40,9 @@ class InstanceTrackingMeta(type):
 
         file = Path(file)
         try:
-            _root_dir = os.path.commonpath([file.resolve(), curdir.resolve()])
-            file_relative = Path(os.path.relpath(file.resolve(), _root_dir))
-            curdir = Path(_root_dir)
+            root_dir = os.path.commonpath([file.resolve(), curdir.resolve()])
+            file_relative = Path(os.path.relpath(file.resolve(), root_dir))
+            curdir = Path(root_dir)
         except ValueError:
             return None
 
@@ -330,6 +330,7 @@ def extract_task_module(f: Union[Callable, TrackedInstance]) -> Tuple[str, str, 
             f = f.task_function
         # If the module is __main__, we need to find the actual module name based on the file path
         inspect_file = inspect.getfile(f)  # type: ignore
+        # get module name for instances in the same file as the __main__ module
         mod_name, _ = InstanceTrackingMeta._find_instance_module()
         return f"{mod_name}.{name}", mod_name, name, os.path.abspath(inspect_file)
 

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -40,7 +40,7 @@ class InstanceTrackingMeta(type):
 
         file = Path(file)
         try:
-            file_relative = file.relative_to(curdir)
+            file_relative = file.resolve().relative_to(curdir)
         except ValueError:
             return None
 
@@ -328,9 +328,8 @@ def extract_task_module(f: Union[Callable, TrackedInstance]) -> Tuple[str, str, 
             f = f.task_function
         # If the module is __main__, we need to find the actual module name based on the file path
         inspect_file = inspect.getfile(f)  # type: ignore
-        file_name, _ = os.path.splitext(os.path.basename(inspect_file))
-        mod_name = get_full_module_path(f, file_name)  # type: ignore
-        return name, mod_name, name, os.path.abspath(inspect_file)
+        mod_name, _ = InstanceTrackingMeta._find_instance_module()
+        return f"{mod_name}.{name}", mod_name, name, os.path.abspath(inspect_file)
 
     mod_name = get_full_module_path(mod, mod_name)
     return f"{mod_name}.{name}", mod_name, name, os.path.abspath(inspect.getfile(mod))

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -884,7 +884,7 @@ class FlyteRemote(object):
         module_file = str(entity._module_file.with_suffix(""))
         if not module_file.endswith(module_path):
             raise ValueError(f"Module file path should end with entity.__module__, got {module_file} and {module_path}")
-        source_path = module_file[: -len(module_path)]
+        source_path = str(pathlib.Path(module_file[: -len(module_path)]))
 
         return self.register_script(
             entity,

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -892,44 +892,6 @@ class FlyteRemote(object):
         fwf._python_interface = entity.python_interface
         return fwf
 
-    def register_workflow_script_mode(
-        self,
-        entity: PythonFunctionWorkflow,
-        image_config: typing.Optional[ImageConfig] = None,
-        project: typing.Optional[str] = None,
-        domain: typing.Optional[str] = None,
-        version: typing.Optional[str] = None,
-        default_launch_plan: typing.Optional[bool] = True,
-        options: typing.Optional[Options] = None,
-    ) -> FlyteWorkflow:
-        if not isinstance(entity, PythonFunctionWorkflow):
-            raise ValueError(
-                "Only PythonFunctionWorkflow entity is supported for script mode registration"
-                "Please use register_script for other types of workflows"
-            )
-
-        if not isinstance(entity._module_file, pathlib.Path):
-            raise ValueError(f"entity._module_file should be pathlib.Path object, got {type(entity._module_file)}")
-
-        mod_name = ".".join(entity.name.split(".")[:-1])
-        module_path = f"{os.sep}".join(entity.name.split(".")[:-1])
-        module_file = str(entity._module_file.with_suffix(""))
-        if not module_file.endswith(module_path):
-            raise ValueError(f"Module file path should end with entity.__module__, got {module_file} and {module_path}")
-        source_path = str(pathlib.Path(module_file[: -len(module_path)]))
-
-        return self.register_script(
-            entity,
-            image_config=image_config,
-            project=project,
-            domain=domain,
-            version=version,
-            default_launch_plan=default_launch_plan,
-            options=options,
-            source_path=source_path,
-            module_name=mod_name,
-        )
-
     def fast_package(
         self,
         root: os.PathLike,

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -852,7 +852,7 @@ class FlyteRemote(object):
                     "Please use register_script for other types of workflows"
                 )
 
-            name, mod, wf_name, source_path = extract_task_module(entity)
+            _, mod_name, _, source_path = extract_task_module(entity)
             project_root = _find_project_root(source_path)
 
             return self.register_script(
@@ -864,7 +864,7 @@ class FlyteRemote(object):
                 default_launch_plan=default_launch_plan,
                 options=options,
                 source_path=project_root,
-                module_name=mod,
+                module_name=mod_name,
             )
 
         if serialization_settings is None:

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -45,7 +45,7 @@ from flytekit.core.reference_entity import ReferenceSpec
 from flytekit.core.task import ReferenceTask
 from flytekit.core.tracker import extract_task_module
 from flytekit.core.type_engine import LiteralsResolver, TypeEngine
-from flytekit.core.workflow import ReferenceWorkflow, WorkflowBase, WorkflowFailurePolicy
+from flytekit.core.workflow import ReferenceWorkflow, WorkflowBase, WorkflowFailurePolicy, PythonFunctionWorkflow
 from flytekit.exceptions import user as user_exceptions
 from flytekit.exceptions.user import (
     FlyteEntityAlreadyExistsException,
@@ -862,18 +862,38 @@ class FlyteRemote(object):
 
     def register_workflow_script_mode(
         self,
-        entity: WorkflowBase,
+        entity: PythonFunctionWorkflow,
+        image_config: typing.Optional[ImageConfig] = None,
+        project: typing.Optional[str] = None,
+        domain: typing.Optional[str] = None,
         version: typing.Optional[str] = None,
         default_launch_plan: typing.Optional[bool] = True,
         options: typing.Optional[Options] = None,
     ) -> FlyteWorkflow:
+        if not isinstance(entity, PythonFunctionWorkflow):
+            raise ValueError(
+                f"Only PythonFunctionWorkflow entity is supported for script mode registration"
+                f"Please use register_script for other types of workflows"           
+            )
+        if not isinstance(entity._module_file, pathlib.Path):
+            raise ValueError(f"Module file path should be a pathlib.Path object, got {type(entity._module_file)}")
+        # import pdb
+        # pdb.set_trace()
         mod_name = ".".join(entity.name.split(".")[:-1])
+        module_path = f"{os.sep}".join(entity.name.split(".")[:-1])
+        module_file = str(entity._module_file.with_suffix(''))
+        if not module_file.endswith(module_path):
+            raise ValueError(f"Module file path should end with the __module__, got {module_file} and {module_path}")
+        source_path = module_file[: -len(module_path)]
         return self.register_script(
             entity,
+            image_config=image_config,
+            project=project,
+            domain=domain,
             version=version,
             default_launch_plan=default_launch_plan,
             options=options,
-            source_path=".",
+            source_path=source_path,
             module_name=mod_name,
         )
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -45,7 +45,7 @@ from flytekit.core.reference_entity import ReferenceSpec
 from flytekit.core.task import ReferenceTask
 from flytekit.core.tracker import extract_task_module
 from flytekit.core.type_engine import LiteralsResolver, TypeEngine
-from flytekit.core.workflow import ReferenceWorkflow, WorkflowBase, WorkflowFailurePolicy, PythonFunctionWorkflow
+from flytekit.core.workflow import PythonFunctionWorkflow, ReferenceWorkflow, WorkflowBase, WorkflowFailurePolicy
 from flytekit.exceptions import user as user_exceptions
 from flytekit.exceptions.user import (
     FlyteEntityAlreadyExistsException,
@@ -872,19 +872,20 @@ class FlyteRemote(object):
     ) -> FlyteWorkflow:
         if not isinstance(entity, PythonFunctionWorkflow):
             raise ValueError(
-                f"Only PythonFunctionWorkflow entity is supported for script mode registration"
-                f"Please use register_script for other types of workflows"           
+                "Only PythonFunctionWorkflow entity is supported for script mode registration"
+                "Please use register_script for other types of workflows"
             )
+
         if not isinstance(entity._module_file, pathlib.Path):
-            raise ValueError(f"Module file path should be a pathlib.Path object, got {type(entity._module_file)}")
-        # import pdb
-        # pdb.set_trace()
+            raise ValueError(f"entity._module_file should be pathlib.Path object, got {type(entity._module_file)}")
+
         mod_name = ".".join(entity.name.split(".")[:-1])
         module_path = f"{os.sep}".join(entity.name.split(".")[:-1])
-        module_file = str(entity._module_file.with_suffix(''))
+        module_file = str(entity._module_file.with_suffix(""))
         if not module_file.endswith(module_path):
-            raise ValueError(f"Module file path should end with the __module__, got {module_file} and {module_path}")
+            raise ValueError(f"Module file path should end with entity.__module__, got {module_file} and {module_path}")
         source_path = module_file[: -len(module_path)]
+
         return self.register_script(
             entity,
             image_config=image_config,

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -860,13 +860,30 @@ class FlyteRemote(object):
         fwf._python_interface = entity.python_interface
         return fwf
 
+    def register_workflow_script_mode(
+        self,
+        entity: WorkflowBase,
+        version: typing.Optional[str] = None,
+        default_launch_plan: typing.Optional[bool] = True,
+        options: typing.Optional[Options] = None,
+    ) -> FlyteWorkflow:
+        mod_name = ".".join(entity.name.split(".")[:-1])
+        return self.register_script(
+            entity,
+            version=version,
+            default_launch_plan=default_launch_plan,
+            options=options,
+            source_path=".",
+            module_name=mod_name,
+        )
+
     def fast_package(
         self,
         root: os.PathLike,
         deref_symlinks: bool = True,
         output: str = None,
         options: typing.Optional[FastPackageOptions] = None,
-    ) -> typing.Tuple[bytes, str]:
+    ) -> typing.Tuple[bytes, str]:        
         """
         Packages the given paths into an installable zip and returns the md5_bytes and the URL of the uploaded location
         :param root: path to the root of the package system that should be uploaded

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -914,7 +914,7 @@ class FlyteRemote(object):
         deref_symlinks: bool = True,
         output: str = None,
         options: typing.Optional[FastPackageOptions] = None,
-    ) -> typing.Tuple[bytes, str]:        
+    ) -> typing.Tuple[bytes, str]:
         """
         Packages the given paths into an installable zip and returns the md5_bytes and the URL of the uploaded location
         :param root: path to the root of the package system that should be uploaded

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -841,7 +841,6 @@ class FlyteRemote(object):
         :param serialization_settings: The serialization settings to be used
         :param default_launch_plan: This should be true if a default launch plan should be created for the workflow
         :param options: Additional execution options that can be configured for the default launchplan
-        :param fast: fast register if true
         :return:
         """
         if serialization_settings is None:
@@ -871,17 +870,13 @@ class FlyteRemote(object):
         options: typing.Optional[Options] = None,
     ) -> FlyteWorkflow:
         """
-        Register a PythonFunctionWorkflow entity with the Flyte backend using the fast registration method.
-        :param entity: The PythonFunctionWorkflow entity to register
-        :param image_config: The image config to use for the registration
-        :param project: The project to register the entity under
-        :param domain: The domain to register the entity under
-        :param version: The version to register the entity under
-        :param default_launch_plan: If True, a default launch plan will be created for the workflow
-        :param options: Additional options to configure the default launch plan
-        :param source_path: The source path of the module containing the workflow
-        :param module_name: The name of the module containing the workflow
-        :return: The registered FlyteWorkflow entity
+        Use this method to register a workflow with zip mode.
+        :param version: version for the entity to be registered as
+        :param entity: The workflow to be registered
+        :param serialization_settings: The serialization settings to be used
+        :param default_launch_plan: This should be true if a default launch plan should be created for the workflow
+        :param options: Additional execution options that can be configured for the default launchplan
+        :return:
         """
         if not isinstance(entity, PythonFunctionWorkflow):
             raise ValueError(
@@ -896,9 +891,7 @@ class FlyteRemote(object):
         module_path = f"{os.sep}".join(entity.name.split(".")[:-1])
         module_file = str(entity._module_file.with_suffix(""))
         if not module_file.endswith(module_path):
-            raise ValueError(
-                f"Module file path should end with entity.__module__, got {module_file} and {module_path}"
-            )
+            raise ValueError(f"Module file path should end with entity.__module__, got {module_file} and {module_path}")
 
         # remove module suffix to get the root
         module_root = str(pathlib.Path(module_file[: -len(module_path)]))

--- a/tests/flytekit/integration/experimental/test_eager_workflows.py
+++ b/tests/flytekit/integration/experimental/test_eager_workflows.py
@@ -36,7 +36,7 @@ from .eager_workflows import eager_wf_local_entrypoint
 MODULE = "eager_workflows"
 MODULE_PATH = Path(__file__).parent / f"{MODULE}.py"
 CONFIG = os.environ.get("FLYTECTL_CONFIG", str(Path.home() / ".flyte" / "config-sandbox.yaml"))
-IMAGE = os.environ.get("FLYTEKIT_IMAGE", "localhost:30000/flytekit:master")
+IMAGE = os.environ.get("FLYTEKIT_IMAGE", "localhost:30000/flytekit:dev")
 
 
 @pytest.fixture(scope="session")

--- a/tests/flytekit/integration/experimental/test_eager_workflows.py
+++ b/tests/flytekit/integration/experimental/test_eager_workflows.py
@@ -36,7 +36,7 @@ from .eager_workflows import eager_wf_local_entrypoint
 MODULE = "eager_workflows"
 MODULE_PATH = Path(__file__).parent / f"{MODULE}.py"
 CONFIG = os.environ.get("FLYTECTL_CONFIG", str(Path.home() / ".flyte" / "config-sandbox.yaml"))
-IMAGE = os.environ.get("FLYTEKIT_IMAGE", "localhost:30000/flytekit:dev")
+IMAGE = os.environ.get("FLYTEKIT_IMAGE", "localhost:30000/flytekit:master")
 
 
 @pytest.fixture(scope="session")

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -585,7 +585,7 @@ def test_register_wf_fast(register):
 
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
     fast_version = f"{VERSION}_fast"
-    registered_wf = remote.register_workflow_script_mode(parent_wf, version=fast_version)
+    registered_wf = remote.register_workflow(parent_wf, version=fast_version, fast=True)
     execution = remote.execute(registered_wf, inputs={"a": 101}, wait=True)
     assert registered_wf.name == "tests.flytekit.integration.remote.workflows.basic.subworkflows.parent_wf"
     assert execution.spec.launch_plan.version == fast_version

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -27,7 +27,7 @@ from flytekit.types.schema import FlyteSchema
 
 MODULE_PATH = pathlib.Path(__file__).parent / "workflows/basic"
 CONFIG = os.environ.get("FLYTECTL_CONFIG", str(pathlib.Path.home() / ".flyte" / "config-sandbox.yaml"))
-IMAGE = os.environ.get("FLYTEKIT_IMAGE", "localhost:30000/flytekit:master")
+IMAGE = os.environ.get("FLYTEKIT_IMAGE", "localhost:30000/flytekit:dev")
 PROJECT = "flytesnacks"
 DOMAIN = "development"
 VERSION = f"v{os.getpid()}"
@@ -582,13 +582,13 @@ class TestLargeFileTransfers:
 
 def test_register_wf_fast(register):
     from .workflows.basic.subworkflows import parent_wf
-    # import pdb
-    # pdb.set_trace()
+
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
-    registered_wf = remote.register_workflow_script_mode(parent_wf, version=f"{VERSION}_fast")
+    fast_version = f"{VERSION}_fast"
+    registered_wf = remote.register_workflow_script_mode(parent_wf, version=fast_version)
     execution = remote.execute(registered_wf, inputs={"a": 101}, wait=True)
     assert registered_wf.name == "tests.flytekit.integration.remote.workflows.basic.subworkflows.parent_wf"
-    assert execution.spec.launch_plan.version == VERSION
+    assert execution.spec.launch_plan.version == fast_version
     # check node execution inputs and outputs
     assert execution.node_executions["n0"].inputs == {"a": 101}
     assert execution.node_executions["n0"].outputs == {"t1_int_output": 103, "c": "world"}

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -27,6 +27,7 @@ from flytekit.types.schema import FlyteSchema
 
 MODULE_PATH = pathlib.Path(__file__).parent / "workflows/basic"
 CONFIG = os.environ.get("FLYTECTL_CONFIG", str(pathlib.Path.home() / ".flyte" / "config-sandbox.yaml"))
+# Run `make build-dev` to build and push the image to the local registry.
 IMAGE = os.environ.get("FLYTEKIT_IMAGE", "localhost:30000/flytekit:dev")
 PROJECT = "flytesnacks"
 DOMAIN = "development"
@@ -207,7 +208,7 @@ def test_fetch_execute_task(register):
 
 def test_execute_python_task(register):
     """Test execution of a @task-decorated python function that is already registered."""
-    from .workflows.basic.basic_workflow import t1
+    from workflows.basic.basic_workflow import t1
 
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
     execution = remote.execute(
@@ -230,7 +231,7 @@ def test_execute_python_task(register):
 
 def test_execute_python_workflow_and_launch_plan(register):
     """Test execution of a @workflow-decorated python function and launchplan that are already registered."""
-    from .workflows.basic.basic_workflow import my_wf
+    from workflows.basic.basic_workflow import my_wf
 
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
     execution = remote.execute(
@@ -278,7 +279,7 @@ def test_fetch_execute_task_convert_dict(register):
 
 def test_execute_python_workflow_dict_of_string_to_string(register):
     """Test execution of a @workflow-decorated python function and launchplan that are already registered."""
-    from .workflows.basic.dict_str_wf import my_wf
+    from workflows.basic.dict_str_wf import my_wf
 
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
     d: typing.Dict[str, str] = {"k1": "v1", "k2": "v2"}
@@ -304,7 +305,7 @@ def test_execute_python_workflow_dict_of_string_to_string(register):
 
 def test_execute_python_workflow_list_of_floats(register):
     """Test execution of a @workflow-decorated python function and launchplan that are already registered."""
-    from .workflows.basic.list_float_wf import my_wf
+    from workflows.basic.list_float_wf import my_wf
 
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
 
@@ -371,7 +372,7 @@ def test_execute_joblib_workflow(register):
 
 
 def test_execute_with_default_launch_plan(register):
-    from .workflows.basic.subworkflows import parent_wf
+    from workflows.basic.subworkflows import parent_wf
 
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
     execution = remote.execute(
@@ -581,13 +582,14 @@ class TestLargeFileTransfers:
 
 
 def test_register_wf_fast(register):
-    from .workflows.basic.subworkflows import parent_wf
+    from workflows.basic.subworkflows import parent_wf
 
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
     fast_version = f"{VERSION}_fast"
-    registered_wf = remote.fast_register_workflow(parent_wf, version=fast_version)
+    serialization_settings = SerializationSettings(image_config=ImageConfig.auto(img_name=IMAGE))
+    registered_wf = remote.fast_register_workflow(parent_wf, serialization_settings, version=fast_version)
     execution = remote.execute(registered_wf, inputs={"a": 101}, wait=True)
-    assert registered_wf.name == "tests.flytekit.integration.remote.workflows.basic.subworkflows.parent_wf"
+    assert registered_wf.name == "workflows.basic.subworkflows.parent_wf"
     assert execution.spec.launch_plan.version == fast_version
     # check node execution inputs and outputs
     assert execution.node_executions["n0"].inputs == {"a": 101}

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -585,7 +585,7 @@ def test_register_wf_fast(register):
 
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
     fast_version = f"{VERSION}_fast"
-    registered_wf = remote.register_workflow(parent_wf, version=fast_version, fast=True)
+    registered_wf = remote.fast_register_workflow(parent_wf, version=fast_version)
     execution = remote.execute(registered_wf, inputs={"a": 101}, wait=True)
     assert registered_wf.name == "tests.flytekit.integration.remote.workflows.basic.subworkflows.parent_wf"
     assert execution.spec.launch_plan.version == fast_version

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -671,9 +671,6 @@ def test_register_wf_script_mode(compress_scripts_mock, upload_file_mock, regist
     upload_file_mock.return_value = md5_bytes, "localhost:30084"
     flyte_remote = FlyteRemote(config=Config.auto(), default_project="p1", default_domain="d1")
     flyte_remote.register_workflow_script_mode(hello_wf, version="v1")
-    """
-    <FlyteLiteral id { project: "flytesnacks" domain: "development" name: "fd02f792c6130428ba1f" } spec { launch_plan { resource_type: LAUNCH_PLAN project: "flytesnacks" domain: "development" name: "entrypoint.wf" version: "HhcYHgbRbQax1d0gUJu__w" } metadata { system_metadata { } } notifications { } labels { } annotations { } auth_role { } } closure { started_at { } duration { } created_at { seconds: 1711555313 nanos: 502192000 } updated_at { seconds: 1711555313
-    """
     serialization_settings = flytekit.configuration.SerializationSettings(
         env=None,
         image_config=ImageConfig.auto(img_name=DefaultImages.default_image()),

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -659,7 +659,7 @@ def test_get_git_report_url_unknown_url(tmp_path):
 
 
 @mock.patch("pathlib.Path.read_bytes")
-@mock.patch("flytekit.remote.remote.FlyteRemote.register_workflow")
+@mock.patch("flytekit.remote.remote.FlyteRemote.register_script")
 @mock.patch("flytekit.remote.remote.FlyteRemote.upload_file")
 @mock.patch("flytekit.remote.remote.compress_scripts")
 def test_register_wf_script_mode(compress_scripts_mock, upload_file_mock, register_workflow_mock, read_bytes_mock):
@@ -670,16 +670,15 @@ def test_register_wf_script_mode(compress_scripts_mock, upload_file_mock, regist
     compress_scripts_mock.return_value = "compressed"
     upload_file_mock.return_value = md5_bytes, "localhost:30084"
     flyte_remote = FlyteRemote(config=Config.auto())
-    flyte_remote.register_workflow_script_mode(hello_wf, version="v1")
-    serialization_settings = flytekit.configuration.SerializationSettings(
-        env=None,
-        image_config=ImageConfig.auto(img_name=DefaultImages.default_image()),
-        git_repo="",
-        fast_serialization_settings=flytekit.configuration.FastSerializationSettings(
-            enabled=True,
-            destination_dir=".",
-            distribution_location="localhost:30084",
-        ),
-        source_root=str(pathlib.Path(flytekit.__file__).parent.parent),
+    flyte_remote.register_workflow(hello_wf, version="v1", fast=True)
+    register_workflow_mock.assert_called_with(
+        hello_wf,
+        image_config=None,
+        project=None,
+        domain=None,
+        version="v1",
+        default_launch_plan=True,
+        options=None,
+        source_path=str(pathlib.Path(flytekit.__file__).parent.parent),
+        module_name="tests.flytekit.unit.remote.resources",
     )
-    register_workflow_mock.assert_called_with(hello_wf, serialization_settings, "v1", True, None)

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -670,7 +670,7 @@ def test_register_wf_script_mode(compress_scripts_mock, upload_file_mock, regist
     compress_scripts_mock.return_value = "compressed"
     upload_file_mock.return_value = md5_bytes, "localhost:30084"
     flyte_remote = FlyteRemote(config=Config.auto())
-    flyte_remote.register_workflow(hello_wf, version="v1", fast=True)
+    flyte_remote.fast_register_workflow(hello_wf, version="v1")
     register_workflow_mock.assert_called_with(
         hello_wf,
         image_config=None,

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -657,45 +657,31 @@ def test_get_git_report_url_unknown_url(tmp_path):
     returned_url = _get_git_repo_url(source_path)
     assert returned_url == ""
 
+
 @mock.patch("pathlib.Path.read_bytes")
 @mock.patch("flytekit.remote.remote.FlyteRemote.register_workflow")
 @mock.patch("flytekit.remote.remote.FlyteRemote.upload_file")
 @mock.patch("flytekit.remote.remote.compress_scripts")
 def test_register_wf_script_mode(compress_scripts_mock, upload_file_mock, register_workflow_mock, read_bytes_mock):
+    from .resources import hello_wf
+
     md5_bytes = bytes([1, 2, 3])
     read_bytes_mock.return_value = bytes([4, 5, 6])
     compress_scripts_mock.return_value = "compressed"
     upload_file_mock.return_value = md5_bytes, "localhost:30084"
-
-
-    @task
-    def say_hello(name: str) -> str:
-        return f"hello {name}!"
-
-    @workflow
-    def sub_wf(name: str = "union"):
-        say_hello(name=name)
-
-
-    import pdb
-    pdb.set_trace()
-    @workflow
-    def wf(name: str = "union"):
-        sub_wf(name=name)
-
-    
     flyte_remote = FlyteRemote(config=Config.auto(), default_project="p1", default_domain="d1")
-    flyte_remote.register_workflow_script_mode(wf, version="v1")
+    flyte_remote.register_workflow_script_mode(hello_wf, version="v1")
     """
     <FlyteLiteral id { project: "flytesnacks" domain: "development" name: "fd02f792c6130428ba1f" } spec { launch_plan { resource_type: LAUNCH_PLAN project: "flytesnacks" domain: "development" name: "entrypoint.wf" version: "HhcYHgbRbQax1d0gUJu__w" } metadata { system_metadata { } } notifications { } labels { } annotations { } auth_role { } } closure { started_at { } duration { } created_at { seconds: 1711555313 nanos: 502192000 } updated_at { seconds: 1711555313
     """
     serialization_settings = flytekit.configuration.SerializationSettings(
         env=None,
         image_config=ImageConfig.auto(img_name=DefaultImages.default_image()),
-        git_repo="",        fast_serialization_settings=flytekit.configuration.FastSerializationSettings(
+        git_repo="",
+        fast_serialization_settings=flytekit.configuration.FastSerializationSettings(
             enabled=True,
             destination_dir=".",
             distribution_location="localhost:30084",
         ),
     )
-    register_workflow_mock.assert_called_with(wf, serialization_settings, "v1", True, None)
+    register_workflow_mock.assert_called_with(hello_wf, serialization_settings, "v1", True, None)

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -669,7 +669,7 @@ def test_register_wf_script_mode(compress_scripts_mock, upload_file_mock, regist
     read_bytes_mock.return_value = bytes([4, 5, 6])
     compress_scripts_mock.return_value = "compressed"
     upload_file_mock.return_value = md5_bytes, "localhost:30084"
-    flyte_remote = FlyteRemote(config=Config.auto(), default_project="p1", default_domain="d1")
+    flyte_remote = FlyteRemote(config=Config.auto())
     flyte_remote.register_workflow_script_mode(hello_wf, version="v1")
     serialization_settings = flytekit.configuration.SerializationSettings(
         env=None,
@@ -680,5 +680,6 @@ def test_register_wf_script_mode(compress_scripts_mock, upload_file_mock, regist
             destination_dir=".",
             distribution_location="localhost:30084",
         ),
+        source_root=str(pathlib.Path(flytekit.__file__).parent.parent),
     )
     register_workflow_mock.assert_called_with(hello_wf, serialization_settings, "v1", True, None)


### PR DESCRIPTION
## Tracking issue
_https://github.com/flyteorg/flyte/issues/4936_

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->



## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

According to https://github.com/flyteorg/flyte/issues/4936, some users encountered difficulties when trying to call `register_workflow`. While `register_scripts` can serve as an alternative, setting up the `source_path` and `module_name` can be pretty annoying. This change also enables execution with a relative path. For example:

file structure
![image](https://github.com/flyteorg/flytekit/assets/58504997/2c71734f-990a-460e-ad8e-c0ad485f1513)
`test_register.py`
```python=
import typing
from flytekit import task, workflow
from flytekit.tools.script_mode import _find_project_root
from flytekit import ImageSpec, Resources, task, workflow
import os
import inspect
import pathlib
import pdb

@task
def say_hello(name: str) -> str:
    return f"hello {name}!"


@task
def greeting_length(greeting: str) -> int:
    return len(greeting)


@workflow
def wf(name: str = "union") -> typing.Tuple[str, int]:
    greeting = say_hello(name=name)
    greeting_len = greeting_length(greeting=greeting)
    return greeting, greeting_len



if __name__ == "__main__":
    from flytekit.remote import FlyteRemote
    from flytekit.configuration import Config, SerializationSettings, ImageConfig

    remote = FlyteRemote(
        config=Config.for_sandbox(),
        default_project="flytesnacks",
        default_domain="development"
    )


    print(wf)
    remote_wf = remote.register_workflow_script_mode(
        entity=wf,
    )

    wf_exe = remote.execute(entity=remote_wf, inputs={"name": "mike"})
    print(wf_exe.id)
```
<!--

```bash=
> tree issue_register 
issue_register
├── func_dir
│   └── test_register_in_func.py
└── test_register.py
```


`test_register.py`
```python=
import typing
from flytekit import task, workflow
from flytekit.tools.script_mode import _find_project_root
from flytekit import ImageSpec, Resources, task, workflow
import os
import inspect
import pathlib
import pdb

@task
def say_hello(name: str) -> str:
    return f"hello {name}!"


@task
def greeting_length(greeting: str) -> int:
    return len(greeting)


@workflow
def wf(name: str = "union") -> typing.Tuple[str, int]:
    greeting = say_hello(name=name)
    greeting_len = greeting_length(greeting=greeting)
    return greeting, greeting_len



if __name__ == "__main__":
    from flytekit.remote import FlyteRemote
    from flytekit.configuration import Config, SerializationSettings, ImageConfig

    remote = FlyteRemote(
        config=Config.for_sandbox(),
        default_project="flytesnacks",
        default_domain="development"
    )


    print(wf)
    remote_wf = remote.register_workflow_script_mode(
        entity=wf,
        version="m0.0.5",
    )
    


    remote.execute(entity=remote_wf, inputs={"name": "mike"})
```
-->
You can run `python test_register.py` or `python ../test_register.py` under `func_dir` without worrying about the `source_path`. 


## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

Added an function `register_workflow_script_mode`, which basically leverages `register_scripts`, but automatically handles the `source_path` and `module_name` params. Also resolved the problem of calling `register_script` in the `__main__` block when the registered workflow is in the same file as the `__main__` block. 

## How was this patch tested?
1. unit test
2. remote integration test
3. local testing


**Since we didn't export `FLYTE_PYTHON_PACKAGE_ROOT` and an `__init__.py` resides under our module `register_test`, it raises an error**
![image](https://github.com/flyteorg/flytekit/assets/58504997/b2a70f81-341b-42a6-9e34-4f333cf33bab)
**After export works fine**
![image](https://github.com/flyteorg/flytekit/assets/58504997/db37b46d-0855-4278-ab04-83c1204ab0f5)
**here an `__init__.py` also resides under `issue_register`, without export would raise an error**
![image](https://github.com/flyteorg/flytekit/assets/58504997/034d4e68-85b2-4375-bad3-e71f4ee36930)
**execute with relative path, again, an `__init__.py` resides under `issue_register`, without export would raise an error**
![image](https://github.com/flyteorg/flytekit/assets/58504997/6363e16e-e247-4436-bd0d-105082180df5)

#### Conclusion: 
when current working dir is inside the module and you want to execute `register_workflow_script_mode`, please run `export FLYTE_PYTHON_PACKAGE_ROOT="."`. While executing in the parent dir of the module works fine. 

#### Test Importing workflows
##### Results of `python entrypoint.py`
**__init__.py** under `register_test`, need export
<img width="428" alt="image" src="https://github.com/flyteorg/flytekit/assets/58504997/dcd556da-dfd6-4b0c-bd8e-54539dd5fac8">

<img width="1115" alt="image" src="https://github.com/flyteorg/flytekit/assets/58504997/9926c7f8-d151-4e2a-88cc-89c88171b695">

`entrypoint.py`

```python=
from issue_register.test_register import wf as sub_wf
from flytekit import workflow
import pdb
import os


@workflow
def wf(name: str = "union") -> str:
    return sub_wf(name=name)[0]

if __name__ == "__main__":
    from flytekit.remote import FlyteRemote
    from flytekit.configuration import Config, SerializationSettings, ImageConfig, FastSerializationSettings
    import pathlib
    CONFIG = os.environ.get("FLYTECTL_CONFIG", str(pathlib.Path.home() / ".flyte" / "config-sandbox.yaml"))

    remote = FlyteRemote(
        config=Config.auto(config_file=CONFIG),
        default_project="flytesnacks",
        default_domain="development"
    )


    remote_sub_wf = remote.register_workflow_script_mode(
        entity=sub_wf,
    )
    remote_wf = remote.register_workflow_script_mode(
        entity=wf,
    )
    from issue_register.func_dir.test_register_in_func import register_wf
    func_remote_wf = register_wf(remote)
    remote.execute(entity=func_remote_wf, inputs={"name": "mike666"}, wait=True)

    subwf_exe = remote.execute(entity=remote_sub_wf, inputs={"name": "mike666"}, wait=True)
    wf_exe = remote.execute(entity=remote_wf, inputs={"name": "mike"}, wait=True)
    # pdb.set_trace()
    print("Func Remote", func_remote_wf.id)
    print("Remote SubWF", subwf_exe.id)
    print("Remote WF", wf_exe.id)
``` 

`test_register_in_func.py`

```python=
from issue_register.test_register import wf


def register_wf(remote):
    from flytekit.remote import FlyteRemote
    from flytekit.configuration import Config, SerializationSettings, ImageConfig, FastSerializationSettings
    import pathlib
    import os


    remote_wf = remote.register_workflow_script_mode(
        entity=wf,
        version="f0.0.1",
    )


    return remote_wf

```

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots
#### test_register.py
<img width="1594" alt="image" src="https://github.com/flyteorg/flytekit/assets/58504997/ab8e1733-4c92-4550-96e2-3ffeccecb79d">

#### entrypoint.py
<img width="1579" alt="image" src="https://github.com/flyteorg/flytekit/assets/58504997/67e4a56f-1307-4e98-98a5-b7d89ef17ea0">



## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
