### PR TITLE
feat: Support ftp when using FlyteFile

### DIFF
--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -180,7 +180,7 @@ class FileAccessProvider(object):
         return self._default_remote
 
     def get_filesystem(
-        self, protocol: typing.Optional[str] = None, anonymous: bool = False, **kwargs
+        self, protocol: typing.Optional[str] = None, anonymous: bool = False, path: str | None = None, **kwargs
     ) -> fsspec.AbstractFileSystem:
         if not protocol:
             return self._default_remote
@@ -195,6 +195,9 @@ class FileAccessProvider(object):
             if anonymous:
                 kwargs["token"] = _ANON
             return fsspec.filesystem(protocol, **kwargs)  # type: ignore
+        elif protocol == "ftp":
+            kwargs.update(fsspec.implementations.ftp.FTPFileSystem._get_kwargs_from_urls(path))
+            return fsspec.filesystem(protocol, **kwargs)
 
         storage_options = get_fsspec_storage_options(
             protocol=protocol, anonymous=anonymous, data_config=self._data_config, **kwargs
@@ -204,7 +207,7 @@ class FileAccessProvider(object):
 
     def get_filesystem_for_path(self, path: str = "", anonymous: bool = False, **kwargs) -> fsspec.AbstractFileSystem:
         protocol = get_protocol(path)
-        return self.get_filesystem(protocol, anonymous=anonymous, **kwargs)
+        return self.get_filesystem(protocol, anonymous=anonymous, path=path, **kwargs)
 
     @staticmethod
     def is_remote(path: Union[str, os.PathLike]) -> bool:

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -180,7 +180,11 @@ class FileAccessProvider(object):
         return self._default_remote
 
     def get_filesystem(
-        self, protocol: typing.Optional[str] = None, anonymous: bool = False, path: str | None = None, **kwargs
+        self,
+        protocol: typing.Optional[str] = None,
+        anonymous: bool = False,
+        path: typing.Optional[str] = None,
+        **kwargs,
     ) -> fsspec.AbstractFileSystem:
         if not protocol:
             return self._default_remote


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/5352

## Why are the changes needed?

FTP is still used in bioinformatics

## What changes were proposed in this pull request?

Add FTP to supported protocols of FlyteFile. If anyone is using path as a kwarg to `get_filesystem`, this will remove it from kwags - I would not expect this to be the case though.

## How was this patch tested?

```python
from flytekit.types.file import FlyteFile

ff = FlyteFile.from_source("ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/new_taxdump.tar.gz")
local = ff.download()
print(local)
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
