### PR TITLE
Fix use default inputs with remote LaunchPlan

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -965,9 +965,8 @@ def create_and_link_node_from_remote(
     for k in sorted(typed_interface.inputs):
         var = typed_interface.inputs[k]
         if k not in kwargs:
-            if _inputs_not_allowed and _ignorable_inputs:
-                if k in _ignorable_inputs or k in _inputs_not_allowed:
-                    continue
+            if (_ignorable_inputs and k in _ignorable_inputs) or (_inputs_not_allowed and k in _inputs_not_allowed):
+                continue
             # TODO to improve the error message, should we show python equivalent types for var.type?
             raise _user_exceptions.FlyteAssertion("Missing input `{}` type `{}`".format(k, var.type))
         v = kwargs[k]

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -77,6 +77,9 @@ def test_create_and_link_node_from_remote_ignore():
         ...
 
     lp = LaunchPlan.get_or_create(wf, name="promise-test", fixed_inputs={"i": 1}, default_inputs={"j": 10})
+    lp_without_fixed_inpus = LaunchPlan.get_or_create(
+        wf, name="promise-test-no-fixed", fixed_inputs=None, default_inputs={"j": 10}
+    )
     ctx = context_manager.FlyteContext.current_context().with_compilation_state(CompilationState(prefix=""))
 
     # without providing the _inputs_not_allowed or _ignorable_inputs, all inputs to lp become required,
@@ -87,9 +90,14 @@ def test_create_and_link_node_from_remote_ignore():
     # Even if j is not provided it will default
     create_and_link_node_from_remote(ctx, lp, _inputs_not_allowed={"i"}, _ignorable_inputs={"j"})
 
+    # Even if i,j is not provided it will default
+    create_and_link_node_from_remote(
+        ctx, lp_without_fixed_inpus, _inputs_not_allowed=None, _ignorable_inputs={"i", "j"}
+    )
+
     # value of `i` cannot be overridden
     with pytest.raises(
-        FlyteAssertion, match="ixed inputs cannot be specified. Please remove the following inputs - {'i'}"
+        FlyteAssertion, match="Fixed inputs cannot be specified. Please remove the following inputs - {'i'}"
     ):
         create_and_link_node_from_remote(ctx, lp, _inputs_not_allowed={"i"}, _ignorable_inputs={"j"}, i=15)
 


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->
https://github.com/flyteorg/flyte/issues/5270

## Why are the changes needed?
These changes are needed to use remote LP without fixed inputs when input + default inputs are provided.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
In line comment
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Unit test and manual test
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
