### PR TITLE
Configure default logger before upgrade_to_rich_logging

### DIFF
--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -83,11 +83,6 @@ def initialize_global_loggers():
     """
     Initializes the global loggers to the default configuration.
     """
-    # Use Rich logging while running in the local execution
-    if os.environ.get("FLYTE_INTERNAL_EXECUTION_ID", None) is None:
-        upgrade_to_rich_logging()
-        return
-
     handler = logging.StreamHandler()
     handler.setLevel(logging.DEBUG)
     formatter = logging.Formatter(fmt="[%(name)s] %(message)s")
@@ -97,6 +92,10 @@ def initialize_global_loggers():
 
     set_flytekit_log_properties(handler, None, _get_env_logging_level())
     set_user_logger_properties(handler, None, logging.INFO)
+
+    # Use Rich logging while running in the local execution
+    if os.environ.get("FLYTE_INTERNAL_EXECUTION_ID", None) is None or interactive.ipython_check():
+        upgrade_to_rich_logging()
 
 
 def is_rich_logging_enabled() -> bool:
@@ -146,8 +145,5 @@ def get_level_from_cli_verbosity(verbosity: int) -> int:
         return logging.DEBUG
 
 
-if interactive.ipython_check():
-    upgrade_to_rich_logging()
-else:
-    # Default initialization
-    initialize_global_loggers()
+# Default initialization
+initialize_global_loggers()


### PR DESCRIPTION
## Tracking issue
https://flyte-org.slack.com/archives/C03CYSL783B/p1715163744990199

## Why are the changes needed?
Now running locally the logging configures the rich logging [here](https://github.com/flyteorg/flytekit/commit/e1e21da4ce75e08308e4f3f212f7efbe546ff8cb#diff-07496df11447f22ac32c6764979e717e23b3543ebd5747f9d24f3f17e788f883R86-R90), but this function was refactored on these [chang](https://github.com/flyteorg/flytekit/commit/e1e21da4ce75e08308e4f3f212f7efbe546ff8cb#diff-07496df11447f22ac32c6764979e717e23b3543ebd5747f9d24f3f17e788f883L97-L122)e, and now the [handler setup](https://github.com/flyteorg/flytekit/commit/e1e21da4ce75e08308e4f3f212f7efbe546ff8cb#diff-07496df11447f22ac32c6764979e717e23b3543ebd5747f9d24f3f17e788f883R121-R124) is inside the try block so if any exception happens there both logger handlers are not configured properly. We detected this because, running some unit test (using tox and pytest), we hit this exception:

```
Inappropriate ioctl for device
```

## What changes were proposed in this pull request?
Set default logger before `upgrade_to_rich_logging()`

## How was this patch tested?
local execution

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA