### PR TITLE
feat(envd): Add switch for custom envd context

### DIFF
--- a/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
+++ b/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
@@ -14,6 +14,7 @@ from flytekit.image_spec.image_spec import _F_IMG_ID, ImageBuildEngine, ImageSpe
 from flytekit.tools.ignore import DockerIgnore, GitIgnore, IgnoreGroup, StandardIgnore
 
 FLYTE_LOCAL_REGISTRY = "localhost:30000"
+FLYTE_ENVD_CONTEXT = "FLYTE_ENVD_CONTEXT"
 
 
 class EnvdImageSpecBuilder(ImageSpecBuilder):
@@ -38,6 +39,9 @@ class EnvdImageSpecBuilder(ImageSpecBuilder):
 
 
 def envd_context_switch(registry: str):
+    if os.getenv(FLYTE_ENVD_CONTEXT):
+        execute_command(f"envd context use --name {os.getenv(FLYTE_ENVD_CONTEXT)}")
+        return
     if registry == FLYTE_LOCAL_REGISTRY:
         # Assume buildkit daemon is running within the sandbox and exposed on port 30003
         command = "envd context create --name flyte-sandbox --builder tcp --builder-address localhost:30003 --use"


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
People cannot use custom envd context.

## What changes were proposed in this pull request?
Add an env var `FLYTE_ENVD_CONTEXT`, which allows people to use custom envd context.

## How was this patch tested?
```bash
FLYTE_ENVD_CONTEXT=flyte pyflyte run --remote flyte-example/getting_started.py wf
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
