### PR TITLE
Ensure that annotations are dropped in the case of the dataclass and dict type transformers

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -391,10 +391,10 @@ jobs:
     steps:
       - name: Fetch the code
         uses: actions/checkout@v4
-      - name: Set up Python 3.8
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.12
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -356,6 +356,7 @@ class DataclassTransformer(TypeTransformer[object]):
         # However, FooSchema is created by flytekit and it's not equal to the user-defined dataclass (Foo).
         # Therefore, we should iterate all attributes in the dataclass and check the type of value in dataclass matches the expected_type.
 
+        expected_type = get_underlying_type(expected_type)
         expected_fields_dict = {}
         for f in dataclasses.fields(expected_type):
             expected_fields_dict[f.name] = f.type

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1642,12 +1642,14 @@ class DictTransformer(TypeTransformer[dict]):
         _origin = get_origin(t)
         _args = get_args(t)
         if _origin is not None:
-            if _origin is Annotated:
-                raise ValueError(
-                    f"Flytekit does not currently have support \
-                        for FlyteAnnotations applied to dicts. {t} cannot be \
-                        parsed."
-                )
+            if _origin is Annotated and _args:
+                # _args holds the type arguments to the dictionary, i.e.
+                # get_args(Dict[int, str]) == (int, str)
+                for x in _args[1:]:
+                    if isinstance(x, FlyteAnnotation):
+                        raise ValueError(
+                            f"Flytekit does not currently have support for FlyteAnnotations applied to dicts. {t} cannot be parsed."
+                        )
             if _origin is dict and _args is not None:
                 return _args  # type: ignore
         return None, None

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1643,8 +1643,10 @@ class DictTransformer(TypeTransformer[dict]):
         _args = get_args(t)
         if _origin is not None:
             if _origin is Annotated and _args:
-                # _args holds the type arguments to the dictionary, i.e.
-                # get_args(Dict[int, str]) == (int, str)
+                # _args holds the type arguments to the dictionary, i.e. get_args(Dict[int, str]) == (int, str).
+                # Or a more complex example:
+                # >>> get_args(Annotated[dict[int, str], FlyteAnnotation("abc")])
+                # (dict[int, str], <flytekit.core.annotation.FlyteAnnotation object at 0x107f6ff80>)
                 for x in _args[1:]:
                     if isinstance(x, FlyteAnnotation):
                         raise ValueError(

--- a/tests/flytekit/unit/core/test_dataclass.py
+++ b/tests/flytekit/unit/core/test_dataclass.py
@@ -4,8 +4,11 @@ from typing import List
 
 import pytest
 from dataclasses_json import DataClassJsonMixin
+from mashumaro.mixins.json import DataClassJSONMixin
+from typing_extensions import Annotated
 
 from flytekit.core.task import task
+from flytekit.core.type_engine import DataclassTransformer
 from flytekit.core.workflow import workflow
 
 
@@ -29,3 +32,12 @@ def test_dataclass():
 
     res = wf()
     assert res.region == "us-west-3"
+
+
+def test_dataclass_assert_works_for_annotated():
+    @dataclass
+    class MyDC(DataClassJSONMixin):
+        my_str: str
+
+    d = Annotated[MyDC, "tag"]
+    DataclassTransformer().assert_type(d, MyDC(my_str="hi"))

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -2161,10 +2161,12 @@ class DataclassTest(DataClassJsonMixin):
     a: int
     b: str
 
+
 @dataclass
 class AnnotatedDataclassTest(DataClassJsonMixin):
     a: int
     b: Annotated[str, "str tag"]
+
 
 @pytest.mark.parametrize(
     "t,expected_type",
@@ -2186,44 +2188,89 @@ class AnnotatedDataclassTest(DataClassJsonMixin):
             typing.Dict[str, typing.Dict[str, int]],
             LiteralType(map_value_type=LiteralType(map_value_type=LiteralType(simple=SimpleType.INTEGER))),
         ),
-        (DataclassTest, LiteralType(
-            simple=SimpleType.STRUCT,
-            metadata={'$schema': 'http://json-schema.org/draft-07/schema#', 'definitions': {'DataclasstestSchema': {'properties': {'a': {'title': 'a', 'type': 'integer'}, 'b': {'title': 'b', 'type': 'string'}}, 'type': 'object', 'additionalProperties': False}}, '$ref': '#/definitions/DataclasstestSchema'},
-            structure=TypeStructure(
-                tag="",
-                dataclass_type={
-                    "a": LiteralType(simple=SimpleType.INTEGER),
-                    "b": LiteralType(simple=SimpleType.STRING),
+        (
+            DataclassTest,
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                metadata={
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "definitions": {
+                        "DataclasstestSchema": {
+                            "properties": {
+                                "a": {"title": "a", "type": "integer"},
+                                "b": {"title": "b", "type": "string"},
+                            },
+                            "type": "object",
+                            "additionalProperties": False,
+                        }
+                    },
+                    "$ref": "#/definitions/DataclasstestSchema",
                 },
+                structure=TypeStructure(
+                    tag="",
+                    dataclass_type={
+                        "a": LiteralType(simple=SimpleType.INTEGER),
+                        "b": LiteralType(simple=SimpleType.STRING),
+                    },
                 ),
             ),
-         ),
+        ),
         #  Similar to the dict[int, str] case, the annotation is not being copied over to the LiteralType
-        (Annotated[DataclassTest, "another-tag"], LiteralType(
-            simple=SimpleType.STRUCT,
-            metadata={'$schema': 'http://json-schema.org/draft-07/schema#', 'definitions': {'DataclasstestSchema': {'properties': {'a': {'title': 'a', 'type': 'integer'}, 'b': {'title': 'b', 'type': 'string'}}, 'type': 'object', 'additionalProperties': False}}, '$ref': '#/definitions/DataclasstestSchema'},
-            structure=TypeStructure(
-                tag="",
-                dataclass_type={
-                    "a": LiteralType(simple=SimpleType.INTEGER),
-                    "b": LiteralType(simple=SimpleType.STRING),
+        (
+            Annotated[DataclassTest, "another-tag"],
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                metadata={
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "definitions": {
+                        "DataclasstestSchema": {
+                            "properties": {
+                                "a": {"title": "a", "type": "integer"},
+                                "b": {"title": "b", "type": "string"},
+                            },
+                            "type": "object",
+                            "additionalProperties": False,
+                        }
+                    },
+                    "$ref": "#/definitions/DataclasstestSchema",
                 },
+                structure=TypeStructure(
+                    tag="",
+                    dataclass_type={
+                        "a": LiteralType(simple=SimpleType.INTEGER),
+                        "b": LiteralType(simple=SimpleType.STRING),
+                    },
                 ),
             ),
-         ),
+        ),
         # Notice how the annotation in the field is not carried over either
-        (Annotated[AnnotatedDataclassTest, "another-tag"], LiteralType(
-            simple=SimpleType.STRUCT,
-            metadata={'$schema': 'http://json-schema.org/draft-07/schema#', 'definitions': {'AnnotateddataclasstestSchema': {'properties': {'a': {'title': 'a', 'type': 'integer'}, 'b': {'title': 'b', 'type': 'string'}}, 'type': 'object', 'additionalProperties': False}}, '$ref': '#/definitions/AnnotateddataclasstestSchema'},
-            structure=TypeStructure(
-                tag="",
-                dataclass_type={
-                    "a": LiteralType(simple=SimpleType.INTEGER),
-                    "b": LiteralType(simple=SimpleType.STRING),
+        (
+            Annotated[AnnotatedDataclassTest, "another-tag"],
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                metadata={
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "definitions": {
+                        "AnnotateddataclasstestSchema": {
+                            "properties": {
+                                "a": {"title": "a", "type": "integer"},
+                                "b": {"title": "b", "type": "string"},
+                            },
+                            "type": "object",
+                            "additionalProperties": False,
+                        }
+                    },
+                    "$ref": "#/definitions/AnnotateddataclasstestSchema",
                 },
+                structure=TypeStructure(
+                    tag="",
+                    dataclass_type={
+                        "a": LiteralType(simple=SimpleType.INTEGER),
+                        "b": LiteralType(simple=SimpleType.STRING),
+                    },
                 ),
             ),
-         ),
+        ),
     ],
 )
 def test_annotated_dicts(t, expected_type):


### PR DESCRIPTION
## Tracking issue
NA

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Why are the changes needed?
The original exception in the `DictTransformer` was put in place to catch the case of `FlyteAnnotation` being set passed to annotated dictionary, e.g. `Annotated[dict, FlyteAnnotation("annotation-1")]` is invalid. A similar argument applies to the dataclass type transformer.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Keep the original exception, but only raise it if the annotation contains a `FlyteAnnotation` in both the dataclass and the dictionary transformers.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
