### PR TITLE
[wip] Use Json type to represent naked dictionaries

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install build-essential vim libmagic1 git -y
 RUN pip install scikit-learn
 COPY . /flytekit
 RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLYTEKIT=$PSEUDO_VERSION pip install --no-cache-dir -U \
-        "git+https://github.com/flyteorg/flyte.git@master#subdirectory=flyteidl" \
+        "git+https://github.com/flyteorg/flyte.git@idl/json-type#subdirectory=flyteidl" \
         -e /flytekit \
         -e /flytekit/plugins/flytekit-k8s-pod \
         -e /flytekit/plugins/flytekit-deck-standard \

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,5 +1,4 @@
 -e file:.#egg=flytekit
-git+https://github.com/flyteorg/flyte.git@master#subdirectory=flyteidl
 
 coverage[toml]
 hypothesis

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -15,6 +15,7 @@ from abc import ABC, abstractmethod
 from functools import lru_cache
 from typing import Dict, List, NamedTuple, Optional, Type, cast
 
+import jsonpickle
 from dataclasses_json import DataClassJsonMixin, dataclass_json
 from flyteidl.core import literals_pb2
 from google.protobuf import json_format as _json_format
@@ -1689,7 +1690,7 @@ class DictTransformer(TypeTransformer[dict]):
         """
         Creates a flyte-specific ``Literal`` value from a native python dictionary.
         """
-        return Literal(scalar=Scalar(json_type=Json(value=json.dumps(v))))
+        return Literal(scalar=Scalar(json_type=Json(value=jsonpickle.dumps(v))))
 
     def get_literal_type(self, t: Type[dict]) -> LiteralType:
         """
@@ -1744,7 +1745,7 @@ class DictTransformer(TypeTransformer[dict]):
         # evaluates to false
         if lv and lv.scalar and lv.scalar.json_type is not None:
             try:
-                return json.loads(lv.scalar.json_type.value)
+                return jsonpickle.loads(lv.scalar.json_type.value)
             except TypeError:
                 raise TypeTransformerFailedError(f"Cannot convert from {lv} to {expected_python_type}")
         raise TypeTransformerFailedError(f"Cannot convert from {lv} to {expected_python_type}")

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1690,7 +1690,7 @@ class DictTransformer(TypeTransformer[dict]):
         """
         Creates a flyte-specific ``Literal`` value from a native python dictionary.
         """
-        return Literal(scalar=Scalar(json_type=Json(value=jsonpickle.dumps(v))))
+        return Literal(scalar=Scalar(json_type=Json(value=jsonpickle.encode(v))))
 
     def get_literal_type(self, t: Type[dict]) -> LiteralType:
         """
@@ -1745,7 +1745,7 @@ class DictTransformer(TypeTransformer[dict]):
         # evaluates to false
         if lv and lv.scalar and lv.scalar.json_type is not None:
             try:
-                return jsonpickle.loads(lv.scalar.json_type.value)
+                return jsonpickle.decode(lv.scalar.json_type.value)
             except TypeError:
                 raise TypeTransformerFailedError(f"Cannot convert from {lv} to {expected_python_type}")
         raise TypeTransformerFailedError(f"Cannot convert from {lv} to {expected_python_type}")

--- a/flytekit/interaction/string_literals.py
+++ b/flytekit/interaction/string_literals.py
@@ -45,6 +45,8 @@ def scalar_to_string(scalar: Scalar) -> typing.Any:
         return MessageToDict(scalar.generic)
     if scalar.union:
         return literal_string_repr(scalar.union.value)
+    if scalar.json_type:
+        return scalar.json_type.value
     raise ValueError(f"Unknown scalar type {scalar}")
 
 

--- a/flytekit/models/literals.py
+++ b/flytekit/models/literals.py
@@ -282,6 +282,32 @@ class Blob(_common.FlyteIdlEntity):
         return cls(metadata=BlobMetadata.from_flyte_idl(proto.metadata), uri=proto.uri)
 
 
+class Json(_common.FlyteIdlEntity):
+    def __init__(self, value: str):
+        """
+        :param Text value:
+        """
+        self._value = value
+
+    @property
+    def value(self):
+        """
+        :rtype: Text
+        """
+        return self._value
+
+    def to_flyte_idl(self):
+        return _literals_pb2.Json(value=self._value)
+
+    @classmethod
+    def from_flyte_idl(cls, proto):
+        """
+        :param flyteidl.core.literals_pb2.Json proto:
+        :rtype: Json
+        """
+        return cls(value=proto.value)
+
+
 class Void(_common.FlyteIdlEntity):
     def to_flyte_idl(self):
         """
@@ -709,6 +735,7 @@ class Scalar(_common.FlyteIdlEntity):
         schema: Schema = None,
         union: Union = None,
         none_type: Void = None,
+        json_type: Json = None,
         error: Error = None,
         generic: Struct = None,
         structured_dataset: StructuredDataset = None,
@@ -732,6 +759,7 @@ class Scalar(_common.FlyteIdlEntity):
         self._schema = schema
         self._union = union
         self._none_type = none_type
+        self._json_type = json_type
         self._error = error
         self._generic = generic
         self._structured_dataset = structured_dataset
@@ -779,6 +807,10 @@ class Scalar(_common.FlyteIdlEntity):
         return self._none_type
 
     @property
+    def json_type(self):
+        return self._json_type
+
+    @property
     def error(self):
         """
         :rtype: Error
@@ -809,6 +841,7 @@ class Scalar(_common.FlyteIdlEntity):
             or self.schema
             or self.union
             or self.none_type
+            or self.json_type
             or self.error
             or self.generic
             or self.structured_dataset
@@ -825,6 +858,7 @@ class Scalar(_common.FlyteIdlEntity):
             schema=self.schema.to_flyte_idl() if self.schema is not None else None,
             union=self.union.to_flyte_idl() if self.union is not None else None,
             none_type=self.none_type.to_flyte_idl() if self.none_type is not None else None,
+            json=self.json_type.to_flyte_idl() if self.json_type is not None else None,
             error=self.error.to_flyte_idl() if self.error is not None else None,
             generic=self.generic,
             structured_dataset=self.structured_dataset.to_flyte_idl() if self.structured_dataset is not None else None,
@@ -844,6 +878,7 @@ class Scalar(_common.FlyteIdlEntity):
             schema=Schema.from_flyte_idl(pb2_object.schema) if pb2_object.HasField("schema") else None,
             union=Union.from_flyte_idl(pb2_object.union) if pb2_object.HasField("union") else None,
             none_type=Void.from_flyte_idl(pb2_object.none_type) if pb2_object.HasField("none_type") else None,
+            json_type=Json.from_flyte_idl(pb2_object.json) if pb2_object.HasField("json") else None,
             error=pb2_object.error if pb2_object.HasField("error") else None,
             generic=pb2_object.generic if pb2_object.HasField("generic") else None,
             structured_dataset=StructuredDataset.from_flyte_idl(pb2_object.structured_dataset)

--- a/flytekit/models/types.py
+++ b/flytekit/models/types.py
@@ -22,6 +22,7 @@ class SimpleType(object):
     BINARY = _types_pb2.BINARY
     ERROR = _types_pb2.ERROR
     STRUCT = _types_pb2.STRUCT
+    JSON = _types_pb2.JSON
 
 
 class SchemaType(_common.FlyteIdlEntity):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "diskcache>=5.2.1",
     "docker>=4.0.0,<7.0.0",
     "docstring-parser>=0.9.0",
-    "flyteidl>=1.11.0b1",
+    # TODO: replace lower-bound version with a released version
+    "flyteidl @ git+https://github.com/flyteorg/flyte.git@idl/json-type#subdirectory=flyteidl",
     "fsspec>=2023.3.0",
     "gcsfs>=2023.3.0",
     "googleapis-common-protos>=1.57",


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5318

## Why are the changes needed?
As described in https://github.com/flyteorg/flyte/issues/5318, we can use a json string as the transport for a variety of types, including naked dictionaries.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Leverage the new Json type defined in https://github.com/flyteorg/flyte/pull/5337 to replace the usage of protobuf Struct as the transport for naked dictionaries with a json-encoded string. 

Keep in mind that this is WIP. TODO:
1. [ ]  define how custom encoders are passed in, if necessary,
2. [ ] make this backwards compatible with the old Struct 
3. [ ] fix+add tests

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
4. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
