### PR TITLE
[MINOR] Support Passing Dataclass Values via Command Line

### DIFF
--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -10,7 +10,7 @@ from typing import cast
 import cloudpickle
 import rich_click as click
 import yaml
-from dataclasses_json import DataClassJsonMixin
+from dataclasses_json import DataClassJsonMixin, dataclass_json
 from pytimeparse import parse
 
 from flytekit import BlobType, FlyteContext, FlyteContextManager, Literal, LiteralType, StructuredDataset
@@ -273,6 +273,11 @@ class JsonParamType(click.ParamType):
 
         if is_pydantic_basemodel(self._python_type):
             return self._python_type.parse_raw(json.dumps(parsed_value))  # type: ignore
+
+        # Ensure that the python type has `from_json` function
+        if not hasattr(self._python_type, "from_json"):
+            self._python_type = dataclass_json(self._python_type)
+
         return cast(DataClassJsonMixin, self._python_type).from_json(json.dumps(parsed_value))
 
 

--- a/tests/flytekit/unit/interaction/test_click_types.py
+++ b/tests/flytekit/unit/interaction/test_click_types.py
@@ -206,3 +206,23 @@ def test_query_passing(param_type: click.ParamType):
     query = a.query()
 
     assert param_type.convert(value=query, param=None, ctx=None) is query
+
+
+def test_dataclass_type():
+    from dataclasses import dataclass
+
+    @dataclass
+    class Datum:
+        x: int
+        y: str
+        z: dict[int, str]
+        w: list[int]
+
+    t = JsonParamType(Datum)
+    value = '{ "x": 1, "y": "2", "z": { "1": "one", "2": "two" }, "w": [1, 2, 3] }'
+    v = t.convert(value=value, param=None, ctx=None)
+
+    assert v.x == 1
+    assert v.y == "2"
+    assert v.z == {1: "one", 2: "two"}
+    assert v.w == [1, 2, 3]


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/4486

## Why are the changes needed?
Currently, we don't support `passing dataclass values via command line` after this [PR](https://github.com/flyteorg/flytekit/pull/2279).

For example, using this command line will raise an error.
`pyflyte run --remote --image localhost:30000/any:0528-1445 dataclass_task.py foo_wf  --a '{ "x": 1, "y": "2", "z": { "1": "one", "2": "two" }, "w": [1, 2, 3] }'`

<img width="892" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/3122e909-b4cb-4a0c-abdd-8a7f122bb531">

## What changes were proposed in this pull request?
If we use only `dataclass` decorator only for our dataclass value, convert it to `dataclass_json`.

## How was this patch tested?
local execution, remote execution and unit test.

### Setup process
```python
from flytekit import task, workflow
from dataclasses import dataclass

@dataclass
class Datum:
    x: int
    y: str
    z: dict[int, str]
    w: list[int]

@task
def foo_dataclass(a: Datum) -> int:
    if type(a) == Datum:
        return a.x
    return 0

@workflow
def foo_wf(a: Datum) -> int:
    return foo_dataclass(a=a)
```

### Screenshots
local execution
<img width="998" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/fae24744-e0f6-4215-bd8a-ff936aa0b798">
remote execution
<img width="1036" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/621fe90a-ce2a-4527-9376-d44ccdb72dd8">
<img width="1095" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/ed9380e2-6302-4aa7-aef4-cbd4f8229122">
unit test
<img width="825" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/adb6ce12-e8cd-41de-bf4e-49ada374499e">

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

