### PR TITLE
[wip] arraynode should be supported in FlyteRemote

### DIFF
--- a/flytekit/remote/entities.py
+++ b/flytekit/remote/entities.py
@@ -349,7 +349,12 @@ class FlyteGateNode(_workflow_model.GateNode):
 class FlyteArrayNode(_workflow_model.ArrayNode):
     @classmethod
     def promote_from_model(cls, model: _workflow_model.ArrayNode):
-        return cls(model._parallelism, model._node, model._min_success_ratio, model._min_successes)
+        return cls(
+            node=model._node,
+            parallelism=model._parallelism,
+            min_successes=model._min_successes,
+            min_success_ratio=model._min_success_ratio,
+        )
 
 
 class FlyteNode(_hash_mixin.HashOnReferenceMixin, _workflow_model.Node):

--- a/flytekit/remote/executions.py
+++ b/flytekit/remote/executions.py
@@ -9,7 +9,8 @@ from flytekit.models import execution as execution_models
 from flytekit.models import node_execution as node_execution_models
 from flytekit.models.admin import task_execution as admin_task_execution_models
 from flytekit.models.core import execution as core_execution_models
-from flytekit.remote.entities import FlyteTask, FlyteWorkflow
+from flytekit.remote.task import FlyteTask
+from flytekit.remote.workflow import FlyteWorkflow
 
 
 class RemoteExecutionBase(object):
@@ -103,7 +104,7 @@ class FlyteWorkflowExecution(RemoteExecutionBase, execution_models.Execution):
         return self._flyte_workflow
 
     @property
-    def node_executions(self) -> Dict[str, FlyteNodeExecution]:
+    def node_executions(self) -> Dict[str, "FlyteNodeExecution"]:
         """Get a dictionary of node executions that are a part of this workflow execution."""
         return self._node_executions or {}
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2112,6 +2112,9 @@ class FlyteRemote(object):
                     "not have inputs and outputs filled in"
                 )
                 return execution
+            elif execution._node.array_node is not None:
+                # array node needs to be handled here
+                ...
             else:
                 logger.error(f"NE {execution} undeterminable, {type(execution._node)}, {execution._node}")
                 raise Exception(f"Node execution undeterminable, entity has type {type(execution._node)}")


### PR DESCRIPTION
## Tracking issue

Fixes flyteorg/flyte#5359

## Why are the changes needed?

Getting executions with Array nodes are not currently supported in `FlyteRemote`

## What changes were proposed in this pull request?

TBD

## How was this patch tested?

TBD

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
