### PR TITLE
Support referencing docker images by digest in addition to by tag

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -187,7 +187,7 @@ class Image(DataClassJsonMixin):
 
     def __post_init__(self):
         if not ((self.tag is None) or (self.digest is None)):
-            raise ValueError(f"Cannot specify both tag or and digest. Got tag={self.tag} and digest={self.digest}")
+            raise ValueError(f"Cannot specify both tag and digest. Got tag={self.tag} and digest={self.digest}")
 
     @property
     def full(self) -> str:
@@ -197,6 +197,13 @@ class Image(DataClassJsonMixin):
         if self.digest is not None:
             return f"{self.fqn}@{self.digest}"
         return f"{self.fqn}:{self.tag}"
+
+    @property
+    def version(self) -> Optional[str]:
+        """
+        Return the version of the image. This could be the tag or digest, whichever is available.
+        """
+        return self.digest or self.tag
 
     @staticmethod
     def look_up_image_info(name: str, image_identifier: str, allow_no_tag_or_digest: bool = False) -> Image:

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -218,7 +218,7 @@ class Image(DataClassJsonMixin):
 
         :param name:
         :param image_identifier: Either the full image identifier string e.g. somedocker.com/myimage:someversion123
-        or a path to a file containing a `ImageSpec`.
+            or a path to a file containing a `ImageSpec`.
         :param allow_no_tag_or_digest:
         :rtype: Image
         """

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -177,6 +177,7 @@ class Image(DataClassJsonMixin):
             #. a repository name
             For example: `hostname/username/reponame`
         tag (str): Optional tag used to specify which version of an image to pull
+        digest (str): Optional digest used to specify which version of an image to pull
     """
 
     name: str

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -229,11 +229,11 @@ class Image(DataClassJsonMixin):
                 ImageBuildEngine.build(image_spec)
                 image_identifier = image_spec.image_name()
 
-        fqn, image_identifier, digest = _parse_image_identifier(image_identifier)
+        fqn, tag, digest = _parse_image_identifier(image_identifier)
 
-        if not allow_no_tag_or_digest and image_identifier is None and digest is None:
+        if not allow_no_tag_or_digest and tag is None and digest is None:
             raise AssertionError(f"Incorrectly formatted image {image_identifier}, missing tag or digest")
-        return Image(name=name, fqn=fqn, tag=image_identifier, digest=digest)
+        return Image(name=name, fqn=fqn, tag=tag, digest=digest)
 
 
 def _parse_image_identifier(image_identifier: str) -> typing.Tuple[str, Optional[str], Optional[str]]:

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -235,12 +235,12 @@ def _parse_image_identifier(image_identifier: str) -> typing.Tuple[str, Optional
     Returns:
         Tuple[str, str, str]: fully_qualified_name, tag, digest
     """
-    parts = image_identifier.rsplit('@', 1)
+    parts = image_identifier.rsplit("@", 1)
     if len(parts) == 2:
         # The image identifier used a digest e.g. `xyz.com/abc@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d`
         return parts[0], None, parts[1]
-    parts = image_identifier.rsplit(':', 1)
-    if len(parts) == 2 and '/' not in parts[1]:
+    parts = image_identifier.rsplit(":", 1)
+    if len(parts) == 2 and "/" not in parts[1]:
         # The image identifier used a tag e.g. `xyz.com/abc:latest`
         return parts[0], parts[1], None
     # The image identifier had no tag or digest e.g. `xyz.com/abc`
@@ -366,7 +366,9 @@ class ImageConfig(DataClassJsonMixin):
         """
         m = m or {}
         def_img = Image.look_up_image_info("default", default_image) if default_image else None
-        other_images = [Image.look_up_image_info(k, image_identifier=v, allow_no_tag_or_digest=True) for k, v in m.items()]
+        other_images = [
+            Image.look_up_image_info(k, image_identifier=v, allow_no_tag_or_digest=True) for k, v in m.items()
+        ]
         return cls.create_from(def_img, other_images)
 
     @classmethod

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -192,11 +192,11 @@ class Image(DataClassJsonMixin):
     @property
     def full(self) -> str:
         """ "
-        Return the full image name with tag.
+        Return the full image name with tag or digest, whichever is available.
+
+        When using a tag the separator is `:` and when using a digest the separator is `@`.
         """
-        if self.digest is not None:
-            return f"{self.fqn}@{self.digest}"
-        return f"{self.fqn}:{self.tag}"
+        return f"{self.fqn}@{self.digest}" if self.digest else f"{self.fqn}:{self.tag}"
 
     @property
     def version(self) -> Optional[str]:

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -185,18 +185,17 @@ class Image(DataClassJsonMixin):
     digest: Optional[str] = None
 
     def __post_init__(self):
-        if not (self.tag is None) ^ (self.digest is None):
-            raise ValueError(f"Exactly one of tag or sha256 must be set. Got tag={self.tag} and digest={self.digest}")
+        if not ((self.tag is None) or (self.digest is None)):
+            raise ValueError(f"Cannot specify both tag or and digest. Got tag={self.tag} and digest={self.digest}")
 
     @property
     def full(self) -> str:
         """ "
         Return the full image name with tag.
         """
-        if self.tag:
-            return f"{self.fqn}:{self.tag}"
-        assert self.digest is not None, "tag or digest must be set. `__post_init__` should enforce this."
-        return f"{self.fqn}@{self.digest}"
+        if self.digest is not None:
+            return f"{self.fqn}@{self.digest}"
+        return f"{self.fqn}:{self.tag}"
 
     @staticmethod
     def look_up_image_info(name: str, image_identifier: str, optional_tag: bool = False) -> Image:

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -296,10 +296,10 @@ def get_registerable_container_image(img: Optional[Union[str, ImageSpec]], cfg: 
             if img_cfg is None:
                 raise AssertionError(f"Image Config with name {name} not found in the configuration")
             if attr == "version":
-                if img_cfg.tag is not None:
-                    img = img.replace(replace_group, img_cfg.tag)
+                if img_cfg.version is not None:
+                    img = img.replace(replace_group, img_cfg.version)
                 else:
-                    img = img.replace(replace_group, cfg.default_image.tag)
+                    img = img.replace(replace_group, cfg.default_image.version)
             elif attr == "fqn":
                 img = img.replace(replace_group, img_cfg.fqn)
             elif attr == "":

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -309,7 +309,7 @@ def get_registerable_container_image(img: Optional[Union[str, ImageSpec]], cfg: 
         return img
     if cfg.default_image is None:
         raise ValueError("An image is required for PythonAutoContainer tasks")
-    return f"{cfg.default_image.fqn}:{cfg.default_image.tag}"
+    return cfg.default_image.full
 
 
 # Matches {{.image.<name>.<attr>}}. A name can be either 'default' indicating the default image passed during

--- a/plugins/flytekit-spark/tests/test_remote_register.py
+++ b/plugins/flytekit-spark/tests/test_remote_register.py
@@ -23,10 +23,11 @@ def test_spark_template_with_remote():
     remote._client = mock_client
     remote._client_initialized = True
 
+    mock_image_config = MagicMock(default_image=MagicMock(full="fake-cr.io/image-name:tag"))
     remote.register_task(
         my_spark,
         serialization_settings=SerializationSettings(
-            image_config=MagicMock(),
+            image_config=mock_image_config,
         ),
         version="v1",
     )
@@ -38,7 +39,7 @@ def test_spark_template_with_remote():
     assert serialized_spec.template.custom["sparkConf"]
 
     remote.register_task(
-        my_python_task, serialization_settings=SerializationSettings(image_config=MagicMock()), version="v1"
+        my_python_task, serialization_settings=SerializationSettings(image_config=mock_image_config), version="v1"
     )
     serialized_spec = mock_client.create_task.call_args.kwargs["task_spec"]
 

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -284,6 +284,11 @@ ic_result_2 = ImageConfig(
         Image(name="asdf", fqn="ghcr.io/asdf/asdf", tag="latest"),
         Image(name="xyz", fqn="docker.io/xyz", tag="latest"),
         Image(name="abc", fqn="docker.io/abc", tag=None),
+        Image(
+            name="bcd",
+            fqn="docker.io/bcd",
+            digest="sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d",
+        ),
     ],
 )
 # test that command line args override the file
@@ -293,6 +298,11 @@ ic_result_3 = ImageConfig(
         Image(name="default", fqn="cr.flyte.org/flyteorg/flytekit", tag="py3.9-latest"),
         Image(name="xyz", fqn="ghcr.io/asdf/asdf", tag="latest"),
         Image(name="abc", fqn="docker.io/abc", tag=None),
+        Image(
+            name="bcd",
+            fqn="docker.io/bcd",
+            digest="sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d",
+        ),
     ],
 )
 
@@ -302,6 +312,11 @@ ic_result_4 = ImageConfig(
         Image(name="default", fqn="flytekit", tag="urw7fglw5pBrIQ9JTW1vQA"),
         Image(name="xyz", fqn="docker.io/xyz", tag="latest"),
         Image(name="abc", fqn="docker.io/abc", tag=None),
+        Image(
+            name="bcd",
+            fqn="docker.io/bcd",
+            digest="sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d",
+        ),
     ],
 )
 

--- a/tests/flytekit/unit/configuration/configs/sample.yaml
+++ b/tests/flytekit/unit/configuration/configs/sample.yaml
@@ -14,3 +14,4 @@ storage:
 images:
   xyz: docker.io/xyz:latest
   abc: docker.io/abc
+  bcd: docker.io/bcd@sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d

--- a/tests/flytekit/unit/configuration/test_image_config.py
+++ b/tests/flytekit/unit/configuration/test_image_config.py
@@ -45,6 +45,7 @@ def test_image_from_flytectl_config():
     image_config = ImageConfig.auto(config_file=None)
     assert image_config.images[0].full == "docker.io/xyz:latest"
     assert image_config.images[1].full == "docker.io/abc:None"
+    assert image_config.images[2].full == "docker.io/bcs@sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d"
 
 
 @mock.patch("flytekit.configuration.default_images.sys")
@@ -61,6 +62,11 @@ def test_image_create():
 
     ic = ImageConfig.from_images("cr.flyte.org/im/g:latest")
     assert ic.default_image.fqn == "cr.flyte.org/im/g"
+    assert ic.default_image.full == "cr.flyte.org/im/g:latest"
+
+    ic = ImageConfig.from_images("cr.flyte.org/im/g@sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d")
+    assert ic.default_image.fqn == "cr.flyte.org/im/g"
+    assert ic.default_image.full == "cr.flyte.org/im/g@sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d"
 
 
 def test_get_version_suffix():

--- a/tests/flytekit/unit/configuration/test_image_config.py
+++ b/tests/flytekit/unit/configuration/test_image_config.py
@@ -45,7 +45,10 @@ def test_image_from_flytectl_config():
     image_config = ImageConfig.auto(config_file=None)
     assert image_config.images[0].full == "docker.io/xyz:latest"
     assert image_config.images[1].full == "docker.io/abc:None"
-    assert image_config.images[2].full == "docker.io/bcd@sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d"
+    assert (
+        image_config.images[2].full
+        == "docker.io/bcd@sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d"
+    )
 
 
 @mock.patch("flytekit.configuration.default_images.sys")
@@ -64,9 +67,14 @@ def test_image_create():
     assert ic.default_image.fqn == "cr.flyte.org/im/g"
     assert ic.default_image.full == "cr.flyte.org/im/g:latest"
 
-    ic = ImageConfig.from_images("cr.flyte.org/im/g@sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d")
+    ic = ImageConfig.from_images(
+        "cr.flyte.org/im/g@sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d"
+    )
     assert ic.default_image.fqn == "cr.flyte.org/im/g"
-    assert ic.default_image.full == "cr.flyte.org/im/g@sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d"
+    assert (
+        ic.default_image.full
+        == "cr.flyte.org/im/g@sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d"
+    )
 
 
 def test_get_version_suffix():

--- a/tests/flytekit/unit/configuration/test_image_config.py
+++ b/tests/flytekit/unit/configuration/test_image_config.py
@@ -45,7 +45,7 @@ def test_image_from_flytectl_config():
     image_config = ImageConfig.auto(config_file=None)
     assert image_config.images[0].full == "docker.io/xyz:latest"
     assert image_config.images[1].full == "docker.io/abc:None"
-    assert image_config.images[2].full == "docker.io/bcs@sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d"
+    assert image_config.images[2].full == "docker.io/bcd@sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d"
 
 
 @mock.patch("flytekit.configuration.default_images.sys")

--- a/tests/flytekit/unit/configuration/test_internal.py
+++ b/tests/flytekit/unit/configuration/test_internal.py
@@ -13,7 +13,11 @@ def test_load_images():
 
     cfg = get_config_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/sample.yaml"))
     imgs = Images.get_specified_images(cfg)
-    assert imgs == {"abc": "docker.io/abc", "xyz": "docker.io/xyz:latest"}
+    assert imgs == {
+        "abc": "docker.io/abc",
+        "bcd": "docker.io/bcd@sha256:26c68657ccce2cb0a31b330cb0hu3b5e108d467f641c62e13ab40cbec258c68d",
+        "xyz": "docker.io/xyz:latest",
+    }
 
 
 def test_no_images():

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -93,6 +93,7 @@ def test_look_up_image_info():
     assert img.digest == "sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
     assert img.full == "localhost:5000/xyz@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
 
+
 @mock.patch("flytekit.configuration.default_images.DefaultImages.default_image")
 def test_validate_image(mock_image):
     mock_image.return_value = "cr.flyte.org/flyteorg/flytekit:py3.9-latest"

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -54,6 +54,9 @@ def test_look_up_image_info():
     assert img.digest is None
     assert img.fqn == "docker.io/xyz"
 
+    with pytest.raises(AssertionError):
+        Image.look_up_image_info(name="x", image_identifier="docker.io/xyz", allow_no_tag_or_digest=False)
+
     img = Image.look_up_image_info(name="x", image_identifier="docker.io/xyz:latest", allow_no_tag_or_digest=True)
     assert img.name == "x"
     assert img.tag == "latest"

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -48,25 +48,25 @@ def test_default():
 
 
 def test_look_up_image_info():
-    img = Image.look_up_image_info(name="x", image_identifier="docker.io/xyz", optional_tag=True)
+    img = Image.look_up_image_info(name="x", image_identifier="docker.io/xyz", allow_no_tag_or_digest=True)
     assert img.name == "x"
     assert img.tag is None
     assert img.digest is None
     assert img.fqn == "docker.io/xyz"
 
-    img = Image.look_up_image_info(name="x", image_identifier="docker.io/xyz:latest", optional_tag=True)
+    img = Image.look_up_image_info(name="x", image_identifier="docker.io/xyz:latest", allow_no_tag_or_digest=True)
     assert img.name == "x"
     assert img.tag == "latest"
     assert img.digest is None
     assert img.fqn == "docker.io/xyz"
 
-    img = Image.look_up_image_info(name="x", image_identifier="docker.io/xyz:latest", optional_tag=False)
+    img = Image.look_up_image_info(name="x", image_identifier="docker.io/xyz:latest", allow_no_tag_or_digest=False)
     assert img.name == "x"
     assert img.tag == "latest"
     assert img.digest is None
     assert img.fqn == "docker.io/xyz"
 
-    img = Image.look_up_image_info(name="x", image_identifier="localhost:5000/xyz:latest", optional_tag=False)
+    img = Image.look_up_image_info(name="x", image_identifier="localhost:5000/xyz:latest", allow_no_tag_or_digest=False)
     assert img.name == "x"
     assert img.tag == "latest"
     assert img.digest is None
@@ -75,7 +75,7 @@ def test_look_up_image_info():
     img = Image.look_up_image_info(
         name="x",
         image_identifier="localhost:5000/xyz@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d",
-        optional_tag=False,
+        allow_no_tag_or_digest=False,
     )
     assert img.fqn == "localhost:5000/xyz"
     assert img.tag is None

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -51,21 +51,25 @@ def test_look_up_image_info():
     img = Image.look_up_image_info(name="x", image_identifier="docker.io/xyz", optional_tag=True)
     assert img.name == "x"
     assert img.tag is None
+    assert img.digest is None
     assert img.fqn == "docker.io/xyz"
 
     img = Image.look_up_image_info(name="x", image_identifier="docker.io/xyz:latest", optional_tag=True)
     assert img.name == "x"
     assert img.tag == "latest"
+    assert img.digest is None
     assert img.fqn == "docker.io/xyz"
 
     img = Image.look_up_image_info(name="x", image_identifier="docker.io/xyz:latest", optional_tag=False)
     assert img.name == "x"
     assert img.tag == "latest"
+    assert img.digest is None
     assert img.fqn == "docker.io/xyz"
 
     img = Image.look_up_image_info(name="x", image_identifier="localhost:5000/xyz:latest", optional_tag=False)
     assert img.name == "x"
     assert img.tag == "latest"
+    assert img.digest is None
     assert img.fqn == "localhost:5000/xyz"
 
     img = Image.look_up_image_info(
@@ -73,7 +77,10 @@ def test_look_up_image_info():
         image_identifier="localhost:5000/xyz@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d",
         optional_tag=False,
     )
-    assert img.fqn == "localhost:5000/xyz@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
+    assert img.fqn == "localhost:5000/xyz"
+    assert img.tag is None
+    assert img.digest == "sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
+    assert img.full == "localhost:5000/xyz@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
 
 
 @mock.patch("flytekit.configuration.default_images.DefaultImages.default_image")

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -57,6 +57,14 @@ def test_look_up_image_info():
     with pytest.raises(AssertionError):
         Image.look_up_image_info(name="x", image_identifier="docker.io/xyz", allow_no_tag_or_digest=False)
 
+    with pytest.raises(ValueError):
+        Image(
+            name="x",
+            fqn="docker.io/xyz",
+            tag="latest",
+            digest="sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d",
+        )
+
     img = Image.look_up_image_info(name="x", image_identifier="docker.io/xyz:latest", allow_no_tag_or_digest=True)
     assert img.name == "x"
     assert img.tag == "latest"
@@ -84,17 +92,6 @@ def test_look_up_image_info():
     assert img.tag is None
     assert img.digest == "sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
     assert img.full == "localhost:5000/xyz@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
-
-
-def test_image_does_not_allow_tag_and_digest():
-    with pytest.raises(ValueError):
-        Image(
-            name="x",
-            fqn="docker.io/xyz",
-            tag="latest",
-            digest="sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d",
-        )
-
 
 @mock.patch("flytekit.configuration.default_images.DefaultImages.default_image")
 def test_validate_image(mock_image):

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -68,6 +68,13 @@ def test_look_up_image_info():
     assert img.tag == "latest"
     assert img.fqn == "localhost:5000/xyz"
 
+    img = Image.look_up_image_info(
+        name="x",
+        tag="localhost:5000/xyz@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d",
+        optional_tag=False,
+    )
+    assert img.fqn == "localhost:5000/xyz@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
+
 
 @mock.patch("flytekit.configuration.default_images.DefaultImages.default_image")
 def test_validate_image(mock_image):
@@ -82,6 +89,7 @@ def test_validate_image(mock_image):
     img3_cli = f"default={img3}"
     img4 = "docker.io/my:azb"
     img4_cli = f"my_img={img4}"
+    img5 = f"docker.io/my@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
 
     ic = ImageConfig.validate_image(None, "image", (img1,))
     assert ic
@@ -109,6 +117,9 @@ def test_validate_image(mock_image):
     assert ic.default_image.full == img3
     assert len(ic.images) == 2
     assert ic.images[1].full == img4
+
+    ic = ImageConfig.validate_image(None, "image", (img5,))
+    assert ic.default_image.full == img5
 
 
 def test_secrets_manager_default():

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -82,6 +82,9 @@ def test_look_up_image_info():
     assert img.digest == "sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
     assert img.full == "localhost:5000/xyz@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
 
+def test_image_does_not_allow_tag_and_digest():
+    with pytest.raises(ValueError):
+        Image(name="x", fqn="docker.io/xyz", tag="latest", digest="sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d")
 
 @mock.patch("flytekit.configuration.default_images.DefaultImages.default_image")
 def test_validate_image(mock_image):

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -272,7 +272,7 @@ def test_serialization_settings_transport():
     ss = SerializationSettings.from_transport(tp)
     assert ss is not None
     assert ss == serialization_settings
-    assert len(tp) == 400
+    assert len(tp) == 408
 
 
 def test_exec_params():

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -48,29 +48,29 @@ def test_default():
 
 
 def test_look_up_image_info():
-    img = Image.look_up_image_info(name="x", tag="docker.io/xyz", optional_tag=True)
+    img = Image.look_up_image_info(name="x", image_identifier="docker.io/xyz", optional_tag=True)
     assert img.name == "x"
     assert img.tag is None
     assert img.fqn == "docker.io/xyz"
 
-    img = Image.look_up_image_info(name="x", tag="docker.io/xyz:latest", optional_tag=True)
+    img = Image.look_up_image_info(name="x", image_identifier="docker.io/xyz:latest", optional_tag=True)
     assert img.name == "x"
     assert img.tag == "latest"
     assert img.fqn == "docker.io/xyz"
 
-    img = Image.look_up_image_info(name="x", tag="docker.io/xyz:latest", optional_tag=False)
+    img = Image.look_up_image_info(name="x", image_identifier="docker.io/xyz:latest", optional_tag=False)
     assert img.name == "x"
     assert img.tag == "latest"
     assert img.fqn == "docker.io/xyz"
 
-    img = Image.look_up_image_info(name="x", tag="localhost:5000/xyz:latest", optional_tag=False)
+    img = Image.look_up_image_info(name="x", image_identifier="localhost:5000/xyz:latest", optional_tag=False)
     assert img.name == "x"
     assert img.tag == "latest"
     assert img.fqn == "localhost:5000/xyz"
 
     img = Image.look_up_image_info(
         name="x",
-        tag="localhost:5000/xyz@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d",
+        image_identifier="localhost:5000/xyz@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d",
         optional_tag=False,
     )
     assert img.fqn == "localhost:5000/xyz@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -82,9 +82,16 @@ def test_look_up_image_info():
     assert img.digest == "sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
     assert img.full == "localhost:5000/xyz@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
 
+
 def test_image_does_not_allow_tag_and_digest():
     with pytest.raises(ValueError):
-        Image(name="x", fqn="docker.io/xyz", tag="latest", digest="sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d")
+        Image(
+            name="x",
+            fqn="docker.io/xyz",
+            tag="latest",
+            digest="sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d",
+        )
+
 
 @mock.patch("flytekit.configuration.default_images.DefaultImages.default_image")
 def test_validate_image(mock_image):
@@ -99,7 +106,7 @@ def test_validate_image(mock_image):
     img3_cli = f"default={img3}"
     img4 = "docker.io/my:azb"
     img4_cli = f"my_img={img4}"
-    img5 = f"docker.io/my@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
+    img5 = "docker.io/my@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
 
     ic = ImageConfig.validate_image(None, "image", (img1,))
     assert ic

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -39,7 +39,7 @@ def test_istestfunction():
 def test_container_image_conversion(mock_image_spec_builder):
     default_img = Image(name="default", fqn="xyz.com/abc", tag="tag1")
     other_img = Image(name="other", fqn="xyz.com/other", tag="tag-other")
-    other_img2 = Image(name="other2", fqn="xyz.com/other2", tag="@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d")
+    other_img2 = Image(name="other2", fqn="xyz.com/other2", digest="sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d")
     cfg = ImageConfig(default_image=default_img, images=[default_img, other_img, other_img2])
     assert get_registerable_container_image(None, cfg) == "xyz.com/abc:tag1"
     assert get_registerable_container_image("", cfg) == "xyz.com/abc:tag1"
@@ -73,7 +73,7 @@ def test_container_image_conversion(mock_image_spec_builder):
 
     assert get_registerable_container_image("{{.image.other2}}", cfg) == "xyz.com/other2@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
 
-    default_img_using_sha = Image(name="default", fqn="xyz.com/abc", tag="@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d")
+    default_img_using_sha = Image(name="default", fqn="xyz.com/abc", digest="sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d")
     cfg = ImageConfig(default_image=default_img_using_sha, images=[default_img, other_img, other_img2])
 
     assert get_registerable_container_image("{{.image.default}}", cfg) == "xyz.com/abc@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -39,7 +39,11 @@ def test_istestfunction():
 def test_container_image_conversion(mock_image_spec_builder):
     default_img = Image(name="default", fqn="xyz.com/abc", tag="tag1")
     other_img = Image(name="other", fqn="xyz.com/other", tag="tag-other")
-    other_img2 = Image(name="other2", fqn="xyz.com/other2", digest="sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d")
+    other_img2 = Image(
+        name="other2",
+        fqn="xyz.com/other2",
+        digest="sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d",
+    )
     cfg = ImageConfig(default_image=default_img, images=[default_img, other_img, other_img2])
     assert get_registerable_container_image(None, cfg) == "xyz.com/abc:tag1"
     assert get_registerable_container_image("", cfg) == "xyz.com/abc:tag1"
@@ -71,12 +75,22 @@ def test_container_image_conversion(mock_image_spec_builder):
 
     assert get_registerable_container_image("{{.image.default}}", cfg) == "xyz.com/abc:tag1"
 
-    assert get_registerable_container_image("{{.image.other2}}", cfg) == "xyz.com/other2@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
+    assert (
+        get_registerable_container_image("{{.image.other2}}", cfg)
+        == "xyz.com/other2@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
+    )
 
-    default_img_using_sha = Image(name="default", fqn="xyz.com/abc", digest="sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d")
+    default_img_using_sha = Image(
+        name="default",
+        fqn="xyz.com/abc",
+        digest="sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d",
+    )
     cfg = ImageConfig(default_image=default_img_using_sha, images=[default_img, other_img, other_img2])
 
-    assert get_registerable_container_image("{{.image.default}}", cfg) == "xyz.com/abc@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
+    assert (
+        get_registerable_container_image("{{.image.default}}", cfg)
+        == "xyz.com/abc@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
+    )
 
     ImageBuildEngine.register("test", mock_image_spec_builder)
     image_spec = ImageSpec(builder="test", python_version="3.7", registry="")

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -39,7 +39,8 @@ def test_istestfunction():
 def test_container_image_conversion(mock_image_spec_builder):
     default_img = Image(name="default", fqn="xyz.com/abc", tag="tag1")
     other_img = Image(name="other", fqn="xyz.com/other", tag="tag-other")
-    cfg = ImageConfig(default_image=default_img, images=[default_img, other_img])
+    other_img2 = Image(name="other2", fqn="xyz.com/other2", tag="@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d")
+    cfg = ImageConfig(default_image=default_img, images=[default_img, other_img, other_img2])
     assert get_registerable_container_image(None, cfg) == "xyz.com/abc:tag1"
     assert get_registerable_container_image("", cfg) == "xyz.com/abc:tag1"
     assert get_registerable_container_image("abc", cfg) == "abc"
@@ -69,6 +70,13 @@ def test_container_image_conversion(mock_image_spec_builder):
         get_registerable_container_image("{{.image.blah}}", cfg)
 
     assert get_registerable_container_image("{{.image.default}}", cfg) == "xyz.com/abc:tag1"
+
+    assert get_registerable_container_image("{{.image.other2}}", cfg) == "xyz.com/other2@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
+
+    default_img_using_sha = Image(name="default", fqn="xyz.com/abc", tag="@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d")
+    cfg = ImageConfig(default_image=default_img_using_sha, images=[default_img, other_img, other_img2])
+
+    assert get_registerable_container_image("{{.image.default}}", cfg) == "xyz.com/abc@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
 
     ImageBuildEngine.register("test", mock_image_spec_builder)
     image_spec = ImageSpec(builder="test", python_version="3.7", registry="")

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -44,7 +44,11 @@ def test_container_image_conversion(mock_image_spec_builder):
         fqn="xyz.com/other2",
         digest="sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d",
     )
-    cfg = ImageConfig(default_image=default_img, images=[default_img, other_img, other_img2])
+    other_img3 = Image(
+        name="other3",
+        fqn="xyz.com/other3",
+    )
+    cfg = ImageConfig(default_image=default_img, images=[default_img, other_img, other_img2, other_img3])
     assert get_registerable_container_image(None, cfg) == "xyz.com/abc:tag1"
     assert get_registerable_container_image("", cfg) == "xyz.com/abc:tag1"
     assert get_registerable_container_image("abc", cfg) == "abc"
@@ -64,6 +68,10 @@ def test_container_image_conversion(mock_image_spec_builder):
         get_registerable_container_image("{{.image.other2.fqn}}@{{.image.other2.version}}", cfg)
         == "xyz.com/other2@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
     )
+    assert (
+        get_registerable_container_image("{{.image.other3.fqn}}:{{.image.other3.version}}", cfg)
+        == "xyz.com/other3:tag1"
+    )
     assert get_registerable_container_image("{{.image.other.fqn}}", cfg) == "xyz.com/other"
     # Works with images instead of just image
     assert get_registerable_container_image("{{.images.other.fqn}}", cfg) == "xyz.com/other"
@@ -76,6 +84,9 @@ def test_container_image_conversion(mock_image_spec_builder):
 
     with pytest.raises(AssertionError):
         get_registerable_container_image("{{.image.blah}}", cfg)
+
+    with pytest.raises(AssertionError):
+        get_registerable_container_image("{{.image.other3.blah}}", cfg)
 
     assert get_registerable_container_image("{{.image.default}}", cfg) == "xyz.com/abc:tag1"
 

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -60,6 +60,9 @@ def test_container_image_conversion(mock_image_spec_builder):
     assert (
         get_registerable_container_image("{{.image.other.fqn}}:{{.image.default.version}}", cfg) == "xyz.com/other:tag1"
     )
+    assert (
+        get_registerable_container_image("{{.image.other2.fqn}}@{{.image.other2.version}}", cfg) == "xyz.com/other2@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
+    )
     assert get_registerable_container_image("{{.image.other.fqn}}", cfg) == "xyz.com/other"
     # Works with images instead of just image
     assert get_registerable_container_image("{{.images.other.fqn}}", cfg) == "xyz.com/other"
@@ -86,9 +89,12 @@ def test_container_image_conversion(mock_image_spec_builder):
         digest="sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d",
     )
     cfg = ImageConfig(default_image=default_img_using_sha, images=[default_img, other_img, other_img2])
-
     assert (
         get_registerable_container_image("{{.image.default}}", cfg)
+        == "xyz.com/abc@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
+    )
+    assert (
+        get_registerable_container_image("{{.image.default.fqn}}@{{.image.default.version}}", cfg)
         == "xyz.com/abc@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
     )
 

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -61,7 +61,8 @@ def test_container_image_conversion(mock_image_spec_builder):
         get_registerable_container_image("{{.image.other.fqn}}:{{.image.default.version}}", cfg) == "xyz.com/other:tag1"
     )
     assert (
-        get_registerable_container_image("{{.image.other2.fqn}}@{{.image.other2.version}}", cfg) == "xyz.com/other2@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
+        get_registerable_container_image("{{.image.other2.fqn}}@{{.image.other2.version}}", cfg)
+        == "xyz.com/other2@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
     )
     assert get_registerable_container_image("{{.image.other.fqn}}", cfg) == "xyz.com/other"
     # Works with images instead of just image


### PR DESCRIPTION
## Tracking issue
Closes: [#5132](https://github.com/flyteorg/flyte/issues/5132)

## Why are the changes needed?
When you want to be confident what code your are running without worrying about cached images its very useful to reference an image using its digest instead of by tag. 

## What changes were proposed in this pull request?
1. Add a separate `digest` field on `Image`. 
    1. Disallow specifying `digest` and `tag` at the same time. 
    1. Add a `version` property that will return either digest or tag whichever is present. 
    1. Update docstring. 
1. Update `Image.look_up_image_info()` so that it sets either `digest` or `tag` derived automatically.
    1. Unfortunately this can be done easily with `docker.utils.parse_repository_tag` because it hides whether its returning a digest or a tag. 
    1. `parse_repository_tag` is a tiny function though so I just copy pasted it and adjusted so that it returns distinguishable `digest` and `tag`. 
    1. Renamed the input arguments to remove the word `tag` since its actually referring to the full image identifier and it could be a digest not a tag. Pretty sure this is the only breaking change introduced. 
    1. Update docstring. 
1. Update `get_registerable_container_image` to use `Image.full` and `Image.version` when substituting. 
1. I added test cases with a `sha256:` to every test I could find for `Image.full`, `Image.look_up_image_info` and `get_registerable_container_image`.
     1. This included add a digest example to `sample.yaml` so this caused a bunch of tests to need updating. 
     1. Also added a few tests for missing coverage very close to my changes.
     1. Adjust mocking in `test_spark_template_with_remote` https://github.com/flyteorg/flytekit/pull/2335#issuecomment-2054003575

### Alternatives considered:
1. Stop separating `fqn` and `tag` and just store a single string. 
    1. This would break `get_registerable_container_image`'s support for substituting just one of `fqn` or `tag`. 
    3. `Image.full` will fill in `@` as the separator for digests and `:` for tags. 
1. Store the `:` or `@` separator in the tag so that `fqn + tag` correctly reconstructs the image identifier string
    1. This would break anyone who is currently using `{{.image.xyz.fqn}}:{{.image.xyz.version}}` as their `container_name` template. These users would get doubled `:`s. 

## How was this patch tested?
New unittests. 
I will also test on our real Flyte setup. 

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly - updated docstring
- [x] All new and existing tests passed - `make test` returned all green. 
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
