### PR TITLE
Improve error handling for docker client

### DIFF
--- a/flytekit/clis/sdk_in_container/utils.py
+++ b/flytekit/clis/sdk_in_container/utils.py
@@ -124,8 +124,9 @@ def pretty_print_exception(e: Exception):
         click.secho(f"Value Error: {e}", fg="red")
         return
 
-    click.secho(f"Failed with Unknown Exception {type(e)} Reason: {e}", fg="red")  # noqa
-    pretty_print_traceback(e)
+    click.secho(f"Failed with Exception {type(e)} Reason:\n{e}", fg="red")  # noqa
+    if e.__cause__:
+        pretty_print_traceback(e.__cause__)
 
 
 class ErrorHandlingCommand(click.RichGroup):

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -148,7 +148,9 @@ class ImageSpec:
                     f"{str(e)}\n"
                     f"Error: Incompatible Docker package version.\n"
                     f"Current version: {docker.__version__}\n"
-                    f"Please upgrade the Docker package to version 7.1.0 or higher."
+                    f"Please upgrade the Docker package to version 7.1.0 or higher.\n"
+                    f"You can upgrade the package by running:\n"
+                    f"    pip install --upgrade docker"
                 )
 
             click.secho(f"Failed to check if the image exists with error : {e}", fg="red")

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -143,6 +143,14 @@ class ImageSpec:
                 if response.status_code == 404 and "not found" in str(response.content):
                     return False
 
+            if "Not supported URL scheme http+docker" in str(e):
+                raise RuntimeError(
+                    f"{str(e)}\n"
+                    f"Error: Incompatible Docker package version.\n"
+                    f"Current version: {docker.__version__}\n"
+                    f"Please upgrade the Docker package to version 7.1.0 or higher."
+                )
+
             click.secho(f"Failed to check if the image exists with error : {e}", fg="red")
             click.secho("Flytekit assumes that the image already exists.", fg="blue")
             return True


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
The error message is cryptic

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
```python
import os

from click.testing import CliRunner

from flytekit import task, workflow, WorkflowFailurePolicy, ImageSpec
from flytekit.clis.sdk_in_container import pyflyte


custom_image = ImageSpec(
    registry="ghcr.io/flyteorg",
    packages=["mlflow", "pandas", "mypy", "flytekit", "requests"],
    apt_packages=["wget", "git"],
)


@task(container_image=custom_image, enable_deck=True)
def t1(a: int) -> int:
    os.getenv("FLYTE_INTERNAL_EXECUTION_ID")
    return 3 + a


@task(container_image=custom_image, enable_deck=True)
def t2(a: int) -> int:
    return 3 + a


@workflow(failure_policy=WorkflowFailurePolicy.FAIL_AFTER_EXECUTABLE_NODES_COMPLETE)
def wf():
    t1(a=3)
    t2(a=3)


if __name__ == "__main__":
    runner = CliRunner()
    result = runner.invoke(
        pyflyte.main,
        [
            "run",
            "--remote",
            "getting_started.py",
            "wf",
        ],
    )
    print(result)
```

### Screenshots
Before:

<img width="1274" alt="Screenshot 2024-06-17 at 11 59 13 PM" src="https://github.com/flyteorg/flytekit/assets/37936015/63cd5100-ca68-4688-843c-4b75b4c04a4b">
<img width="1274" alt="Screenshot 2024-06-17 at 11 59 16 PM" src="https://github.com/flyteorg/flytekit/assets/37936015/b017a083-3fcc-4d2f-8989-7aef14f496ba">

After:

<img width="1274" alt="Screenshot 2024-06-18 at 12 06 42 AM" src="https://github.com/flyteorg/flytekit/assets/37936015/a1292fe7-602a-4928-b860-a0ce36e67c85">


- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
