### PR TITLE
refactor(pathlib): Replace joinpath with slash

### DIFF
--- a/flytekit/core/checkpointer.py
+++ b/flytekit/core/checkpointer.py
@@ -101,7 +101,7 @@ class SyncCheckpoint(Checkpoint):
 
         if path is None:
             p = Path(self._td.name)
-            path = p.joinpath(self.SRC_LOCAL_FOLDER)
+            path = p / self.SRC_LOCAL_FOLDER
             path.mkdir(exist_ok=True)
         elif isinstance(path, str):
             path = Path(path)
@@ -133,7 +133,7 @@ class SyncCheckpoint(Checkpoint):
             raise ValueError(f"Only a valid path or IOBase type (reader) should be provided, received {type(cp)}")
 
         p = Path(self._td.name)
-        dest_cp = p.joinpath(self.TMP_DST_PATH)
+        dest_cp = p / self.TMP_DST_PATH
         with dest_cp.open("wb") as f:
             f.write(cp.read())
 

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -131,7 +131,7 @@ class ExecutionParameters(object):
             prefix = self.working_directory.name
         task_sandbox_dir = tempfile.mkdtemp(prefix=prefix)  # type: ignore
         p = pathlib.Path(task_sandbox_dir)
-        cp_dir = p.joinpath("__cp")
+        cp_dir = p / "__cp"
         cp_dir.mkdir(exist_ok=True)
         cp = SyncCheckpoint(checkpoint_dest=str(cp_dir))
         b = self.new_builder(self)

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -393,9 +393,7 @@ def test_pyflyte_run_run(
     image_tuple = (image_string,)
     image_config = ImageConfig.validate_image(None, "", image_tuple)
 
-    pp = pathlib.Path.joinpath(
-        pathlib.Path(__file__).parent.parent.parent, "configuration/configs/", leaf_configuration_file_name
-    )
+    pp = pathlib.Path(__file__).parent.parent.parent / "configuration" / "configs" / leaf_configuration_file_name
 
     obj = RunLevelParams(
         project="p",

--- a/tests/flytekit/unit/core/test_checkpoint.py
+++ b/tests/flytekit/unit/core/test_checkpoint.py
@@ -13,7 +13,7 @@ def test_sync_checkpoint_write(tmpdir):
     cp = SyncCheckpoint(checkpoint_dest=tmpdir)
     assert cp.read() is None
     assert cp.restore() is None
-    dst_path = td_path.joinpath(SyncCheckpoint.TMP_DST_PATH)
+    dst_path = td_path / SyncCheckpoint.TMP_DST_PATH
     assert not dst_path.exists()
     cp.write(b"bytes")
     assert dst_path.exists()
@@ -22,9 +22,9 @@ def test_sync_checkpoint_write(tmpdir):
 def test_sync_checkpoint_save_file(tmpdir):
     td_path = Path(tmpdir)
     cp = SyncCheckpoint(checkpoint_dest=tmpdir)
-    dst_path = td_path.joinpath(SyncCheckpoint.TMP_DST_PATH)
+    dst_path = td_path / SyncCheckpoint.TMP_DST_PATH
     assert not dst_path.exists()
-    inp = td_path.joinpath("test")
+    inp = td_path / "test"
     with inp.open("wb") as f:
         f.write(b"blah")
     with inp.open("rb") as f:
@@ -42,9 +42,9 @@ def test_sync_checkpoint_save_filepath(tmpdir):
     chkpnt_path = Path(os.path.join(tmpdir, "dest"))
     chkpnt_path.mkdir()
     cp = SyncCheckpoint(checkpoint_dest=str(chkpnt_path))
-    dst_path = chkpnt_path.joinpath("test")
+    dst_path = chkpnt_path / "test"
     assert not dst_path.exists()
-    inp = src_path.joinpath("test")
+    inp = src_path / "test"
     with inp.open("wb") as f:
         f.write(b"blah")
     cp.save(inp)
@@ -53,16 +53,16 @@ def test_sync_checkpoint_save_filepath(tmpdir):
 
 def test_sync_checkpoint_restore(tmpdir):
     td_path = Path(tmpdir)
-    dest = td_path.joinpath("dest")
+    dest = td_path / "dest"
     dest.mkdir()
-    src = td_path.joinpath("src")
+    src = td_path / "src"
     src.mkdir()
-    prev = src.joinpath("prev")
+    prev = src / "prev"
     p = b"prev-bytes"
     with prev.open("wb") as f:
         f.write(p)
     cp = SyncCheckpoint(checkpoint_dest=str(dest), checkpoint_src=str(src))
-    user_dest = td_path.joinpath("user_dest")
+    user_dest = td_path / "user_dest"
 
     with pytest.raises(ValueError):
         cp.restore(user_dest)
@@ -74,16 +74,16 @@ def test_sync_checkpoint_restore(tmpdir):
 
 def test_sync_checkpoint_restore_corrupt(tmpdir):
     td_path = Path(tmpdir)
-    dest = td_path.joinpath("dest")
+    dest = td_path / "dest"
     dest.mkdir()
-    src = td_path.joinpath("src")
+    src = td_path / "src"
     src.mkdir()
-    prev = src.joinpath("prev")
+    prev = src / "prev"
     p = b"prev-bytes"
     with prev.open("wb") as f:
         f.write(p)
     cp = SyncCheckpoint(checkpoint_dest=str(dest), checkpoint_src=str(src))
-    user_dest = td_path.joinpath("user_dest")
+    user_dest = td_path / "user_dest"
     user_dest.mkdir()
 
     # Simulate a failed upload of the checkpoint e.g. due to preemption
@@ -99,11 +99,11 @@ def test_sync_checkpoint_restore_corrupt(tmpdir):
 
 def test_sync_checkpoint_restore_default_path(tmpdir):
     td_path = Path(tmpdir)
-    dest = td_path.joinpath("dest")
+    dest = td_path / "dest"
     dest.mkdir()
-    src = td_path.joinpath("src")
+    src = td_path / "src"
     src.mkdir()
-    prev = src.joinpath("prev")
+    prev = src / "prev"
     p = b"prev-bytes"
     with prev.open("wb") as f:
         f.write(p)
@@ -115,9 +115,9 @@ def test_sync_checkpoint_restore_default_path(tmpdir):
 
 def test_sync_checkpoint_read_empty_dir(tmpdir):
     td_path = Path(tmpdir)
-    dest = td_path.joinpath("dest")
+    dest = td_path / "dest"
     dest.mkdir()
-    src = td_path.joinpath("src")
+    src = td_path / "src"
     src.mkdir()
     cp = SyncCheckpoint(checkpoint_dest=str(dest), checkpoint_src=str(src))
     assert cp.read() is None
@@ -128,12 +128,12 @@ def test_sync_checkpoint_read_multiple_files(tmpdir):
     Read can only work with one file.
     """
     td_path = Path(tmpdir)
-    dest = td_path.joinpath("dest")
+    dest = td_path / "dest"
     dest.mkdir()
-    src = td_path.joinpath("src")
+    src = td_path / "src"
     src.mkdir()
-    prev = src.joinpath("prev")
-    prev2 = src.joinpath("prev2")
+    prev = src / "prev"
+    prev2 = src / "prev2"
     p = b"prev-bytes"
     with prev.open("wb") as f:
         f.write(p)


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?

In `pathlib`, `joinpath` and the `/` operator have the same functionality, but the `/` operator is easier to read.

## What changes were proposed in this pull request?

Replace all `joinpath` with `/` operator.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
