### PR TITLE
Move SageMakerEndpointMetadata to agent.py

### DIFF
--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -457,7 +457,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
         self,
         task_type: str,
         name: str,
-        task_config: Optional[T],
+        task_config: Optional[T] = None,
         interface: Optional[Interface] = None,
         environment: Optional[Dict[str, str]] = None,
         disable_deck: Optional[bool] = None,

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/agent.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/agent.py
@@ -1,14 +1,15 @@
 import json
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 import cloudpickle
 
 from flytekit.extend.backend.base_agent import (
     AgentRegistry,
     AsyncAgentBase,
-    Resource, ResourceMeta,
+    Resource,
+    ResourceMeta,
 )
 from flytekit.extend.backend.utils import convert_to_flyte_phase
 from flytekit.models.literals import LiteralMap

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/agent.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/agent.py
@@ -1,18 +1,35 @@
 import json
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Dict, Any
+
+import cloudpickle
 
 from flytekit.extend.backend.base_agent import (
     AgentRegistry,
     AsyncAgentBase,
-    Resource,
+    Resource, ResourceMeta,
 )
 from flytekit.extend.backend.utils import convert_to_flyte_phase, get_agent_secret
 from flytekit.models.literals import LiteralMap
 from flytekit.models.task import TaskTemplate
 
 from .boto3_mixin import Boto3AgentMixin
-from .task import SageMakerEndpointMetadata
+
+
+@dataclass
+class SageMakerEndpointMetadata(ResourceMeta):
+    config: Dict[str, Any]
+    region: Optional[str] = None
+    inputs: Optional[LiteralMap] = None
+
+    def encode(self) -> bytes:
+        return cloudpickle.dumps(self)
+
+    @classmethod
+    def decode(cls, data: bytes) -> "SageMakerEndpointMetadata":
+        return cloudpickle.loads(data)
+
 
 states = {
     "Creating": "Running",

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_agent.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_agent.py
@@ -53,9 +53,6 @@ class BotoAgent(SyncAgentBase):
             config=config,
             images=images,
             inputs=inputs,
-            aws_access_key_id=get_agent_secret(secret_key="aws-access-key"),
-            aws_secret_access_key=get_agent_secret(secret_key="aws-secret-access-key"),
-            aws_session_token=get_agent_secret(secret_key="aws-session-token"),
         )
 
         outputs = None

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/task.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/task.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Any, Dict, Optional, Type, Union
 
 from flytekit import ImageSpec, kwtypes
@@ -6,7 +5,6 @@ from flytekit.configuration import SerializationSettings
 from flytekit.core.base_task import PythonTask
 from flytekit.core.interface import Interface
 from flytekit.extend.backend.base_agent import AsyncAgentExecutorMixin
-from flytekit.models.literals import LiteralMap
 
 from .boto3_task import BotoConfig, BotoTask
 

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/task.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/task.py
@@ -102,7 +102,7 @@ class SageMakerEndpointTask(AsyncAgentExecutorMixin, PythonTask):
         self._region = region
 
     def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
-        return {"config": self.task_config.config, "region": self.task_config.region}
+        return {"config": self._config, "region": self._region}
 
 
 class SageMakerDeleteEndpointTask(BotoTask):

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/task.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/task.py
@@ -75,14 +75,7 @@ class SageMakerEndpointConfigTask(BotoTask):
         )
 
 
-@dataclass
-class SageMakerEndpointMetadata(object):
-    config: Dict[str, Any]
-    region: Optional[str] = None
-    inputs: Optional[LiteralMap] = None
-
-
-class SageMakerEndpointTask(AsyncAgentExecutorMixin, PythonTask[SageMakerEndpointMetadata]):
+class SageMakerEndpointTask(AsyncAgentExecutorMixin, PythonTask):
     _TASK_TYPE = "sagemaker-endpoint"
 
     def __init__(
@@ -103,14 +96,12 @@ class SageMakerEndpointTask(AsyncAgentExecutorMixin, PythonTask[SageMakerEndpoin
         """
         super().__init__(
             name=name,
-            task_config=SageMakerEndpointMetadata(
-                config=config,
-                region=region,
-            ),
             task_type=self._TASK_TYPE,
             interface=Interface(inputs=inputs, outputs=kwtypes(result=str)),
             **kwargs,
         )
+        self._config = config
+        self._region = region
 
     def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
         return {"config": self.task_config.config, "region": self.task_config.region}


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
agent failed to encode the metadata
![image](https://github.com/flyteorg/flytekit/assets/37936015/44b7af50-82fe-41f4-9440-d548a76a3ac5)


## What changes were proposed in this pull request?
Move SageMakerEndpointMetadata to agent.py and override encode()/decode() method

## How was this patch tested?
Remote

### Setup process

### Screenshots
<img width="1909" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/ecdb7093-62af-4763-b5d9-d62b99d5e3e3">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
