### PR TITLE
fix(import): Fix relative import path error

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -333,7 +333,7 @@ def get_entities_in_file(filename: pathlib.Path, should_delete: bool) -> Entitie
     if filename.is_relative_to(pathlib.Path.cwd()):
         additional_path = str(pathlib.Path.cwd())
     else:
-        additional_path = str(filename.parent.parent)
+        additional_path = _find_project_root(filename)
     module_name = str(filename.relative_to(additional_path).with_suffix("")).replace(os.path.sep, ".")
     with context_manager.FlyteContextManager.with_context(flyte_ctx):
         with module_loader.add_sys_path(additional_path):

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -330,12 +330,11 @@ def get_entities_in_file(filename: pathlib.Path, should_delete: bool) -> Entitie
     Returns a list of flyte workflow names and list of Flyte tasks in a file.
     """
     flyte_ctx = context_manager.FlyteContextManager.current_context().new_builder()
-    if filename.is_relative_to("."):
-        module_name = str(filename.relative_to(".").with_suffix("")).replace(os.path.sep, ".")
+    if filename.is_relative_to(pathlib.Path.cwd()):
         additional_path = str(pathlib.Path.cwd())
     else:
-        module_name = str(filename.stem)
-        additional_path = str(filename.parent)
+        additional_path = str(filename.parent.parent)
+    module_name = str(filename.relative_to(additional_path).with_suffix("")).replace(os.path.sep, ".")
     with context_manager.FlyteContextManager.with_context(flyte_ctx):
         with module_loader.add_sys_path(additional_path):
             importlib.import_module(module_name)


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?

Running `pyflyte run examples/basics/basics/documenting_workflows.py` in the `flytesnacks` repo raises error.

![image](https://github.com/flyteorg/flytekit/assets/47914085/72762465-44b4-444a-bc84-84d4de20d637)


## What changes were proposed in this pull request?

Because `documenting_workflows.py` has relative imports in it, the `additional_path` should be its parent folder's parent folder.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
