### PR TITLE
add escape hatch to binding union handling

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -697,6 +697,13 @@ def binding_data_from_python_std(
         )
 
     elif t_value is not None and expected_literal_type.union_type is not None:
+        # If the value is not a container type, then we can directly convert it to a scalar in the Union case.
+        # This pushes the handling of the Union types to the type engine.
+        if not isinstance(t_value, list) and not isinstance(t_value, dict):
+            scalar = TypeEngine.to_literal(ctx, t_value, t_value_type or type(t_value), expected_literal_type).scalar
+            return _literals_models.BindingData(scalar=scalar)
+
+        # If it is a container type, then we need to iterate over the variants in the Union type.
         for i in range(len(expected_literal_type.union_type.variants)):
             try:
                 lt_type = expected_literal_type.union_type.variants[i]

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -703,7 +703,9 @@ def binding_data_from_python_std(
             scalar = TypeEngine.to_literal(ctx, t_value, t_value_type or type(t_value), expected_literal_type).scalar
             return _literals_models.BindingData(scalar=scalar)
 
-        # If it is a container type, then we need to iterate over the variants in the Union type.
+        # If it is a container type, then we need to iterate over the variants in the Union type, try each one. This is
+        # akin to what the Type Engine does when it finds a Union type (see the UnionTransformer), but we can't rely on
+        # that in this case, because of the mix and match of realized values, and Promises.
         for i in range(len(expected_literal_type.union_type.variants)):
             try:
                 lt_type = expected_literal_type.union_type.variants[i]

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -13,6 +13,7 @@ from flytekit.core.context_manager import CompilationState, FlyteContextManager
 from flytekit.core.promise import (
     Promise,
     VoidPromise,
+    binding_data_from_python_std,
     create_and_link_node,
     create_and_link_node_from_remote,
     resolve_attr_path_in_promise,
@@ -20,6 +21,7 @@ from flytekit.core.promise import (
 )
 from flytekit.core.type_engine import TypeEngine
 from flytekit.exceptions.user import FlyteAssertion, FlytePromiseAttributeResolveException
+from flytekit.models.types import LiteralType, SimpleType, TypeStructure
 from flytekit.types.pickle.pickle import BatchSize
 
 
@@ -234,3 +236,16 @@ def test_resolve_attr_path_in_promise():
     # exception
     with pytest.raises(FlytePromiseAttributeResolveException):
         tgt_promise = resolve_attr_path_in_promise(src_promise["c"])
+
+
+def test_prom():
+    ctx = FlyteContextManager.current_context()
+    pt = typing.Union[str, int]
+    lt = TypeEngine.to_literal_type(pt)
+    assert lt.union_type.variants == [
+        LiteralType(simple=SimpleType.STRING, structure=TypeStructure(tag="str")),
+        LiteralType(simple=SimpleType.INTEGER, structure=TypeStructure(tag="int")),
+    ]
+
+    bd = binding_data_from_python_std(ctx, lt, 3, pt, [])
+    print(bd)

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -238,7 +238,7 @@ def test_resolve_attr_path_in_promise():
         tgt_promise = resolve_attr_path_in_promise(src_promise["c"])
 
 
-def test_prom():
+def test_prom_with_union_literals():
     ctx = FlyteContextManager.current_context()
     pt = typing.Union[str, int]
     lt = TypeEngine.to_literal_type(pt)
@@ -248,4 +248,6 @@ def test_prom():
     ]
 
     bd = binding_data_from_python_std(ctx, lt, 3, pt, [])
-    print(bd)
+    assert bd.scalar.union.stored_type.structure.tag == "int"
+    bd = binding_data_from_python_std(ctx, lt, "hello", pt, [])
+    assert bd.scalar.union.stored_type.structure.tag == "str"

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1790,9 +1790,9 @@ def test_union_containers():
     }
     ctx = FlyteContextManager.current_context()
     lv = TypeEngine.to_literal(ctx, list_of_maps_of_list_ints, pt, lt)
-    print(lv)
+    assert lv.scalar.union.stored_type.structure.tag == "Typed List"
     lv = TypeEngine.to_literal(ctx, map_of_list_ints, pt, lt)
-    print(lv)
+    assert lv.scalar.union.stored_type.structure.tag == "Python Dictionary"
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP604 requires >=3.10.")


### PR DESCRIPTION
## Tracking issue
Related to https://github.com/flyteorg/flyte/issues/5321.  This was discovered while implementing [that PR](https://github.com/flyteorg/flytekit/pull/2401).

## Why are the changes needed?
The main issue is highlighted in the test added to the test type engine file.  When you call `TypeEngine.to_literal` on a Union type, you should get back a Flyte literal with a `Union` [message](https://github.com/flyteorg/flyte/blob/9ffc54fa4d69f3058ce635a53ce2fa594a9cc5d9/flyteidl/protos/flyteidl/core/literals.proto#L56).  This was happening correctly in the Type Engine but for some reason this wasn't happening for Binding Data.

That is, if you had

```python
@task
def say_hello(a: int | str) -> str:
    print(f"Type is {type(a)}")
    if type(a) == str:
        return f"Hello, {a}!"
    return "Hello, World!"

@workflow
def hello_world_wf()-> str:
    res = say_hello(a="world")
    return res
```

the node for the `say_hello` invocation was being bound to a BindingData Literal Scalar that was just the raw string "world", not a Union that contained that string literal.

## What changes were proposed in this pull request?
This adds an escape mechanism and some comments in the binding data from python std function.

## How was this patch tested?
Before: https://www.test.cluster/console/projects/flytesnacks/domains/development/executions/f6ba77e8684e94e1092a
After: https://www.test.cluster/console/projects/flytesnacks/domains/development/executions/f06eaea2298ad4884952
Both runs succeed.

Before: https://www.test.cluster/api/v1/workflows/flytesnacks/development/unions.hello_world_wf/4jItAJN7eckVByTXKxjsPg
After: https://www.test.cluster/api/v1/workflows/flytesnacks/development/unions.hello_world_wf/gmbOol0QMeiiHF_y99A97g
Note the after definition binds the node to a union literal, not a plain scalar.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
