### PR TITLE
Fix flaky test_initialise_azure_file_provider_with_default_credential

### DIFF
--- a/tests/flytekit/unit/core/test_data_persistence.py
+++ b/tests/flytekit/unit/core/test_data_persistence.py
@@ -165,8 +165,14 @@ def test_initialise_azure_file_provider_with_service_principal():
         assert fp.get_filesystem().tenant_id == "tenantid"
 
 
-@mock.patch.dict(os.environ, {"FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname", "AZURE_STORAGE_ANON": "false"})
 def test_initialise_azure_file_provider_with_default_credential():
-    fp = FileAccessProvider("/tmp", "abfs://container/path/within/container")
-    assert fp.get_filesystem().account_name == "accountname"
-    assert isinstance(fp.get_filesystem().sync_credential, DefaultAzureCredential)
+    with mock.patch.dict(
+            os.environ,
+            {
+                "FLYTE_AZURE_STORAGE_ACCOUNT_NAME": "accountname",
+                "AZURE_STORAGE_ANON": "false",
+            },
+    ):
+        fp = FileAccessProvider("/tmp", "abfs://container/path/within/container")
+        assert fp.get_filesystem().account_name == "accountname"
+        assert isinstance(fp.get_filesystem().sync_credential, DefaultAzureCredential)


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
This test is flaky. Seems like `os.env` was overridden by other tests

> The @mock.patch.dict decorator patches the dictionary in place, while the with @mock.patch.dict decorator creates a temporary copy of the dictionary and patches that.

## What changes were proposed in this pull request?
Use `with mock.patch.dict` instead

## How was this patch tested?
unit test

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
