### PR TITLE
Use new fileaccess to build execution state

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -384,7 +384,7 @@ def _execute_task(
                 f"Test detected, returning. Args were {inputs} {output_prefix} {raw_output_data_prefix} {resolver} {resolver_args}"
             )
             return
-        _dispatch_execute(ctx, _task_def, inputs, output_prefix)
+        _handle_annotated_task(ctx, _task_def, inputs, output_prefix)
 
 
 @_scopes.system_entry_point

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -289,13 +289,15 @@ def setup_execution(
         logger.error(f"No data plugin found for raw output prefix {raw_output_data_prefix}")
         raise
 
+    ctx = ctx.new_builder().with_file_access(file_access).build()
+
     es = ctx.new_execution_state().with_params(
         mode=ExecutionState.Mode.TASK_EXECUTION,
         user_space_params=execution_parameters,
     )
     # create new output metadata tracker
     omt = OutputMetadataTracker()
-    cb = ctx.new_builder().with_file_access(file_access).with_execution_state(es).with_output_metadata_tracker(omt)
+    cb = ctx.new_builder().with_execution_state(es).with_output_metadata_tracker(omt)
 
     if compressed_serialization_settings:
         ss = SerializationSettings.from_transport(compressed_serialization_settings)
@@ -382,7 +384,7 @@ def _execute_task(
                 f"Test detected, returning. Args were {inputs} {output_prefix} {raw_output_data_prefix} {resolver} {resolver_args}"
             )
             return
-        _handle_annotated_task(ctx, _task_def, inputs, output_prefix)
+        _dispatch_execute(ctx, _task_def, inputs, output_prefix)
 
 
 @_scopes.system_entry_point


### PR DESCRIPTION
## Tracking issue
COR-982

## Why are the changes needed?
In cases where the python interpreter is not shut down between executions, we need to make sure we don't accidentally pick up an old errors.pb file.

## What changes were proposed in this pull request?
When starting a new execution, we run the `setup_execution` context manager. One of the things it does is create a new execution state object, which [creates](https://github.com/flyteorg/flytekit/blob/c03eaadd72fbe302003baf98e3e8e2fac237eaac/flytekit/core/context_manager.py#L512) a new engine dir based on the working dir.  This working dir is based on the file access provider [local_sandbox_dir](https://github.com/flyteorg/flytekit/blob/c03eaadd72fbe302003baf98e3e8e2fac237eaac/flytekit/core/context_manager.py#L694).  That local sandbox dir is [created anew](https://github.com/flyteorg/flytekit/pull/2452/files#diff-932d345851356237c198d139fa9a11d53d68257dc05387e933680ed2e764a50fL283) upon every invocation, but the new engine dir was happening before it was getting used.  This PR just picks up that new workdir first, before building the execution state object.

## How was this patch tested?
locally.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
