### PR TITLE
Fix `__annotations__` key not found

### DIFF
--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -161,8 +161,7 @@ def extract_cols_and_format(
             if hasattr(aa, "__annotations__"):
                 # handle dataclass argument
                 d = collections.OrderedDict()
-                dm = vars(aa)
-                d.update(dm["__annotations__"])
+                d.update(aa.__annotations__)
                 ordered_dict_cols = d
             elif isinstance(aa, dict):
                 d = collections.OrderedDict()


### PR DESCRIPTION
## Tracking issue

cc @pingsutw 
![image](https://github.com/flyteorg/flytekit/assets/35886692/b8a88b4f-fd3f-4f5c-a9ad-05f82de07dd6)
![image](https://github.com/flyteorg/flytekit/assets/35886692/79615533-649d-4ea6-a311-e8edf4ae935c)

## Why are the changes needed?

The error happened from some Python version (like `3.10.13`) but worked in some others.
`Failed with Unknown Exception <class 'KeyError'> Reason: '__annotations__'`

However, I can't reproduce the error on my python environment with version `3.10.13`.

There might be other package version issues, because it works in different python environment with different set of packages installed.

## What changes were proposed in this pull request?

In spite of the unknown root cause of the error, we can still eliminate error by simply using `.` to select attribute path, `aa.__annotations__`.

Original approach returns the `__dict__` of a class as type Dictionary via `vars()` then get it by `obj['__annotations__']`, see https://docs.python.org/3/library/functions.html#vars .

As the usage of selecting attribute `__annotations__`, please check https://docs.python.org/3.12/howto/annotations.html .

![image](https://github.com/flyteorg/flytekit/assets/35886692/84822827-4c28-4c01-8696-5839bc5b06fc)

## How was this patch tested?

### Setup process

`pyflyte register ...` and I can't assure 100% you can reproduce the error.

### Screenshots

1. _3.10.13_
![image](https://github.com/flyteorg/flytekit/assets/35886692/ec6f6b56-e095-45cd-aefe-5423e917964c)

3. _3.10.0_
![image](https://github.com/flyteorg/flytekit/assets/35886692/f9dd9d47-a1f2-4ce2-9b12-09331cb8da9d)

4. _3.9.19_
![image](https://github.com/flyteorg/flytekit/assets/35886692/485760cd-dcd5-4619-9a36-a53c36505e49)

6. _3.8.19_
![image](https://github.com/flyteorg/flytekit/assets/35886692/f32ec1f3-ea82-46db-aa11-5883f2c43972)

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flytekit/commit/0cc8bbcd795d7f7e3f5898a077a7ef77ccfee951

## Docs link
