### PR TITLE
Fix test_image_spec

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -127,7 +127,10 @@ class ImageSpec:
         except Exception as e:
             tag = calculate_hash_from_image_spec(self)
             # if docker engine is not running locally, use requests to check if the image exists.
-            if DOCKER_HUB in self.registry:
+            container_registry = DOCKER_HUB
+            if self.registry and "/" in self.registry:
+                container_registry = self.registry.split("/")[0]
+            if container_registry == DOCKER_HUB and "localhost" not in self.registry:
                 url = f"https://hub.docker.com/v2/repositories/{self.registry}/{self.name}/tags/{tag}"
                 response = requests.get(url)
                 if response.status_code == 200:

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -120,17 +120,14 @@ class ImageSpec:
             return True
         except APIError as e:
             if e.response.status_code == 404:
-                return True
+                return False
             return True
         except ImageNotFound:
-            return True
+            return False
         except Exception as e:
             tag = calculate_hash_from_image_spec(self)
-            # if docker engine is not running locally
-            container_registry = DOCKER_HUB
-            if self.registry and "/" in self.registry:
-                container_registry = self.registry.split("/")[0]
-            if container_registry == DOCKER_HUB:
+            # if docker engine is not running locally, use requests to check if the image exists.
+            if DOCKER_HUB in self.registry:
                 url = f"https://hub.docker.com/v2/repositories/{self.registry}/{self.name}/tags/{tag}"
                 response = requests.get(url)
                 if response.status_code == 200:

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -104,7 +104,6 @@ class ImageSpec:
             return os.environ.get(_F_IMG_ID) == self.image_name()
         return True
 
-    @lru_cache
     def exist(self) -> bool:
         """
         Check if the image exists in the registry.
@@ -121,7 +120,7 @@ class ImageSpec:
             return True
         except APIError as e:
             if e.response.status_code == 404:
-                return True
+                return False
             return True
         except ImageNotFound:
             return False

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -130,7 +130,7 @@ class ImageSpec:
             container_registry = DOCKER_HUB
             if self.registry and "/" in self.registry:
                 container_registry = self.registry.split("/")[0]
-            if container_registry == DOCKER_HUB and "localhost" not in self.registry:
+            if container_registry == DOCKER_HUB and "localhost:" not in self.registry:
                 url = f"https://hub.docker.com/v2/repositories/{self.registry}/{self.name}/tags/{tag}"
                 response = requests.get(url)
                 if response.status_code == 200:

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -121,7 +121,7 @@ class ImageSpec:
             return True
         except APIError as e:
             if e.response.status_code == 404:
-                return False
+                return True
             return True
         except ImageNotFound:
             return False

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -127,12 +127,13 @@ class ImageSpec:
         except Exception as e:
             tag = calculate_hash_from_image_spec(self)
             # if docker engine is not running locally, use requests to check if the image exists.
-            if "localhost:" not in self.registry:
-                container_registry = DOCKER_HUB
-            else:
+            if "localhost:" in self.registry:
                 container_registry = self.registry
-            if self.registry and "/" in self.registry:
+            elif self.registry and "/" in self.registry:
                 container_registry = self.registry.split("/")[0]
+            else:
+                # Assume the image is in docker hub if users don't specify a registry, such as ghcr.io, docker.io.
+                container_registry = DOCKER_HUB
             if container_registry == DOCKER_HUB:
                 url = f"https://hub.docker.com/v2/repositories/{self.registry}/{self.name}/tags/{tag}"
                 response = requests.get(url)

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -120,7 +120,7 @@ class ImageSpec:
             return True
         except APIError as e:
             if e.response.status_code == 404:
-                return False
+                return True
             return True
         except ImageNotFound:
             return True

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -123,7 +123,7 @@ class ImageSpec:
                 return False
             return True
         except ImageNotFound:
-            return False
+            return True
         except Exception as e:
             tag = calculate_hash_from_image_spec(self)
             # if docker engine is not running locally

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -127,10 +127,13 @@ class ImageSpec:
         except Exception as e:
             tag = calculate_hash_from_image_spec(self)
             # if docker engine is not running locally, use requests to check if the image exists.
-            container_registry = DOCKER_HUB
+            if "localhost:" not in self.registry:
+                container_registry = DOCKER_HUB
+            else:
+                container_registry = self.registry
             if self.registry and "/" in self.registry:
                 container_registry = self.registry.split("/")[0]
-            if container_registry == DOCKER_HUB and "localhost:" not in self.registry:
+            if container_registry == DOCKER_HUB:
                 url = f"https://hub.docker.com/v2/repositories/{self.registry}/{self.name}/tags/{tag}"
                 response = requests.get(url)
                 if response.status_code == 200:

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -19,7 +19,7 @@ def test_image_spec(mock_image_spec_builder):
         packages=["pandas"],
         apt_packages=["git"],
         python_version="3.8",
-        registry="localhost:30000",
+        registry="localhost:30001",
         base_image="cr.flyte.org/flyteorg/flytekit:py3.8-latest",
         cuda="11.2.2",
         cudnn="8",
@@ -37,7 +37,7 @@ def test_image_spec(mock_image_spec_builder):
     assert image_spec.base_image == "cr.flyte.org/flyteorg/flytekit:py3.8-latest"
     assert image_spec.packages == ["pandas", "numpy"]
     assert image_spec.apt_packages == ["git", "wget"]
-    assert image_spec.registry == "localhost:30000"
+    assert image_spec.registry == "localhost:30001"
     assert image_spec.requirements == REQUIREMENT_FILE
     assert image_spec.registry_config == REGISTRY_CONFIG_FILE
     assert image_spec.cuda == "11.2.2"
@@ -53,12 +53,12 @@ def test_image_spec(mock_image_spec_builder):
 
     tag = calculate_hash_from_image_spec(image_spec)
     assert "=" != tag[-1]
-    assert image_spec.image_name() == f"localhost:30000/flytekit:{tag}"
+    assert image_spec.image_name() == f"localhost:30001/flytekit:{tag}"
     ctx = context_manager.FlyteContext.current_context()
     with context_manager.FlyteContextManager.with_context(
         ctx.with_execution_state(ctx.execution_state.with_params(mode=ExecutionState.Mode.TASK_EXECUTION))
     ):
-        os.environ[_F_IMG_ID] = "localhost:30000/flytekit:123"
+        os.environ[_F_IMG_ID] = "localhost:30001/flytekit:123"
         assert image_spec.is_container() is False
 
     ImageBuildEngine.register("dummy", mock_image_spec_builder)

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -66,7 +66,7 @@ def test_image_spec(mock_image_spec_builder):
 
     assert "dummy" in ImageBuildEngine._REGISTRY
     assert calculate_hash_from_image_spec(image_spec) == tag
-    # assert image_spec.exist() is True
+    assert image_spec.exist() is True
 
     # Remove the dummy builder, and build the image again
     # The image has already been built, so it shouldn't fail.

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -19,7 +19,7 @@ def test_image_spec(mock_image_spec_builder):
         packages=["pandas"],
         apt_packages=["git"],
         python_version="3.8",
-        registry="localhost:30001",
+        registry="localhost:30000",
         base_image="cr.flyte.org/flyteorg/flytekit:py3.8-latest",
         cuda="11.2.2",
         cudnn="8",
@@ -37,7 +37,7 @@ def test_image_spec(mock_image_spec_builder):
     assert image_spec.base_image == "cr.flyte.org/flyteorg/flytekit:py3.8-latest"
     assert image_spec.packages == ["pandas", "numpy"]
     assert image_spec.apt_packages == ["git", "wget"]
-    assert image_spec.registry == "localhost:30001"
+    assert image_spec.registry == "localhost:30000"
     assert image_spec.requirements == REQUIREMENT_FILE
     assert image_spec.registry_config == REGISTRY_CONFIG_FILE
     assert image_spec.cuda == "11.2.2"
@@ -53,12 +53,12 @@ def test_image_spec(mock_image_spec_builder):
 
     tag = calculate_hash_from_image_spec(image_spec)
     assert "=" != tag[-1]
-    assert image_spec.image_name() == f"localhost:30001/flytekit:{tag}"
+    assert image_spec.image_name() == f"localhost:30000/flytekit:{tag}"
     ctx = context_manager.FlyteContext.current_context()
     with context_manager.FlyteContextManager.with_context(
         ctx.with_execution_state(ctx.execution_state.with_params(mode=ExecutionState.Mode.TASK_EXECUTION))
     ):
-        os.environ[_F_IMG_ID] = "localhost:30001/flytekit:123"
+        os.environ[_F_IMG_ID] = "localhost:30000/flytekit:123"
         assert image_spec.is_container() is False
 
     ImageBuildEngine.register("dummy", mock_image_spec_builder)

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -66,7 +66,7 @@ def test_image_spec(mock_image_spec_builder):
 
     assert "dummy" in ImageBuildEngine._REGISTRY
     assert calculate_hash_from_image_spec(image_spec) == tag
-    assert image_spec.exist() is True
+    # assert image_spec.exist() is True
 
     # Remove the dummy builder, and build the image again
     # The image has already been built, so it shouldn't fail.


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flytekit/actions/runs/9475012693/job/26105636011

## Why are the changes needed?
Unit test is failing

## What changes were proposed in this pull request?
if image registry is `localhost:30000`, we should not use `request` to check if the image exists on docker hub

## How was this patch tested?
unit test

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA