### PR TITLE
Influxdb query agent

### DIFF
--- a/plugins/flytekit-influxdb/README.md
+++ b/plugins/flytekit-influxdb/README.md
@@ -1,8 +1,8 @@
 # Flytekit InfluxDB Plugin
 
-InfluxDB, coupled with the power of pandas, facilitates streamlined management and analysis of time-series data. 
-By integrating the InfluxDB plugin with Flyte, you gain access to time-series data manipulation capabilities directly within your workflows. 
-This plugin is tailored to interact with pandas DataFrames, allowing for creation, retrieval, and deletion of time-series data stored in InfluxDB. 
+InfluxDB, coupled with the power of pandas, facilitates streamlined management and analysis of time-series data.
+By integrating the InfluxDB plugin with Flyte, you gain access to time-series data manipulation capabilities directly within your workflows.
+This plugin is tailored to interact with pandas DataFrames, allowing for creation, retrieval, and deletion of time-series data stored in InfluxDB.
 
 ## Example
 ```python
@@ -11,8 +11,8 @@ from flytekit import task, workflow
 from flytekitplugins.influxdb import InfluxDBTask, Aggregation, influx_json_to_df
 
 influx_query_task = InfluxDBTask(
-    name="influx_task", 
-    url="http://my-influxdb.com", 
+    name="influx_task",
+    url="http://my-influxdb.com",
     org="my_org")
 
 @workflow

--- a/plugins/flytekit-influxdb/README.md
+++ b/plugins/flytekit-influxdb/README.md
@@ -1,0 +1,44 @@
+# Flytekit InfluxDB Plugin
+
+InfluxDB, coupled with the power of pandas, facilitates streamlined management and analysis of time-series data. 
+By integrating the InfluxDB plugin with Flyte, you gain access to time-series data manipulation capabilities directly within your workflows. 
+This plugin is tailored to interact with pandas DataFrames, allowing for creation, retrieval, and deletion of time-series data stored in InfluxDB. 
+
+## Example
+```python
+from datetime import datetime, timedelta
+from flytekit import task, workflow
+from flytekitplugins.influxdb import InfluxDBTask, Aggregation, influx_json_to_df
+
+influx_query_task = InfluxDBTask(
+    name="influx_task", 
+    url="http://my-influxdb.com", 
+    org="my_org")
+
+@workflow
+def wf(bucket: str, measurement: str) -> str:
+    start_time = datetime(2024, 4, 25, 0, 0, 0)
+    data = influx_query_task(
+        bucket=bucket,
+        measurement=measurement,
+        start_time=start_time,
+        end_time=start_time + timedelta(days=2),
+        tag_dict={"my_tags": ["tag_1", "tag_2"]},
+        fields=["fields_1", "fields_2"],
+        aggregation=Aggregation.LAST,
+        period_min=30
+    )
+    return influx_json_to_df(data)
+
+
+if __name__ == "__main__":
+    print(wf(bucket="my_bucket", measurement="my_measurement"))
+```
+
+To install the plugin, run the following command:
+
+```bash
+pip install flytekitplugins-influxdb
+```
+
+To configure InfluxDB in the Flyte deployment's backend, follow the [configuration guide](none).

--- a/plugins/flytekit-influxdb/flytekitplugins/influxdb/__init__.py
+++ b/plugins/flytekit-influxdb/flytekitplugins/influxdb/__init__.py
@@ -1,0 +1,18 @@
+"""
+.. currentmodule:: flytekitplugins.influxdb
+
+This package contains things that are useful when extending Flytekit.
+
+.. autosummary::
+   :template: custom.rst
+   :toctree: generated/
+
+   BigQueryConfig
+   BigQueryTask
+   BigQueryAgent
+"""
+
+
+from .agent import InfluxDBAgent
+from .task import InfluxDBTask
+from .utils import Aggregation, influx_json_to_df

--- a/plugins/flytekit-influxdb/flytekitplugins/influxdb/agent.py
+++ b/plugins/flytekit-influxdb/flytekitplugins/influxdb/agent.py
@@ -1,0 +1,123 @@
+import logging
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from flyteidl.core.execution_pb2 import TaskExecution
+from influxdb_client import InfluxDBClient
+from utils import DATETIME_FORMAT, Aggregation
+
+from flytekit import FlyteContextManager
+from flytekit.core.type_engine import TypeEngine
+from flytekit.extend.backend.base_agent import AgentRegistry, Resource, SyncAgentBase
+from flytekit.extend.backend.utils import get_agent_secret
+from flytekit.models.literals import LiteralMap
+from flytekit.models.task import TaskTemplate
+
+INFLUX_API_KEY = "MY_INFLUX_API_KEY"
+
+
+class InfluxDBAgent(SyncAgentBase):
+    name = "InfluxDB Agent"
+
+    def __init__(self):
+        super().__init__(task_type_name="influxdb")
+
+    def do(self, task_template: TaskTemplate, inputs: Optional[LiteralMap] = None, **kwargs) -> Resource:
+        ctx = FlyteContextManager.current_context()
+        input_python_value = TypeEngine.literal_map_to_kwargs(
+            ctx,
+            inputs,
+            {
+                "bucket": str,
+                "measurement": str,
+                "start_time": datetime,
+                "end_time": datetime,
+                "fields": List[str],
+                "tag_dict": Dict[str, List[str]],
+                "period_min": int,
+                "aggregation": Aggregation,
+            },
+        )
+
+        custom = task_template.custom
+        client = InfluxDBClient(
+            url=custom["url"],
+            token=get_agent_secret(secret_key=INFLUX_API_KEY),
+            org=custom["org"],
+        )
+
+        bucket = input_python_value["bucket"]
+        measurement = input_python_value["measurement"]
+        start_time = input_python_value["start_time"]
+        end_time = input_python_value["end_time"]
+        fields = input_python_value["fields"]
+        tag_dict = input_python_value["tag_dict"]
+        period_min = input_python_value["period_min"]
+        aggregation = input_python_value["aggregation"]
+
+        query = InfluxDBAgent.format_query(
+            bucket=bucket,
+            measurement=measurement,
+            start_time=start_time,
+            end_time=end_time,
+            fields=fields,
+            tag_dict=tag_dict,
+            period_min=period_min,
+            aggregation=aggregation,
+        )
+
+        logger = logging.getLogger("httpx")
+        logger.setLevel(logging.WARNING)
+
+        df = client.query_api().query_data_frame(query)
+        outputs = {"o0": df.to_json()}
+
+        return Resource(phase=TaskExecution.SUCCEEDED, outputs=outputs)
+
+    @staticmethod
+    def format_query(
+        bucket: str,
+        measurement: str,
+        start_time: datetime,
+        end_time: datetime,
+        fields: List[str] = None,
+        tag_dict: Dict[str, List[str]] = None,
+        period_min: int = None,
+        aggregation: Aggregation = None,
+    ) -> str:
+        start_time_str = start_time.strftime(DATETIME_FORMAT)
+        end_time_str = end_time.strftime(DATETIME_FORMAT)
+        query = (
+            f'from(bucket:"{bucket}")\n'
+            f"|> range(start: {start_time_str},stop: {end_time_str} )\n"
+            f'|> filter(fn: (r) => r._measurement == "{measurement}")\n'
+        )
+
+        if fields is not None:
+            filed_dict = {"_field": fields}
+            query += InfluxDBAgent.make_query_filter(filed_dict)
+
+        if tag_dict is not None:
+            query += InfluxDBAgent.make_query_filter(tag_dict)
+
+        if period_min is not None and aggregation is not None:
+            aggregation = f"|> aggregateWindow(every: {period_min}m, fn: {aggregation.value}, " f"createEmpty: true)\n "
+            query += aggregation
+
+        query += '  |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")'
+
+        return query
+
+    @staticmethod
+    def make_query_filter(filter_dict: dict) -> str:
+        filter_list = []
+        for key, value in filter_dict.items():
+            value = [value] if type(value) != list else value
+            single_filter = " or ".join([f'r.{key} == "{v}"' for v in value])
+            filter_list.append(single_filter)
+
+        filters = " and ".join(filter_list)
+        return f"|> filter(fn: (r) => {filters})\n"
+
+
+AgentRegistry.register(InfluxDBAgent())

--- a/plugins/flytekit-influxdb/flytekitplugins/influxdb/task.py
+++ b/plugins/flytekit-influxdb/flytekitplugins/influxdb/task.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+from typing import Any, Dict, List
+
+from utils import Aggregation
+
+from flytekit.configuration import SerializationSettings
+from flytekit.core.base_task import PythonTask
+from flytekit.core.interface import Interface
+from flytekit.extend.backend.base_agent import SyncAgentExecutorMixin
+
+
+class InfluxDBTask(SyncAgentExecutorMixin, PythonTask):
+    _TASK_TYPE = "influxdb"
+
+    def __init__(self, name: str, url: str, org: str, **kwargs):
+        """InfluxDB agent task.
+
+        Args:
+            name (str): Name of the task.
+            url (str): InfluxDB server API url.
+            org (str): InfluxDB organization name.
+        """
+        task_config = {"url": url, "org": org}
+
+        inputs = {
+            "bucket": str,
+            "measurement": str,
+            "start_time": datetime,
+            "end_time": datetime,
+            "fields": List[str],
+            "tag_dict": Dict[str, List[str]],
+            "period_min": int,
+            "aggregation": Aggregation,
+        }
+        outputs = {"o0": str}
+
+        super().__init__(
+            task_type=self._TASK_TYPE,
+            name=name,
+            task_config=task_config,
+            interface=Interface(inputs=inputs, outputs=outputs),
+            **kwargs,
+        )
+
+    def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
+        return {
+            "url": self.task_config["url"],
+            "org": self.task_config["org"],
+        }

--- a/plugins/flytekit-influxdb/flytekitplugins/influxdb/utils.py
+++ b/plugins/flytekit-influxdb/flytekitplugins/influxdb/utils.py
@@ -1,0 +1,28 @@
+from enum import Enum
+from io import StringIO
+
+import pandas as pd
+
+DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+class Aggregation(Enum):
+    """Aggregation types."""
+
+    FIRST = "first"
+    LAST = "last"
+    MEAN = "mean"
+    MODE = "mode"
+
+
+def influx_json_to_df(json_data: str) -> pd.DataFrame:
+    """Converts JSON data output of InfluxDBAgent to a Pandas DataFrame.
+
+    Args:
+        json_data (str): JSON data output of InfluxDBAgent.
+
+    Returns:
+        pd.DataFrame: A Pandas DataFrame containing the queried data.
+    """
+    df = pd.read_json(StringIO(json_data))
+    return df.drop(columns=["table", "result", "_start", "_stop", "_measurement"])

--- a/plugins/flytekit-influxdb/setup.py
+++ b/plugins/flytekit-influxdb/setup.py
@@ -1,0 +1,36 @@
+from setuptools import setup
+
+PLUGIN_NAME = "influxdb"
+
+microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
+
+plugin_requires = ["flytekit>1.10.7", "influxdb-client>1.42.0", "pandas>2.2.2", "flyteidl>1.10.7"]
+
+__version__ = "0.0.0+develop"
+
+setup(
+    name=microlib_name,
+    version=__version__,
+    author="flyteorg",
+    author_email="admin@flyte.org",
+    description="This package holds the InfluxDB plugins for flytekit",
+    namespace_packages=["flytekitplugins"],
+    packages=[f"flytekitplugins.{PLUGIN_NAME}"],
+    install_requires=plugin_requires,
+    license="apache2",
+    python_requires=">=3.8",
+    classifiers=[
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Software Development",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+    entry_points={"flytekit.plugins": [f"{PLUGIN_NAME}=flytekitplugins.{PLUGIN_NAME}"]},
+)

--- a/plugins/flytekit-influxdb/tests/test_agent.py
+++ b/plugins/flytekit-influxdb/tests/test_agent.py
@@ -1,0 +1,110 @@
+import unittest
+from datetime import datetime, timedelta
+from io import StringIO
+from unittest import mock
+
+import pandas as pd
+from pandas._testing import assert_frame_equal
+
+from flytekit.extend.backend.base_agent import AgentRegistry
+from flytekit.interfaces.cli_identifiers import Identifier
+from flytekit.models import literals
+from flytekit.models.core.identifier import ResourceType
+from flytekit.models.literals import LiteralMap
+from flytekit.models.task import RuntimeMetadata, TaskMetadata, TaskTemplate
+
+dummy_data = {
+    "result": ["_result", "_result"],
+    "table": [0, 0],
+    "_start": ["2024-04-25 00:00:00+00:00", "2024-04-25 00:00:00+00:00"],
+    "_stop": ["2024-04-25 00:00:30+00:00", "2024-04-25 00:00:30+00:00"],
+    "_time": ["2024-04-25 00:00:00+00:00", "2024-04-25 00:00:30+00:00"],
+    "_measurement": ["testing_measurement", "testing_measurement"],
+    "testing_tag_key": ["testing_tag_value", "testing_tag_value"],
+    "testing_field": [10.5, 20.3],
+}
+
+
+class TestInfluxDBClient(unittest.TestCase):
+    @mock.patch("influxdb_client.client.query_api.QueryApi.query_data_frame")
+    def test_get_data_from_influxdb(self, mock_dataframe):
+        mock_dataframe.return_value = pd.DataFrame(dummy_data)
+
+        agent = AgentRegistry.get_agent("influxdb")
+        task_id = Identifier(
+            resource_type=ResourceType.TASK, project="project", domain="domain", name="name", version="version"
+        )
+        task_config = {
+            "url": "http://dummyurl:8086",
+            "org": "my_testing_org",
+        }
+        task_metadata = TaskMetadata(
+            True,
+            RuntimeMetadata(RuntimeMetadata.RuntimeType.FLYTE_SDK, "1.0.0", "python"),
+            timedelta(days=1),
+            literals.RetryStrategy(3),
+            True,
+            "0.1.1b0",
+            "This is deprecated!",
+            True,
+            "A",
+            (),
+        )
+        tmp = TaskTemplate(
+            id=task_id,
+            custom=task_config,
+            metadata=task_metadata,
+            interface=None,
+            type="influxdb",
+        )
+
+        task_inputs = LiteralMap(
+            {
+                "bucket": literals.Literal(
+                    scalar=literals.Scalar(primitive=literals.Primitive(string_value="testing_bucket"))
+                ),
+                "measurement": literals.Literal(
+                    scalar=literals.Scalar(primitive=literals.Primitive(string_value="testing_measurement"))
+                ),
+                "start_time": literals.Literal(
+                    scalar=literals.Scalar(primitive=literals.Primitive(datetime=datetime(2024, 4, 25, 0, 0, 0)))
+                ),
+                "end_time": literals.Literal(
+                    scalar=literals.Scalar(primitive=literals.Primitive(datetime=datetime(2024, 4, 26, 0, 0, 30)))
+                ),
+                "fields": literals.Literal(
+                    collection=literals.LiteralCollection(
+                        literals=[
+                            literals.Literal(
+                                scalar=literals.Scalar(primitive=literals.Primitive(string_value="testing_field"))
+                            )
+                        ]
+                    )
+                ),
+                "tag_dict": literals.Literal(
+                    map=literals.LiteralMap(
+                        literals={
+                            "testing_tag_key": literals.Literal(
+                                collection=literals.LiteralCollection(
+                                    literals=[
+                                        literals.Literal(
+                                            scalar=literals.Scalar(
+                                                primitive=literals.Primitive(string_value="testing_tag_value")
+                                            )
+                                        )
+                                    ]
+                                )
+                            )
+                        }
+                    )
+                ),
+                "period_min": literals.Literal(scalar=literals.Scalar(primitive=literals.Primitive(integer=30))),
+                "aggregation": literals.Literal(
+                    scalar=literals.Scalar(primitive=literals.Primitive(string_value="last"))
+                ),
+            },
+        )
+
+        response = agent.do(tmp, task_inputs)
+        df = pd.read_json(StringIO(response.outputs["o0"]))
+        assert_frame_equal(df, pd.DataFrame(dummy_data))

--- a/plugins/flytekit-influxdb/tests/test_influxdb.py
+++ b/plugins/flytekit-influxdb/tests/test_influxdb.py
@@ -1,0 +1,54 @@
+from collections import OrderedDict
+
+from flytekitplugins.influxdb import InfluxDBTask
+
+from flytekit.configuration import Image, ImageConfig, SerializationSettings
+from flytekit.extend import get_serializable
+from flytekit.models.types import SimpleType
+
+
+def test_chatgpt_task():
+    influx_query_task = InfluxDBTask(
+        name="influx",
+        url="http://dummyurl:8086",
+        org="my_testing_org",
+    )
+
+    assert len(influx_query_task.interface.inputs) == 8
+    assert len(influx_query_task.interface.outputs) == 1
+
+    default_img = Image(name="default", fqn="test", tag="tag")
+    serialization_settings = SerializationSettings(
+        project="proj",
+        domain="dom",
+        version="123",
+        image_config=ImageConfig(default_image=default_img, images=[default_img]),
+        env={},
+    )
+
+    influx_task_spec = get_serializable(OrderedDict(), serialization_settings, influx_query_task)
+    custom = influx_task_spec.template.custom
+    assert custom["url"] == "http://dummyurl:8086"
+    assert custom["org"] == "my_testing_org"
+
+    assert len(influx_task_spec.template.interface.inputs) == 8
+    assert len(influx_task_spec.template.interface.outputs) == 1
+
+    assert influx_task_spec.template.interface.inputs["bucket"].type.simple == SimpleType.STRING
+    assert influx_task_spec.template.interface.inputs["measurement"].type.simple == SimpleType.STRING
+    assert influx_task_spec.template.interface.inputs["start_time"].type.simple == SimpleType.DATETIME
+    assert influx_task_spec.template.interface.inputs["end_time"].type.simple == SimpleType.DATETIME
+    assert influx_task_spec.template.interface.inputs["fields"].type.collection_type.simple == SimpleType.STRING
+    assert (
+        influx_task_spec.template.interface.inputs["tag_dict"].type.map_value_type.collection_type.simple
+        == SimpleType.STRING
+    )
+    assert influx_task_spec.template.interface.inputs["period_min"].type.simple == SimpleType.INTEGER
+    assert influx_task_spec.template.interface.inputs["aggregation"].type.enum_type.values == [
+        "first",
+        "last",
+        "mean",
+        "mode",
+    ]
+
+    assert influx_task_spec.template.interface.outputs["o0"].type.simple == SimpleType.STRING


### PR DESCRIPTION
## Why are the changes needed?
Adding a sync agent to query from influxdb; a timeseries database.

## What changes were proposed in this pull request?

Added an influxdb task and agent to pull timeseries data as a pandas dataframe.

### Example
```python
from datetime import datetime, timedelta
from flytekit import task, workflow
from flytekitplugins.influxdb import InfluxDBTask, Aggregation, influx_json_to_df

influx_query_task = InfluxDBTask(
    name="influx_task",
    url="http://my-influxdb.com",
    org="my_org")

@workflow
def wf(bucket: str, measurement: str) -> str:
    start_time = datetime(2024, 4, 25, 0, 0, 0)
    data = influx_query_task(
        bucket=bucket,
        measurement=measurement,
        start_time=start_time,
        end_time=start_time + timedelta(days=2),
        tag_dict={"my_tags": ["tag_1", "tag_2"]},
        fields=["fields_1", "fields_2"],
        aggregation=Aggregation.LAST,
        period_min=30
    )
    return influx_json_to_df(data)


if __name__ == "__main__":
    print(wf(bucket="my_bucket", measurement="my_measurement"))
```

## How was this patch tested?

Added unit tests for the task and the agent in plugins/flytekit-influxdb/tests/

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
