### PR TITLE
[BUG] set primary_container_name annotation for pod template configured pods w/ multiple containers

### DIFF
--- a/flytekit/core/pod_template.py
+++ b/flytekit/core/pod_template.py
@@ -27,4 +27,4 @@ class PodTemplate(object):
             raise _user_exceptions.FlyteValidationException("A primary container name cannot be undefined")
         if self.annotations is None:
             self.annotations = {}
-        self.annotations['primary_container_name'] = self.primary_container_name
+        self.annotations["primary_container_name"] = self.primary_container_name

--- a/flytekit/core/pod_template.py
+++ b/flytekit/core/pod_template.py
@@ -25,3 +25,6 @@ class PodTemplate(object):
             self.pod_spec = V1PodSpec(containers=[])
         if not self.primary_container_name:
             raise _user_exceptions.FlyteValidationException("A primary container name cannot be undefined")
+        if self.annotations is None:
+            self.annotations = {}
+        self.annotations['primary_container_name'] = self.primary_container_name

--- a/tests/flytekit/unit/core/test_python_auto_container.py
+++ b/tests/flytekit/unit/core/test_python_auto_container.py
@@ -175,7 +175,7 @@ def test_pod_template(default_serialization_settings):
     # labels/annotations should be passed
     metadata = k8s_pod.metadata
     assert metadata.labels == {"lKeyA": "lValA", "lKeyB": "lValB"}
-    assert metadata.annotations == {"aKeyA": "aValA", "aKeyB": "aValB"}
+    assert metadata.annotations == {"aKeyA": "aValA", "aKeyB": "aValB", "primary_container_name": "primary"}
 
     pod_spec = k8s_pod.pod_spec
     primary_container = pod_spec["containers"][1]
@@ -275,7 +275,7 @@ def test_minimum_pod_template(serialization_settings):
 
     metadata = k8s_pod.metadata
     assert metadata.labels == {"lKeyA": "lValA"}
-    assert metadata.annotations == {"aKeyA": "aValA"}
+    assert metadata.annotations == {"aKeyA": "aValA", "primary_container_name": "primary"}
 
     pod_spec = k8s_pod.pod_spec
     primary_container = pod_spec["containers"][0]

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -194,6 +194,28 @@ def test_pod_template():
     def func_with_pod_template(i: str):
         print(i + "a")
 
+    @task(
+        container_image="repo/image:0.0.0",
+        pod_template=PodTemplate(
+            primary_container_name="primary",
+            labels={"lKeyA": "lValA"},
+            annotations={"aKeyA": "aValA"},
+            pod_spec=V1PodSpec(
+                containers=[
+                    V1Container(
+                        name="primary",
+                    ),
+                    V1Container(
+                        name="secondary",
+                    ),
+                ]
+            ),
+        ),
+        pod_template_name="A",
+    )
+    def func_with_pod_template_multi_container(i: str):
+        print(i + "a")
+
     default_image = Image(name="default", fqn="docker.io/xyz", tag="some-git-hash")
     default_image_config = ImageConfig(default_image=default_image)
     default_serialization_settings = SerializationSettings(
@@ -212,6 +234,9 @@ def test_pod_template():
     metadata = k8s_pod.metadata
     assert metadata.labels == {"lKeyA": "lValA"}
     assert metadata.annotations == {"aKeyA": "aValA", "primary_container_name": "primary"}
+
+    k8s_pod_multi = func_with_pod_template_multi_container.get_k8s_pod(default_serialization_settings)
+    assert k8s_pod_multi.metadata.annotations == {"aKeyA": "aValA", "primary_container_name": "primary"}
 
     pod_spec = k8s_pod.pod_spec
     primary_container = pod_spec["containers"][0]

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -211,7 +211,7 @@ def test_pod_template():
 
     metadata = k8s_pod.metadata
     assert metadata.labels == {"lKeyA": "lValA"}
-    assert metadata.annotations == {"aKeyA": "aValA"}
+    assert metadata.annotations == {"aKeyA": "aValA", "primary_container_name": "primary"}
 
     pod_spec = k8s_pod.pod_spec
     primary_container = pod_spec["containers"][0]


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

PrimaryContainerKey annotation is not set on pods when a pod configured by PodTemplate has multiple containers. This causes for a task to be stuck in a [running state](https://github.com/flyteorg/flyte/blob/c77e2c32ef83dbc8015e771d27def194eba5a36c/flyteplugins/go/tasks/plugins/k8s/pod/plugin.go#L196).

## What changes were proposed in this pull request?

Remove some abstraction with how primary_container_name annotation is set and have it set during __post_init__

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

- Added unit test
- Ran wf locally to confirm that annotations were getting set correctly

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
```from flytekit import task, workflow, Resources
import requests
from flytekit.core.pod_template import PodTemplate
from kubernetes.client.models import (
    V1Container,
    V1PodSpec,
    V1ResourceRequirements,
    V1ContainerPort,
    V1Probe,
    V1HTTPGetAction
)


@task(
    pod_template=PodTemplate(
        primary_container_name="primary",
        pod_spec=V1PodSpec(
            containers=[
                V1Container(
                    name="primary",
                    resources=V1ResourceRequirements(
                        requests={"cpu": "2", "memory": "1Gi"},
                        limits={"cpu": "2", "memory": "1Gi"},
                    ),
                    ports=[V1ContainerPort(container_port=80, name="http-primary")],
                    readiness_probe=V1Probe(
                        initial_delay_seconds=20,
                        period_seconds=5,
                        failure_threshold=5,
                        http_get=V1HTTPGetAction(path="/", port=80),
                    ),
                    liveness_probe=V1Probe(
                        initial_delay_seconds=20,
                        period_seconds=5,
                        failure_threshold=5,
                        http_get=V1HTTPGetAction(path="/", port=80),
                    ),
                ),
                V1Container(
                    name="secondary",
                    image="python",
                    command=["/bin/sh"],
                    args=[
                        "-c",
                        "python -m http.server 80",
                    ],
                    ports=[V1ContainerPort(container_port=80, name="http-api")],
                    readiness_probe=V1Probe(
                        initial_delay_seconds=20,
                        period_seconds=5,
                        failure_threshold=5,
                        http_get=V1HTTPGetAction(path="/", port=80),
                    ),
                    liveness_probe=V1Probe(
                        initial_delay_seconds=20,
                        period_seconds=5,
                        failure_threshold=5,
                        http_get=V1HTTPGetAction(path="/", port=80),
                    ),
                    resources=V1ResourceRequirements(
                        requests={"cpu": "2", "memory": "1Gi"},
                        limits={"cpu": "2", "memory": "1Gi"},
                    ),
                ),
            ],
        ),
    ),
    requests=Resources(
        mem="1G",
    ),
)
def multiple_containers_pod_task() -> int:
    url = "http://localhost:80/"
    response = requests.get(url)
    print(response)
    return response.status_code


@workflow
def multiple_containers_pod_workflow() -> int:
    code = multiple_containers_pod_task()
    return code

```

### Screenshots

`Annotations:      cluster-autoscaler.kubernetes.io/safe-to-evict: false
                  primary_container_name: primary`

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
