### PR TITLE
Improve error message for pyflyte run

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -510,7 +510,8 @@ def run_command(ctx: click.Context, entity: typing.Union[PythonFunctionWorkflow,
         # By the time we get to this function, all the loading has already happened
 
         run_level_params: RunLevelParams = ctx.obj
-        logger.debug(f"Running {entity.name} with {kwargs} and run_level_params {run_level_params}")
+        entity_type = "workflow" if isinstance(entity, PythonFunctionWorkflow) else "task"
+        logger.debug(f"Running {entity_type} {entity.name} with input {kwargs}")
 
         click.secho(f"Running Execution on {'Remote' if run_level_params.is_remote else 'local'}.", fg="cyan")
         try:

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -513,7 +513,7 @@ def run_command(ctx: click.Context, entity: typing.Union[PythonFunctionWorkflow,
         entity_type = "workflow" if isinstance(entity, PythonFunctionWorkflow) else "task"
         logger.debug(f"Running {entity_type} {entity.name} with input {kwargs}")
 
-        click.secho(f"Running Execution on {'Remote' if run_level_params.is_remote else 'local'}.", fg="cyan")
+        click.secho(f"Running Execution on {'Remote' if run_level_params.is_remote else 'local'}",  fg="cyan")
         try:
             inputs = {}
             for input_name, _ in entity.python_interface.inputs.items():

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -513,7 +513,7 @@ def run_command(ctx: click.Context, entity: typing.Union[PythonFunctionWorkflow,
         entity_type = "workflow" if isinstance(entity, PythonFunctionWorkflow) else "task"
         logger.debug(f"Running {entity_type} {entity.name} with input {kwargs}")
 
-        click.secho(f"Running Execution on {'Remote' if run_level_params.is_remote else 'local'}", fg="cyan")
+        click.secho(f"Running Execution on {'Remote' if run_level_params.is_remote else 'local'}.", fg="cyan")
         try:
             inputs = {}
             for input_name, _ in entity.python_interface.inputs.items():

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -513,7 +513,7 @@ def run_command(ctx: click.Context, entity: typing.Union[PythonFunctionWorkflow,
         entity_type = "workflow" if isinstance(entity, PythonFunctionWorkflow) else "task"
         logger.debug(f"Running {entity_type} {entity.name} with input {kwargs}")
 
-        click.secho(f"Running Execution on {'Remote' if run_level_params.is_remote else 'local'}",  fg="cyan")
+        click.secho(f"Running Execution on {'Remote' if run_level_params.is_remote else 'local'}", fg="cyan")
         try:
             inputs = {}
             for input_name, _ in entity.python_interface.inputs.items():

--- a/flytekit/clis/sdk_in_container/serve.py
+++ b/flytekit/clis/sdk_in_container/serve.py
@@ -8,6 +8,8 @@ from flyteidl.service.agent_pb2_grpc import (
     add_AsyncAgentServiceServicer_to_server,
     add_SyncAgentServiceServicer_to_server,
 )
+from rich.console import Console
+from rich.table import Table
 
 
 @click.group("serve")
@@ -105,32 +107,16 @@ def print_agents_metadata():
 
     agents = AgentRegistry.list_agents()
 
-    data = [["Agent Name", "Support Task Types", "Is Sync"]]
+    table = Table(title="Agent Metadata")
+    table.add_column("Agent Name", style="cyan", no_wrap=True)
+    table.add_column("Support Task Types", style="cyan")
+    table.add_column("Is Sync", style="green")
+
     for a in agents:
         categories = ""
         for c in a.supported_task_categories:
             categories += f"{c.name} (v{c.version}) "
-        data.append([a.name, categories, str(a.is_sync)])
+        table.add_row(a.name, categories, str(a.is_sync))
 
-    _print_table(data)
-
-
-def _print_table(data):
-    # Calculate the width of each column
-    col_widths = [max(len(str(item)) for item in col) for col in zip(*data)]
-
-    # Generate the format string for each row
-    row_format = "| " + " | ".join([f"{{:<{w}}}" for w in col_widths]) + " |"
-
-    # Print the top border
-    print("+" + "+".join(["-" * (w + 2) for w in col_widths]) + "+")
-
-    # Print each row in the table
-    for i, row in enumerate(data):
-        print(row_format.format(*row))
-        # Print separator after the header row
-        if i == 0:
-            print("+" + "+".join(["-" * (w + 2) for w in col_widths]) + "+")
-
-    # Print the bottom border
-    print("+" + "+".join(["-" * (w + 2) for w in col_widths]) + "+")
+    console = Console()
+    console.print(table)

--- a/flytekit/clis/sdk_in_container/serve.py
+++ b/flytekit/clis/sdk_in_container/serve.py
@@ -55,8 +55,8 @@ def agent(_: click.Context, port, worker, timeout):
 async def _start_grpc_server(port: int, worker: int, timeout: int):
     from flytekit.extend.backend.agent_service import AgentMetadataService, AsyncAgentService, SyncAgentService
 
+    click.secho("🚀 Starting the agent service...")
     _start_http_server()
-    click.secho("Starting the agent service...", fg="blue")
     print_agents_metadata()
 
     server = grpc.aio.server(futures.ThreadPoolExecutor(max_workers=worker))
@@ -75,7 +75,7 @@ def _start_http_server():
     try:
         from prometheus_client import start_http_server
 
-        click.secho("Starting up the server to expose the prometheus metrics...", fg="blue")
+        click.secho("Starting up the server to expose the prometheus metrics...")
         start_http_server(9090)
     except ImportError as e:
         click.secho(f"Failed to start the prometheus server with error {e}", fg="red")
@@ -104,24 +104,13 @@ def print_agents_metadata():
     from flytekit.extend.backend.base_agent import AgentRegistry
 
     agents = AgentRegistry.list_agents()
-    for agent in agents:
-        name = agent.name
-        metadata = [category.name for category in agent.supported_task_categories]
-        click.secho(f"Starting {name} that supports task categories {metadata}", fg="blue")
 
-    data = [
-        ["Agent Name", "Age", "City"],
-        ["Alice", 30, "New York"],
-        ["Bob", 25, "Los Angeles"],
-        ["Charlie", 35, "Chicago"]
-    ]
-
-    # Calculate the column widths
-    col_widths = [max(len(str(value)) for value in col) for col in zip(*data)]
-
-    # Print the table
-    for row in data:
-        print(" | ".join(f"{str(value).ljust(width)}" for value, width in zip(row, col_widths)))
+    data = [["Agent Name", "Support Task Types", "Is Sync"]]
+    for a in agents:
+        categories = ""
+        for c in a.supported_task_categories:
+            categories += f"{c.name} (v{c.version}) "
+        data.append([a.name, categories, str(a.is_sync)])
 
     _print_table(data)
 

--- a/flytekit/clis/sdk_in_container/serve.py
+++ b/flytekit/clis/sdk_in_container/serve.py
@@ -108,3 +108,40 @@ def print_agents_metadata():
         name = agent.name
         metadata = [category.name for category in agent.supported_task_categories]
         click.secho(f"Starting {name} that supports task categories {metadata}", fg="blue")
+
+    data = [
+        ["Agent Name", "Age", "City"],
+        ["Alice", 30, "New York"],
+        ["Bob", 25, "Los Angeles"],
+        ["Charlie", 35, "Chicago"]
+    ]
+
+    # Calculate the column widths
+    col_widths = [max(len(str(value)) for value in col) for col in zip(*data)]
+
+    # Print the table
+    for row in data:
+        print(" | ".join(f"{str(value).ljust(width)}" for value, width in zip(row, col_widths)))
+
+    print_table(data)
+
+
+def print_table(data):
+    # Calculate the width of each column
+    col_widths = [max(len(str(item)) for item in col) for col in zip(*data)]
+
+    # Generate the format string for each row
+    row_format = "| " + " | ".join([f"{{:<{w}}}" for w in col_widths]) + " |"
+
+    # Print the top border
+    print("+" + "+".join(["-" * (w + 2) for w in col_widths]) + "+")
+
+    # Print each row in the table
+    for i, row in enumerate(data):
+        print(row_format.format(*row))
+        # Print separator after the header row
+        if i == 0:
+            print("+" + "+".join(["-" * (w + 2) for w in col_widths]) + "+")
+
+    # Print the bottom border
+    print("+" + "+".join(["-" * (w + 2) for w in col_widths]) + "+")

--- a/flytekit/clis/sdk_in_container/serve.py
+++ b/flytekit/clis/sdk_in_container/serve.py
@@ -123,10 +123,10 @@ def print_agents_metadata():
     for row in data:
         print(" | ".join(f"{str(value).ljust(width)}" for value, width in zip(row, col_widths)))
 
-    print_table(data)
+    _print_table(data)
 
 
-def print_table(data):
+def _print_table(data):
     # Calculate the width of each column
     col_widths = [max(len(str(item)) for item in col) for col in zip(*data)]
 

--- a/flytekit/clis/sdk_in_container/utils.py
+++ b/flytekit/clis/sdk_in_container/utils.py
@@ -9,7 +9,7 @@ import rich_click as click
 
 from flytekit.exceptions.base import FlyteException
 from flytekit.exceptions.user import FlyteInvalidInputException
-from flytekit.loggers import get_level_from_cli_verbosity, logger, upgrade_to_rich_logging
+from flytekit.loggers import get_level_from_cli_verbosity, logger
 
 project_option = click.Option(
     param_decls=["-p", "--project"],

--- a/flytekit/clis/sdk_in_container/utils.py
+++ b/flytekit/clis/sdk_in_container/utils.py
@@ -136,7 +136,7 @@ class ErrorHandlingCommand(click.RichGroup):
     def invoke(self, ctx: click.Context) -> typing.Any:
         verbose = ctx.params["verbose"]
         log_level = get_level_from_cli_verbosity(verbose)
-        upgrade_to_rich_logging(log_level=log_level)
+        logger.setLevel(log_level)
         try:
             return super().invoke(ctx)
         except Exception as e:

--- a/flytekit/configuration/file.py
+++ b/flytekit/configuration/file.py
@@ -219,7 +219,6 @@ class ConfigFile(object):
                 d = d[k]
             return d
         except KeyError:
-            logger.debug(f"Switch {c.switch} could not be found in yaml config")
             return None
 
     def get(self, c: typing.Union[LegacyConfigEntry, YamlConfigEntry]) -> typing.Any:

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -729,7 +729,6 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
 
                 return self._async_execute(native_inputs, native_outputs, ctx, exec_ctx, new_user_params)
 
-            logger.debug("Task executed successfully in user level")
             # Lets run the post_execute method. This may result in a IgnoreOutputs Exception, which is
             # bubbled up to be handled at the callee layer.
             native_outputs = self.post_execute(new_user_params, native_outputs)

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -33,7 +33,7 @@ from flytekit.core.data_persistence import FileAccessProvider, default_local_fil
 from flytekit.core.node import Node
 from flytekit.interfaces.cli_identifiers import WorkflowExecutionIdentifier
 from flytekit.interfaces.stats import taggable
-from flytekit.loggers import logger, user_space_logger
+from flytekit.loggers import user_space_logger
 from flytekit.models.core import identifier as _identifier
 
 if typing.TYPE_CHECKING:
@@ -858,10 +858,6 @@ class FlyteContextManager(object):
         context_list = flyte_context_Var.get()
         context_list.append(ctx)
         flyte_context_Var.set(context_list)
-        t = "\t"
-        logger.debug(
-            f"{t * ctx.level}[{len(flyte_context_Var.get())}] Pushing context - {'compile' if ctx.compilation_state else 'execute'}, branch[{ctx.in_a_condition}], {ctx.get_origin_stackframe_repr()}"
-        )
         return ctx
 
     @staticmethod
@@ -869,10 +865,6 @@ class FlyteContextManager(object):
         context_list = flyte_context_Var.get()
         ctx = context_list.pop()
         flyte_context_Var.set(context_list)
-        t = "\t"
-        logger.debug(
-            f"{t * ctx.level}[{len(flyte_context_Var.get()) + 1}] Popping context - {'compile' if ctx.compilation_state else 'execute'}, branch[{ctx.in_a_condition}], {ctx.get_origin_stackframe_repr()}"
-        )
         if len(flyte_context_Var.get()) == 0:
             raise AssertionError(f"Illegal Context state! Popped, {ctx}")
         return ctx

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -33,7 +33,7 @@ from flytekit.core.data_persistence import FileAccessProvider, default_local_fil
 from flytekit.core.node import Node
 from flytekit.interfaces.cli_identifiers import WorkflowExecutionIdentifier
 from flytekit.interfaces.stats import taggable
-from flytekit.loggers import user_space_logger
+from flytekit.loggers import developer_logger, user_space_logger
 from flytekit.models.core import identifier as _identifier
 
 if typing.TYPE_CHECKING:
@@ -858,6 +858,10 @@ class FlyteContextManager(object):
         context_list = flyte_context_Var.get()
         context_list.append(ctx)
         flyte_context_Var.set(context_list)
+        t = "\t"
+        developer_logger.debug(
+            f"{t * ctx.level}[{len(flyte_context_Var.get())}] Pushing context - {'compile' if ctx.compilation_state else 'execute'}, branch[{ctx.in_a_condition}], {ctx.get_origin_stackframe_repr()}"
+        )
         return ctx
 
     @staticmethod
@@ -865,6 +869,10 @@ class FlyteContextManager(object):
         context_list = flyte_context_Var.get()
         ctx = context_list.pop()
         flyte_context_Var.set(context_list)
+        t = "\t"
+        developer_logger.debug(
+            f"{t * ctx.level}[{len(flyte_context_Var.get()) + 1}] Popping context - {'compile' if ctx.compilation_state else 'execute'}, branch[{ctx.in_a_condition}], {ctx.get_origin_stackframe_repr()}"
+        )
         if len(flyte_context_Var.get()) == 0:
             raise AssertionError(f"Illegal Context state! Popped, {ctx}")
         return ctx

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -510,7 +510,6 @@ def extract_return_annotation(return_annotation: Union[Type, Tuple, None]) -> Di
 
     else:
         # Handle all other single return types
-        logger.debug(f"Task returns unnamed native tuple {return_annotation}")
         return {default_output_name(): cast(Type, return_annotation)}
 
 

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -16,7 +16,7 @@ from flytekit.core.docstring import Docstring
 from flytekit.core.sentinel import DYNAMIC_INPUT_BINDING
 from flytekit.core.type_engine import TypeEngine, UnionTransformer
 from flytekit.exceptions.user import FlyteValidationException
-from flytekit.loggers import logger
+from flytekit.loggers import developer_logger, logger
 from flytekit.models import interface as _interface_models
 from flytekit.models.literals import Literal, Scalar, Void
 
@@ -510,6 +510,7 @@ def extract_return_annotation(return_annotation: Union[Type, Tuple, None]) -> Di
 
     else:
         # Handle all other single return types
+        developer_logger.debug(f"Task returns unnamed native tuple {return_annotation}")
         return {default_output_name(): cast(Type, return_annotation)}
 
 

--- a/flytekit/core/reference_entity.py
+++ b/flytekit/core/reference_entity.py
@@ -124,7 +124,6 @@ class ReferenceEntity(object):
         except Exception as e:
             logger.exception(f"Exception when executing {e}")
             raise e
-        logger.debug("Task executed successfully in user level")
 
         expected_output_names = list(self.python_interface.outputs.keys())
         if len(expected_output_names) == 1:

--- a/flytekit/core/shim_task.py
+++ b/flytekit/core/shim_task.py
@@ -108,7 +108,6 @@ class ExecutableTemplateShimTask(object):
                 logger.exception(f"Exception when executing {e}")
                 raise e
 
-            logger.debug("Task executed successfully in user level")
             # Lets run the post_execute method. This may result in a IgnoreOutputs Exception, which is
             # bubbled up to be handled at the callee layer.
             native_outputs = self.post_execute(new_user_params, native_outputs)

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -129,12 +129,10 @@ class TrackedInstance(metaclass=InstanceTrackingMeta):
         if self._instantiated_in is None or self._instantiated_in == "":
             raise _system_exceptions.FlyteSystemException(f"Object {self} does not have an _instantiated in")
 
-        logger.debug(f"Looking for LHS for {self} from {self._instantiated_in}")
         m = importlib.import_module(self._instantiated_in)
         for k in dir(m):
             try:
                 if getattr(m, k) is self:
-                    logger.debug(f"Found LHS for {self}, {k}")
                     self._lhs = k
                     return k
             except ValueError as err:

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -9,7 +9,7 @@ from typing import Callable, Optional, Tuple, Union
 
 from flytekit.configuration.feature_flags import FeatureFlags
 from flytekit.exceptions import system as _system_exceptions
-from flytekit.loggers import logger
+from flytekit.loggers import developer_logger, logger
 
 
 def import_module_from_file(module_name, file):
@@ -129,10 +129,12 @@ class TrackedInstance(metaclass=InstanceTrackingMeta):
         if self._instantiated_in is None or self._instantiated_in == "":
             raise _system_exceptions.FlyteSystemException(f"Object {self} does not have an _instantiated in")
 
+        developer_logger.debug(f"Looking for LHS for {self} from {self._instantiated_in}")
         m = importlib.import_module(self._instantiated_in)
         for k in dir(m):
             try:
                 if getattr(m, k) is self:
+                    developer_logger.debug(f"Found LHS for {self}, {k}")
                     self._lhs = k
                     return k
             except ValueError as err:

--- a/flytekit/core/utils.py
+++ b/flytekit/core/utils.py
@@ -335,13 +335,7 @@ class timeit:
             )
         )
 
-        logger.info(
-            "{}. [Wall Time: {}s, Process Time: {}s]".format(
-                self._name,
-                end_wall_time - self._start_wall_time,
-                end_process_time - self._start_process_time,
-            )
-        )
+        logger.info(f"{self._name}. [Time: {end_wall_time - self._start_wall_time:.6f}s]")
 
 
 class ClassDecorator(ABC):

--- a/flytekit/extend/backend/base_agent.py
+++ b/flytekit/extend/backend/base_agent.py
@@ -272,8 +272,8 @@ class SyncAgentExecutorMixin:
             return await mirror_async_methods(
                 agent.do, task_template=template, inputs=literal_map, output_prefix=output_prefix
             )
-        except Exception as error_message:
-            raise FlyteUserException(f"Failed to run the task {self.name} with error: {error_message}")
+        except Exception as e:
+            raise FlyteUserException(f"Failed to run the task {self.name} with error: {e}") from None
 
 
 class AsyncAgentExecutorMixin:

--- a/flytekit/extend/backend/base_agent.py
+++ b/flytekit/extend/backend/base_agent.py
@@ -18,7 +18,7 @@ from flyteidl.core.execution_pb2 import TaskExecution, TaskLog
 from rich.logging import RichHandler
 from rich.progress import Progress
 
-from flytekit import FlyteContext, PythonFunctionTask, logger
+from flytekit import FlyteContext, PythonFunctionTask
 from flytekit.configuration import ImageConfig, SerializationSettings
 from flytekit.core import utils
 from flytekit.core.base_task import PythonTask

--- a/flytekit/extend/backend/base_agent.py
+++ b/flytekit/extend/backend/base_agent.py
@@ -210,8 +210,6 @@ class AgentRegistry(object):
             )
             AgentRegistry._METADATA[agent.name] = agent_metadata
 
-        logger.info(f"Registering {agent.name} for task type: {agent.task_category}")
-
     @staticmethod
     def get_agent(task_type_name: str, task_type_version: int = 0) -> Union[SyncAgentBase, AsyncAgentBase]:
         task_category = TaskCategory(name=task_type_name, version=task_type_version)

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -120,13 +120,11 @@ def upgrade_to_rich_logging(log_level: typing.Optional[int] = logging.WARNING):
         tracebacks_suppress=[click, flytekit],
         rich_tracebacks=True,
         omit_repeated_times=False,
-        # show_time=False,
-        # show_level=False,
         show_path=False,
         log_time_format="%H:%M:%S.%f",
         console=Console(width=os.get_terminal_size().columns),
     )
-    # logger
+
     formatter = logging.Formatter(fmt="%(filename)s:%(lineno)d - %(message)s")
     handler.setFormatter(formatter)
     set_flytekit_log_properties(handler, None, _get_env_logging_level(default_level=log_level))

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -52,7 +52,7 @@ from flytekit.exceptions.user import (
     FlyteEntityNotExistException,
     FlyteValueException,
 )
-from flytekit.loggers import logger
+from flytekit.loggers import developer_logger, logger
 from flytekit.models import common as common_models
 from flytekit.models import filters as filter_models
 from flytekit.models import launch_plan as launch_plan_models
@@ -912,6 +912,10 @@ class FlyteRemote(object):
                     rsp.status_code,
                     f"Request to send data {upload_location.signed_url} failed.\nResponse: {rsp.text}",
                 )
+
+        developer_logger.debug(
+            f"Uploading {to_upload} to {upload_location.signed_url} native url {upload_location.native_url}"
+        )
 
         return md5_bytes, upload_location.native_url
 

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -515,7 +515,6 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
                 f"Already registered a handler for {(h.python_type, protocol, h.supported_format)}"
             )
         lowest_level[h.supported_format] = h
-        logger.debug(f"Registered {type(h).__name__} for protocol [{protocol}]")
 
         if (default_format_for_type or default_for_type) and h.supported_format != GENERIC_FORMAT:
             if h.python_type in cls.DEFAULT_FORMATS and not override:

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -18,7 +18,7 @@ from flytekit import lazy_module
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.type_engine import TypeEngine, TypeTransformer
 from flytekit.deck.renderer import Renderable
-from flytekit.loggers import logger
+from flytekit.loggers import developer_logger, logger
 from flytekit.models import literals
 from flytekit.models import types as type_models
 from flytekit.models.literals import Literal, Scalar, StructuredDatasetMetadata
@@ -515,6 +515,9 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
                 f"Already registered a handler for {(h.python_type, protocol, h.supported_format)}"
             )
         lowest_level[h.supported_format] = h
+        developer_logger.debug(
+            f"Registered {h} as handler for {h.python_type}, protocol {protocol}, fmt {h.supported_format}"
+        )
 
         if (default_format_for_type or default_for_type) and h.supported_format != GENERIC_FORMAT:
             if h.python_type in cls.DEFAULT_FORMATS and not override:

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -515,7 +515,7 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
                 f"Already registered a handler for {(h.python_type, protocol, h.supported_format)}"
             )
         lowest_level[h.supported_format] = h
-        logger.debug(f"Registered {h} as handler for {h.python_type}, protocol {protocol}, fmt {h.supported_format}")
+        logger.debug(f"Registered {type(h).__name__} for protocol [{protocol}]")
 
         if (default_format_for_type or default_for_type) and h.supported_format != GENERIC_FORMAT:
             if h.python_type in cls.DEFAULT_FORMATS and not override:
@@ -524,9 +524,7 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
                         f"Not using handler {h} with format {h.supported_format} as default for {h.python_type}, {cls.DEFAULT_FORMATS[h.python_type]} already specified."
                     )
             else:
-                logger.debug(
-                    f"Setting format {h.supported_format} for dataframes of type {h.python_type} from handler {h}"
-                )
+                logger.debug(f"Use {type(h).__name__} as default handler for {h.python_type}.")
                 cls.DEFAULT_FORMATS[h.python_type] = h.supported_format
         if default_storage_for_type or default_for_type:
             if h.protocol in cls.DEFAULT_PROTOCOLS and not override:


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
The error message is cryptic

## What changes were proposed in this pull request?
- Add developer logger
- Update logger format
- Update log for structured dataset
- remove verbose message
- Limiting floats to two decimal points
- Print a table with agent information when running `pyflyte serve agent`
- Improve error handling for agent task failures
- Improve error handling for `git config not found` error

## How was this patch tested?
```bash
pyflyte -vv run --remote flyte-example/improve_error_handling.py wf
pyflyte serve agent
```

### Setup process
```python
import os
from flytekit import task, workflow, WorkflowFailurePolicy, ImageSpec


custom_image = ImageSpec(
    registry="ghcr.io/flyteorg",
    packages=["pandas"],
)


@task(container_image=custom_image, enable_deck=True)
def t1(a: int) -> int:
    os.getenv("FLYTE_INTERNAL_EXECUTION_ID")
    return 3 + a


@task(container_image=custom_image, enable_deck=True)
def t2(a: int) -> str:
    return "hello world"


@workflow(failure_policy=WorkflowFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE)
def wf() -> str:
    t1(a=3)
    return t2(a=3)

```

### Screenshots

Before:

<img width="1310" alt="Screenshot 2024-06-18 at 4 46 20 AM" src="https://github.com/flyteorg/flytekit/assets/37936015/6293cd35-8f16-4337-b298-a051d6d4481f">

<img width="1310" alt="Screenshot 2024-06-18 at 4 46 35 AM" src="https://github.com/flyteorg/flytekit/assets/37936015/ae63c984-9269-4dc7-b7b4-38e1cd3e3483">

<img width="1310" alt="Screenshot 2024-06-18 at 4 46 38 AM" src="https://github.com/flyteorg/flytekit/assets/37936015/11de9aa9-c429-4976-899a-12187375b935">

<img width="1310" alt="Screenshot 2024-06-18 at 4 46 41 AM" src="https://github.com/flyteorg/flytekit/assets/37936015/0a3ec0a3-776e-46a2-8e26-89e43dbe868a">

<img width="1310" alt="Screenshot 2024-06-18 at 4 46 42 AM" src="https://github.com/flyteorg/flytekit/assets/37936015/3e1968d9-5544-40c8-8811-dbae9e73724f">

<img width="1310" alt="Screenshot 2024-06-18 at 4 51 40 AM" src="https://github.com/flyteorg/flytekit/assets/37936015/c2cd2e5e-6065-4605-a5e4-164a1f60ce9a">

<img width="1310" alt="Screenshot 2024-06-18 at 4 47 57 AM" src="https://github.com/flyteorg/flytekit/assets/37936015/83ce1a46-4c71-47d5-9e96-2b6613d48746">

After:

<img width="1310" alt="Screenshot 2024-06-18 at 4 54 55 AM" src="https://github.com/flyteorg/flytekit/assets/37936015/5b3d0d30-fa11-4efa-8982-d1c84b3b0b54">

<img width="1310" alt="Screenshot 2024-06-18 at 4 55 14 AM" src="https://github.com/flyteorg/flytekit/assets/37936015/24e22c9e-2e83-4394-a6b6-8c6ef2a3bf96">

<img width="1310" alt="Screenshot 2024-06-18 at 4 55 32 AM" src="https://github.com/flyteorg/flytekit/assets/37936015/49f31e96-0757-4d88-b3fc-51d55c79913f">

![Screenshot 2024-06-20 at 4 30 01 PM](https://github.com/flyteorg/flytekit/assets/37936015/2eaa7442-237c-43ad-ace2-66d5f11458f5)


<img width="1310" alt="Screenshot 2024-06-18 at 5 10 27 AM" src="https://github.com/flyteorg/flytekit/assets/37936015/088492ad-2e84-429e-a4e0-a63164de1b15">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
