### PR TITLE
Adds jinja2 to dependnecies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "grpcio-status",
     "importlib-metadata",
     "isodate",
+    "jinja2",
     "joblib",
     "jsonpickle",
     "keyring>=18.0.1",


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->
Follow up to https://github.com/flyteorg/flytekit/pull/2360

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
In https://github.com/flyteorg/flytekit/pull/2360, we removed the cookiecutter dependency, which also removed `jinja2`. We require `jinja2` to construct Flyte Decks.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR adds `jinja2` as as a direct dependency.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I built a Flytekit image without jinja2 installed and got this error:

```
{"asctime": "2024-05-14 16:16:05,571", "name": "flytekit", "levelname": "ERROR", "message": "Failed to write flyte deck html with error No module named 'jinja2'.", "taskName": null}
```

Once `jinja2` is installed, the FlyteDeck button appears.

For reference the code is here:

https://github.com/flyteorg/flytekit/blob/cc3a7a9277852dc06bc1b2c041a962be973d8faf/flytekit/deck/deck.py#L162-L176