### PR TITLE
[easy] Show `failed_node_id` in failure node local execution

### DIFF
--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -288,9 +288,8 @@ class WorkflowBase(object):
         except Exception as exc:
             if self.on_failure:
                 if self.on_failure.python_interface and "err" in self.on_failure.python_interface.inputs:
-                    input_kwargs["err"] = FlyteError(
-                        failed_node_id=self.failure_node.id if self.failure_node else "", message=str(exc)
-                    )
+                    id = self.failure_node.id if self.failure_node else ""
+                    input_kwargs["err"] = FlyteError(failed_node_id=id, message=str(exc))
                 self.on_failure(**input_kwargs)
             raise exc
 

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -288,7 +288,7 @@ class WorkflowBase(object):
         except Exception as exc:
             if self.on_failure:
                 if self.on_failure.python_interface and "err" in self.on_failure.python_interface.inputs:
-                    input_kwargs["err"] = FlyteError(failed_node_id="", message=str(exc))
+                    input_kwargs["err"] = FlyteError(failed_node_id=self.failure_node.id, message=str(exc))
                 self.on_failure(**input_kwargs)
             raise exc
 

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -288,7 +288,9 @@ class WorkflowBase(object):
         except Exception as exc:
             if self.on_failure:
                 if self.on_failure.python_interface and "err" in self.on_failure.python_interface.inputs:
-                    input_kwargs["err"] = FlyteError(failed_node_id=self.failure_node.id, message=str(exc))
+                    input_kwargs["err"] = FlyteError(
+                        failed_node_id=self.failure_node.id if self.failure_node else "", message=str(exc)
+                    )
                 self.on_failure(**input_kwargs)
             raise exc
 


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/1506

## Why are the changes needed?
Better user experience.

## What changes were proposed in this pull request?
unit tests, local execution and debugger

reference: https://realpython.com/lessons/mocking-print-unit-tests/

## How was this patch tested?


### Setup process
```bash
pyflyte run kevin_example.py wf2 
```
```python
# source: https://github.com/flyteorg/flyte/pull/4308
import typing
from click.testing import CliRunner

from flytekit import task, workflow, WorkflowFailurePolicy
from flytekit.clis.sdk_in_container import pyflyte
from flytekit.types.error.error import FlyteError

@task()
def create_cluster(name: str):
    print(f"Creating cluster: {name}")


@task()
def t1(a: int, b: str):
    print(f"{a} {b}")
    raise ValueError("Fail!")


@task()
def delete_cluster(name: str, err: typing.Optional[FlyteError] = None):
    print(f"Deleting cluster {name}")
    print(err)


@task()
def clean_up(name: str, err: typing.Optional[FlyteError] = None):
    print(f"Deleting cluster {name} due to {err}")
    print("This is err:", err)


@workflow(on_failure=clean_up)
def subwf(name: str = "kevin"):
    c = create_cluster(name=name)
    t = t1(a=1, b="2")
    d = delete_cluster(name=name)
    c >> t >> d


@workflow(on_failure=clean_up, failure_policy=WorkflowFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE)
def wf1(name: str = "kevin"):
    c = create_cluster(name=name)
    subwf(name="pingsutw")
    t = t1(a=1, b="2")
    d = delete_cluster(name=name)
    c >> t >> d

@workflow(on_failure=clean_up)
def wf2(name: str = "kevin"):
    c = create_cluster(name=name)
    t = t1(a=1, b="2")
    d = delete_cluster(name=name)
    c >> t >> d
```
### Screenshots
<img width="889" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/e6e12626-3cdf-4949-b823-8b34245dbf84">
<img width="731" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/62800208-7756-4420-9185-c870c6cee044">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
