### PR TITLE
Enable string conversion for `Scalar` objects that contain a `schema`

### DIFF
--- a/flytekit/interaction/string_literals.py
+++ b/flytekit/interaction/string_literals.py
@@ -37,6 +37,8 @@ def scalar_to_string(scalar: Scalar) -> typing.Any:
         return scalar.error.message
     if scalar.structured_dataset:
         return scalar.structured_dataset.uri
+    if scalar.schema:
+        return scalar.schema.uri
     if scalar.blob:
         return scalar.blob.uri
     if scalar.binary:

--- a/tests/flytekit/unit/interaction/test_string_literals.py
+++ b/tests/flytekit/unit/interaction/test_string_literals.py
@@ -22,10 +22,11 @@ from flytekit.models.literals import (
     Primitive,
     Scalar,
     StructuredDataset,
+    Schema,
     Union,
     Void,
 )
-from flytekit.models.types import Error, LiteralType, SimpleType
+from flytekit.models.types import Error, LiteralType, SimpleType, SchemaType
 
 
 def test_primitive_to_string():
@@ -63,6 +64,9 @@ def test_scalar_to_string():
 
     scalar = Scalar(structured_dataset=StructuredDataset(uri="uri"))
     assert scalar_to_string(scalar) == "uri"
+
+    scalar = Scalar(schema=Schema(uri="schema_uri", type=SchemaType(columns=[])))
+    assert scalar_to_string(scalar) == "schema_uri"
 
     scalar = Scalar(
         blob=Blob(


### PR DESCRIPTION
## Why are the changes needed?

If attempting to create a string representation of a literal whose scalar contains a `schema` (e.g. pandera DataFrames), an "Unknown scalar type" `ValueError` is raised.

It is often nice to just print out the outputs of a workflow execution, but that's currently not possible if a pandera-typed DataFrame is one of them. 

## What changes were proposed in this pull request?

We simply return the schema's URI, similarly to how `structured_dataset` is handled.

## How was this patch tested?

I expanded on the existing unit test
