### PR TITLE
Remove post-execute hook from ray task

### DIFF
--- a/plugins/flytekit-ray/flytekitplugins/ray/task.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/task.py
@@ -56,10 +56,6 @@ class RayFunctionTask(PythonFunctionTask):
         ray.init(address=self._task_config.address)
         return user_params
 
-    def post_execute(self, user_params: ExecutionParameters, rval: Any) -> Any:
-        ray.shutdown()
-        return rval
-
     def get_custom(self, settings: SerializationSettings) -> Optional[Dict[str, Any]]:
         cfg = self._task_config
 


### PR DESCRIPTION
Issue: https://github.com/ray-project/kuberay/issues/1975
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
`ray.shutdown()` will always be automatically called (registered through `atexit` [here](https://github.com/ray-project/ray/blob/f79a9a720807ae7d50fd99d8b801627bbaba7cf9/python/ray/_private/worker.py#L1853) at ray import time). We should rather rely on the one registered with `atexit` hook instead of explicitly calling it again especially as we don't set `_exiting_interpreter=True` which may result in disconnecting too soon before worker logs are flushed to driver.

## What changes were proposed in this pull request?
remove the `post_execute` of ray task
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
test with a simple example:
```python
import typing

from flytekit import ImageSpec, Resources, task, workflow

commit_hash = "03fd5605996e53e848ba77e48608e3395189319a"
ray_plugin = f"git+https://github.com/yundai424/flytekit.git@{commit_hash}#subdirectory=plugins/flytekit-ray"

custom_image = ImageSpec(
    name="ray-flyte-plugin",
    registry="localhost:30000",
    packages=[ray_plugin],
    apt_packages=['git', 'wget', 'vim'],
)

# if custom_image.is_container():
import ray
from flytekitplugins.ray import HeadNodeConfig, RayJobConfig, WorkerNodeConfig

@ray.remote
def f(x):
    print(f"ray task get {x}")
    return x * x

@task(
    task_config=RayJobConfig(
        head_node_config=HeadNodeConfig(ray_start_params={"log-color": "True", "block": "true"}),
        worker_node_config=[WorkerNodeConfig(group_name="ray-group", replicas=1)],
        runtime_env={"pip": []},
    ),
    requests=Resources(mem="4Gi", cpu="1"),
    container_image=custom_image,
)
def ray_task(n: int) -> typing.List[int]:
    futures = [f.remote(i) for i in range(n)]
    l = ray.get(futures)
    print(l, 2)
    return l

@workflow
def ray_workflow(n: int) -> typing.List[int]:
    return ray_task(n=n)

```
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
