### PR TITLE
Adds type information to flytekit.models in repr

### DIFF
--- a/flytekit/models/common.py
+++ b/flytekit/models/common.py
@@ -61,7 +61,8 @@ class FlyteIdlEntity(object, metaclass=FlyteType):
         :rtype: Text
         """
         literal_str = re.sub(r"\s+", " ", str(self.to_flyte_idl())).strip()
-        return f"<FlyteLiteral {literal_str}>"
+        type_str = type(self).__name__
+        return f"<FlyteLiteral({type_str}) {literal_str}>"
 
     def verbose_string(self):
         """

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -84,7 +84,7 @@ def test_create_and_link_node_from_remote_ignore():
 
     # without providing the _inputs_not_allowed or _ignorable_inputs, all inputs to lp become required,
     # which is incorrect
-    with pytest.raises(FlyteAssertion, match="Missing input `i` type `<FlyteLiteral simple: INTEGER>`"):
+    with pytest.raises(FlyteAssertion, match=r"Missing input `i` type `<FlyteLiteral\(LiteralType\) simple: INTEGER>`"):
         create_and_link_node_from_remote(ctx, lp)
 
     # Even if j is not provided it will default

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1701,7 +1701,7 @@ def test_union_type():
         match=re.escape(
             "Error encountered while executing 'wf2':\n"
             f"  Failed to convert inputs of task '{prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
-            '  Cannot convert from <FlyteLiteral scalar { union { value { scalar { primitive { string_value: "2" } } } '
+            '  Cannot convert from <FlyteLiteral(Literal) scalar { union { value { scalar { primitive { string_value: "2" } } } '
             'type { simple: STRING structure { tag: "str" } } } }> to typing.Union[float, dict] (using tag str)'
         ),
     ):

--- a/tests/flytekit/unit/models/test_common.py
+++ b/tests/flytekit/unit/models/test_common.py
@@ -103,3 +103,10 @@ def test_auth_role_empty():
     x = obj.to_flyte_idl()
     y = _common.AuthRole.from_flyte_idl(x)
     assert y == obj
+
+
+def test_short_string_raw_output_data_config():
+    """"""
+    obj = _common.RawOutputDataConfig("s3://bucket")
+    assert "FlyteLiteral(RawOutputDataConfig)" in obj.short_string()
+    assert "FlyteLiteral(RawOutputDataConfig)" in repr(obj)


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
When interacting with `FlyteRemote`, it's hard to see the actual types of the returned objects. I frequently will call `type` to get the actual class:

![Screenshot 2024-05-02 at 12 11 41 PM](https://github.com/flyteorg/flytekit/assets/5402633/d57a4baa-6f0a-438a-b10f-fbcdf1735004)

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
Adds the actual type to the `repr` so it's easier to distinguish between `FlyteLiterals`.


## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I added a unit test to make sure the class name is in the repr.