### PR TITLE
Run CI checks using python 3.11

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -100,7 +100,6 @@ jobs:
           pip freeze
       - name: Run extras unit tests with coverage
         # Skip this step if running on python 3.12 due to https://github.com/tensorflow/tensorflow/issues/62003
-        # and https://github.com/pytorch/pytorch/issues/110436
         if: ${{ matrix.python-version != '3.12' }}
         run: |
           make unit_test_extras_codecov

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -28,7 +28,7 @@ jobs:
           if [[ ${{ github.event_name }} == "schedule" ]]; then
             echo "python_versions=[\"3.8\",\"3.9\",\"3.10\",\"3.11\",\"3.12\"]" >> $GITHUB_ENV
           else
-            echo "python_versions=[\"3.12\"]" >> $GITHUB_ENV
+            echo "python_versions=[\"3.11\"]" >> $GITHUB_ENV
           fi
 
   build:

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -27,9 +27,7 @@ tensorflow; python_version<'3.12'
 # Newer versions of torch bring in nvidia dependencies that are not present in windows, so
 # we put this constraint while we do not have per-environment requirements files
 torch<=1.12.1; python_version<'3.11'
-# pytorch 2 supports python 3.11
-# pytorch 2 does not support 3.12 yet: https://github.com/pytorch/pytorch/issues/110436
-torch; python_version<'3.12'
+torch; python_version>='3.11'
 
 # TODO: Currently, the python-magic library causes build errors on Windows due to its dependency on DLLs for libmagic.
 # We have temporarily disabled this feature on Windows and are using python-magic for Mac OS and Linux instead.


### PR DESCRIPTION
## Why are the changes needed?
We haven't been running the extras unit tests due to a combination of https://github.com/flyteorg/flytekit/pull/2237, https://github.com/flyteorg/flytekit/pull/2247, and https://github.com/flyteorg/flytekit/blob/master/.github/workflows/pythonbuild.yml#L101-L106 (which skips those tests in case we're running in python 3.12).

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
This PR makes it so that we run python 3.11 to run all tests. We might think about running tests in both versions.

In the meantime, pytorch added support for python 3.12, so I'm also removing the comments.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
