### PR TITLE
fix(core): Handle missing metadata in DictTransformer

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1805,16 +1805,16 @@ class DictTransformer(TypeTransformer[dict]):
         # for empty generic we have to explicitly test for lv.scalar.generic is not None as empty dict
         # evaluates to false
         if lv and lv.scalar and lv.scalar.generic is not None:
-            if lv.metadata["format"] == "json":
-                try:
-                    return json.loads(_json_format.MessageToJson(lv.scalar.generic))
-                except TypeError:
-                    raise TypeTransformerFailedError(f"Cannot convert from {lv} to {expected_python_type}")
-            elif lv.metadata["format"] == "pickle":
+            if lv.metadata and lv.metadata.get("format", None) == "pickle":
                 from flytekit.types.pickle import FlytePickle
 
                 uri = json.loads(_json_format.MessageToJson(lv.scalar.generic)).get("pickle_file")
                 return FlytePickle.from_pickle(uri)
+
+            try:
+                return json.loads(_json_format.MessageToJson(lv.scalar.generic))
+            except TypeError:
+                raise TypeTransformerFailedError(f"Cannot convert from {lv} to {expected_python_type}")
 
         raise TypeTransformerFailedError(f"Cannot convert from {lv} to {expected_python_type}")
 

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -560,6 +560,16 @@ def test_dict_transformer():
         typing.Dict[str, int],
     )
 
+    lv = d.to_literal(
+        ctx,
+        {"x": "hello"},
+        dict,
+        LiteralType(simple=SimpleType.STRUCT),
+    )
+
+    lv._metadata = None
+    assert d.to_python_value(ctx, lv, dict) == {"x": "hello"}
+
 
 def test_convert_marshmallow_json_schema_to_python_class():
     @dataclass


### PR DESCRIPTION
## Tracking issue
closed https://github.com/flyteorg/flyte/issues/5450

## Why are the changes needed?
When metadata is None, DictTrasformer will fail to deserialize literal.

## What changes were proposed in this pull request?
Always use `json.loads` in DictTrasformer if metadata['format'] is not equal to pickle

## How was this patch tested?
unit test

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
