### PR TITLE
feat(bindings): Task arguments default value binding

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1086,16 +1086,7 @@ def create_and_link_node(
                     raise _user_exceptions.FlyteAssertion("Cannot use non-hashable object as default argument")
                 kwargs[k] = default_val
             else:
-                from flytekit.core.base_task import Task
-
                 error_msg = f"Input {k} of type {interface.inputs[k]} was not specified for function {entity.name}"
-
-                _, _default = interface.inputs_with_defaults[k]
-                if isinstance(entity, Task) and _default is not None:
-                    error_msg += (
-                        ". Flyte workflow syntax is a domain-specific language (DSL) for building execution graphs which "
-                        "supports a subset of Python’s semantics. When calling tasks, all kwargs have to be provided."
-                    )
 
                 raise _user_exceptions.FlyteAssertion(error_msg)
         v = kwargs[k]

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import collections
 import inspect
-import typing
 from copy import deepcopy
 from enum import Enum
-from typing import Any, Coroutine, Dict, List, Optional, Set, Tuple, Union, cast
+from typing import Any, Coroutine, Dict, Hashable, List, Optional, Set, Tuple, Union, cast, get_args
 
 from google.protobuf import struct_pb2 as _struct
-from typing_extensions import Protocol, get_args
+from typing_extensions import Protocol
 
 from flytekit.core import constants as _common_constants
 from flytekit.core import context_manager as _flyte_context
@@ -24,7 +23,13 @@ from flytekit.core.context_manager import (
 )
 from flytekit.core.interface import Interface
 from flytekit.core.node import Node
-from flytekit.core.type_engine import DictTransformer, ListTransformer, TypeEngine, TypeTransformerFailedError
+from flytekit.core.type_engine import (
+    DictTransformer,
+    ListTransformer,
+    TypeEngine,
+    TypeTransformerFailedError,
+    UnionTransformer,
+)
 from flytekit.exceptions import user as _user_exceptions
 from flytekit.exceptions.user import FlytePromiseAttributeResolveException
 from flytekit.loggers import logger
@@ -1067,27 +1072,21 @@ def create_and_link_node(
 
     for k in sorted(interface.inputs):
         var = typed_interface.inputs[k]
+        if var.type.simple == SimpleType.NONE:
+            raise TypeError("Arguments do not have type annotation")
         if k not in kwargs:
-            is_optional = False
-            if var.type.union_type:
-                for variant in var.type.union_type.variants:
-                    if variant.simple == SimpleType.NONE:
-                        val, _default = interface.inputs_with_defaults[k]
-                        if _default is not None:
-                            raise ValueError(
-                                f"The default value for the optional type must be None, but got {_default}"
-                            )
-                        is_optional = True
-            if is_optional:
-                continue
-            if k in interface.inputs_with_defaults and interface.inputs_with_defaults[k][1] is not None:
+            # interface.inputs_with_defaults[k][0] is the type of the default argument
+            # interface.inputs_with_defaults[k][1] is the value of the default argument
+            if k in interface.inputs_with_defaults and (
+                interface.inputs_with_defaults[k][1] is not None
+                or UnionTransformer.is_optional_type(interface.inputs_with_defaults[k][0])
+            ):
                 default_val = interface.inputs_with_defaults[k][1]
-                if not isinstance(default_val, typing.Hashable):
+                if not isinstance(default_val, Hashable):
                     raise _user_exceptions.FlyteAssertion("Cannot use non-hashable object as default argument")
                 kwargs[k] = default_val
             else:
                 error_msg = f"Input {k} of type {interface.inputs[k]} was not specified for function {entity.name}"
-
                 raise _user_exceptions.FlyteAssertion(error_msg)
         v = kwargs[k]
         # This check ensures that tuples are not passed into a function, as tuples are not supported by Flyte

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -690,7 +690,6 @@ def binding_data_from_python_std(
     t_value: Any,
     t_value_type: type,
     nodes: List[Node],
-    is_union_type_variants_expanded: bool = True,
 ) -> _literals_models.BindingData:
     # This handles the case where the given value is the output of another task
     if isinstance(t_value, Promise):
@@ -713,7 +712,6 @@ def binding_data_from_python_std(
         # If it is a container type, then we need to iterate over the variants in the Union type, try each one. This is
         # akin to what the Type Engine does when it finds a Union type (see the UnionTransformer), but we can't rely on
         # that in this case, because of the mix and match of realized values, and Promises.
-    elif t_value is not None and is_union_type_variants_expanded and expected_literal_type.union_type is not None:
         for i in range(len(expected_literal_type.union_type.variants)):
             try:
                 lt_type = expected_literal_type.union_type.variants[i]
@@ -780,7 +778,6 @@ def binding_from_python_std(
     expected_literal_type: _type_models.LiteralType,
     t_value: Any,
     t_value_type: type,
-    is_union_type_variants_expanded: bool = True,
 ) -> Tuple[_literals_models.Binding, List[Node]]:
     nodes: List[Node] = []
     binding_data = binding_data_from_python_std(
@@ -789,7 +786,6 @@ def binding_from_python_std(
         t_value,
         t_value_type,
         nodes,
-        is_union_type_variants_expanded=is_union_type_variants_expanded,
     )
     return _literals_models.Binding(var=var_name, binding=binding_data), nodes
 
@@ -1082,7 +1078,6 @@ def create_and_link_node(
 
     for k in sorted(interface.inputs):
         var = typed_interface.inputs[k]
-        is_default_arg_used = False
         if var.type.simple == SimpleType.NONE:
             raise TypeError("Arguments do not have type annotation")
         if k not in kwargs:
@@ -1096,7 +1091,6 @@ def create_and_link_node(
                 if not isinstance(default_val, Hashable):
                     raise _user_exceptions.FlyteAssertion("Cannot use non-hashable object as default argument")
                 kwargs[k] = default_val
-                is_default_arg_used = True
             else:
                 error_msg = f"Input {k} of type {interface.inputs[k]} was not specified for function {entity.name}"
                 raise _user_exceptions.FlyteAssertion(error_msg)
@@ -1116,7 +1110,6 @@ def create_and_link_node(
                 expected_literal_type=var.type,
                 t_value=v,
                 t_value_type=interface.inputs[k],
-                is_union_type_variants_expanded=not is_default_arg_used,
             )
             bindings.append(b)
             nodes.extend(n)

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1555,7 +1555,7 @@ class UnionTransformer(TypeTransformer[T]):
         super().__init__("Typed Union", typing.Union)
 
     @staticmethod
-    def is_optional_type(t: Type[T]) -> bool:
+    def is_optional_type(t: Type) -> bool:
         """Return True if `t` is a Union or Optional type."""
         return _is_union_type(t) or type(None) in get_args(t)
 

--- a/tests/flytekit/unit/core/test_composition.py
+++ b/tests/flytekit/unit/core/test_composition.py
@@ -1,7 +1,5 @@
 from typing import Dict, List, NamedTuple, Optional, Union
 
-import pytest
-
 from flytekit.core import launch_plan
 from flytekit.core.task import task
 from flytekit.core.workflow import workflow
@@ -186,15 +184,3 @@ def test_optional_input():
         return t2(a=a)
 
     assert wf() is None
-
-    with pytest.raises(ValueError, match="The default value for the optional type must be None, but got 3"):
-
-        @task()
-        def t3(c: Optional[int] = 3) -> Optional[int]:
-            ...
-
-        @workflow
-        def wf():
-            return t3()
-
-        wf()

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -48,6 +48,14 @@ def test_create_and_link_node():
     assert p.ref.var == "o0"
     assert len(p.ref.node.bindings) == 0
 
+    @task
+    def t_default_value(a: int = 1) -> int:
+        return a
+
+    p = create_and_link_node(ctx, t_default_value)
+    assert p.ref.var == "o0"
+    assert len(p.ref.node.bindings) == 1
+
 
 def test_create_and_link_node_from_remote():
     @task

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -46,14 +46,6 @@ def test_create_and_link_node():
 
     p = create_and_link_node(ctx, t2)
     assert p.ref.var == "o0"
-    assert len(p.ref.node.bindings) == 0
-
-    @task
-    def t_default_value(a: int = 1) -> int:
-        return a
-
-    p = create_and_link_node(ctx, t_default_value)
-    assert p.ref.var == "o0"
     assert len(p.ref.node.bindings) == 1
 
 

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -623,7 +623,15 @@ def test_default_args_task_optional_int_type_default_none():
         ),
     )
     assert wf_with_input_spec.template.nodes[0].inputs[0].binding.value == Scalar(
-        primitive=Primitive(integer=input_val)
+        union=Union(
+            value=Literal(
+                scalar=Scalar(primitive=Primitive(integer=input_val)),
+            ),
+            stored_type=LiteralType(
+                simple=SimpleType.INTEGER,
+                structure=TypeStructure(tag="int"),
+            ),
+        ),
     )
 
     output_type = LiteralType(
@@ -685,7 +693,15 @@ def test_default_args_task_optional_int_type_default_int():
         ),
     )
     assert wf_with_input_spec.template.nodes[0].inputs[0].binding.value == Scalar(
-        primitive=Primitive(integer=input_val)
+        union=Union(
+            value=Literal(
+                scalar=Scalar(primitive=Primitive(integer=input_val)),
+            ),
+            stored_type=LiteralType(
+                simple=SimpleType.INTEGER,
+                structure=TypeStructure(tag="int"),
+            ),
+        ),
     )
 
     output_type = LiteralType(

--- a/tests/flytekit/unit/types/pickle/test_flyte_pickle.py
+++ b/tests/flytekit/unit/types/pickle/test_flyte_pickle.py
@@ -1,7 +1,7 @@
 import sys
 from collections import OrderedDict
 from collections.abc import Sequence
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
 import numpy as np
 import pytest
@@ -11,6 +11,7 @@ import flytekit.configuration
 from flytekit.configuration import Image, ImageConfig
 from flytekit.core import context_manager
 from flytekit.core.task import task
+from flytekit.core.workflow import workflow
 from flytekit.models.core.types import BlobType
 from flytekit.models.literals import BlobMetadata
 from flytekit.models.types import LiteralType
@@ -126,3 +127,52 @@ def test_artf():
     task_spec = get_serializable(OrderedDict(), serialization_settings, t1)
     md = task_spec.template.interface.outputs["o0"].type.metadata["python_class_name"]
     assert "0x" not in str(md)
+
+
+def test_default_args_task():
+    default_val = 123
+    input_val = "foo"
+
+    @task
+    def t1(a: Any = default_val) -> Any:
+        return a
+
+    @workflow
+    def wf_no_input() -> Any:
+        return t1()
+
+    @workflow
+    def wf_with_input() -> Any:
+        return t1(a=input_val)
+
+    @workflow
+    def wf_with_sub_wf() -> tuple[Any, Any]:
+        return (wf_no_input(), wf_with_input())
+
+    wf_no_input_spec = get_serializable(OrderedDict(), serialization_settings, wf_no_input)
+    wf_with_input_spec = get_serializable(OrderedDict(), serialization_settings, wf_with_input)
+
+    metadata = BlobMetadata(
+        type=BlobType(
+            format="PythonPickle",
+            dimensionality=BlobType.BlobDimensionality.SINGLE,
+        ),
+    )
+    assert wf_no_input_spec.template.nodes[0].inputs[0].binding.value.blob.metadata == metadata
+    assert wf_with_input_spec.template.nodes[0].inputs[0].binding.value.blob.metadata == metadata
+
+    output_type = LiteralType(
+        blob=BlobType(
+            format="PythonPickle",
+            dimensionality=BlobType.BlobDimensionality.SINGLE,
+        ),
+        metadata={
+            "python_class_name": "typing.Any",
+        },
+    )
+    assert wf_no_input_spec.template.interface.outputs["o0"].type == output_type
+    assert wf_with_input_spec.template.interface.outputs["o0"].type == output_type
+
+    assert wf_no_input() == default_val
+    assert wf_with_input() == input_val
+    assert wf_with_sub_wf() == (default_val, input_val)


### PR DESCRIPTION
## Tracking issue

Resolves: flyteorg/flyte#5321

## Why are the changes needed?

See the issue description for details.

## What changes were proposed in this pull request?

if the key is not in `kwargs` but in `interface.inputs_with_defaults`, add the value in `interface.inputs_with_defaults` to `kwargs`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
