### PR TITLE
Log Agents In The Agent Server

### DIFF
--- a/flytekit/clis/sdk_in_container/serve.py
+++ b/flytekit/clis/sdk_in_container/serve.py
@@ -57,6 +57,8 @@ async def _start_grpc_server(port: int, worker: int, timeout: int):
 
     _start_http_server()
     click.secho("Starting the agent service...", fg="blue")
+    print_agents_metadata()
+
     server = grpc.aio.server(futures.ThreadPoolExecutor(max_workers=worker))
 
     add_AsyncAgentServiceServicer_to_server(AsyncAgentService(), server)
@@ -96,3 +98,17 @@ def _start_health_check_server(server: grpc.Server, worker: int):
 
     except ImportError as e:
         click.secho(f"Failed to start the health check servicer with error {e}", fg="red")
+
+
+def print_agents_metadata():
+    from flytekit.extend.backend.base_agent import AgentRegistry
+
+    agents = AgentRegistry.list_agents()
+    for agent in agents:
+        name = agent.name
+        task_type = "sync" if agent.is_sync else "async"
+        for task_category in agent.supported_task_categories:
+            click.secho(
+                f"Starting {name} supports {task_type} task {task_category.name} with version {task_category.version}",
+                fg="blue",
+            )

--- a/flytekit/clis/sdk_in_container/serve.py
+++ b/flytekit/clis/sdk_in_container/serve.py
@@ -106,9 +106,4 @@ def print_agents_metadata():
     agents = AgentRegistry.list_agents()
     for agent in agents:
         name = agent.name
-        task_type = "sync" if agent.is_sync else "async"
-        for task_category in agent.supported_task_categories:
-            click.secho(
-                f"Starting {name} supports {task_type} task {task_category.name} with version {task_category.version}",
-                fg="blue",
-            )
+        click.secho(f"Starting {name}...", fg="blue")

--- a/flytekit/clis/sdk_in_container/serve.py
+++ b/flytekit/clis/sdk_in_container/serve.py
@@ -106,4 +106,5 @@ def print_agents_metadata():
     agents = AgentRegistry.list_agents()
     for agent in agents:
         name = agent.name
-        click.secho(f"Starting {name}...", fg="blue")
+        metadata = [category.name for category in agent.supported_task_categories]
+        click.secho(f"Starting {name} that supports task categories {metadata}", fg="blue")

--- a/plugins/flytekit-snowflake/flytekitplugins/snowflake/agent.py
+++ b/plugins/flytekit-snowflake/flytekitplugins/snowflake/agent.py
@@ -59,6 +59,8 @@ def get_connection(metadata: SnowflakeJobMetadata) -> snowflake_connector:
 
 
 class SnowflakeAgent(AsyncAgentBase):
+    name = "Snowflake Agent"
+
     def __init__(self):
         super().__init__(task_type_name=TASK_TYPE, metadata_type=SnowflakeJobMetadata)
 

--- a/tests/flytekit/unit/extend/test_agent.py
+++ b/tests/flytekit/unit/extend/test_agent.py
@@ -405,8 +405,8 @@ def test_print_agents_metadata_output(list_agents_mock, mock_secho, sample_agent
     list_agents_mock.return_value = sample_agents
     print_agents_metadata()
     expected_calls = [
-        (("Starting Sensor...",), {"fg": "blue"}),
-        (("Starting ChatGPT Agent...",), {"fg": "blue"}),
+        (("Starting Sensor that supports task categories ['sensor']",), {"fg": "blue"}),
+        (("Starting ChatGPT Agent that supports task categories ['chatgpt']",), {"fg": "blue"}),
     ]
     mock_secho.assert_has_calls(expected_calls, any_order=True)
     assert mock_secho.call_count == len(expected_calls)

--- a/tests/flytekit/unit/extend/test_agent.py
+++ b/tests/flytekit/unit/extend/test_agent.py
@@ -405,8 +405,8 @@ def test_print_agents_metadata_output(list_agents_mock, mock_secho, sample_agent
     list_agents_mock.return_value = sample_agents
     print_agents_metadata()
     expected_calls = [
-        (("Starting Sensor supports async task sensor with version 0",), {"fg": "blue"}),
-        (("Starting ChatGPT Agent supports sync task chatgpt with version 0",), {"fg": "blue"}),
+        (("Starting Sensor...",), {"fg": "blue"}),
+        (("Starting ChatGPT Agent...",), {"fg": "blue"}),
     ]
     mock_secho.assert_has_calls(expected_calls, any_order=True)
     assert mock_secho.call_count == len(expected_calls)


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
Let users can observe available agents in the agent pod.

## What changes were proposed in this pull request?
add a function `print_agents_metadata`
```python
def print_agents_metadata():
    from flytekit.extend.backend.base_agent import AgentRegistry

    agents = AgentRegistry.list_agents()
    for agent in agents:
        name = agent.name
        task_type = "sync" if agent.is_sync else "async"
        for task_category in agent.supported_task_categories:
            click.secho(
                f"Starting {name} supports {task_type} task {task_category.name} with version {task_category.version}",
                fg="blue",
            )
```

## How was this patch tested?
1. Use the `pyflyte serve agent` command to print output to the terminal.
2. unit tests


### Setup process
`pyflyte serve agent`

### Screenshots
<img width="471" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/3560b404-4116-4b98-b7b6-b7e68df02e57">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

