### PR TITLE
Boolean flag to show local container logs to the terminal

### DIFF
--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -59,6 +59,7 @@ class ContainerTask(PythonTask):
         secret_requests: Optional[List[Secret]] = None,
         pod_template: Optional["PodTemplate"] = None,
         pod_template_name: Optional[str] = None,
+        local_logs: bool = False,
         **kwargs,
     ):
         sec_ctx = None
@@ -93,6 +94,7 @@ class ContainerTask(PythonTask):
             requests=requests if requests else Resources(), limits=limits if limits else Resources()
         )
         self.pod_template = pod_template
+        self.local_logs = local_logs
 
     @property
     def resources(self) -> ResourceSpec:
@@ -249,6 +251,11 @@ class ContainerTask(PythonTask):
         )
         # Wait for the container to finish the task
         # TODO: Add a 'timeout' parameter to control the max wait time for the container to finish the task.
+
+        if self.local_logs:
+            for log in container.logs(stream=True):
+                print(f"[Local Container] {log.strip()}")
+                
         container.wait()
 
         output_dict = self._get_output_dict(output_directory)

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -255,7 +255,7 @@ class ContainerTask(PythonTask):
         if self.local_logs:
             for log in container.logs(stream=True):
                 print(f"[Local Container] {log.strip()}")
-                
+
         container.wait()
 
         output_dict = self._get_output_dict(output_directory)


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
Closes flyteorg/flyte#5436
<!-- Remove this section if not applicable -->

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
Added a boolean flag variable local_logs that controls if local container tasks output logs to the terminal.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
