### PR TITLE
Add ImageSpec reference docs to flyte docs

### DIFF
--- a/docs/source/docs_index.rst
+++ b/docs/source/docs_index.rst
@@ -8,6 +8,7 @@ Flytekit API Reference
    design/index
    flytekit
    configuration
+   imagespec
    remote
    clients
    testing

--- a/docs/source/imagespec.rst
+++ b/docs/source/imagespec.rst
@@ -1,0 +1,4 @@
+.. automodule:: flytekit.image_spec
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/flytekit/image_spec/__init__.py
+++ b/flytekit/image_spec/__init__.py
@@ -1,1 +1,16 @@
+"""
+==========
+ImageSpec
+==========
+
+.. currentmodule:: flytekit.image_spec
+
+This module contains the ImageSpec class parameters and methods.
+
+.. autosummary::
+   :toctree: generated/
+
+   ImageSpec
+"""
+
 from .image_spec import ImageSpec


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds changes needed to add ImageSpec reference docs to the Flyte docs site.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Docs link

TK
