### PR TITLE
Consistent formatting for artifact id spec

### DIFF
--- a/flytekit/core/artifact.py
+++ b/flytekit/core/artifact.py
@@ -136,6 +136,9 @@ class ArtifactIDSpecification(object):
         )
         return artifact_id
 
+    def __repr__(self):
+        return f"ArtifactIDSpecification({self.artifact.name}, {self.artifact.partition_keys}, TP: {self.artifact.time_partitioned})"
+
 
 class ArtifactQuery(object):
     def __init__(

--- a/tests/flytekit/unit/core/test_data_persistence.py
+++ b/tests/flytekit/unit/core/test_data_persistence.py
@@ -166,7 +166,9 @@ def test_initialise_azure_file_provider_with_service_principal():
 
 
 def test_initialise_azure_file_provider_with_default_credential():
-    with mock.patch.dict(os.environ, {"FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname"}):
+    with mock.patch.dict(
+        os.environ, {"FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname", "AZURE_STORAGE_ANON": "false"}
+    ):
         fp = FileAccessProvider("/tmp", "abfs://container/path/within/container")
         assert fp.get_filesystem().account_name == "accountname"
         assert isinstance(fp.get_filesystem().sync_credential, DefaultAzureCredential)

--- a/tests/flytekit/unit/types/pickle/test_flyte_pickle.py
+++ b/tests/flytekit/unit/types/pickle/test_flyte_pickle.py
@@ -108,3 +108,21 @@ def test_union():
     assert variants[0].blob.format == "NumpyArray"
     assert variants[1].structured_dataset_type.format == ""
     assert variants[2].blob.format == FlytePickleTransformer.PYTHON_PICKLE_FORMAT
+
+
+def test_artf():
+    from flytekit.core.artifact import Artifact
+
+    a1 = Artifact(name="my_a1", partition_keys=["a"])
+
+    class Foo(object):
+        def __init__(self, number: int):
+            self.number = number
+
+    @task
+    def t1(a: int) -> Annotated[Foo, a1(a="bar")]:
+        return Foo(number=a)
+
+    task_spec = get_serializable(OrderedDict(), serialization_settings, t1)
+    md = task_spec.template.interface.outputs["o0"].type.metadata["python_class_name"]
+    assert "0x" not in str(md)


### PR DESCRIPTION
## Why are the changes needed?
The new artifact ID causes weird issues with the metadata field.  The field itself is not used I don't think for the vast majority of Flyte, but is included in Admin's digest check, which is causing repeat registrations to fail with
```
task with different structure already exists with id resource_type:TASK  project:"flytesnacks"  domain:"development"  name:"ingest_data.merge_embeddings"  version:"GHP2gevxt5ywddhM92TU9A"
```

Had to amend an unrelated Azure FS test because of https://github.com/fsspec/adlfs/issues/270.  We started picking up the latest version of [adlfs](https://pypi.org/project/adlfs/) over the weekend which is causing the test to fail.

## What changes were proposed in this pull request?
Add a pretty print to the object, which should remediate the conflict at least.

## How was this patch tested?
Unit tested and tested register with previously failing scenario.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
