### PR TITLE
refactor: Improve error handling and logging

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -815,6 +815,7 @@ class WorkflowCommand(click.RichGroup):
             is_workflow = exe_entity in self._entities.workflows
         if not os.path.exists(self._filename):
             click.secho(f"File {self._filename} does not exist.", fg="red")
+            exit(1)
 
         project_root = _find_project_root(self._filename)
 

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -814,7 +814,7 @@ class WorkflowCommand(click.RichGroup):
         if self._entities:
             is_workflow = exe_entity in self._entities.workflows
         if not os.path.exists(self._filename):
-            raise ValueError(f"File {self._filename} does not exist")
+            click.secho(f"File {self._filename} does not exist.", fg="red")
 
         project_root = _find_project_root(self._filename)
 

--- a/flytekit/exceptions/scopes.py
+++ b/flytekit/exceptions/scopes.py
@@ -215,6 +215,8 @@ def user_entry_point(wrapped, args, kwargs):
             fn_name = wrapped.__name__
             try:
                 return wrapped(*args, **kwargs)
+            except FlyteScopedException as exc:
+                raise exc.type(f"Error encountered while executing '{fn_name}':\n  {exc.value}") from exc
             except Exception as exc:
                 exc_type, exc_value, tb = sys.exc_info()
                 tb = tb.tb_next  # Remove the top frame [wrapped(*args, **kwargs)] from the stack

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -99,10 +99,12 @@ def initialize_global_loggers():
     set_user_logger_properties(handler, None, logging.INFO)
 
 
-def upgrade_to_rich_logging(
-    console: typing.Optional["rich.console.Console"] = None, log_level: typing.Optional[int] = logging.WARNING
-):
-    if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) == "0":
+def is_rich_logging_enabled() -> bool:
+    return os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0"
+
+
+def upgrade_to_rich_logging(log_level: typing.Optional[int] = logging.WARNING):
+    if not is_rich_logging_enabled():
         return
     try:
         import click

--- a/plugins/conftest.py
+++ b/plugins/conftest.py
@@ -1,0 +1,8 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def set_default_envs():
+    os.environ["FLYTE_EXIT_ON_USER_EXCEPTION"] = "0"

--- a/tests/flytekit/conftest.py
+++ b/tests/flytekit/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 import flytekit.configuration.plugin
@@ -9,3 +11,8 @@ def configure_plugin():
     """If a plugin is installed then the global plugin refers to an external plugin.
     For testing, we want to test against flytekit's own plugin, so we override the state."""
     flytekit.configuration.plugin._GLOBAL_CONFIG["plugin"] = FlytekitPlugin
+
+
+@pytest.fixture(scope="module", autouse=True)
+def smtp_connection():
+    os.environ["FLYTE_EXIT_ON_USER_EXCEPTION"] = "0"

--- a/tests/flytekit/conftest.py
+++ b/tests/flytekit/conftest.py
@@ -14,5 +14,5 @@ def configure_plugin():
 
 
 @pytest.fixture(scope="module", autouse=True)
-def smtp_connection():
+def set_default_envs():
     os.environ["FLYTE_EXIT_ON_USER_EXCEPTION"] = "0"


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
It's difficult to debug since flytekit generates lots of irrelevant log messages.

## What changes were proposed in this pull request?
Only print the traceback raised from the user code.

## How was this patch tested?

```python
import pandas as pd

from flytekit import task, workflow, ImageSpec, StructuredDataset

new_flytekit = "git+https://github.com/flyteorg/flytekit@44479af966f979ededd4b1aeabd1915027740231"


image = ImageSpec(registry="ghcr.io/unionai-oss", packages=["flytekitplugins-flyteinteractive"])


@task()
def t1() -> int:
    sd = StructuredDataset(uri="s3://abc")
    sd.open(pd.DataFrame).all()
    return 3 + 2


@task()
def t2() -> int:
    raise ValueError("failed")


@workflow
def wf():
    t1()
    t2()


if __name__ == "__main__":
    t1()
```

### Screenshots

Before:

<img width="1352" alt="Screenshot 2024-04-16 at 9 51 59 PM" src="https://github.com/flyteorg/flytekit/assets/37936015/da37357e-6204-44de-a593-38f50f5bf03a">

<img width="1352" alt="Screenshot 2024-04-16 at 9 52 16 PM" src="https://github.com/flyteorg/flytekit/assets/37936015/f1c5c3c2-18f1-4949-9c4e-b1d66862fcc8">

<img width="1352" alt="Screenshot 2024-04-16 at 9 52 32 PM" src="https://github.com/flyteorg/flytekit/assets/37936015/f5c86335-d86b-4b6e-8775-e06a252f3dab">


After:

<img width="1352" alt="Screenshot 2024-04-16 at 9 50 13 PM" src="https://github.com/flyteorg/flytekit/assets/37936015/6f3e4b61-ead5-428e-a59d-6a48202a845d">

<img width="1352" alt="Screenshot 2024-04-16 at 9 50 25 PM" src="https://github.com/flyteorg/flytekit/assets/37936015/621a1c7f-abd3-4a38-ab18-28416e1a7b45">

<img width="1352" alt="Screenshot 2024-04-16 at 9 51 21 PM" src="https://github.com/flyteorg/flytekit/assets/37936015/3c37c119-e4b9-4d70-a736-8d53b1a82d1d">

<img width="1352" alt="Screenshot 2024-04-16 at 9 53 40 PM" src="https://github.com/flyteorg/flytekit/assets/37936015/21a30068-c273-451e-af03-fbb93e382f30">


- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
