### PR TITLE
Use default serialization settings if serialization_settings is None

### DIFF
--- a/flytekit/models/admin/task_execution.py
+++ b/flytekit/models/admin/task_execution.py
@@ -42,7 +42,7 @@ class TaskExecutionClosure(_common.FlyteIdlEntity):
     def phase(self):
         """
         Enum value from flytekit.models.core.execution.TaskExecutionPhase
-        :rtype: int
+        :rtype: flytekit.models.core.execution.TaskExecutionPhase
         """
         return self._phase
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -759,7 +759,7 @@ class FlyteRemote(object):
         for entity, cp_entity in cp_task_entity_map.items():
             tasks.append(
                 loop.run_in_executor(
-                    None, functools.partial(self.raw_register, cp_entity, settings, version, og_entity=entity)
+                    None, functools.partial(self.raw_register, cp_entity, serialization_settings, version, og_entity=entity)
                 )
             )
         ident = []
@@ -767,7 +767,7 @@ class FlyteRemote(object):
         # serial register
         cp_other_entities = OrderedDict(filter(lambda x: not isinstance(x[1], task_models.TaskSpec), m.items()))
         for entity, cp_entity in cp_other_entities.items():
-            ident.append(self.raw_register(cp_entity, settings, version, og_entity=entity))
+            ident.append(self.raw_register(cp_entity, serialization_settings, version, og_entity=entity))
         return ident[-1]
 
     def register_task(


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Failed to register a workflow when serialization settings is None

```bash
            if create_default_launchplan:
                if not og_entity:
                    raise user_exceptions.FlyteValueException(
                        "To create default launch plan, please pass in the original flytekit workflow `og_entity`"
                    )
    
                # Let us also create a default launch-plan, ideally the default launchplan should be added
                # to the orderedDict, but we do not.
                self.file_access._get_upload_signed_url_fn = functools.partial(
>                   self.client.get_upload_signed_url, project=settings.project, domain=settings.domain
                )
E               AttributeError: 'NoneType' object has no attribute 'project'

```

## What changes were proposed in this pull request?
Create a default serialization settings if it's None


## How was this patch tested?

```python
@task(container_image=image_spec)
def t2(second: int):
    sleep(second)


@workflow
def wf(second: int = 60):
    for i in range(10):
        t2(second=second)

flyte_workflow = remote.register_workflow(
        entity=wf, version=version
    )
    exe = remote.execute(
        entity=flyte_workflow, inputs={}, wait=False, options=Options(max_parallelism=3)
    )
```

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
