### PR TITLE
Do not check for secret groups during runtime

### DIFF
--- a/flytekit/configuration/plugin.py
+++ b/flytekit/configuration/plugin.py
@@ -76,7 +76,7 @@ class FlytekitPlugin:
 
     @staticmethod
     def secret_requires_group() -> bool:
-        """Return True if secrets require group entry."""
+        """Return True if secrets require group entry during registration time."""
         return True
 
     @staticmethod

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -360,7 +360,6 @@ class SecretsManager(object):
         Retrieves a secret using the resolution order -> Env followed by file. If not found raises a ValueError
         param encode_mode, defines the mode to open files, it can either be "r" to read file, or "rb" to read binary file
         """
-        self.check_group_key(group)
         env_var = self.get_secrets_env_var(group, key, group_version)
         fpath = self.get_secrets_file(group, key, group_version)
         v = os.environ.get(env_var)
@@ -380,7 +379,6 @@ class SecretsManager(object):
         """
         Returns a string that matches the ENV Variable to look for the secrets
         """
-        self.check_group_key(group)
         l = [k.upper() for k in filter(None, (group, group_version, key))]
         return f"{self._env_prefix}{'_'.join(l)}"
 
@@ -390,17 +388,9 @@ class SecretsManager(object):
         """
         Returns a path that matches the file to look for the secrets
         """
-        self.check_group_key(group)
         l = [k.lower() for k in filter(None, (group, group_version, key))]
         l[-1] = f"{self._file_prefix}{l[-1]}"
         return os.path.join(self._base_dir, *l)
-
-    @staticmethod
-    def check_group_key(group: Optional[str]):
-        from flytekit.configuration.plugin import get_plugin
-
-        if get_plugin().secret_requires_group() and (group is None or group == ""):
-            raise ValueError("secrets group is a mandatory field.")
 
 
 @dataclass(frozen=True)

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -151,8 +151,6 @@ def test_secrets_manager_default():
 
 def test_secrets_manager_get_envvar():
     sec = SecretsManager()
-    with pytest.raises(ValueError):
-        sec.get_secrets_env_var("", "x")
     cfg = SecretsConfig.auto()
     assert sec.get_secrets_env_var("group", "test") == f"{cfg.env_prefix}GROUP_TEST"
     assert sec.get_secrets_env_var("group", "test", "v1") == f"{cfg.env_prefix}GROUP_V1_TEST"
@@ -168,8 +166,6 @@ def test_secret_manager_no_group(monkeypatch):
 
     sec = SecretsManager()
     cfg = SecretsConfig.auto()
-    sec.check_group_key(None)
-    sec.check_group_key("")
 
     assert sec.get_secrets_env_var(key="ABC") == f"{cfg.env_prefix}ABC"
 
@@ -180,8 +176,6 @@ def test_secret_manager_no_group(monkeypatch):
 
 def test_secrets_manager_get_file():
     sec = SecretsManager()
-    with pytest.raises(ValueError):
-        sec.get_secrets_file("", "x")
     cfg = SecretsConfig.auto()
     assert sec.get_secrets_file("group", "test") == os.path.join(
         cfg.default_dir,

--- a/tests/flytekit/unit/models/core/test_security.py
+++ b/tests/flytekit/unit/models/core/test_security.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock
 
+import pytest
+
 import flytekit.configuration.plugin
 from flytekit.models.security import Secret
 
@@ -14,6 +16,17 @@ def test_secret():
     obj2 = Secret.from_flyte_idl(obj.to_flyte_idl())
     assert obj2.key is None
     assert obj2.group_version == "v1"
+
+
+def test_secret_error(monkeypatch):
+    # Mock configuration to require groups for this test
+    plugin_mock = Mock()
+    plugin_mock.secret_requires_group.return_value = True
+    mock_global_plugin = {"plugin": plugin_mock}
+    monkeypatch.setattr(flytekit.configuration.plugin, "_GLOBAL_CONFIG", mock_global_plugin)
+
+    with pytest.raises(ValueError, match="Group is a required parameter"):
+        Secret(key="my_key")
 
 
 def test_secret_no_group(monkeypatch):


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

With this PR, secret managers that do not require groups, can configure the client to disable the secret group check and have it work remotely without changing the `flytekit` base image.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

On main, the secrets groups are checked during registration time and runtime. This PR keeps the registration time check and removes the runtime check. 


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests that check for the groups were removed. I added a new test to make sure that groups are checked during registration time.