### PR TITLE
Add .gitignore and .dockerignore behavior to ImageSpec

### DIFF
--- a/flytekit/remote/executions.py
+++ b/flytekit/remote/executions.py
@@ -103,7 +103,7 @@ class FlyteWorkflowExecution(RemoteExecutionBase, execution_models.Execution):
         return self._flyte_workflow
 
     @property
-    def node_executions(self) -> Dict[str, "FlyteNodeExecution"]:
+    def node_executions(self) -> Dict[str, FlyteNodeExecution]:
         """Get a dictionary of node executions that are a part of this workflow execution."""
         return self._node_executions or {}
 

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -61,7 +61,7 @@ def compute_digest(source: os.PathLike, filter: Optional[callable] = None) -> st
     """
     Walks the entirety of the source dir to compute a deterministic md5 hex digest of the dir contents.
     :param os.PathLike source:
-    :param Ignore ignore:
+    :param callable filter:
     :return Text:
     """
     hasher = hashlib.md5()

--- a/flytekit/tools/ignore.py
+++ b/flytekit/tools/ignore.py
@@ -11,7 +11,7 @@ from docker.utils.build import PatternMatcher
 
 from flytekit.loggers import logger
 
-STANDARD_IGNORE_PATTERNS = ["*.pyc", ".cache", ".cache/*", "__pycache__", "**/__pycache__"]
+STANDARD_IGNORE_PATTERNS = ["*.pyc", ".cache", ".cache/*", "__pycache__/*", "**/__pycache__/*"]
 
 
 class Ignore(ABC):
@@ -79,7 +79,8 @@ class DockerIgnore(Ignore):
         if os.path.isfile(dockerignore):
             with open(dockerignore, "r") as f:
                 patterns = [l.strip() for l in f.readlines() if l and not l.startswith("#")]
-        logger.info(f"No .dockerignore found in {self.root}, not applying any filters")
+        else:
+            logger.info(f"No .dockerignore found in {self.root}, not applying any filters")
         return PatternMatcher(patterns)
 
     def _is_ignored(self, path: str) -> bool:

--- a/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
+++ b/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
@@ -143,9 +143,9 @@ def build():
         envd_version = metadata.version("envd")
         # Indentation is required by envd
         if Version(envd_version) <= Version("0.3.37"):
-            envd_config += '    io.copy(host_path="./", envd_path="/root")'
+            envd_config += '    io.copy(host_path="./", envd_path="/root")\n'
         else:
-            envd_config += '    io.copy(source="./", target="/root")'
+            envd_config += '    io.copy(source="./", target="/root")\n'
 
     with open(cfg_path, "w+") as f:
         f.write(envd_config)

--- a/plugins/flytekit-envd/tests/.dockerignore
+++ b/plugins/flytekit-envd/tests/.dockerignore
@@ -1,0 +1,1 @@
+README.md

--- a/plugins/flytekit-envd/tests/test_image_spec.py
+++ b/plugins/flytekit-envd/tests/test_image_spec.py
@@ -61,6 +61,7 @@ def build():
     config.pip_index(url="https://private-pip-index/simple")
     install.python(version="3.8")
     io.copy(source="./", target="/root")
+
 """
     )
 

--- a/plugins/flytekit-envd/tests/test_image_spec.py
+++ b/plugins/flytekit-envd/tests/test_image_spec.py
@@ -60,6 +60,7 @@ def build():
     runtime.environ(env={{'PYTHONPATH': '/root', '_F_IMG_ID': '{image_name}'}}, extra_path=['/root'])
     config.pip_index(url="https://private-pip-index/simple")
     install.python(version="3.8")
+    io.copy(source="./", target="/root")
 """
     )
 

--- a/plugins/flytekit-envd/tests/test_image_spec.py
+++ b/plugins/flytekit-envd/tests/test_image_spec.py
@@ -38,7 +38,7 @@ def test_image_spec():
         python_version="3.8",
         base_image=base_image,
         pip_index="https://private-pip-index/simple",
-        source_root=os.path.dirname(os.path.realpath(__file__))
+        source_root=os.path.dirname(os.path.realpath(__file__)),
     )
 
     image_spec = image_spec.with_commands("echo hello")

--- a/plugins/flytekit-envd/tests/test_image_spec.py
+++ b/plugins/flytekit-envd/tests/test_image_spec.py
@@ -61,7 +61,6 @@ def build():
     config.pip_index(url="https://private-pip-index/simple")
     install.python(version="3.8")
     io.copy(source="./", target="/root")
-
 """
     )
 

--- a/plugins/flytekit-envd/tests/test_image_spec.py
+++ b/plugins/flytekit-envd/tests/test_image_spec.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from textwrap import dedent
 
@@ -37,6 +38,7 @@ def test_image_spec():
         python_version="3.8",
         base_image=base_image,
         pip_index="https://private-pip-index/simple",
+        source_root=os.path.dirname(os.path.realpath(__file__))
     )
 
     image_spec = image_spec.with_commands("echo hello")

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -7,13 +7,14 @@ import sys
 
 import mock
 import pytest
+import yaml
 from click.testing import CliRunner
 
 from flytekit.clis.sdk_in_container import pyflyte
 from flytekit.clis.sdk_in_container.run import RunLevelParams, get_entities_in_file, run_command
 from flytekit.configuration import Config, Image, ImageConfig
 from flytekit.core.task import task
-from flytekit.image_spec.image_spec import ImageBuildEngine
+from flytekit.image_spec.image_spec import ImageBuildEngine, ImageSpec, calculate_hash_from_image_spec
 from flytekit.interaction.click_types import DirParamType, FileParamType
 from flytekit.remote import FlyteRemote
 
@@ -347,10 +348,17 @@ ic_result_3 = ImageConfig(
     ],
 )
 
+IMAGE_SPEC = os.path.join(os.path.dirname(os.path.realpath(__file__)), "imageSpec.yaml")
+
+with open(IMAGE_SPEC, "r") as f:
+    image_spec_dict = yaml.safe_load(f)
+    image_spec = ImageSpec(**image_spec_dict)
+    tag = calculate_hash_from_image_spec(image_spec)
+
 ic_result_4 = ImageConfig(
-    default_image=Image(name="default", fqn="flytekit", tag="urw7fglw5pBrIQ9JTW1vQA"),
+    default_image=Image(name="default", fqn="flytekit", tag=tag),
     images=[
-        Image(name="default", fqn="flytekit", tag="urw7fglw5pBrIQ9JTW1vQA"),
+        Image(name="default", fqn="flytekit", tag=tag),
         Image(name="xyz", fqn="docker.io/xyz", tag="latest"),
         Image(name="abc", fqn="docker.io/abc", tag=None),
         Image(
@@ -360,8 +368,6 @@ ic_result_4 = ImageConfig(
         ),
     ],
 )
-
-IMAGE_SPEC = os.path.join(os.path.dirname(os.path.realpath(__file__)), "imageSpec.yaml")
 
 
 @mock.patch("flytekit.configuration.default_images.DefaultImages.default_image")

--- a/tests/flytekit/unit/tools/test_fast_registration.py
+++ b/tests/flytekit/unit/tools/test_fast_registration.py
@@ -70,6 +70,7 @@ def test_package_with_symlink(flyte_project, tmp_path):
         assert sorted(tar.getnames()) == [
             "util",
             "workflows",
+            "workflows/__pycache__",
             "workflows/hello_world.py",
         ]
         util = tar.getmember("util")

--- a/tests/flytekit/unit/tools/test_fast_registration.py
+++ b/tests/flytekit/unit/tools/test_fast_registration.py
@@ -53,6 +53,7 @@ def test_package(flyte_project, tmp_path):
             "src",
             "src/util",
             "src/workflows",
+            "src/workflows/__pycache__",
             "src/workflows/hello_world.py",
             "utils",
             "utils/util.py",

--- a/tests/flytekit/unit/tools/test_ignore.py
+++ b/tests/flytekit/unit/tools/test_ignore.py
@@ -204,7 +204,7 @@ def test_all_ignore(all_ignore):
     ignore = IgnoreGroup(all_ignore, [GitIgnore, DockerIgnore, StandardIgnore])
     assert not ignore.is_ignored("sub")
     assert not ignore.is_ignored("sub/some.bar")
-    assert ignore.is_ignored("sub/__pycache__")
+    assert ignore.is_ignored("sub/__pycache__/")
     assert ignore.is_ignored("sub/__pycache__/some.pyc")
     assert ignore.is_ignored("data")
     assert ignore.is_ignored("data/reallybigfile.bar")
@@ -222,7 +222,7 @@ def test_all_ignore_tar_filter(all_ignore):
     ignore = IgnoreGroup(all_ignore, [GitIgnore, DockerIgnore, StandardIgnore])
     assert ignore.tar_filter(TarInfo(name="sub")).name == "sub"
     assert ignore.tar_filter(TarInfo(name="sub/some.bar")).name == "sub/some.bar"
-    assert not ignore.tar_filter(TarInfo(name="sub/__pycache__"))
+    assert not ignore.tar_filter(TarInfo(name="sub/__pycache__/"))
     assert not ignore.tar_filter(TarInfo(name="sub/__pycache__/some.pyc"))
     assert not ignore.tar_filter(TarInfo(name="data"))
     assert not ignore.tar_filter(TarInfo(name="data/reallybigfile.bar"))


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Pycache, Venv, and some other irreverent files are copied to the docker image.

## What changes were proposed in this pull request?
Use `.dockerignore` file to exclude files and directories from images built from ImageSpec

## How was this patch tested?
local sandbox

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
