### PR TITLE
Adds support for wandb backlinks through FLYTE_EXECUTION_URL

### DIFF
--- a/plugins/flytekit-wandb/flytekitplugins/wandb/tracking.py
+++ b/plugins/flytekit-wandb/flytekitplugins/wandb/tracking.py
@@ -94,7 +94,15 @@ class wandb_init(ClassDecorator):
             else:
                 wand_id = self.id
 
-        wandb.init(project=self.project, entity=self.entity, id=wand_id, **self.init_kwargs)
+        run = wandb.init(project=self.project, entity=self.entity, id=wand_id, **self.init_kwargs)
+
+        execution_url = os.getenv("FLYTE_EXECUTION_URL")
+        if execution_url is not None:
+            notes_list = [f"[Execution URL]({execution_url})"]
+            if run.notes:
+                notes_list.append(run.notes)
+            run.notes = os.linesep.join(notes_list)
+
         output = self.task_function(*args, **kwargs)
         wandb.finish()
         return output

--- a/plugins/flytekit-wandb/flytekitplugins/wandb/tracking.py
+++ b/plugins/flytekit-wandb/flytekitplugins/wandb/tracking.py
@@ -96,6 +96,7 @@ class wandb_init(ClassDecorator):
 
         run = wandb.init(project=self.project, entity=self.entity, id=wand_id, **self.init_kwargs)
 
+        # If FLYTE_EXECUTION_URL is defined, inject it into wandb to link back to the execution.
         execution_url = os.getenv("FLYTE_EXECUTION_URL")
         if execution_url is not None:
             notes_list = [f"[Execution URL]({execution_url})"]


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->
Follow up to https://github.com/flyteorg/flytekit/pull/2405

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
With this PR, a backlink is injected into the notes. This allows user to go from wandb interface back to the execution. In the wandb UI, it will end up here:

![Screenshot 2024-06-18 at 4 54 35 PM](https://github.com/flyteorg/flytekit/assets/5402633/400ff128-eb9e-40ef-a911-4a305eaa4423)


## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR looks for `FLYTE_EXECUTION_URL` and injects it into the notes if it is available.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
The unit tests were updated to check this change.