### PR TITLE
Catch silent subproc_execute failures

### DIFF
--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -79,8 +79,14 @@ def subproc_execute(command: typing.Union[List[str], str], **kwargs) -> ProcessR
     try:
         # Execute the command and capture stdout and stderr
         result = subprocess.run(command, **kwargs)
+        print(result.check_returncode())
 
-        assert result.stderr == ""
+        if "|" in command and kwargs.get("shell"):
+            logger.warning(
+                """Found a pipe in the command and shell=True.
+                This can lead to silent failures if subsequent commands
+                succeed despite previous failures."""
+            )
 
         # Access the stdout and stderr output
         return ProcessResult(result.returncode, result.stdout, result.stderr)
@@ -94,9 +100,6 @@ def subproc_execute(command: typing.Union[List[str], str], **kwargs) -> ProcessR
             Did you specify a container image in the task definition if using
             custom dependencies?\n{e}"""
         )
-
-    except AssertionError:
-        raise Exception(f"Command: {command}\nexperienced a silent failure, likely due to shell=True:\n{result.stderr}")
 
 
 def _dummy_task_func():

--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -80,6 +80,8 @@ def subproc_execute(command: typing.Union[List[str], str], **kwargs) -> ProcessR
         # Execute the command and capture stdout and stderr
         result = subprocess.run(command, **kwargs)
 
+        assert result.stderr == ""
+
         # Access the stdout and stderr output
         return ProcessResult(result.returncode, result.stdout, result.stderr)
 
@@ -92,6 +94,9 @@ def subproc_execute(command: typing.Union[List[str], str], **kwargs) -> ProcessR
             Did you specify a container image in the task definition if using
             custom dependencies?\n{e}"""
         )
+
+    except AssertionError:
+        raise Exception(f"Command: {command}\nexperienced a silent failure, likely due to shell=True:\n{result.stderr}")
 
 
 def _dummy_task_func():

--- a/tests/flytekit/unit/extras/tasks/test_shell.py
+++ b/tests/flytekit/unit/extras/tasks/test_shell.py
@@ -370,3 +370,27 @@ def test_subproc_execute_with_shell():
         subproc_execute(cmd, shell=True)
         cont = open(opth).read()
         assert "hello" in cont
+
+
+def test_subproc_execute_missing_dep():
+    cmd = ["non-existent", "blah"]
+    with pytest.raises(Exception) as e:
+        subproc_execute(cmd)
+    assert "executable could not be found" in str(e.value)
+
+
+def test_subproc_execute_error():
+    cmd = ["ls", "--banana"]
+    with pytest.raises(Exception) as e:
+        subproc_execute(cmd)
+    assert "Failed with return code" in str(e.value)
+
+
+def test_subproc_execute_shell_error(tmp_path):
+    # This is a corner case I ran into that really shouldn't
+    # ever happen. The assert catches anything in stderr despite
+    # a 0 exit.
+    cmd = " ".join(["bcftools", "isec", "|", "gzip", "-c", ">", f"{tmp_path.joinpath('out')}"])
+    with pytest.raises(Exception) as e:
+        subproc_execute(cmd, shell=True)
+    assert "silent failure" in str(e.value)

--- a/tests/flytekit/unit/extras/tasks/test_shell.py
+++ b/tests/flytekit/unit/extras/tasks/test_shell.py
@@ -384,13 +384,3 @@ def test_subproc_execute_error():
     with pytest.raises(Exception) as e:
         subproc_execute(cmd)
     assert "Failed with return code" in str(e.value)
-
-
-def test_subproc_execute_shell_error(tmp_path):
-    # This is a corner case I ran into that really shouldn't
-    # ever happen. The assert catches anything in stderr despite
-    # a 0 exit.
-    cmd = " ".join(["bcftools", "isec", "|", "gzip", "-c", ">", f"{tmp_path.joinpath('out')}"])
-    with pytest.raises(Exception) as e:
-        subproc_execute(cmd, shell=True)
-    assert "silent failure" in str(e.value)


### PR DESCRIPTION
## Why are the changes needed?
Under some circumstances, subproc_execute will exit with 0 but have a non-null stderr.

## What changes were proposed in this pull request?
Adds an assert statement to handle 0 exit with stderr.

## How was this patch tested?
Unit test to capture AssertionError and ensure the message contains the right content.

### Setup process
`make setup`
`make unit_test`