### PR TITLE
Fix `_serialize_pod_spec` with no default image

### DIFF
--- a/flytekit/core/utils.py
+++ b/flytekit/core/utils.py
@@ -163,15 +163,12 @@ def _serialize_pod_spec(
         # with the values given to ContainerTask.
         # The attributes include: image, command, args, resource, and env (env is unioned)
 
-        # resolve the image name if it is image spec or placeholder
-        resolved_image = get_registerable_container_image(container.image, settings.image_config)
-
         if container.name == cast(PodTemplate, pod_template).primary_container_name:
             if container.image is None:
                 # Copy the image from primary_container only if the image is not specified in the pod spec.
                 container.image = primary_container.image
             else:
-                container.image = resolved_image
+                container.image = get_registerable_container_image(container.image, settings.image_config)
 
             container.command = primary_container.command
             container.args = primary_container.args
@@ -190,7 +187,7 @@ def _serialize_pod_spec(
                     container.env or []
                 )
         else:
-            container.image = resolved_image
+            container.image = get_registerable_container_image(container.image, settings.image_config)
 
         final_containers.append(container)
     cast(V1PodSpec, pod_template.pod_spec).containers = final_containers

--- a/tests/flytekit/unit/core/test_python_auto_container.py
+++ b/tests/flytekit/unit/core/test_python_auto_container.py
@@ -51,7 +51,7 @@ def minimal_serialization_settings_no_default_image(no_default_image_config):
     ],
     scope="function",
 )
-def all_serialisation_settings(request):
+def serialization_settings(request):
     return request.getfixturevalue(request.param)
 
 
@@ -264,15 +264,15 @@ task_with_minimum_pod_template = DummyAutoContainerTask(
 )
 
 
-def test_minimum_pod_template(all_serialisation_settings):
+def test_minimum_pod_template(serialization_settings):
     #################
     # Test get_k8s_pod
     #################
 
-    container = task_with_minimum_pod_template.get_container(all_serialisation_settings)
+    container = task_with_minimum_pod_template.get_container(serialization_settings)
     assert container is None
 
-    k8s_pod = task_with_minimum_pod_template.get_k8s_pod(all_serialisation_settings)
+    k8s_pod = task_with_minimum_pod_template.get_k8s_pod(serialization_settings)
 
     metadata = k8s_pod.metadata
     assert metadata.labels == {"lKeyA": "lValA"}
@@ -304,7 +304,7 @@ def test_minimum_pod_template(all_serialisation_settings):
         "task_with_minimum_pod_template",
     ]
 
-    config = task_with_minimum_pod_template.get_config(all_serialisation_settings)
+    config = task_with_minimum_pod_template.get_config(serialization_settings)
     assert config == {"primary_container_name": "primary"}
 
     #################
@@ -315,7 +315,7 @@ def test_minimum_pod_template(all_serialisation_settings):
     #################
     # Test Serialization
     #################
-    ts = get_serializable_task(OrderedDict(), all_serialisation_settings, task_with_minimum_pod_template)
+    ts = get_serializable_task(OrderedDict(), serialization_settings, task_with_minimum_pod_template)
     assert ts.template.container is None
     # k8s_pod content is already verified above, so only check the existence here
     assert ts.template.k8s_pod is not None

--- a/tests/flytekit/unit/core/test_python_auto_container.py
+++ b/tests/flytekit/unit/core/test_python_auto_container.py
@@ -2,14 +2,12 @@ from collections import OrderedDict
 from typing import Any
 
 import pytest
-from kubernetes.client.models import (V1Container, V1EnvVar, V1PodSpec,
-                                      V1ResourceRequirements, V1Volume)
+from kubernetes.client.models import V1Container, V1EnvVar, V1PodSpec, V1ResourceRequirements, V1Volume
 
 from flytekit.configuration import Image, ImageConfig, SerializationSettings
 from flytekit.core.base_task import TaskMetadata
 from flytekit.core.pod_template import PodTemplate
-from flytekit.core.python_auto_container import (
-    PythonAutoContainerTask, get_registerable_container_image)
+from flytekit.core.python_auto_container import PythonAutoContainerTask, get_registerable_container_image
 from flytekit.core.resources import Resources
 from flytekit.image_spec.image_spec import ImageBuildEngine, ImageSpec
 from flytekit.tools.translator import get_serializable_task
@@ -19,6 +17,7 @@ from flytekit.tools.translator import get_serializable_task
 def default_image_config():
     default_image = Image(name="default", fqn="docker.io/xyz", tag="some-git-hash")
     return ImageConfig(default_image=default_image)
+
 
 @pytest.fixture
 def no_default_image_config():

--- a/tests/flytekit/unit/core/test_python_auto_container.py
+++ b/tests/flytekit/unit/core/test_python_auto_container.py
@@ -2,12 +2,14 @@ from collections import OrderedDict
 from typing import Any
 
 import pytest
-from kubernetes.client.models import V1Container, V1EnvVar, V1PodSpec, V1ResourceRequirements, V1Volume
+from kubernetes.client.models import (V1Container, V1EnvVar, V1PodSpec,
+                                      V1ResourceRequirements, V1Volume)
 
 from flytekit.configuration import Image, ImageConfig, SerializationSettings
 from flytekit.core.base_task import TaskMetadata
 from flytekit.core.pod_template import PodTemplate
-from flytekit.core.python_auto_container import PythonAutoContainerTask, get_registerable_container_image
+from flytekit.core.python_auto_container import (
+    PythonAutoContainerTask, get_registerable_container_image)
 from flytekit.core.resources import Resources
 from flytekit.image_spec.image_spec import ImageBuildEngine, ImageSpec
 from flytekit.tools.translator import get_serializable_task
@@ -17,6 +19,11 @@ from flytekit.tools.translator import get_serializable_task
 def default_image_config():
     default_image = Image(name="default", fqn="docker.io/xyz", tag="some-git-hash")
     return ImageConfig(default_image=default_image)
+
+@pytest.fixture
+def no_default_image_config():
+    other_image = Image(name="other", fqn="docker.io/xyz", tag="some-git-hash")
+    return ImageConfig.create_from(default_image=None, other_images=[other_image])
 
 
 @pytest.fixture
@@ -29,6 +36,23 @@ def default_serialization_settings(default_image_config):
 @pytest.fixture
 def minimal_serialization_settings(default_image_config):
     return SerializationSettings(project="p", domain="d", version="v", image_config=default_image_config)
+
+
+@pytest.fixture
+def minimal_serialization_settings_no_default_image(no_default_image_config):
+    return SerializationSettings(project="p", domain="d", version="v", image_config=no_default_image_config)
+
+
+@pytest.fixture(
+    params=[
+        "default_serialization_settings",
+        "minimal_serialization_settings",
+        "minimal_serialization_settings_no_default_image",
+    ],
+    scope="function",
+)
+def all_serialisation_settings(request):
+    return request.getfixturevalue(request.param)
 
 
 def test_image_name_interpolation(default_image_config):
@@ -240,15 +264,15 @@ task_with_minimum_pod_template = DummyAutoContainerTask(
 )
 
 
-def test_minimum_pod_template(default_serialization_settings):
+def test_minimum_pod_template(all_serialisation_settings):
     #################
     # Test get_k8s_pod
     #################
 
-    container = task_with_minimum_pod_template.get_container(default_serialization_settings)
+    container = task_with_minimum_pod_template.get_container(all_serialisation_settings)
     assert container is None
 
-    k8s_pod = task_with_minimum_pod_template.get_k8s_pod(default_serialization_settings)
+    k8s_pod = task_with_minimum_pod_template.get_k8s_pod(all_serialisation_settings)
 
     metadata = k8s_pod.metadata
     assert metadata.labels == {"lKeyA": "lValA"}
@@ -280,7 +304,7 @@ def test_minimum_pod_template(default_serialization_settings):
         "task_with_minimum_pod_template",
     ]
 
-    config = task_with_minimum_pod_template.get_config(default_serialization_settings)
+    config = task_with_minimum_pod_template.get_config(all_serialisation_settings)
     assert config == {"primary_container_name": "primary"}
 
     #################
@@ -291,7 +315,7 @@ def test_minimum_pod_template(default_serialization_settings):
     #################
     # Test Serialization
     #################
-    ts = get_serializable_task(OrderedDict(), default_serialization_settings, task_with_minimum_pod_template)
+    ts = get_serializable_task(OrderedDict(), all_serialisation_settings, task_with_minimum_pod_template)
     assert ts.template.container is None
     # k8s_pod content is already verified above, so only check the existence here
     assert ts.template.k8s_pod is not None


### PR DESCRIPTION
## Tracking issue
_https://github.com/flyteorg/flyte/issues/5220_

## Why are the changes needed?
Avoid an exception in a valid scenario.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
1. Defer call to `get_registerable_container_image` until we know it is actually needed. There is no point computing this value if its not needed and if it raises an exception in blocks a valid scenario. 
2. Add tests. Specifically I updated `test_minimum_pod_template` so that it runs with 3 different serialisation settings. Importantly one of these uses an `ImageConfig` with no `default_image`. 
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
3. If there is design documentation, please add the link.
-->

## How was this patch tested?
Add unittests
Deployed this in real Flyte setup

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly - not applicable
- [x] All new and existing tests passed - `make test` looks good
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
