### PR TITLE
refactor(core): Improve dataclass attribute serialization

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -591,10 +591,10 @@ class DataclassTransformer(TypeTransformer[object]):
             else:
                 return python_val
         else:
-            for v in dataclasses.fields(python_type):
-                val = python_val.__getattribute__(v.name)
-                field_type = v.type
-                python_val.__setattr__(v.name, self._serialize_flyte_type(val, field_type))
+            dataclass_attributes = typing.get_type_hints(python_type)
+            for n, t in dataclass_attributes.items():
+                val = python_val.__getattribute__(n)
+                python_val.__setattr__(n, self._serialize_flyte_type(val, t))
             return python_val
 
     def _deserialize_flyte_type(self, python_val: T, expected_python_type: Type) -> Optional[T]:

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -930,10 +930,10 @@ def test_dataclass_with_postponed_annotation():
     tf = DataclassTransformer()
     t = tf.get_literal_type(Data)
     assert t.simple == SimpleType.STRUCT
-    with tempfile.NamedTemporaryFile() as fp:
-        fp.write(b'Hello world!')
+    with tempfile.NamedTemporaryFile() as f:
+        f.write(b'Hello world!')
 
-        pv = Data(a=1, f=FlyteFile(fp.name))
+        pv = Data(a=1, f=FlyteFile(f.name))
         tf.to_literal(ctx, pv, Data, t)
 
 

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -920,6 +920,23 @@ def test_dataclass_int_preserving():
     assert ot == o
 
 
+def test_dataclass_with_postponed_annotation():
+    @dataclass
+    class Data:
+        a: int
+        f: "FlyteFile"
+
+    ctx = FlyteContext.current_context()
+    tf = DataclassTransformer()
+    t = tf.get_literal_type(Data)
+    assert t.simple == SimpleType.STRUCT
+    with tempfile.NamedTemporaryFile() as fp:
+        fp.write(b'Hello world!')
+
+        pv = Data(a=1, f=FlyteFile(fp.name))
+        tf.to_literal(ctx, pv, Data, t)
+
+
 @mock.patch("flytekit.core.data_persistence.FileAccessProvider.put_data")
 def test_optional_flytefile_in_dataclass(mock_upload_dir):
     mock_upload_dir.return_value = True

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -930,10 +930,12 @@ def test_dataclass_with_postponed_annotation():
     tf = DataclassTransformer()
     t = tf.get_literal_type(Data)
     assert t.simple == SimpleType.STRUCT
-    with tempfile.NamedTemporaryFile() as f:
-        f.write(b'Hello world!')
+    with tempfile.TemporaryDirectory() as tmp:
+        test_file = os.path.join(tmp, "abc.txt")
+        with open(test_file, "w") as f:
+            f.write("123")
 
-        pv = Data(a=1, f=FlyteFile(f.name))
+        pv = Data(a=1, f=FlyteFile(test_file))
         tf.to_literal(ctx, pv, Data, t)
 
 


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
The Flytefile is not uploaded to S3 when having that ​​`from ­­­future­­­ import annotations`​​ import inside the file. 

That's because `dataclasses.fields(python_type)[0].type` will return a string ('flytefile') instead of the actual type when postponed annotations is enabled.

## What changes were proposed in this pull request?
Use `typing.get_type_hints` to explicitly get the type from dataclass.

## How was this patch tested?
remote cluster

### Setup process

```python
from __future__ import annotations
from flytekit import task, workflow, ImageSpec
from flytekit.types.file import FlyteFile
from dataclasses import dataclass


new_flytekit = "git+https://github.com/flyteorg/flytekit.git@c5e6cefbc99f8db1190a87c10d921445f3e7b7d1"

custom_image = ImageSpec(
    registry="ghcr.io/flyteorg",
    packages=[new_flytekit],
    apt_packages=["git"],
)

@dataclass
class DebugOutput:
    file: FlyteFile


def get_file_test() -> FlyteFile:
    local_path = "file.txt"
    f = open(local_path, "a")
    f.write("1")
    f.close()
    return FlyteFile(local_path)


@task(container_image=custom_image)
def debug() -> DebugOutput:
    file = get_file_test()
    return DebugOutput(file=file)


@workflow
def wf() -> DebugOutput:
    return debug()


if __name__ == '__main__':
    wf()
```

```python
from __future__ import annotations
from flytekit import task, workflow, ImageSpec
from flytekit.types.file import FlyteFile
from dataclasses import dataclass


new_flytekit = "git+https://github.com/flyteorg/flytekit.git@c5e6cefbc99f8db1190a87c10d921445f3e7b7d1"

custom_image = ImageSpec(
    registry="ghcr.io/flyteorg",
    packages=[new_flytekit],
    apt_packages=["git"],
)

@dataclass
class DebugOutput:
    file: "FlyteFile"


def get_file_test() -> FlyteFile:
    local_path = "file.txt"
    f = open(local_path, "a")
    f.write("1")
    f.close()
    return FlyteFile(local_path)


@task(container_image=custom_image)
def debug() -> DebugOutput:
    file = get_file_test()
    return DebugOutput(file=file)


@workflow
def wf() -> DebugOutput:
    return debug()


if __name__ == '__main__':
    wf()
```

### Screenshots
<img width="1899" alt="Screenshot 2024-06-25 at 3 06 12 AM" src="https://github.com/flyteorg/flytekit/assets/37936015/7c6500ac-1c54-417f-9173-fe47a2287d01">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
