### PR TITLE
Remove redundant `secho()`

### DIFF
--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -278,7 +278,6 @@ def register(
             is_lp = True
         else:
             og_id = cp_entity.template.id
-        secho(og_id, "")
         try:
             if not dry_run:
                 try:


### PR DESCRIPTION
## Tracking issue

None

## Why are the changes needed?

CLI (`flytekit/tools/repo.py`) shows redundant status message when registration.

## What changes were proposed in this pull request?

Remove redundant `secho()`.

## How was this patch tested?

Register with and without this `secho()`.

### Setup process

`pyflyte register wf.py`

### Screenshots

1. Before removing
![image](https://github.com/flyteorg/flytekit/assets/35886692/a624eb3f-c72d-474c-813d-45fd395d316e)

2. afte removing
![image](https://github.com/flyteorg/flytekit/assets/35886692/4e2a883d-bb52-404d-9110-2665e5a0ecef)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Related PRs

## Docs link
