### PR TITLE
Add optional execution metadata to objects written to storage for easy attribution

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -272,10 +272,18 @@ def setup_execution(
         task_id=_identifier.Identifier(_identifier.ResourceType.TASK, tk_project, tk_domain, tk_name, tk_version),
     )
 
+    metadata = {
+        "flyte-execution-project": exe_project,
+        "flyte-execution-domain": exe_domain,
+        "flyte-execution-launchplan": exe_lp,
+        "flyte-execution-workflow": exe_wf,
+        "flyte-execution-name": exe_name,
+    }
     try:
         file_access = FileAccessProvider(
             local_sandbox_dir=tempfile.mkdtemp(prefix="flyte"),
             raw_output_prefix=raw_output_data_prefix,
+            execution_metadata=metadata,
         )
     except TypeError:  # would be thrown from DataPersistencePlugins.find_plugin
         logger.error(f"No data plugin found for raw output prefix {raw_output_data_prefix}")

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -599,6 +599,24 @@ class GCSConfig(object):
 
 
 @dataclass(init=True, repr=True, eq=True, frozen=True)
+class GenericPersistenceConfig(object):
+    """
+    Data storage configuration that applies across any provider.
+    """
+
+    attach_execution_metadata: bool = True
+
+    @classmethod
+    def auto(cls, config_file: typing.Union[str, ConfigFile] = None) -> GCSConfig:
+        config_file = get_config_file(config_file)
+        kwargs = {}
+        kwargs = set_if_exists(
+            kwargs, "attach_execution_metadata", _internal.Persistence.ATTACH_EXECUTION_METADATA.read(config_file)
+        )
+        return GenericPersistenceConfig(**kwargs)
+
+
+@dataclass(init=True, repr=True, eq=True, frozen=True)
 class AzureBlobStorageConfig(object):
     """
     Any Azure Blob Storage specific configuration.
@@ -633,6 +651,7 @@ class DataConfig(object):
     s3: S3Config = S3Config()
     gcs: GCSConfig = GCSConfig()
     azure: AzureBlobStorageConfig = AzureBlobStorageConfig()
+    generic: GenericPersistenceConfig = GenericPersistenceConfig()
 
     @classmethod
     def auto(cls, config_file: typing.Union[str, ConfigFile] = None) -> DataConfig:
@@ -641,6 +660,7 @@ class DataConfig(object):
             azure=AzureBlobStorageConfig.auto(config_file),
             s3=S3Config.auto(config_file),
             gcs=GCSConfig.auto(config_file),
+            generic=GenericPersistenceConfig.auto(config_file),
         )
 
 

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -35,6 +35,11 @@ class Images(object):
             return cfg.yaml_config.get("images", images)
 
 
+class Persistence(object):
+    SECTION = "persistence"
+    ATTACH_EXECUTION_METADATA = ConfigEntry(LegacyConfigEntry(SECTION, "attach_execution_metadata", bool))
+
+
 class AWS(object):
     SECTION = "aws"
     S3_ENDPOINT = ConfigEntry(LegacyConfigEntry(SECTION, "endpoint"), YamlConfigEntry("storage.connection.endpoint"))


### PR DESCRIPTION
## Why are the changes needed?
These changes allow easy attribution of cost in storage to particular executions, workflows, etc., without needing to parse data out of the path or correlate with flyteadmin and the data catalog.

Since this may have cost implications (at least in GCS, metadata of this sort is added to the total file size billed), I made it configurable in case folks would like to turn it off.

I have tested that this works on GCS, and verified that the same metadata option exists for S3 in fsspec. I did not check Azure.

I'd like to follow this up with another PR to allow user-specified metadata to be attached to all writes as well.

## How was this patch tested?

I ran workflows in our development environment hooked up to GCS.
```
gcloud storage objects list --raw gs://<bucket>/metadata/propeller/sandbox-development-atcf27bztrw2ptb62n94/pyprojectworkflowsexamplescomputesquaresquared/data/0/outputs.pb
---
bucket: <bucket>
contentType: application/octet-stream
crc32c: qMS05A==
etag: CMDav/nx1IUDEAE=
generation: '1713756898848064'
id: <bucket>/metadata/propeller/sandbox-development-atcf27bztrw2ptb62n94/pyprojectworkflowsexamplescomputesquaresquared/data/0/outputs.pb/1713756898848064
kind: storage#object
md5Hash: sthGD8qYLWByHwZKWVW2kg==
mediaLink: https://storage.googleapis.com/download/storage/v1/b/<bucket>/o/metadata%2Fpropeller%2Fsandbox-development-atcf27bztrw2ptb62n94%2Fpyprojectworkflowsexamplescomputesquaresquared%2Fdata%2F0%2Foutputs.pb?generation=1713756898848064&alt=media
metadata:
  flyte-execution-domain: development
  flyte-execution-launchplan: ''
  flyte-execution-name: atcf27bztrw2ptb62n94
  flyte-execution-project: sandbox
  flyte-execution-workflow: sandbox:development:.flytegen.pyproject.workflows.examples.compute_square.squared
metageneration: '1'
name: metadata/propeller/sandbox-development-atcf27bztrw2ptb62n94/pyprojectworkflowsexamplescomputesquaresquared/data/0/outputs.pb
selfLink: https://www.googleapis.com/storage/v1/b/<bucket>/o/metadata%2Fpropeller%2Fsandbox-development-atcf27bztrw2ptb62n94%2Fpyprojectworkflowsexamplescomputesquaresquared%2Fdata%2F0%2Foutputs.pb
size: '14'
storageClass: STANDARD
timeCreated: '2024-04-22T03:34:58.849000+00:00'
timeStorageClassUpdated: '2024-04-22T03:34:58.849000+00:00'
updated: '2024-04-22T03:34:58.849000+00:00'
```

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
