### PR TITLE
Fix: Fix deprecated numpy type and make numpy<2 explicit dependency

### DIFF
--- a/flytekit/types/schema/types.py
+++ b/flytekit/types/schema/types.py
@@ -334,7 +334,7 @@ class FlyteSchemaTransformer(TypeTransformer[FlyteSchema]):
         datetime.datetime: SchemaType.SchemaColumn.SchemaColumnType.DATETIME,
         _np.timedelta64: SchemaType.SchemaColumn.SchemaColumnType.DURATION,
         datetime.timedelta: SchemaType.SchemaColumn.SchemaColumnType.DURATION,
-        _np.string_: SchemaType.SchemaColumn.SchemaColumnType.STRING,
+        _np.bytes_: SchemaType.SchemaColumn.SchemaColumnType.STRING,
         _np.str_: SchemaType.SchemaColumn.SchemaColumnType.STRING,
         _np.object_: SchemaType.SchemaColumn.SchemaColumnType.STRING,
         str: SchemaType.SchemaColumn.SchemaColumnType.STRING,

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -340,7 +340,7 @@ def get_supported_types():
         _datetime.datetime: type_models.LiteralType(simple=type_models.SimpleType.DATETIME),
         _np.timedelta64: type_models.LiteralType(simple=type_models.SimpleType.DURATION),
         _datetime.timedelta: type_models.LiteralType(simple=type_models.SimpleType.DURATION),
-        _np.string_: type_models.LiteralType(simple=type_models.SimpleType.STRING),
+        _np.bytes_: type_models.LiteralType(simple=type_models.SimpleType.STRING),
         _np.str_: type_models.LiteralType(simple=type_models.SimpleType.STRING),
         _np.object_: type_models.LiteralType(simple=type_models.SimpleType.STRING),
         str: type_models.LiteralType(simple=type_models.SimpleType.STRING),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "marshmallow-enum",
     "marshmallow-jsonschema>=0.12.0",
     "mashumaro>=3.11",
-    "numpy",
+    "numpy<2",
     "protobuf!=4.25.0",
     "pyarrow",
     "pygments",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "marshmallow-enum",
     "marshmallow-jsonschema>=0.12.0",
     "mashumaro>=3.11",
+    "numpy",
     "protobuf!=4.25.0",
     "pyarrow",
     "pygments",


### PR DESCRIPTION
## Why are the changes needed?

Today, `numpy==2.0.0` was released. This new release broke the [sandbox-bundled-functional-tests](https://github.com/flyteorg/flyte/actions/runs/9536915121/job/26284633221?pr=4726#logs) in https://github.com/flyteorg/flyte/pull/4726:

```console
Collecting numpy>=1.26.0 (from pandas->flytekitplugins-deck-standard)
  Downloading numpy-2.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (60 kB)
...
Failed with Unknown Exception <class 'AttributeError'> Reason: `np.string_` was removed in the NumPy 2.0 release. Use `np.bytes_` instead.
...
File "/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/flytekit/types/schema/types.py", line 340, in FlyteSchemaTransformer
    _np.string_: SchemaType.SchemaColumn.SchemaColumnType.STRING,
    ^^^^^^^^^^^
```

The [docs of numpy 1.26](https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.string_) also show that `string_` is just an alias to `bytes_`.

---

I noticed that numpy isn't an explicit flytekit dependency even though flytekit imports numpy. I fix this as well and pin numpy to <2 for now as CI jobs of several plugins fail with numpy errors currently.

---


- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

