### PR TITLE
Do not print message twice with ClickException

### DIFF
--- a/flytekit/clis/sdk_in_container/utils.py
+++ b/flytekit/clis/sdk_in_container/utils.py
@@ -100,7 +100,6 @@ def pretty_print_exception(e: Exception):
         raise e
 
     if isinstance(e, click.ClickException):
-        click.secho(e.message, fg="red")
         raise e
 
     if isinstance(e, FlyteException):


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

When `click.ClickException` is raised, the message is already printed. For example, running this:

```python
import click

from flytekit.clis.sdk_in_container.utils import ErrorHandlingCommand


@click.group("cli", invoke_without_command=True, cls=ErrorHandlingCommand)
@click.option(
    "-v",
    "--verbose",
    required=False,
    count=True,
    default=0,
    type=int,
)
def main(verbose):
    my_error_msg = "This is an error message"
    raise click.ClickException(my_error_msg)


if __name__ == "__main__":
    main()
```

On `master` I get the error message twice:

![Screenshot 2024-04-04 at 5 16 05 PM](https://github.com/flyteorg/flytekit/assets/5402633/ff8f4266-f9ea-41bd-a234-e8ca7dab1468)

With this PR, the error message appears once:

![Screenshot 2024-04-04 at 5 19 22 PM](https://github.com/flyteorg/flytekit/assets/5402633/476045a9-278c-4f2d-9a3e-b55e46a2b5b8)