### PR TITLE
fix(ImageSpec): Do not build image during executions

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -14,7 +14,6 @@ import click
 import requests
 from packaging.version import Version
 
-from flytekit.core.context_manager import FlyteContextManager
 from flytekit.exceptions.user import FlyteAssertion
 
 DOCKER_HUB = "docker.io"
@@ -235,6 +234,8 @@ class ImageBuildEngine:
     @classmethod
     @lru_cache
     def build(cls, image_spec: ImageSpec):
+        from flytekit.core.context_manager import FlyteContextManager
+
         execution_mode = FlyteContextManager.current_context().execution_state.mode
         # Do not build in executions
         if execution_mode is not None:

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -14,6 +14,7 @@ import click
 import requests
 from packaging.version import Version
 
+from flytekit.core.context_manager import FlyteContextManager
 from flytekit.exceptions.user import FlyteAssertion
 
 DOCKER_HUB = "docker.io"
@@ -233,7 +234,12 @@ class ImageBuildEngine:
 
     @classmethod
     @lru_cache
-    def build(cls, image_spec: ImageSpec) -> str:
+    def build(cls, image_spec: ImageSpec):
+        execution_mode = FlyteContextManager.current_context().execution_state.mode
+        # Do not build in executions
+        if execution_mode is not None:
+            return
+
         if isinstance(image_spec.base_image, ImageSpec):
             cls.build(image_spec.base_image)
             image_spec.base_image = image_spec.base_image.image_name()

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -122,3 +122,17 @@ def test_custom_tag():
     )
     spec_hash = calculate_hash_from_image_spec(spec)
     assert spec.image_name() == f"my_image:{spec_hash}-dev"
+
+
+def test_no_build_during_execution():
+    # Check that no builds are called during executions
+    ImageBuildEngine._build_image = Mock()
+
+    ctx = context_manager.FlyteContext.current_context()
+    with context_manager.FlyteContextManager.with_context(
+        ctx.with_execution_state(ctx.execution_state.with_params(mode=ExecutionState.Mode.TASK_EXECUTION))
+    ):
+        spec = ImageSpec(name="my_image_v2", python_version="3.12")
+        ImageBuildEngine.build(spec)
+
+    ImageBuildEngine._build_image.assert_not_called()


### PR DESCRIPTION
## Tracking issue
Partly address https://github.com/flyteorg/flyte/issues/4374

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
Dynamic workflows will try to build the image spec during execution.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR stops the image builder from building during any execution mode.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I added unit test to check that the image builder does not launch. I also ran the following to check that it worked in the sandbox. 

```python
from flytekit import ImageSpec, task, dynamic

repro_img = ImageSpec(
    name="flytekit",
    base_image="ghcr.io/flyteorg/flytekit:py3.11-latest",
    builder="envd",
    packages=[
        "git+https://github.com/thomasjpfan/flytekit.git@3700c4710a606f5b1e13f3c815c233c39cc9f425"
    ],
    apt_packages=["git"],
    registry="localhost:30000",
)


@task(container_image=repro_img)
def foo():
    print("foo")


@dynamic(container_image=repro_img)
def bar():
    foo()

```

Note that this does not completely solve the issue. For example, if the `dynamic` workflow uses a different image, the execution will hang:

```python
new_image = repro_img.with_packages(["curl"])
another_image = repro_img.with_packages(["wget"])


@task(container_image=new_image)
def foo():
    print("foo")


@dynamic(container_image=another_image)
def bar():
    foo()
```