### PR TITLE
fix: Fix to consider /union-persist-data files as remote files so they can be used as inputs to FlyteRemote 

### DIFF
--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -221,7 +221,7 @@ class FileAccessProvider(object):
         protocol = get_protocol(str(path))
         if protocol is None:
             return False
-        return protocol != "file"
+        return protocol != "file" or str(path).startswith("/union-persistent-data")
 
     @property
     def local_sandbox_dir(self) -> os.PathLike:


### PR DESCRIPTION
## Tracking issue
n/a

## Why are the changes needed?

Using persist files with FlyteRemote execute does not work current.

## What changes were proposed in this pull request?

Consider files prefixed with `/union-persistent-data` to be "remote"

## How was this patch tested?

1. Create a task that accepts FlyteFile

```python
@task
def dummy_task(ff: FlyteFile) -> FlyteFile:
   return ff
```

2. Call this with FlyteRemote
```python
from flytekit.configuration import Config
from flytekit.remote.remote import FlyteRemote

remote = FlyteRemote()
task = "dummy_task"
inputs = {
    "ff": "/union-persistent-data/..."
}
# inputs = eval(repr(inputs))
task = remote.fetch_task(name=task)
remote.execute(task, inputs=inputs)
```
### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
