### PR TITLE
Set lower bound for flytekit in envd plugin

### DIFF
--- a/plugins/flytekit-envd/setup.py
+++ b/plugins/flytekit-envd/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "envd"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit", "envd"]
+plugin_requires = ["flytekit>=1.12.0", "envd"]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
[pip_extra_index_url ](https://github.com/flyteorg/flytekit/blob/master/flytekit/image_spec/image_spec.py#L69) is added to ImageSpec in flytekit 1.12.0, so we should set the flytekit's lower bound to 1.12.0 as well.

## What changes were proposed in this pull request?
Set lower bound for flytekit

## How was this patch tested?
Unit test

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
