### PR TITLE
Add filter support to recent_executions

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -576,12 +576,14 @@ class FlyteRemote(object):
         project: typing.Optional[str] = None,
         domain: typing.Optional[str] = None,
         limit: typing.Optional[int] = 100,
+        filters: typing.Optional[typing.List[filter_models.Filter]] = None,
     ) -> typing.List[FlyteWorkflowExecution]:
         # Ignore token for now
         exec_models, _ = self.client.list_executions_paginated(
             project or self.default_project,
             domain or self.default_domain,
             limit,
+            filters=filters,
             sort_by=MOST_RECENT_FIRST,
         )
         return [FlyteWorkflowExecution.promote_from_model(e) for e in exec_models]


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Users can't specify `filter` when listing executions

## What changes were proposed in this pull request?
Add filter arg to recent_executions

## How was this patch tested?
flytekit remote

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
