### PR TITLE
FLYTE_INTERNAL_IMAGE should have higher precedence

### DIFF
--- a/flytekit/configuration/default_images.py
+++ b/flytekit/configuration/default_images.py
@@ -4,7 +4,7 @@ import sys
 import typing
 from contextlib import suppress
 
-from flytekit.core.constants import FLYTE_INTERNAL_IMAGE
+from flytekit.core.constants import FLYTE_INTERNAL_IMAGE_ENV_VAR
 
 
 class PythonVersion(enum.Enum):
@@ -43,7 +43,7 @@ class DefaultImages(object):
     def find_image_for(
         cls, python_version: typing.Optional[PythonVersion] = None, flytekit_version: typing.Optional[str] = None
     ) -> str:
-        default_image_str = os.getenv(FLYTE_INTERNAL_IMAGE)
+        default_image_str = os.getenv(FLYTE_INTERNAL_IMAGE_ENV_VAR)
         if default_image_str:
             return default_image_str
 

--- a/flytekit/configuration/default_images.py
+++ b/flytekit/configuration/default_images.py
@@ -35,13 +35,16 @@ class DefaultImages(object):
             if default_image is not None:
                 return default_image
 
-        default_image_str = os.environ.get("FLYTE_INTERNAL_IMAGE", cls.find_image_for())
-        return default_image_str
+        return cls.find_image_for()
 
     @classmethod
     def find_image_for(
         cls, python_version: typing.Optional[PythonVersion] = None, flytekit_version: typing.Optional[str] = None
     ) -> str:
+        default_image_str = os.getenv("FLYTE_INTERNAL_IMAGE")
+        if default_image_str:
+            return default_image_str
+
         if python_version is None:
             python_version = PythonVersion((sys.version_info.major, sys.version_info.minor))
 

--- a/flytekit/configuration/default_images.py
+++ b/flytekit/configuration/default_images.py
@@ -4,6 +4,8 @@ import sys
 import typing
 from contextlib import suppress
 
+from flytekit.core.constants import FLYTE_INTERNAL_IMAGE
+
 
 class PythonVersion(enum.Enum):
     PYTHON_3_8 = (3, 8)
@@ -41,7 +43,7 @@ class DefaultImages(object):
     def find_image_for(
         cls, python_version: typing.Optional[PythonVersion] = None, flytekit_version: typing.Optional[str] = None
     ) -> str:
-        default_image_str = os.getenv("FLYTE_INTERNAL_IMAGE")
+        default_image_str = os.getenv(FLYTE_INTERNAL_IMAGE)
         if default_image_str:
             return default_image_str
 

--- a/flytekit/core/constants.py
+++ b/flytekit/core/constants.py
@@ -9,3 +9,6 @@ GLOBAL_INPUT_NODE_ID = ""
 
 START_NODE_ID = "start-node"
 END_NODE_ID = "end-node"
+
+# To override the default container image or the default base image in ImageSpec, set this environment variable.
+FLYTE_INTERNAL_IMAGE = "FLYTE_INTERNAL_IMAGE"

--- a/flytekit/core/constants.py
+++ b/flytekit/core/constants.py
@@ -10,5 +10,5 @@ GLOBAL_INPUT_NODE_ID = ""
 START_NODE_ID = "start-node"
 END_NODE_ID = "end-node"
 
-# To override the default container image or the default base image in ImageSpec, set this environment variable.
+# If set this environment variable overrides the default container image and the default base image in ImageSpec.
 FLYTE_INTERNAL_IMAGE = "FLYTE_INTERNAL_IMAGE"

--- a/flytekit/core/constants.py
+++ b/flytekit/core/constants.py
@@ -11,4 +11,4 @@ START_NODE_ID = "start-node"
 END_NODE_ID = "end-node"
 
 # If set this environment variable overrides the default container image and the default base image in ImageSpec.
-FLYTE_INTERNAL_IMAGE = "FLYTE_INTERNAL_IMAGE"
+FLYTE_INTERNAL_IMAGE_ENV_VAR = "FLYTE_INTERNAL_IMAGE"

--- a/tests/flytekit/unit/configuration/test_image_config.py
+++ b/tests/flytekit/unit/configuration/test_image_config.py
@@ -8,6 +8,7 @@ import pytest
 import flytekit
 from flytekit.configuration import ImageConfig
 from flytekit.configuration.default_images import DefaultImages, PythonVersion
+from flytekit.core.constants import FLYTE_INTERNAL_IMAGE
 
 
 @pytest.mark.parametrize(
@@ -39,7 +40,7 @@ def test_image_config_auto(monkeypatch):
     version_str = f"{sys.version_info.major}.{sys.version_info.minor}"
     assert x.images[0].full == f"cr.flyte.org/flyteorg/flytekit:py{version_str}-latest"
 
-    monkeypatch.setenv("FLYTE_INTERNAL_IMAGE", "test")
+    monkeypatch.setenv(FLYTE_INTERNAL_IMAGE, "test")
     assert DefaultImages.find_image_for() == "test"
 
 

--- a/tests/flytekit/unit/configuration/test_image_config.py
+++ b/tests/flytekit/unit/configuration/test_image_config.py
@@ -8,7 +8,7 @@ import pytest
 import flytekit
 from flytekit.configuration import ImageConfig
 from flytekit.configuration.default_images import DefaultImages, PythonVersion
-from flytekit.core.constants import FLYTE_INTERNAL_IMAGE
+from flytekit.core.constants import FLYTE_INTERNAL_IMAGE_ENV_VAR
 
 
 @pytest.mark.parametrize(
@@ -40,7 +40,7 @@ def test_image_config_auto(monkeypatch):
     version_str = f"{sys.version_info.major}.{sys.version_info.minor}"
     assert x.images[0].full == f"cr.flyte.org/flyteorg/flytekit:py{version_str}-latest"
 
-    monkeypatch.setenv(FLYTE_INTERNAL_IMAGE, "test")
+    monkeypatch.setenv(FLYTE_INTERNAL_IMAGE_ENV_VAR, "test")
     assert DefaultImages.find_image_for() == "test"
 
 

--- a/tests/flytekit/unit/configuration/test_image_config.py
+++ b/tests/flytekit/unit/configuration/test_image_config.py
@@ -33,11 +33,14 @@ def test_set_both(python_version_enum, flytekit_version, expected_image_string):
     assert DefaultImages.find_image_for(python_version_enum, flytekit_version) == expected_image_string
 
 
-def test_image_config_auto():
+def test_image_config_auto(monkeypatch):
     x = ImageConfig.auto_default_image()
     assert x.images[0].name == "default"
     version_str = f"{sys.version_info.major}.{sys.version_info.minor}"
     assert x.images[0].full == f"cr.flyte.org/flyteorg/flytekit:py{version_str}-latest"
+
+    monkeypatch.setenv("FLYTE_INTERNAL_IMAGE", "test")
+    assert DefaultImages.find_image_for() == "test"
 
 
 def test_image_from_flytectl_config():


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
When unionai is installed, it will ignore `FLYTE_INTERNAL_IMAGE`, and always use the default [flytekit image](https://github.com/flyteorg/flytekit/blob/739d379029a12428171bab601f7f7f61ef86ed43/flytekit/configuration/default_images.py#L21-L27).

That's because flytekit will call `get_plugin().get_default_image()`, and then `DefaultImages.find_image_for()`. Thus, it skip the FLYTE_INTERNAL_IMAGE.

## What changes were proposed in this pull request?
Move `os.getenv("FLYTE_INTERNAL_IMAGE")` to `find_image_for()`

## How was this patch tested?
unit test

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
