### PR TITLE
Show a dataproc link on FlyteConsole

### DIFF
--- a/plugins/flytekit-airflow/flytekitplugins/airflow/agent.py
+++ b/plugins/flytekit-airflow/flytekitplugins/airflow/agent.py
@@ -1,17 +1,17 @@
 import asyncio
 import typing
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import List, Optional
 
 import cloudpickle
 import jsonpickle
-from flyteidl.core.execution_pb2 import TaskExecution
+from flyteidl.core.execution_pb2 import TaskExecution, TaskLog
 from flytekitplugins.airflow.task import AirflowObj, _get_airflow_instance
 
 from airflow.exceptions import AirflowException, TaskDeferred
 from airflow.models import BaseOperator
 from airflow.sensors.base import BaseSensorOperator
-from airflow.triggers.base import TriggerEvent
+from airflow.triggers.base import BaseTrigger, TriggerEvent
 from airflow.utils.context import Context
 from flytekit import logger
 from flytekit.exceptions.user import FlyteUserException
@@ -134,10 +134,33 @@ class AirflowAgent(AsyncAgentBase):
         else:
             raise FlyteUserException("Only sensor and operator are supported.")
 
-        return Resource(phase=cur_phase, message=message)
+        return Resource(
+            phase=cur_phase,
+            message=message,
+            log_links=get_log_links(airflow_operator_instance, resource_meta.airflow_operator.parameters),
+        )
 
     async def delete(self, resource_meta: AirflowMetadata, **kwargs):
         return
+
+
+def get_log_links(
+    airflow_operator: BaseOperator, airflow_trigger: Optional[BaseTrigger] = None
+) -> Optional[List[TaskLog]]:
+    log_links: List[TaskLog] = []
+    try:
+        from airflow.providers.google.cloud.operators.dataproc import DataprocJobBaseOperator, DataprocSubmitTrigger
+
+        if isinstance(airflow_operator, DataprocJobBaseOperator):
+            log_link = TaskLog(
+                uri=f"https://console.cloud.google.com/dataproc/jobs/{typing.cast(DataprocSubmitTrigger, airflow_trigger).job_id}/monitoring?region={airflow_operator.region}&project={airflow_operator.project_id}",
+                name="Dataproc Console",
+            )
+            log_links.append(log_link)
+            return log_links
+    except ImportError:
+        ...
+    return log_links
 
 
 AgentRegistry.register(AirflowAgent())

--- a/plugins/flytekit-airflow/flytekitplugins/airflow/agent.py
+++ b/plugins/flytekit-airflow/flytekitplugins/airflow/agent.py
@@ -137,7 +137,7 @@ class AirflowAgent(AsyncAgentBase):
         return Resource(
             phase=cur_phase,
             message=message,
-            log_links=get_log_links(airflow_operator_instance, resource_meta.airflow_operator.parameters),
+            log_links=get_log_links(airflow_operator_instance, airflow_trigger_instance),
         )
 
     async def delete(self, resource_meta: AirflowMetadata, **kwargs):


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
It will show the log link on FlyteConsole

## What changes were proposed in this pull request?
Get the log link in agent and return to Propeller

## How was this patch tested?
```python
from datetime import datetime, timedelta

from airflow.operators.bash import BashOperator
from airflow.providers.google.cloud.operators.dataproc import DataprocDeleteClusterOperator, \
    DataprocSubmitSparkJobOperator, DataprocCreateClusterOperator
from airflow.utils import trigger_rule
from pytz import UTC
from flytekit import workflow

x = (datetime.now(tz=UTC) + timedelta(seconds=21)).time()
cluster_name = "flyte-dataproc-demo"


@workflow
def airflow_wf():
    # TimeSensor(task_id="time_sensor", target_time=x)
    BashOperator(task_id="airflow_bash_operator", bash_command="echo hello")

    create_cluster = DataprocCreateClusterOperator(
        task_id="create_dataproc_cluster1",
        image_version="2.0.27-debian10",
        storage_bucket="opta-gcp-dogfood-gcp",
        service_account="dogfoodgcp-userflyterol-odkb@dogfood-gcp-dataplane.iam.gserviceaccount.com",
        # service_account_scopes=["https://www.googleapis.com/auth/cloud-platform"],
        master_machine_type="n1-highmem-32",
        master_disk_size=1024,
        num_workers=2,
        worker_machine_type="n1-highmem-64",
        worker_disk_size=1024,
        region="us-west1",
        cluster_name=cluster_name,
        project_id="dogfood-gcp-dataplane",
    )

    spark_on_dataproc = DataprocSubmitSparkJobOperator(
        job_name="spark_pi",
        task_id="run_spark",
        dataproc_jars=["file:///usr/lib/spark/examples/jars/spark-examples.jar"],
        main_class="org.apache.spark.examples.JavaWordCount",
        arguments=["gs://opta-gcp-dogfood-gcp/spark/file.txt"],
        cluster_name=cluster_name,
        region="us-west1",
        # project_id="dogfood-gcp-dataplane",
    )

    delete_cluster = DataprocDeleteClusterOperator(
        task_id="delete_dataproc_cluster1",
        project_id="dogfood-gcp-dataplane",
        cluster_name=cluster_name,
        region="us-west1",
        retries=3,
        retry_delay=timedelta(minutes=5),
        email_on_failure=True,
        trigger_rule=trigger_rule.TriggerRule.ALL_DONE,
    )

    create_cluster >> spark_on_dataproc >> delete_cluster

```

### Setup process

### Screenshots
<img width="1833" alt="image" src="https://github.com/flyteorg/flytekit/assets/37936015/5d1e19b7-9bad-43c0-a2d2-24a065402b56">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
