### PR TITLE
use sphinx-design directives instead of sphinx-panels

### DIFF
--- a/docs/source/extras.accelerators.rst
+++ b/docs/source/extras.accelerators.rst
@@ -1,4 +1,4 @@
 .. automodule:: flytekit.extras.accelerators
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -35,7 +35,7 @@ file format. Invoke the :ref:`flytectl config init <flytectl_config_init>` comma
 ``~/.flyte/config.yaml`` file, and  ``flytectl --help`` to learn about all of the configuration yaml options.
 
 .. dropdown:: See example ``config.yaml`` file
-   :title: text-muted
+   :color: muted
    :animate: fade-in-slide-down
 
    .. literalinclude:: ../../tests/flytekit/unit/configuration/configs/sample.yaml
@@ -49,7 +49,7 @@ file in two places:
 2. A file in ``~/.flyte/config`` in the home directory as detected by Python.
 
 .. dropdown:: See example ``flytekit.config`` file
-   :title: text-muted
+   :color: muted
    :animate: fade-in-slide-down
 
    .. literalinclude:: ../../tests/flytekit/unit/configuration/configs/images.config

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -6,6 +6,8 @@
 .. currentmodule:: flytekit.core.base_task
 
 .. autosummary::
+   :nosignatures:
+   :template: custom.rst
    :toctree: generated/
 
    kwtypes

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -390,7 +390,9 @@ class Promise(object):
     def is_ready(self) -> bool:
         """
         Returns if the Promise is READY (is not a reference and the val is actually ready)
-        Usage:
+
+        Usage ::
+
            p = Promise(...)
            ...
            if p.is_ready():

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -6,6 +6,8 @@
 .. currentmodule:: flytekit.core.python_function_task
 
 .. autosummary::
+   :nosignatures:
+   :template: custom.rst
    :toctree: generated/
 
    PythonFunctionTask

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -957,6 +957,7 @@ class TypeEngine(typing.Generic[T]):
 
           d = dictionary of registered transformers, where is a python `type`
           v = lookup type
+
         Step 1:
             If the type is annotated with a TypeTransformer instance, use that.
 

--- a/flytekit/deck/__init__.py
+++ b/flytekit/deck/__init__.py
@@ -8,6 +8,8 @@ Flyte Deck
 Contains deck renderers provided by flytekit.
 
 .. autosummary::
+   :nosignatures:
+   :template: custom.rst
    :toctree: generated/
 
    Deck

--- a/flytekit/extend/__init__.py
+++ b/flytekit/extend/__init__.py
@@ -8,6 +8,8 @@ Extending Flytekit
 This package contains things that are useful when extending Flytekit.
 
 .. autosummary::
+   :nosignatures:
+   :template: custom.rst
    :toctree: generated/
 
    get_serializable

--- a/flytekit/extras/accelerators.py
+++ b/flytekit/extras/accelerators.py
@@ -78,7 +78,6 @@ if you want to use a fractional GPU, you can use the ``partitioned`` method on t
 .. currentmodule:: flytekit.extras.accelerators
 
 .. autosummary::
-   :template: custom.rst
    :toctree: generated/
    :nosignatures:
 

--- a/flytekit/extras/accelerators.py
+++ b/flytekit/extras/accelerators.py
@@ -31,6 +31,9 @@ These classes can be used to create custom accelerator type constants. For examp
 .. currentmodule:: flytekit.extras.accelerators
 
 .. autosummary::
+   :template: custom.rst
+   :toctree: generated/
+   :nosignatures:
 
    BaseAccelerator
    GPUAccelerator
@@ -75,6 +78,9 @@ if you want to use a fractional GPU, you can use the ``partitioned`` method on t
 .. currentmodule:: flytekit.extras.accelerators
 
 .. autosummary::
+   :template: custom.rst
+   :toctree: generated/
+   :nosignatures:
 
    A10G
    L4

--- a/flytekit/image_spec/__init__.py
+++ b/flytekit/image_spec/__init__.py
@@ -8,6 +8,8 @@ ImageSpec
 This module contains the ImageSpec class parameters and methods.
 
 .. autosummary::
+   :nosignatures:
+   :template: custom.rst
    :toctree: generated/
 
    ImageSpec

--- a/flytekit/testing/__init__.py
+++ b/flytekit/testing/__init__.py
@@ -9,6 +9,7 @@ The imports exposed in this package will help you unit test your Flyte tasks. Th
 testing workflows that contain tasks that cannot run locally (a Hive task for instance).
 
 .. autosummary::
+   :template: custom.rst
    :toctree: generated/
 
    patch - A decorator similar to the regular one you're probably used to

--- a/flytekit/types/error/__init__.py
+++ b/flytekit/types/error/__init__.py
@@ -4,6 +4,8 @@ Flytekit Error Type
 .. currentmodule:: flytekit.types.error
 
 .. autosummary::
+   :nosignatures:
+   :template: custom.rst
    :toctree: generated/
 
    FlyteError

--- a/flytekit/types/iterator/__init__.py
+++ b/flytekit/types/iterator/__init__.py
@@ -2,8 +2,11 @@
 Flytekit Iterator Type
 ==========================================================
 .. currentmodule:: flytekit.types.iterator
+
 .. autosummary::
+   :nosignatures:
    :toctree: generated/
+
    FlyteIterator
 """
 

--- a/flytekit/types/pickle/__init__.py
+++ b/flytekit/types/pickle/__init__.py
@@ -4,6 +4,7 @@ Flytekit Pickle Type
 .. currentmodule:: flytekit.types.pickle
 
 .. autosummary::
+   :template: custom.rst
    :toctree: generated/
 
    FlytePickle


### PR DESCRIPTION
## Why are the changes needed?

We are currently using [sphinx-panels](https://sphinx-panels.readthedocs.io/en/latest/) for various documentation elements like dropdowns and tabs. However, `sphinx-panels` is no longer maintained and is restricting the version of sphinx we use to `4.5.0`. The up-to-date solution for this is [sphinx-design](https://sphinx-design.readthedocs.io/en/latest/).

NOTE: We'll have to merge the related PRs in the following order:
1. https://github.com/flyteorg/flytekit/pull/2364, https://github.com/flyteorg/flytesnacks/pull/1652, https://github.com/flyteorg/flytectl/pull/471
2. https://github.com/flyteorg/flyte/pull/5254

## What changes were proposed in this pull request?

This PR:
- Makes changes to the docs to use `sphinx-design` directives
- Cleans up API docs to leverage the upgraded furo version that displays the right sidebar

<img width="1250" alt="image" src="https://github.com/flyteorg/flyte/assets/2816689/81e88999-64c7-4e6c-af95-31d676ceb16f">


## How was this patch tested?

Build the docs locally:

Make sure you have the `sphinx-design` branch checked out in the `flytekit`, `flytesnacks`, and `flytectl` repo. Then build the docs in the `flyte` repo like so:

```
FLYTEKIT_LOCAL_PATH=~/git/flytekit FLYTESNACKS_LOCAL_PATH=~/git/flytesnacks FLYTECTL_LOCAL_PATH=~/git/flytectl make docs
```
