### PR TITLE
Add way to create FlyteFile/Directory from remote location

### DIFF
--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -235,6 +235,25 @@ class FlyteDirectory(DataClassJsonMixin, os.PathLike, typing.Generic[T]):
         new_path = self.sep.join([str(self.path).rstrip(self.sep), name])  # trim trailing sep if any and join
         return FlyteDirectory(path=new_path)
 
+    @classmethod
+    def from_source(cls, source: str | os.PathLike) -> FlyteDirectory:
+        """
+        Create a new FlyteDirectory object with the remote source set to the input
+        """
+        ctx = FlyteContextManager.current_context()
+        lit = Literal(
+            scalar=Scalar(
+                blob=Blob(
+                    metadata=BlobMetadata(
+                        type=BlobType(format="", dimensionality=BlobType.BlobDimensionality.MULTIPART)
+                    ),
+                    uri=source,
+                )
+            )
+        )
+        t = FlyteDirToMultipartBlobTransformer()
+        return t.to_python_value(ctx, lit, cls)
+
     def download(self) -> str:
         return self.__fspath__()
 

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -157,6 +157,23 @@ class FlyteFile(os.PathLike, typing.Generic[T], DataClassJSONMixin):
         remote_path = ctx.file_access.join(ctx.file_access.raw_output_prefix, r)
         return cls(path=remote_path)
 
+    @classmethod
+    def from_source(cls, source: str | os.PathLike) -> FlyteFile:
+        """
+        Create a new FlyteFile object with the remote source set to the input
+        """
+        ctx = FlyteContextManager.current_context()
+        lit = Literal(
+            scalar=Scalar(
+                blob=Blob(
+                    metadata=BlobMetadata(type=BlobType(format="", dimensionality=BlobType.BlobDimensionality.SINGLE)),
+                    uri=source,
+                )
+            )
+        )
+        t = FlyteFilePathTransformer()
+        return t.to_python_value(ctx, lit, cls)
+
     def __class_getitem__(cls, item: typing.Union[str, typing.Type]) -> typing.Type[FlyteFile]:
         from flytekit.types.file import FileExt
 

--- a/tests/flytekit/unit/core/test_flyte_file.py
+++ b/tests/flytekit/unit/core/test_flyte_file.py
@@ -593,7 +593,6 @@ def test_flyte_file_annotated_hashmethod(local_dummy_file):
     wf(path=local_dummy_file)
 
 
-@pytest.mark.sandbox_test
 def test_for_downloading():
     ff = FlyteFile.from_source(source="s3://sample-path/file")
     assert ff.path

--- a/tests/flytekit/unit/core/test_flyte_file.py
+++ b/tests/flytekit/unit/core/test_flyte_file.py
@@ -594,6 +594,18 @@ def test_flyte_file_annotated_hashmethod(local_dummy_file):
 
 
 @pytest.mark.sandbox_test
+def test_for_downloading():
+    ff = FlyteFile.from_source(source="s3://sample-path/file")
+    assert ff.path
+    assert ff._downloader is not None
+    assert not ff.downloaded
+
+    if os.name != "nt":
+        fl = FlyteFile.from_source(source=__file__)
+        assert fl.path == __file__
+
+
+@pytest.mark.sandbox_test
 def test_file_open_things():
     @task
     def write_this_file_to_s3() -> FlyteFile:


### PR DESCRIPTION
## Why are the changes needed?
Add a couple of class methods
```
def from_source(cls, source: str | os.PathLike) -> FlyteFile
def from_source(cls, source: str | os.PathLike) -> FlyteDirectory
```
meant to be used with remote paths.  This is because if you create a file with an s3/gs link as the path using the normal constructor, it doesn't come with a download function, forcing users to manually call into the data persistence layer manually.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
