### PR TITLE
Added remote path helper function

### DIFF
--- a/flytekit/extras/helpers.py
+++ b/flytekit/extras/helpers.py
@@ -1,0 +1,33 @@
+import os
+import random
+import string
+
+
+def rand_str(len: int) -> str:
+    """Generate a random string of length `len`
+
+    Args:
+        len (int): Length of the random string
+
+    Returns:
+        str: Random string
+    """
+    characters = string.ascii_letters + string.digits
+    return "".join(random.choices(characters, k=len))
+
+
+def generate_remote_path(bucket_prefix: str, fname: str) -> str:
+    """Generate a random remote path for an object in a bucket
+
+    Args:
+        bucket_prefix (str): Bucket prefix
+        fname (str): Filename
+
+    Returns:
+        str: Remote object prefix
+    """
+    try:
+        hn = os.environ["HOSTNAME"]
+    except KeyError as e:
+        raise e("HOSTNAME environment variable not set")
+    return f"{bucket_prefix}/{rand_str(2)}/{hn}/{rand_str(32)}/{fname}"

--- a/tests/flytekit/unit/extras/test_helpers.py
+++ b/tests/flytekit/unit/extras/test_helpers.py
@@ -1,0 +1,12 @@
+from flytekit.extras.helpers import generate_remote_path, rand_str
+
+
+def test_rand_str():
+    assert len(rand_str(10)) == 10
+
+
+def test_generate_remote_path():
+    try:
+        generate_remote_path("s3://bucket", "file")
+    except KeyError as e:
+        assert str(e) == "HOSTNAME environment variable not set"


### PR DESCRIPTION
## Why are the changes needed?

Users will sometimes want to push blobs to custom buckets but maintain the naming convention that flyte creates by default

## What changes were proposed in this pull request?

This adds a small helpers module with this function and associated tests

## How was this patch tested?

2 small unit tests, one for each new function

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.
