### PR TITLE
fix: Prevent local files from being moved when using FlyteFile on local executions

### DIFF
--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -435,7 +435,7 @@ class FlyteFilePathTransformer(TypeTransformer[FlyteFile]):
                     f" specified. Since a simpler type was specified, we'll skip uploading!"
                 )
                 should_upload = False
-            if ctx.execution_state.is_local_execution:
+            if ctx.execution_state.is_local_execution and python_val.remote_path is None:
                 should_upload = False
 
             # Set the remote destination if one was given instead of triggering a random one below

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -435,11 +435,12 @@ class FlyteFilePathTransformer(TypeTransformer[FlyteFile]):
                     f" specified. Since a simpler type was specified, we'll skip uploading!"
                 )
                 should_upload = False
-            if ctx.execution_state.is_local_execution and python_val.remote_path is None:
-                should_upload = False
 
             # Set the remote destination if one was given instead of triggering a random one below
             remote_path = python_val.remote_path or None
+
+            if ctx.execution_state.is_local_execution and python_val.remote_path is None:
+                should_upload = False
 
         elif isinstance(python_val, pathlib.Path) or isinstance(python_val, str):
             source_path = str(python_val)

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -220,9 +220,6 @@ class FlyteFile(os.PathLike, typing.Generic[T], DataClassJSONMixin):
         self._remote_source: typing.Optional[str] = None
 
     def __fspath__(self):
-        if os.path.exists(self.path):
-            # Provided path is a local file
-            return self.path
         # This is where a delayed downloading of the file will happen
         if not self._downloaded:
             self._downloader()

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -220,6 +220,9 @@ class FlyteFile(os.PathLike, typing.Generic[T], DataClassJSONMixin):
         self._remote_source: typing.Optional[str] = None
 
     def __fspath__(self):
+        if os.path.exists(self.path):
+            # Provided path is a local file
+            return self.path
         # This is where a delayed downloading of the file will happen
         if not self._downloaded:
             self._downloader()

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -435,6 +435,8 @@ class FlyteFilePathTransformer(TypeTransformer[FlyteFile]):
                     f" specified. Since a simpler type was specified, we'll skip uploading!"
                 )
                 should_upload = False
+            if ctx.execution_state.is_local_execution:
+                should_upload = False
 
             # Set the remote destination if one was given instead of triggering a random one below
             remote_path = python_val.remote_path or None

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -457,6 +457,8 @@ class FlyteFilePathTransformer(TypeTransformer[FlyteFile]):
                         p = pathlib.Path(python_val)
                         if not p.is_file():
                             raise TypeTransformerFailedError(f"Error converting {python_val} because it's not a file.")
+                        if ctx.execution_state.is_local_execution:
+                            should_upload = False
             # python_type must be os.PathLike - see check at beginning of function
             else:
                 should_upload = False

--- a/tests/flytekit/unit/core/test_flyte_file.py
+++ b/tests/flytekit/unit/core/test_flyte_file.py
@@ -205,7 +205,7 @@ def test_file_handling_remote_default_wf_input():
     assert sample_lp.parameters.parameters["fname"].default.scalar.blob.uri == SAMPLE_DATA
 
 
-def test_file_handling_local_file_gets_copied():
+def test_file_handling_local_file_does_not_get_copied():
     @task
     def t1() -> FlyteFile:
         # Use this test file itself, since we know it exists.
@@ -223,12 +223,7 @@ def test_file_handling_local_file_gets_copied():
         assert len(top_level_files) == 1  # the flytekit_local folder
 
         x = my_wf()
-
-        # After running, this test file should've been copied to the mock remote location.
-        mock_remote_files = os.listdir(os.path.join(random_dir, "mock_remote"))
-        assert len(mock_remote_files) == 1  # the file
-        # File should've been copied to the mock remote folder
-        assert x.path.startswith(random_dir)
+        assert x.path == __file__
 
 
 def test_file_handling_local_file_gets_force_no_copy():


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?

When running local executions, local files that exist should not need to be copied. When running large files, this can become a bottleneck.

## What changes were proposed in this pull request?

Check if running a local task execution when converting FlyteFile to literal.

## How was this patch tested?

```python
from flytekit import task
from flytekit.types.file import FlyteFile


@task
def example(ff: FlyteFile) -> str:
    downloaded_path = ff.download()
    print(downloaded_path)
    return str(ff.path)


example(ff=__file__)
```

Before the fix, this printed:
```console
/var/folders/d1/n1tj86t11pj_drgfg7_br5n00000gn/T/flyte-qd4bk3t0/raw/0fee47924014b3cb5f12295a48330c0f/tmp.py
```

After the fix, this printed:
```console
/Users/ggydush/dev/delve/flytekit/flytekit/types/file/tmp.py
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
