### PR TITLE
fix: add task config to version hash calculation

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -414,6 +414,7 @@ class PlatformConfig(object):
     :param auth_mode: The OAuth mode to use. Defaults to pkce flow
     :param ca_cert_file_path: [optional] str Root Cert to be loaded and used to verify admin
     :param http_proxy_url: [optional] HTTP Proxy to be used for OAuth requests
+    :param version_hash_skip_task_config: [optional] HTTP Proxy to be used for OAuth requests
     """
 
     endpoint: str = "localhost:30080"
@@ -430,6 +431,7 @@ class PlatformConfig(object):
     audience: typing.Optional[str] = None
     rpc_retries: int = 3
     http_proxy_url: typing.Optional[str] = None
+    version_hash_skip_task_config: bool = True
 
     @classmethod
     def auto(cls, config_file: typing.Optional[typing.Union[str, ConfigFile]] = None) -> PlatformConfig:
@@ -481,6 +483,9 @@ class PlatformConfig(object):
         kwargs = set_if_exists(kwargs, "console_endpoint", _internal.Platform.CONSOLE_ENDPOINT.read(config_file))
 
         kwargs = set_if_exists(kwargs, "http_proxy_url", _internal.Platform.HTTP_PROXY_URL.read(config_file))
+        kwargs = set_if_exists(
+            kwargs, "version_hash_skip_task_config", _internal.Platform.VERSION_HASH_SKIP_TASK_CONFIG.read(config_file)
+        )
         return PlatformConfig(**kwargs)
 
     @classmethod

--- a/flytekit/configuration/internal.py
+++ b/flytekit/configuration/internal.py
@@ -151,6 +151,7 @@ class Platform(object):
         LegacyConfigEntry(SECTION, "ca_cert_file_path"), YamlConfigEntry("admin.caCertFilePath")
     )
     HTTP_PROXY_URL = ConfigEntry(LegacyConfigEntry(SECTION, "http_proxy_url"), YamlConfigEntry("admin.httpProxyURL"))
+    VERSION_HASH_SKIP_TASK_CONFIG = ConfigEntry(LegacyConfigEntry(SECTION, "version_hash_skip_task_config"), YamlConfigEntry("admin.versionHashSkipTaskConfig", bool))
 
 
 class LocalSDK(object):

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1024,6 +1024,16 @@ class FlyteRemote(object):
                     return image_names
                 return []
 
+            def _get_task_configs(entity: typing.Union[PythonAutoContainerTask, WorkflowBase]) -> typing.List[str]:
+                if isinstance(entity, PythonTask):
+                    return [str(entity.task_config)]
+                if isinstance(entity, WorkflowBase):
+                    task_configs = []
+                    for n in entity.nodes:
+                        task_configs.extend(_get_task_configs(n.flyte_entity))
+                    return task_configs
+                return []
+
             default_inputs = None
             if isinstance(entity, WorkflowBase):
                 default_inputs = entity.python_interface.default_inputs_as_kwargs
@@ -1032,7 +1042,7 @@ class FlyteRemote(object):
             # but we don't have to use it when registering with the Flyte backend.
             # For that add the hash of the compilation settings to hash of file
             version = self._version_from_hash(
-                md5_bytes, serialization_settings, default_inputs, *_get_image_names(entity)
+                md5_bytes, serialization_settings, default_inputs, *_get_image_names(entity), *_get_task_configs(entity)
             )
 
         if isinstance(entity, PythonTask):

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1037,12 +1037,16 @@ class FlyteRemote(object):
             default_inputs = None
             if isinstance(entity, WorkflowBase):
                 default_inputs = entity.python_interface.default_inputs_as_kwargs
+            
+            task_configs = []
+            if not self.config.platform.version_hash_skip_task_config:
+                task_configs = _get_task_configs(entity)
 
             # The md5 version that we send to S3/GCS has to match the file contents exactly,
             # but we don't have to use it when registering with the Flyte backend.
             # For that add the hash of the compilation settings to hash of file
             version = self._version_from_hash(
-                md5_bytes, serialization_settings, default_inputs, *_get_image_names(entity), *_get_task_configs(entity)
+                md5_bytes, serialization_settings, default_inputs, *_get_image_names(entity), *task_configs
             )
 
         if isinstance(entity, PythonTask):


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/5364

## Why are the changes needed?

Failed to register a workflow if users update the task config – especially in the case of custom tasks

## What changes were proposed in this pull request?

hash should be calculated from the task config

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

Tangentially related PRs:
https://github.com/flyteorg/flyte/issues/4904
https://github.com/flyteorg/flytekit/pull/2356
https://github.com/flyteorg/flytekit/pull/2120

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
