### PR TITLE
refactor(click_types): skip serialization for default values

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -531,9 +531,8 @@ def run_command(ctx: click.Context, entity: typing.Union[PythonFunctionWorkflow,
                         raise click.UsageError(
                             f"Default for '{input_name}' is a query, which must be specified when running locally."
                         )
-                inputs[input_name] = (
-                    processed_click_value or entity.python_interface.default_inputs_as_kwargs[input_name]
-                )
+                if processed_click_value is not None:
+                    inputs[input_name] = processed_click_value
 
             if not run_level_params.is_remote:
                 with FlyteContextManager.with_context(_update_flyte_context(run_level_params)):

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -531,7 +531,9 @@ def run_command(ctx: click.Context, entity: typing.Union[PythonFunctionWorkflow,
                         raise click.UsageError(
                             f"Default for '{input_name}' is a query, which must be specified when running locally."
                         )
-                inputs[input_name] = processed_click_value
+                inputs[input_name] = (
+                    processed_click_value or entity.python_interface.default_inputs_as_kwargs[input_name]
+                )
 
             if not run_level_params.is_remote:
                 with FlyteContextManager.with_context(_update_flyte_context(run_level_params)):

--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -383,7 +383,7 @@ class FlyteLiteralConverter(object):
             if self._python_type is datetime.date:
                 # Click produces datetime, so converting to date to avoid type mismatch error
                 value = value.date()
-            # If the input matches the one in the default launch plan, serialization can be skipped.
+            # If the input matches the default value in the launch plan, serialization can be skipped.
             if value == param.default:
                 return None
             lit = TypeEngine.to_literal(self._flyte_ctx, value, self._python_type, self._literal_type)

--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -383,7 +383,7 @@ class FlyteLiteralConverter(object):
             if self._python_type is datetime.date:
                 # Click produces datetime, so converting to date to avoid type mismatch error
                 value = value.date()
-            # If the input matches that of the default Launch Plan, serialization can be skipped.
+            # If the input matches the one in the default launch plan, serialization can be skipped.
             if value == param.default:
                 return None
             lit = TypeEngine.to_literal(self._flyte_ctx, value, self._python_type, self._literal_type)

--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -384,7 +384,7 @@ class FlyteLiteralConverter(object):
                 # Click produces datetime, so converting to date to avoid type mismatch error
                 value = value.date()
             # If the input matches the default value in the launch plan, serialization can be skipped.
-            if value == param.default:
+            if param and value == param.default:
                 return None
             lit = TypeEngine.to_literal(self._flyte_ctx, value, self._python_type, self._literal_type)
 

--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -383,6 +383,9 @@ class FlyteLiteralConverter(object):
             if self._python_type is datetime.date:
                 # Click produces datetime, so converting to date to avoid type mismatch error
                 value = value.date()
+            # If the input matches that of the default Launch Plan, serialization can be skipped.
+            if value == param.default:
+                return None
             lit = TypeEngine.to_literal(self._flyte_ctx, value, self._python_type, self._literal_type)
 
             if not self._is_remote:


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Default workflow inputs are serialized twice in the flytekit

1. https://github.com/flyteorg/flytekit/blob/6d881a8321908a4ea9cf56fbfdfe38a11aef18d2/flytekit/interaction/click_types.py#L389
2. https://github.com/flyteorg/flytekit/blob/93f690c2124d1c15c6c65cd98d384f881dba41fb/flytekit/core/interface.py#L243

## What changes were proposed in this pull request?
Skip serialization if the input matches the default value in the launch plan.

## How was this patch tested?
`pyflyte run` & `pyflyte run --remote ...`

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA