### PR TITLE
Remove databricks token from the task config

### DIFF
--- a/plugins/flytekit-spark/flytekitplugins/spark/models.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/models.py
@@ -26,7 +26,6 @@ class SparkJob(_common.FlyteIdlEntity):
         hadoop_conf: Dict[str, str],
         executor_path: str,
         databricks_conf: Dict[str, Dict[str, Dict]] = {},
-        databricks_token: Optional[str] = None,
         databricks_instance: Optional[str] = None,
     ):
         """
@@ -36,7 +35,6 @@ class SparkJob(_common.FlyteIdlEntity):
         :param dict[Text, Text] spark_conf: A definition of key-value pairs for spark config for the job.
         :param dict[Text, Text] hadoop_conf: A definition of key-value pairs for hadoop config for the job.
         :param Optional[dict[Text, dict]] databricks_conf: A definition of key-value pairs for databricks config for the job. Refer to https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunsSubmit.
-        :param Optional[str] databricks_token: databricks access token.
         :param Optional[str] databricks_instance: Domain name of your deployment. Use the form <account>.cloud.databricks.com.
         """
         self._application_file = application_file
@@ -46,7 +44,6 @@ class SparkJob(_common.FlyteIdlEntity):
         self._spark_conf = spark_conf
         self._hadoop_conf = hadoop_conf
         self._databricks_conf = databricks_conf
-        self._databricks_token = databricks_token
         self._databricks_instance = databricks_instance
 
     def with_overrides(
@@ -71,7 +68,6 @@ class SparkJob(_common.FlyteIdlEntity):
             spark_conf=new_spark_conf,
             hadoop_conf=new_hadoop_conf,
             databricks_conf=new_databricks_conf,
-            databricks_token=self.databricks_token,
             databricks_instance=self.databricks_instance,
             executor_path=self.executor_path,
         )
@@ -134,14 +130,6 @@ class SparkJob(_common.FlyteIdlEntity):
         return self._databricks_conf
 
     @property
-    def databricks_token(self) -> str:
-        """
-        Databricks access token
-        :rtype: str
-        """
-        return self._databricks_token
-
-    @property
     def databricks_instance(self) -> str:
         """
         Domain name of your deployment. Use the form <account>.cloud.databricks.com.
@@ -176,7 +164,6 @@ class SparkJob(_common.FlyteIdlEntity):
             sparkConf=self.spark_conf,
             hadoopConf=self.hadoop_conf,
             databricksConf=databricks_conf,
-            databricksToken=self.databricks_token,
             databricksInstance=self.databricks_instance,
         )
 
@@ -203,6 +190,5 @@ class SparkJob(_common.FlyteIdlEntity):
             hadoop_conf=pb2_object.hadoopConf,
             executor_path=pb2_object.executorPath,
             databricks_conf=json_format.MessageToDict(pb2_object.databricksConf),
-            databricks_token=pb2_object.databricksToken,
             databricks_instance=pb2_object.databricksInstance,
         )

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -54,12 +54,10 @@ class Databricks(Spark):
         databricks_conf: Databricks job configuration compliant with API version 2.1, supporting 2.0 use cases.
         For the configuration structure, visit here.https://docs.databricks.com/dev-tools/api/2.0/jobs.html#request-structure
         For updates in API 2.1, refer to: https://docs.databricks.com/en/workflows/jobs/jobs-api-updates.html
-        databricks_token: Databricks access token. https://docs.databricks.com/dev-tools/api/latest/authentication.html.
         databricks_instance: Domain name of your deployment. Use the form <account>.cloud.databricks.com.
     """
 
     databricks_conf: Optional[Dict[str, Union[str, dict]]] = None
-    databricks_token: Optional[str] = None
     databricks_instance: Optional[str] = None
 
 
@@ -156,7 +154,6 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         if isinstance(self.task_config, Databricks):
             cfg = cast(Databricks, self.task_config)
             job._databricks_conf = cfg.databricks_conf
-            job._databricks_token = cfg.databricks_token
             job._databricks_instance = cfg.databricks_instance
 
         return MessageToDict(job.to_flyte_idl())

--- a/plugins/flytekit-spark/tests/test_agent.py
+++ b/plugins/flytekit-spark/tests/test_agent.py
@@ -99,7 +99,6 @@ async def test_databricks_agent():
         interface=None,
         type="spark",
     )
-    mocked_token = "mocked_databricks_token"
     mocked_context = mock.patch("flytekit.current_context", autospec=True).start()
     mocked_context.return_value.secrets.get.return_value = mocked_token
 

--- a/plugins/flytekit-spark/tests/test_agent.py
+++ b/plugins/flytekit-spark/tests/test_agent.py
@@ -99,6 +99,7 @@ async def test_databricks_agent():
         interface=None,
         type="spark",
     )
+    mocked_token = "mocked_databricks_token"
     mocked_context = mock.patch("flytekit.current_context", autospec=True).start()
     mocked_context.return_value.secrets.get.return_value = mocked_token
 

--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -78,7 +78,6 @@ def test_spark_task(reset_spark_session):
     assert ("spark", "1") in configs
     assert ("spark.app.name", "FlyteSpark: ex:local:local:local") in configs
 
-    databricks_token = "token"
     databricks_instance = "account.cloud.databricks.com"
 
     @task(
@@ -86,7 +85,6 @@ def test_spark_task(reset_spark_session):
             spark_conf={"spark": "2"},
             databricks_conf=databricks_conf,
             databricks_instance="account.cloud.databricks.com",
-            databricks_token="token",
         )
     )
     def my_databricks(a: int) -> int:
@@ -98,7 +96,6 @@ def test_spark_task(reset_spark_session):
     assert my_databricks.task_config.spark_conf == {"spark": "2"}
     assert my_databricks.task_config.databricks_conf == databricks_conf
     assert my_databricks.task_config.databricks_instance == databricks_instance
-    assert my_databricks.task_config.databricks_token == databricks_token
     assert my_databricks(a=3) == 3
 
 


### PR DESCRIPTION
## Tracking issue
Related to https://github.com/flyteorg/flyte/issues/5385

## Why are the changes needed?
The token in the task config is stored in the database and exposed in the UI, which is not secured. We should not allow users to do that.

## What changes were proposed in this pull request?
Remove databricks token in the task config

## How was this patch tested?
unit test

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA