### PR TITLE
Use grpc metadata limit from Admin

### DIFF
--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -45,9 +45,10 @@ class RawSynchronousFlyteClient(object):
           url: The server address.
           insecure: if insecure is desired
         """
+        options = (('grpc.max_metadata_size', 100000),)
         self._cfg = cfg
         self._channel = wrap_exceptions_channel(
-            cfg, upgrade_channel_to_authenticated(cfg, upgrade_channel_to_proxy_authenticated(cfg, get_channel(cfg)))
+            cfg, upgrade_channel_to_authenticated(cfg, upgrade_channel_to_proxy_authenticated(cfg, get_channel(cfg, options=options)))
         )
         self._stub = _admin_service.AdminServiceStub(self._channel)
         self._signal = signal_service.SignalServiceStub(self._channel)

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -45,10 +45,16 @@ class RawSynchronousFlyteClient(object):
           url: The server address.
           insecure: if insecure is desired
         """
-        options = (('grpc.max_metadata_size', 100000),)
+        # Set the value here to match the limit in Admin, otherwise the client will cut off and the user gets a
+        # StreamRemoved exception.
+        # https://github.com/flyteorg/flyte/blob/e8588f3a04995a420559327e78c3f95fbf64dc01/flyteadmin/pkg/common/constants.go#L14
+        options = (("grpc.max_metadata_size", 32000),)
         self._cfg = cfg
         self._channel = wrap_exceptions_channel(
-            cfg, upgrade_channel_to_authenticated(cfg, upgrade_channel_to_proxy_authenticated(cfg, get_channel(cfg, options=options)))
+            cfg,
+            upgrade_channel_to_authenticated(
+                cfg, upgrade_channel_to_proxy_authenticated(cfg, get_channel(cfg, options=options))
+            ),
         )
         self._stub = _admin_service.AdminServiceStub(self._channel)
         self._signal = signal_service.SignalServiceStub(self._channel)


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5224

## Why are the changes needed?
Admin already gates large error messages, but flytekit does not set the max metadata size.  The default is 16KB, so now we're bumping it up to roughly 32KB, in line with the cutoff from Admin.

## What changes were proposed in this pull request?
Add a grpc dial option to the channel to configure max metadata size.

## How was this patch tested?
This was tested by artificially creating a fake large error message in Admin (larger than 32KB in size) and confirming that it was received correctly by flytectl but not by flytekit.  Adding this option lets flytekit receive the error correctly.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
