### PR TITLE
Add name to union param

### DIFF
--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -185,6 +185,10 @@ class UnionParamType(click.ParamType):
         super().__init__()
         self._types = self._sort_precedence(types)
 
+    @property
+    def name(self) -> str:
+        return "|".join([t.name for t in self._types])
+
     @staticmethod
     def _sort_precedence(tp: typing.List[click.ParamType]) -> typing.List[click.ParamType]:
         unprocessed = []


### PR DESCRIPTION
## Why are the changes needed?
If you had a union type, `pyflyte run` was failing when you ran `--help` with

```
  File "/Users/ytong/envs/experiments/lib/python3.11/site-packages/click/core.py", line 2220, in make_metavar
    metavar = self.type.name.upper()
              ^^^^^^^^^^^^^^

'UnionParamType' object has no attribute 'name'
```

This just adds the name property.

## How was this patch tested?
![image](https://github.com/flyteorg/flytekit/assets/2896568/f5fd9f0a-1a4b-49a7-8eab-bb8cb5a53eca)

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
