### PR TITLE
[TypeTransformer] Support non-Any Python types as Any input in workflows

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1178,7 +1178,8 @@ class TypeEngine(typing.Generic[T]):
             lv.hash = hash
 
         metadata = lv.metadata or {}
-        metadata.update({"py_type": python_type})
+        print("type engine python type", python_type.__name__)
+        metadata.update({"py_type": python_type.__name__})
         lv.set_metadata(metadata=metadata)
         return lv
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1183,6 +1183,7 @@ class TypeEngine(typing.Generic[T]):
         """
         Converts a Literal value with an expected python type into a python value.
         """
+        print("Expected Python Type: ", expected_python_type)
         transformer = cls.get_transformer(expected_python_type)
         return transformer.to_python_value(ctx, lv, expected_python_type)
 
@@ -1239,9 +1240,13 @@ class TypeEngine(typing.Generic[T]):
         kwargs = {}
         for i, k in enumerate(lm.literals):
             try:
+                print("converting input: ", k, " with value: ", lm.literals[k])
+                print("Type 1: ", python_interface_inputs[k])
                 kwargs[k] = TypeEngine.to_python_value(ctx, lm.literals[k], python_interface_inputs[k])
+                print("kwargs[k]:", kwargs[k])
             except TypeTransformerFailedError as exc:
                 raise TypeTransformerFailedError(f"Error converting input '{k}' at position {i}:\n  {exc}") from exc
+
         return kwargs
 
     @classmethod

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1183,7 +1183,6 @@ class TypeEngine(typing.Generic[T]):
         """
         Converts a Literal value with an expected python type into a python value.
         """
-        # print("Expected Python Type: ", expected_python_type)
         transformer = cls.get_transformer(expected_python_type)
         return transformer.to_python_value(ctx, lv, expected_python_type)
 
@@ -1240,13 +1239,9 @@ class TypeEngine(typing.Generic[T]):
         kwargs = {}
         for i, k in enumerate(lm.literals):
             try:
-                # print("converting input: ", k, " with value: ", lm.literals[k])
-                # print("Type 1: ", python_interface_inputs[k])
                 kwargs[k] = TypeEngine.to_python_value(ctx, lm.literals[k], python_interface_inputs[k])
-                # print("kwargs[k]:", kwargs[k])
             except TypeTransformerFailedError as exc:
                 raise TypeTransformerFailedError(f"Error converting input '{k}' at position {i}:\n  {exc}") from exc
-
         return kwargs
 
     @classmethod

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1183,7 +1183,7 @@ class TypeEngine(typing.Generic[T]):
         """
         Converts a Literal value with an expected python type into a python value.
         """
-        print("Expected Python Type: ", expected_python_type)
+        # print("Expected Python Type: ", expected_python_type)
         transformer = cls.get_transformer(expected_python_type)
         return transformer.to_python_value(ctx, lv, expected_python_type)
 
@@ -1240,10 +1240,10 @@ class TypeEngine(typing.Generic[T]):
         kwargs = {}
         for i, k in enumerate(lm.literals):
             try:
-                print("converting input: ", k, " with value: ", lm.literals[k])
-                print("Type 1: ", python_interface_inputs[k])
+                # print("converting input: ", k, " with value: ", lm.literals[k])
+                # print("Type 1: ", python_interface_inputs[k])
                 kwargs[k] = TypeEngine.to_python_value(ctx, lm.literals[k], python_interface_inputs[k])
-                print("kwargs[k]:", kwargs[k])
+                # print("kwargs[k]:", kwargs[k])
             except TypeTransformerFailedError as exc:
                 raise TypeTransformerFailedError(f"Error converting input '{k}' at position {i}:\n  {exc}") from exc
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1178,11 +1178,16 @@ class TypeEngine(typing.Generic[T]):
             lv.hash = hash
 
         metadata = lv.metadata or {}
-        print("type engine python type", python_type.__name__)
+        # print("type engine python type", python_type.__name__)
         # f"{Datum.__module__}.{Datum.__qualname__}"
-        metadata.update({"python_dotted_path": f"{python_type.__module__}.{python_type.__qualname__}"})
-        metadata.update({"transformer": transformer.name})
-        lv.set_metadata(metadata=metadata)
+        try:
+            print("python_type:", python_type)
+            print("python_dotted_path:", f"{python_type.__module__}.{python_type.__qualname__}")
+            metadata.update({"python_dotted_path": f"{python_type.__module__}.{python_type.__qualname__}"})
+            lv.set_metadata(metadata=metadata)
+        except AttributeError as e:
+            logger.warning(f"Attribute error occurred: {e}")
+
         return lv
 
     @classmethod

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1179,7 +1179,9 @@ class TypeEngine(typing.Generic[T]):
 
         metadata = lv.metadata or {}
         print("type engine python type", python_type.__name__)
-        metadata.update({"py_type": python_type.__name__})
+        # f"{Datum.__module__}.{Datum.__qualname__}"
+        metadata.update({"python_dotted_path": f"{python_type.__module__}.{python_type.__qualname__}"})
+        metadata.update({"transformer": transformer.name})
         lv.set_metadata(metadata=metadata)
         return lv
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1176,6 +1176,10 @@ class TypeEngine(typing.Generic[T]):
         modify_literal_uris(lv)
         if hash is not None:
             lv.hash = hash
+
+        metadata = lv.metadata or {}
+        metadata.update({"py_type": python_type})
+        lv.set_metadata(metadata=metadata)
         return lv
 
     @classmethod

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1180,14 +1180,18 @@ class TypeEngine(typing.Generic[T]):
         metadata = lv.metadata or {}
         # print("type engine python type", python_type.__name__)
         # f"{Datum.__module__}.{Datum.__qualname__}"
+        print("Python Type:", python_type)
         try:
-            print("python_type:", python_type)
-            print("python_dotted_path:", f"{python_type.__module__}.{python_type.__qualname__}")
-            metadata.update({"python_dotted_path": f"{python_type.__module__}.{python_type.__qualname__}"})
+            # print("python_type:", python_type)
+            # print("python_dotted_path:", f"{python_type.__module__}.{python_type.__qualname__}")
+            # metadata.update({"python_dotted_path": f"{python_type.__module__}.{python_type.__qualname__}"})
+            metadata.update({"python_type": str(python_type)})
+            
             lv.set_metadata(metadata=metadata)
         except AttributeError as e:
             logger.warning(f"Attribute error occurred: {e}")
-
+        print("@@@ final metadata:", metadata)
+        # print("@@@ type engine final literal:", lv)
         return lv
 
     @classmethod
@@ -1419,7 +1423,8 @@ class ListTransformer(TypeTransformer[T]):
             t = self.get_sub_type(python_type)
             lit_list = [TypeEngine.to_literal(ctx, x, t, expected.collection_type) for x in python_val]  # type: ignore
         return Literal(collection=LiteralCollection(literals=lit_list))
-
+    # literal: List[int]
+    # 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> typing.List[typing.Any]:  # type: ignore
         try:
             lits = lv.collection.literals

--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -10,7 +10,7 @@ from typing import cast
 import cloudpickle
 import rich_click as click
 import yaml
-from dataclasses_json import DataClassJsonMixin
+from dataclasses_json import DataClassJsonMixin, dataclass_json
 from pytimeparse import parse
 
 from flytekit import BlobType, FlyteContext, FlyteContextManager, Literal, LiteralType, StructuredDataset
@@ -273,6 +273,10 @@ class JsonParamType(click.ParamType):
 
         if is_pydantic_basemodel(self._python_type):
             return self._python_type.parse_raw(json.dumps(parsed_value))  # type: ignore
+
+        if not  hasattr(self._python_type, "from_json"):
+            self._python_type = dataclass_json(self._python_type)
+
         return cast(DataClassJsonMixin, self._python_type).from_json(json.dumps(parsed_value))
 
 

--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -274,7 +274,8 @@ class JsonParamType(click.ParamType):
         if is_pydantic_basemodel(self._python_type):
             return self._python_type.parse_raw(json.dumps(parsed_value))  # type: ignore
 
-        if not  hasattr(self._python_type, "from_json"):
+        # Ensure that the python type has `from_json` function
+        if not hasattr(self._python_type, "from_json"):
             self._python_type = dataclass_json(self._python_type)
 
         return cast(DataClassJsonMixin, self._python_type).from_json(json.dumps(parsed_value))

--- a/flytekit/models/literals.py
+++ b/flytekit/models/literals.py
@@ -1,6 +1,6 @@
 from datetime import datetime as _datetime
 from datetime import timezone as _timezone
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from flyteidl.core import literals_pb2 as _literals_pb2
 from google.protobuf.struct_pb2 import Struct
@@ -859,7 +859,7 @@ class Literal(_common.FlyteIdlEntity):
         collection: Optional[LiteralCollection] = None,
         map: Optional[LiteralMap] = None,
         hash: Optional[str] = None,
-        metadata: Optional[Dict[str, str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ):
         """
         This IDL message represents a literal value in the Flyte ecosystem.
@@ -919,7 +919,7 @@ class Literal(_common.FlyteIdlEntity):
         self._hash = value
 
     @property
-    def metadata(self) -> Optional[Dict[str, str]]:
+    def metadata(self) -> Optional[Dict[str, Any]]:
         """
         This value holds metadata about the literal.
         """

--- a/flytekit/models/literals.py
+++ b/flytekit/models/literals.py
@@ -859,7 +859,7 @@ class Literal(_common.FlyteIdlEntity):
         collection: Optional[LiteralCollection] = None,
         map: Optional[LiteralMap] = None,
         hash: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Optional[Dict[str, str]] = None,
     ):
         """
         This IDL message represents a literal value in the Flyte ecosystem.
@@ -919,7 +919,7 @@ class Literal(_common.FlyteIdlEntity):
         self._hash = value
 
     @property
-    def metadata(self) -> Optional[Dict[str, Any]]:
+    def metadata(self) -> Optional[Dict[str, str]]:
         """
         This value holds metadata about the literal.
         """

--- a/flytekit/models/literals.py
+++ b/flytekit/models/literals.py
@@ -1,6 +1,6 @@
 from datetime import datetime as _datetime
 from datetime import timezone as _timezone
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
 
 from flyteidl.core import literals_pb2 as _literals_pb2
 from google.protobuf.struct_pb2 import Struct

--- a/flytekit/models/types.py
+++ b/flytekit/models/types.py
@@ -22,6 +22,7 @@ class SimpleType(object):
     BINARY = _types_pb2.BINARY
     ERROR = _types_pb2.ERROR
     STRUCT = _types_pb2.STRUCT
+    ANY = _types_pb2.ANY
 
 
 class SchemaType(_common.FlyteIdlEntity):

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -87,30 +87,7 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
         # Every type can serialize to pickle, so we don't need to check the type here.
         ...
 
-    # def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
-    #     try:
-    #         uri = lv.scalar.blob.uri
-    #         return FlytePickle.from_pickle(uri)
-    #     except Exception as e:
-    #         from datetime import datetime, timedelta
-
-    #         if lv.scalar:
-    #             if lv.scalar.primitive:
-    #                 if lv.scalar.primitive.integer:
-    #                     return TypeEngine.to_python_value(ctx, lv, int)
-    #                 elif lv.scalar.primitive.float_value:
-    #                     return TypeEngine.to_python_value(ctx, lv, float)
-    #                 elif lv.scalar.primitive.string_value:
-    #                     return TypeEngine.to_python_value(ctx, lv, str)
-    #                 elif lv.scalar.primitive.boolean:
-    #                     return TypeEngine.to_python_value(ctx, lv, bool)
-    #                 elif lv.scalar.primitive.datetime:
-    #                     return TypeEngine.to_python_value(ctx, lv, datetime)
-    #                 elif lv.scalar.primitive.duration:
-    #                     return TypeEngine.to_python_value(ctx, lv, timedelta)
-    #         raise None
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
-        print("lv:", lv)
         primitive = lv.scalar.primitive
         if primitive:
             from datetime import datetime, timedelta

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -95,7 +95,7 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
             return FlytePickle.from_pickle(uri)
         except Exception as e:
             from pydoc import locate
-    
+
             metadata = lv.metadata
             if metadata and metadata.get("python_dotted_path"):
                 python_dotted_path = metadata.get("python_dotted_path")
@@ -104,9 +104,6 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
                 if py_type != typing.Any:
                     return TypeEngine.to_python_value(ctx, lv, py_type)
             raise e
-
-
-        
 
     def to_literal(self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:
         if python_val is None:

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -94,9 +94,13 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
             uri = lv.scalar.blob.uri
             return FlytePickle.from_pickle(uri)
         except Exception as e:
+            from pydoc import locate
+    
             metadata = lv.metadata
             if metadata and metadata.get("py_type"):
                 py_type = metadata.get("py_type")
+                py_type = locate(py_type)
+
                 if py_type != typing.Any:
                     return TypeEngine.to_python_value(ctx, lv, py_type)
             raise e

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -88,6 +88,8 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
         ...
 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
+        print("@@@ lv.scalar:", lv.scalar)
+        print("@@@ lv.metadata:", lv.metadata)
         try:
             uri = lv.scalar.blob.uri
             return FlytePickle.from_pickle(uri)
@@ -98,6 +100,8 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
                 if py_type != typing.Any:
                     return TypeEngine.to_python_value(ctx, lv, py_type)
             raise e
+
+
         
 
     def to_literal(self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -97,10 +97,10 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
             from pydoc import locate
     
             metadata = lv.metadata
-            if metadata and metadata.get("py_type"):
-                py_type = metadata.get("py_type")
-                py_type = locate(py_type)
-
+            if metadata and metadata.get("python_dotted_path"):
+                python_dotted_path = metadata.get("python_dotted_path")
+                py_type = locate(python_dotted_path)
+                print("@@@ pickle -> py_type:", py_type)
                 if py_type != typing.Any:
                     return TypeEngine.to_python_value(ctx, lv, py_type)
             raise e

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -88,21 +88,11 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
         ...
 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
-        primitive = lv.scalar.primitive
-        if primitive:
-            from datetime import datetime, timedelta
-
-            type_mapping = {
-                "integer": int,
-                "float_value": float,
-                "string_value": str,
-                "boolean": bool,
-                "datetime": datetime,
-                "duration": timedelta,
-            }
-            for attr, py_type in type_mapping.items():
-                if getattr(primitive, attr) is not None:
-                    return TypeEngine.to_python_value(ctx, lv, py_type)
+        metadata = lv.metadata
+        if metadata and metadata.get("py_type"):
+            py_type = metadata.get("py_type")
+            if py_type != typing.Any:
+                return TypeEngine.to_python_value(ctx, lv, py_type)
 
         uri = lv.scalar.blob.uri
         return FlytePickle.from_pickle(uri)

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -106,6 +106,7 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
             raise e
 
     def to_literal(self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:
+        # to blob or bytes
         if python_val is None:
             raise AssertionError("Cannot pickle None Value.")
         meta = BlobMetadata(

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -8,7 +8,7 @@ from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.type_engine import TypeEngine, TypeTransformer
 from flytekit.models.core import types as _core_types
 from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
-from flytekit.models.types import LiteralType
+from flytekit.models.types import LiteralType, SimpleType
 
 T = typing.TypeVar("T")
 
@@ -127,11 +127,7 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
         raise ValueError(f"Transformer {self} cannot reverse {literal_type}")
 
     def get_literal_type(self, t: Type[T]) -> LiteralType:
-        lt = LiteralType(
-            blob=_core_types.BlobType(
-                format=self.PYTHON_PICKLE_FORMAT, dimensionality=_core_types.BlobType.BlobDimensionality.SINGLE
-            )
-        )
+        lt = LiteralType(simple=SimpleType.ANY)
         lt.metadata = {"python_class_name": str(t)}
         return lt
 

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -88,8 +88,30 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
         ...
 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
-        uri = lv.scalar.blob.uri
-        return FlytePickle.from_pickle(uri)
+        try:
+            uri = lv.scalar.blob.uri
+            return FlytePickle.from_pickle(uri)
+        except Exception as e:
+            from datetime import datetime, timedelta
+            if lv.scalar:
+                if lv.scalar.primitive:
+                    if lv.scalar.primitive.integer:
+                        return TypeEngine.to_python_value(ctx, lv, int)
+                    elif lv.scalar.primitive.float_value:
+                        return TypeEngine.to_python_value(ctx, lv, float)
+                    elif lv.scalar.primitive.string_value:
+                        return TypeEngine.to_python_value(ctx, lv, str)
+                    elif lv.scalar.primitive.boolean:
+                        return TypeEngine.to_python_value(ctx, lv, bool)
+                    elif lv.scalar.primitive.datetime:
+                        return TypeEngine.to_python_value(ctx, lv, datetime)
+                    elif lv.scalar.primitive.duration:
+                        return TypeEngine.to_python_value(ctx, lv, timedelta)
+            return None
+            print("expected_python_type: ", expected_python_type)
+            print(f"Failed to convert value from pickle {e}")
+            # return None 
+            return TypeEngine.to_python_value(ctx, lv, int)
 
     def to_literal(self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:
         if python_val is None:

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -87,28 +87,48 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
         # Every type can serialize to pickle, so we don't need to check the type here.
         ...
 
+    # def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
+    #     try:
+    #         uri = lv.scalar.blob.uri
+    #         return FlytePickle.from_pickle(uri)
+    #     except Exception as e:
+    #         from datetime import datetime, timedelta
+
+    #         if lv.scalar:
+    #             if lv.scalar.primitive:
+    #                 if lv.scalar.primitive.integer:
+    #                     return TypeEngine.to_python_value(ctx, lv, int)
+    #                 elif lv.scalar.primitive.float_value:
+    #                     return TypeEngine.to_python_value(ctx, lv, float)
+    #                 elif lv.scalar.primitive.string_value:
+    #                     return TypeEngine.to_python_value(ctx, lv, str)
+    #                 elif lv.scalar.primitive.boolean:
+    #                     return TypeEngine.to_python_value(ctx, lv, bool)
+    #                 elif lv.scalar.primitive.datetime:
+    #                     return TypeEngine.to_python_value(ctx, lv, datetime)
+    #                 elif lv.scalar.primitive.duration:
+    #                     return TypeEngine.to_python_value(ctx, lv, timedelta)
+    #         raise None
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
-        try:
-            uri = lv.scalar.blob.uri
-            return FlytePickle.from_pickle(uri)
-        except Exception as e:
+        print("lv:", lv)
+        primitive = lv.scalar.primitive
+        if primitive:
             from datetime import datetime, timedelta
 
-            if lv.scalar:
-                if lv.scalar.primitive:
-                    if lv.scalar.primitive.integer:
-                        return TypeEngine.to_python_value(ctx, lv, int)
-                    elif lv.scalar.primitive.float_value:
-                        return TypeEngine.to_python_value(ctx, lv, float)
-                    elif lv.scalar.primitive.string_value:
-                        return TypeEngine.to_python_value(ctx, lv, str)
-                    elif lv.scalar.primitive.boolean:
-                        return TypeEngine.to_python_value(ctx, lv, bool)
-                    elif lv.scalar.primitive.datetime:
-                        return TypeEngine.to_python_value(ctx, lv, datetime)
-                    elif lv.scalar.primitive.duration:
-                        return TypeEngine.to_python_value(ctx, lv, timedelta)
-            raise e
+            type_mapping = {
+                "integer": int,
+                "float_value": float,
+                "string_value": str,
+                "boolean": bool,
+                "datetime": datetime,
+                "duration": timedelta,
+            }
+            for attr, py_type in type_mapping.items():
+                if getattr(primitive, attr) is not None:
+                    return TypeEngine.to_python_value(ctx, lv, py_type)
+
+        uri = lv.scalar.blob.uri
+        return FlytePickle.from_pickle(uri)
 
     def to_literal(self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:
         if python_val is None:

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -88,14 +88,17 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
         ...
 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: Type[T]) -> T:
-        metadata = lv.metadata
-        if metadata and metadata.get("py_type"):
-            py_type = metadata.get("py_type")
-            if py_type != typing.Any:
-                return TypeEngine.to_python_value(ctx, lv, py_type)
-
-        uri = lv.scalar.blob.uri
-        return FlytePickle.from_pickle(uri)
+        try:
+            uri = lv.scalar.blob.uri
+            return FlytePickle.from_pickle(uri)
+        except Exception as e:
+            metadata = lv.metadata
+            if metadata and metadata.get("py_type"):
+                py_type = metadata.get("py_type")
+                if py_type != typing.Any:
+                    return TypeEngine.to_python_value(ctx, lv, py_type)
+            raise e
+        
 
     def to_literal(self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:
         if python_val is None:

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -93,6 +93,7 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
             return FlytePickle.from_pickle(uri)
         except Exception as e:
             from datetime import datetime, timedelta
+
             if lv.scalar:
                 if lv.scalar.primitive:
                     if lv.scalar.primitive.integer:
@@ -107,11 +108,7 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
                         return TypeEngine.to_python_value(ctx, lv, datetime)
                     elif lv.scalar.primitive.duration:
                         return TypeEngine.to_python_value(ctx, lv, timedelta)
-            return None
-            print("expected_python_type: ", expected_python_type)
-            print(f"Failed to convert value from pickle {e}")
-            # return None 
-            return TypeEngine.to_python_value(ctx, lv, int)
+            raise e
 
     def to_literal(self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType) -> Literal:
         if python_val is None:

--- a/plugins/flytekit-huggingface/setup.py
+++ b/plugins/flytekit-huggingface/setup.py
@@ -6,7 +6,7 @@ microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 plugin_requires = [
     "flytekit>=1.3.0b2,<2.0.0",
-    "datasets>=2.4.0",
+    "datasets>=2.4.0,<2.19.2",
 ]
 
 __version__ = "0.0.0+develop"

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -2275,7 +2275,7 @@ def test_pass_annotated_to_downstream_tasks():
         downstream_t(a=v, df=df)
 
         return v_1
-    
+
     @workflow
     def wf(a: int) -> int:
         return t1(a=a)

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -2275,8 +2275,12 @@ def test_pass_annotated_to_downstream_tasks():
         downstream_t(a=v, df=df)
 
         return v_1
+    
+    @workflow
+    def wf(a: int) -> int:
+        return t1(a=a)
 
-    assert t1(a=3) == 9
+    assert wf(a=3) == 9
 
 
 def test_literal_hash_int_can_be_set():


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5366

## Why are the changes needed?
We want to allow the Any type to accept all kinds of inputs and outputs, not just the types we currently can't handle.

For example, workflow like this.
```python
@task
def foo(a: Any) -> int:
    if type(a) == int:
        return a + 1
    return 0

@workflow
def wf(a: int) -> int:
    return foo(a=a)
```

Note: This PR only supports `Any` in python, if we want to support java, we will need to add more code.

## What changes were proposed in this pull request?
Check if the literal's scalar has a primitive type.
If it does, convert it to a Python value using the corresponding type transformer.

## How was this patch tested?
unit test and remote cluster

```python
from flytekit import task, workflow
from typing import Any

@task
def foo(a: Any) -> int:
    if type(a) == int:
        return a + 1
    return 0

@workflow
def wf(a: int) -> int:
    return foo(a=a)
```
```Dockerfile
FROM python:3.9-slim-buster
USER root
WORKDIR /root
ENV PYTHONPATH /root
RUN apt-get update && apt-get install build-essential -y
RUN apt-get install git -y

RUN pip install -U git+https://github.com/flyteorg/flytekit.git@3804a5155a523e2028ece8e7e581f794ebabd788
```

### Setup process
```python
pyflyte run --remote --image localhost:30000/any:0522 any_task.py wf --a 1
```
### Screenshots
<img width="919" alt="image" src="https://github.com/flyteorg/flyte/assets/76461262/7c190a8d-1857-4cfa-bbcf-43d407c6edbe">
<img width="1201" alt="image" src="https://github.com/flyteorg/flyte/assets/76461262/260409ac-590a-40c2-a13f-60c68865d3de">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flyte/pull/5408
