### PR TITLE
fix(ImageSpec): Ensure all APIErrors return a value

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -121,7 +121,9 @@ class ImageSpec:
             return True
         except APIError as e:
             if e.response.status_code == 404:
+                print("404")
                 return False
+            print("test")
             return True
         except ImageNotFound:
             return False

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -141,8 +141,7 @@ class ImageSpec:
                 if response.status_code == 200:
                     return True
 
-                if response.status_code == 404:
-                    print("sddddddddddddddddddddd")
+                if response.status_code == 404 and "not found" in str(response.content):
                     return False
 
             click.secho(f"Failed to check if the image exists with error : {e}", fg="red")

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -142,6 +142,7 @@ class ImageSpec:
                     return True
 
                 if response.status_code == 404:
+                    print("sddddddddddddddddddddd")
                     return False
 
             click.secho(f"Failed to check if the image exists with error : {e}", fg="red")

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -112,6 +112,7 @@ class ImageSpec:
         import docker
         from docker.errors import APIError, ImageNotFound
 
+        print("exist.................")
         try:
             client = docker.from_env()
             if self.registry:

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -122,6 +122,7 @@ class ImageSpec:
         except APIError as e:
             if e.response.status_code == 404:
                 return False
+            return True
         except ImageNotFound:
             return False
         except Exception as e:

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -112,7 +112,6 @@ class ImageSpec:
         import docker
         from docker.errors import APIError, ImageNotFound
 
-        print("exist.................")
         try:
             client = docker.from_env()
             if self.registry:
@@ -122,12 +121,9 @@ class ImageSpec:
             return True
         except APIError as e:
             if e.response.status_code == 404:
-                print("404")
                 return False
-            print("test")
             return True
         except ImageNotFound:
-            print("ImageNotFound")
             return False
         except Exception as e:
             tag = calculate_hash_from_image_spec(self)

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -126,6 +126,7 @@ class ImageSpec:
             print("test")
             return True
         except ImageNotFound:
+            print("ImageNotFound")
             return False
         except Exception as e:
             tag = calculate_hash_from_image_spec(self)

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -19,7 +19,7 @@ def test_image_spec(mock_image_spec_builder):
         packages=["pandas"],
         apt_packages=["git"],
         python_version="3.8",
-        registry="",
+        registry="localhost:30001",
         base_image="cr.flyte.org/flyteorg/flytekit:py3.8-latest",
         cuda="11.2.2",
         cudnn="8",
@@ -37,7 +37,7 @@ def test_image_spec(mock_image_spec_builder):
     assert image_spec.base_image == "cr.flyte.org/flyteorg/flytekit:py3.8-latest"
     assert image_spec.packages == ["pandas", "numpy"]
     assert image_spec.apt_packages == ["git", "wget"]
-    assert image_spec.registry == ""
+    assert image_spec.registry == "localhost:30001"
     assert image_spec.requirements == REQUIREMENT_FILE
     assert image_spec.registry_config == REGISTRY_CONFIG_FILE
     assert image_spec.cuda == "11.2.2"
@@ -53,12 +53,12 @@ def test_image_spec(mock_image_spec_builder):
 
     tag = calculate_hash_from_image_spec(image_spec)
     assert "=" != tag[-1]
-    assert image_spec.image_name() == f"flytekit:{tag}"
+    assert image_spec.image_name() == f"localhost:30001/flytekit:{tag}"
     ctx = context_manager.FlyteContext.current_context()
     with context_manager.FlyteContextManager.with_context(
         ctx.with_execution_state(ctx.execution_state.with_params(mode=ExecutionState.Mode.TASK_EXECUTION))
     ):
-        os.environ[_F_IMG_ID] = "flytekit:123"
+        os.environ[_F_IMG_ID] = "localhost:30001/flytekit:123"
         assert image_spec.is_container() is False
 
     ImageBuildEngine.register("dummy", mock_image_spec_builder)
@@ -66,7 +66,7 @@ def test_image_spec(mock_image_spec_builder):
 
     assert "dummy" in ImageBuildEngine._REGISTRY
     assert calculate_hash_from_image_spec(image_spec) == tag
-    assert image_spec.exist() is False
+    assert image_spec.exist() is True
 
     # Remove the dummy builder, and build the image again
     # The image has already been built, so it shouldn't fail.


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
image.exists() return None when the docker client raises an error & the error code is not 404

## What changes were proposed in this pull request?
Always return true if error code is not 404

## How was this patch tested?
local sandbox

### Setup process
```python
from flytekit import ImageSpec, task, dynamic


new_flytekit = "git+https://github.com/flyteorg/flytekit.git@285148f1189cd1b14503b50caf60ba63222272e9"

repro_img = ImageSpec(
    name="flytekit",
    base_image="ghcr.io/flyteorg/flytekit:py3.11-latest",
    builder="envd",
    packages=[new_flytekit],
    apt_packages=["curl", "git"],
    registry="localhost:30000",
)


@task(container_image=repro_img)
def foo():
    print("foo")


@dynamic(container_image=repro_img)
def bar():
    foo()


if __name__ == "__main__":
    print("image", repro_img.exist())
```

### Screenshots
<img width="1888" alt="Screenshot 2024-05-11 at 5 55 07 AM" src="https://github.com/flyteorg/flytekit/assets/37936015/ac961c99-ac36-4ccd-861f-5df51a10f561">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
