### PR TITLE
Fix the `uri` value of the input with Any type in the workflow when running remotely.

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1698,7 +1698,7 @@ class DictTransformer(TypeTransformer[dict]):
         return None, None
 
     @staticmethod
-    def dict_to_generic_literal(v: dict, allow_pickle: bool) -> Literal:
+    def dict_to_generic_literal(ctx: FlyteContext, v: dict, allow_pickle: bool) -> Literal:
         """
         Creates a flyte-specific ``Literal`` value from a native python dictionary.
         """
@@ -1711,7 +1711,7 @@ class DictTransformer(TypeTransformer[dict]):
             )
         except TypeError as e:
             if allow_pickle:
-                remote_path = FlytePickle.to_pickle(v)
+                remote_path = FlytePickle.to_pickle(ctx, v)
                 return Literal(
                     scalar=Scalar(
                         generic=_json_format.Parse(json.dumps({"pickle_file": remote_path}), _struct.Struct())
@@ -1769,7 +1769,7 @@ class DictTransformer(TypeTransformer[dict]):
             allow_pickle, base_type = DictTransformer.is_pickle(python_type)
 
         if expected and expected.simple and expected.simple == SimpleType.STRUCT:
-            return self.dict_to_generic_literal(python_val, allow_pickle)
+            return self.dict_to_generic_literal(ctx, python_val, allow_pickle)
 
         lit_map = {}
         for k, v in python_val.items():

--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -7,13 +7,12 @@ import pathlib
 import typing
 from typing import cast
 
-import cloudpickle
 import rich_click as click
 import yaml
 from dataclasses_json import DataClassJsonMixin, dataclass_json
 from pytimeparse import parse
 
-from flytekit import BlobType, FlyteContext, FlyteContextManager, Literal, LiteralType, StructuredDataset
+from flytekit import BlobType, FlyteContext, Literal, LiteralType, StructuredDataset
 from flytekit.core.artifact import ArtifactQuery
 from flytekit.core.data_persistence import FileAccessProvider
 from flytekit.core.type_engine import TypeEngine
@@ -133,17 +132,7 @@ class PickleParamType(click.ParamType):
     def convert(
         self, value: typing.Any, param: typing.Optional[click.Parameter], ctx: typing.Optional[click.Context]
     ) -> typing.Any:
-        if isinstance(value, ArtifactQuery):
-            return value
-        # set remote_directory to false if running pyflyte run locally. This makes sure that the original
-        # file is used and not a random one.
-        remote_path = None if getattr(ctx.obj, "is_remote", None) else False
-        if os.path.isfile(value):
-            return FlyteFile(path=value, remote_path=remote_path)
-        uri = FlyteContextManager.current_context().file_access.get_random_local_path()
-        with open(uri, "w+b") as outfile:
-            cloudpickle.dump(value, outfile)
-        return FlyteFile(path=str(pathlib.Path(uri).resolve()), remote_path=remote_path)
+        return value
 
 
 class JSONIteratorParamType(click.ParamType):

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -100,6 +100,8 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
             )
         )
         remote_path = FlytePickle.to_pickle(python_val)
+        if not ctx.file_access.is_remote(remote_path):
+            remote_path = ctx.file_access.put_raw_data(remote_path)
         return Literal(scalar=Scalar(blob=Blob(metadata=meta, uri=remote_path)))
 
     def guess_python_type(self, literal_type: LiteralType) -> typing.Type[FlytePickle[typing.Any]]:

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -99,8 +99,6 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
             )
         )
         remote_path = FlytePickle.to_pickle(ctx, python_val)
-        if not ctx.file_access.is_remote(remote_path):
-            remote_path = ctx.file_access.put_raw_data(remote_path)
         return Literal(scalar=Scalar(blob=Blob(metadata=meta, uri=remote_path)))
 
     def guess_python_type(self, literal_type: LiteralType) -> typing.Type[FlytePickle[typing.Any]]:

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -52,8 +52,7 @@ class FlytePickle(typing.Generic[T]):
         return _SpecificFormatClass
 
     @classmethod
-    def to_pickle(cls, python_val: typing.Any) -> str:
-        ctx = FlyteContextManager.current_context()
+    def to_pickle(cls, ctx: FlyteContext, python_val: typing.Any) -> str:
         local_dir = ctx.file_access.get_random_local_directory()
         os.makedirs(local_dir, exist_ok=True)
         local_path = ctx.file_access.get_random_local_path()
@@ -99,7 +98,7 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
                 format=self.PYTHON_PICKLE_FORMAT, dimensionality=_core_types.BlobType.BlobDimensionality.SINGLE
             )
         )
-        remote_path = FlytePickle.to_pickle(python_val)
+        remote_path = FlytePickle.to_pickle(ctx, python_val)
         if not ctx.file_access.is_remote(remote_path):
             remote_path = ctx.file_access.put_raw_data(remote_path)
         return Literal(scalar=Scalar(blob=Blob(metadata=meta, uri=remote_path)))


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
https://github.com/flyteorg/flyte/issues/5426
<!-- Remove this section if not applicable -->

## Why are the changes needed?
Previously, the `to_literal()` function of the `FlytePickleTransformer` class had the output prefix information in the `ctx` argument. However, the `to_pickle()` function of the `FlytePickle` class did not utilize this information and instead used `FlyteContextManager.current_context()`. The output prefix from `FlyteContextManager.current_context()` did not reflect the correct path for workflows running remotely.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Pass the `ctx` value to the `to_pickle()` function. This will ensure the correct path is given.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
I tested this task with customized code running in both the local environment and the sandbox cluster.

- `remote_uri.py`: This code tests the correctness of the upload path in the `to_pickle()` function in different settings, including workflow with input, without input, and with a default value.

    ```
    from flytekit import task, workflow, ImageSpec
    from typing import Any
    
    key = "42c2f4ba8d8296023735d1c096a380c21ba2a3b9"
    flytekit_dev_version = f"https://github.com/Mecoli1219/flytekit.git@{key}"
    image = ImageSpec(
        registry="localhost:30000",
        platform="linux/amd64",
        builder="fast-builder",
        apt_packages=["git"],
        packages=[
            f"git+{flytekit_dev_version}",
        ],
    )
    
    @task(container_image=image)
    def t1(a: Any) -> int:
        try:
            return int(a) + 1
        except:
            return 0
    
    @workflow()
    def any_wf(a: Any) -> int:
        return t1(a=a)
    
    @workflow()
    def default_wf(a: Any = 1) -> int:
        return t1(a=a)
    
    @workflow()
    def no_any_wf() -> int:
        return t1(a=1)
    
    if __name__ == '__main__':
        from click.testing import CliRunner
        from flytekit.clis.sdk_in_container import pyflyte
    
        runner = CliRunner()
        print("=============== Running any_wf remotely ===============")
        result = runner.invoke(pyflyte.main, ["run", "--remote", "./remote_uri.py", "any_wf", "--a", "1"])
        print(result.output)
        print("=============== Running any_wf locally===============")
        result = runner.invoke(pyflyte.main, ["run", "./remote_uri.py", "any_wf", "--a", "1"])
        print(result.output)
        print("=============== Running no_any_wf remotely ===============")
        result = runner.invoke(pyflyte.main, ["run", "--remote", "./remote_uri.py", "no_any_wf"])
        print(result.output)
        print("=============== Running no_any_wf locally ===============")
        result = runner.invoke(pyflyte.main, ["run", "./remote_uri.py", "no_any_wf"])
        print(result.output)
        print("=============== Running default_wf remotely ===============")
        result = runner.invoke(pyflyte.main, ["run", "--remote", "./remote_uri.py", "default_wf"])
        print(result.output)
        print("=============== Running default_wf locally ===============")
        result = runner.invoke(pyflyte.main, ["run", "./remote_uri.py", "default_wf"])
        print(result.output)
        print("=============== Running default_wf with value remotely ===============")
        result = runner.invoke(pyflyte.main, ["run", "--remote", "./remote_uri.py", "default_wf", "--a", "2"])
        print(result.output)
        print("=============== Running default_wf with value locally ===============")
        result = runner.invoke(pyflyte.main, ["run", "./remote_uri.py", "default_wf", "--a", "2"])
        print(result.output)
    ```

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Screenshots
<img width="1051" alt="image" src="https://github.com/flyteorg/flytekit/assets/72752478/da00a579-b21c-49e8-9187-1e5d8d54839d">
<img width="1474" alt="image" src="https://github.com/flyteorg/flytekit/assets/72752478/cbeb2a4a-287d-45dc-9e08-dc4e7c28eaec">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

