### PR TITLE
Only check for secret groups during registration context

### DIFF
--- a/flytekit/models/security.py
+++ b/flytekit/models/security.py
@@ -44,7 +44,7 @@ class Secret(_common.FlyteIdlEntity):
         from flytekit.configuration.plugin import get_plugin
         from flytekit.core.context_manager import FlyteContextManager
 
-        # Only check for the groups during registration
+        # Only check for the groups during registration.
         execution = FlyteContextManager.current_context().execution_state
         in_registration_context = execution.mode is None
         if in_registration_context and get_plugin().secret_requires_group() and self.group is None:

--- a/flytekit/models/security.py
+++ b/flytekit/models/security.py
@@ -42,8 +42,11 @@ class Secret(_common.FlyteIdlEntity):
 
     def __post_init__(self):
         from flytekit.configuration.plugin import get_plugin
+        from flytekit.core.context_manager import FlyteContextManager
 
-        if get_plugin().secret_requires_group() and self.group is None:
+        execution = FlyteContextManager.current_context().execution_state
+        registration_context = execution.mode is None
+        if registration_context and get_plugin().secret_requires_group() and self.group is None:
             raise ValueError("Group is a required parameter")
 
     def to_flyte_idl(self) -> _sec.Secret:

--- a/flytekit/models/security.py
+++ b/flytekit/models/security.py
@@ -44,9 +44,10 @@ class Secret(_common.FlyteIdlEntity):
         from flytekit.configuration.plugin import get_plugin
         from flytekit.core.context_manager import FlyteContextManager
 
+        # Only check for the groups during registration
         execution = FlyteContextManager.current_context().execution_state
-        registration_context = execution.mode is None
-        if registration_context and get_plugin().secret_requires_group() and self.group is None:
+        in_registration_context = execution.mode is None
+        if in_registration_context and get_plugin().secret_requires_group() and self.group is None:
             raise ValueError("Group is a required parameter")
 
     def to_flyte_idl(self) -> _sec.Secret:

--- a/tests/flytekit/unit/models/core/test_security.py
+++ b/tests/flytekit/unit/models/core/test_security.py
@@ -3,8 +3,8 @@ from unittest.mock import Mock
 import pytest
 
 import flytekit.configuration.plugin
-from flytekit.models.security import Secret
 from flytekit.core.context_manager import ExecutionState
+from flytekit.models.security import Secret
 
 
 def test_secret():

--- a/tests/flytekit/unit/models/core/test_security.py
+++ b/tests/flytekit/unit/models/core/test_security.py
@@ -4,6 +4,7 @@ import pytest
 
 import flytekit.configuration.plugin
 from flytekit.models.security import Secret
+from flytekit.core.context_manager import ExecutionState
 
 
 def test_secret():
@@ -35,5 +36,18 @@ def test_secret_no_group(monkeypatch):
     mock_global_plugin = {"plugin": plugin_mock}
     monkeypatch.setattr(flytekit.configuration.plugin, "_GLOBAL_CONFIG", mock_global_plugin)
 
+    s = Secret(key="key")
+    assert s.group is None
+
+
+@pytest.mark.parametrize("execution_mode", list(ExecutionState.Mode))
+def test_security_execution_context(monkeypatch, execution_mode, tmpdir):
+    # Check that groups in Secrets during any execution state
+    context_manager = Mock()
+    context = Mock()
+    context_manager.current_context.return_value = context
+    context.execution_state = ExecutionState(working_dir=tmpdir, mode=execution_mode)
+
+    monkeypatch.setattr(flytekit.core.context_manager, "FlyteContextManager", context_manager)
     s = Secret(key="key")
     assert s.group is None


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->
Follow up to https://github.com/flyteorg/flytekit/pull/2355

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
This is required to make sure that the secrets groups check never happens during execution time.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
With this PR, the secrets group check only happens during registration time.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
There are current tests that checks `Secrets` construction when `Execution.mode` is `None`. I added more tests to make sure that the groups are not checked during execution time.