### PR TITLE
Add another Rust remote client that directly utilizes the `flyteidl-rust` Python bindings.

### DIFF
--- a/flytekit/clis/sdk_in_container/helpers.py
+++ b/flytekit/clis/sdk_in_container/helpers.py
@@ -6,7 +6,7 @@ import rich_click as click
 from flytekit.clis.sdk_in_container.constants import CTX_CONFIG_FILE
 from flytekit.configuration import ImageConfig
 from flytekit.configuration.plugin import get_plugin
-from flytekit.remote.remote import FlyteRemote
+from flytekit.remote.remote_rs import FlyteRemote
 
 FLYTE_REMOTE_INSTANCE_KEY = "flyte_remote"
 

--- a/flytekit/configuration/plugin.py
+++ b/flytekit/configuration/plugin.py
@@ -25,9 +25,7 @@ from importlib_metadata import entry_points
 
 from flytekit.configuration import Config, get_config_file
 from flytekit.loggers import logger
-
 from flytekit.remote.remote_rs import FlyteRemote
-
 
 
 @runtime_checkable

--- a/flytekit/configuration/plugin.py
+++ b/flytekit/configuration/plugin.py
@@ -25,7 +25,9 @@ from importlib_metadata import entry_points
 
 from flytekit.configuration import Config, get_config_file
 from flytekit.loggers import logger
-from flytekit.remote import FlyteRemote
+
+from flytekit.remote.remote_rs import FlyteRemote
+
 
 
 @runtime_checkable

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -41,8 +41,6 @@ from typing import (
     cast,
 )
 
-# from flyteidl.core import artifact_id_pb2 as art_id
-# from flyteidl.core import tasks_pb2
 import flyteidl_rust as flyteidl
 
 from flytekit.configuration import LocalConfig, SerializationSettings
@@ -134,7 +132,7 @@ class TaskMetadata(object):
     timeout: Optional[Union[datetime.timedelta, int]] = None
     pod_template_name: Optional[str] = None
     generates_deck: Optional[bool] = False
-    tags: Optional[Dict[str, str]] = field(default_factory=dict)
+    tags: Optional[Dict[str, str]] = field(default_factory=dict)  # type: ignore
 
     def __post_init__(self):
         if self.timeout:
@@ -166,9 +164,9 @@ class TaskMetadata(object):
             runtime=flyteidl.core.RuntimeMetadata(int(flyteidl.core.RuntimeType.FlyteSdk), __version__, "python"),
             timeout=flyteidl.wkt.Duration(
                 seconds=(
-                    self.timeout.days * 24 * 60 * 60 + self.timeout.seconds + self.timeout.microseconds // 1_000_000
+                    self.timeout.days * 24 * 60 * 60 + self.timeout.seconds + self.timeout.microseconds // 1_000_000  # type: ignore
                 ),
-                nanos=(self.timeout.microseconds % 1_000_000 * 1_000),
+                nanos=(self.timeout.microseconds % 1_000_000 * 1_000),  # type: ignore
             )
             if not isinstance(self.timeout, int)
             else flyteidl.wkt.Duration(seconds=int(self.timeout), nanos=0),
@@ -293,7 +291,7 @@ class Task(object):
             kwargs = translate_inputs_to_literals(
                 ctx,
                 incoming_values=kwargs,
-                flyte_interface_types=dict(self.interface.inputs.variables),
+                flyte_interface_types=self.interface.inputs.variables,
                 native_types=self.get_input_types(),  # type: ignore
             )
         except TypeTransformerFailedError as exc:
@@ -349,7 +347,7 @@ class Task(object):
         # TODO maybe this is the part that should be done for local execution, we pass the outputs to some special
         #    location, otherwise we dont really need to right? The higher level execute could just handle literalMap
         # After running, we again have to wrap the outputs, if any, back into Promise objects
-        output_names = list(dict(self.interface.outputs.variables).keys())  # type: ignore
+        output_names = list(self.interface.outputs.variables.keys())  # type: ignore
         if len(output_names) != len(outputs_literals):
             # Length check, clean up exception
             raise AssertionError(f"Length difference {len(output_names)} {len(outputs_literals)}")
@@ -639,7 +637,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                                 metadata[md_key] = md_val
                             logger.info(f"Adding {om.additional_items} additional metadata items {metadata} for {k}")
                         if om.dynamic_partitions or om.time_partition:
-                            a = art_id.ArtifactID(
+                            a = art_id.ArtifactID(  # type: ignore
                                 partitions=idl_partitions_from_dict(om.dynamic_partitions),
                                 time_partition=idl_time_partition_from_datetime(
                                     om.time_partition, om.artifact.time_partition_granularity

--- a/flytekit/core/local_cache.py
+++ b/flytekit/core/local_cache.py
@@ -45,7 +45,8 @@ def _calculate_cache_key(
     # Generate a stable representation of the underlying protobuf by passing `deterministic=True` to the
     # protobuf library.
     hashed_inputs = (
-        flyteidl.core.LiteralMap(literal_map_overridden).to_flyte_idl().SerializeToString(deterministic=True)
+        # TODO: we don't have `SerializeToString()` at present.
+        flyteidl.core.LiteralMap(literal_map_overridden).SerializeToString(deterministic=True)
     )
     # Use joblib to hash the string representation of the literal into a fixed length string
     return f"{task_name}-{cache_version}-{joblib.hash(hashed_inputs)}"

--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -4,7 +4,7 @@ import datetime
 import typing
 from typing import Any, List
 
-from flyteidl.core import tasks_pb2
+import flyteidl_rust as flyteidl
 
 from flytekit.core.resources import Resources, convert_resources_to_resource_model
 from flytekit.core.utils import _dnsify
@@ -64,7 +64,7 @@ class Node(object):
         self._aliases: _workflow_model.Alias = None
         self._outputs = None
         self._resources: typing.Optional[_resources_model] = None
-        self._extended_resources: typing.Optional[tasks_pb2.ExtendedResources] = None
+        self._extended_resources: typing.Optional[flyteidl.ExtendedResources] = None
         self._container_image: typing.Optional[str] = None
 
     def runs_before(self, other: Node):
@@ -199,7 +199,7 @@ class Node(object):
         if "accelerator" in kwargs:
             v = kwargs["accelerator"]
             assert_not_promise(v, "accelerator")
-            self._extended_resources = tasks_pb2.ExtendedResources(gpu_accelerator=v.to_flyte_idl())
+            self._extended_resources = flyteidl.ExtendedResources(gpu_accelerator=v.to_flyte_idl())
 
         if "cache" in kwargs:
             v = kwargs["cache"]

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -100,6 +100,7 @@ def translate_inputs_to_literals(
     return result
 
 
+# TODO: refactor to `flyteidl-rust`
 def resolve_attr_path_in_promise(p: Promise) -> Promise:
     """
     resolve_attr_path_in_promise resolves the attribute path in a promise and returns a new promise with the resolved value
@@ -688,7 +689,7 @@ def create_task_output(
 
     # These should be OrderedDicts so it should be safe to iterate over the keys.
     if entity_interface:
-        variables = [k for k in dict(entity_interface.outputs.variables).keys()]
+        variables = [k for k in dict(entity_interface.outputs.variables).keys()]  # type: ignore
 
     named_tuple_name = "DefaultNamedTupleOutput"
     if entity_interface and entity_interface.output_tuple_name:

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from enum import Enum
 from typing import Any, Coroutine, Dict, Hashable, List, Optional, Set, Tuple, Union, cast, get_args
 
+import flyteidl_rust as flyteidl
 from google.protobuf import struct_pb2 as _struct
 from typing_extensions import Protocol
 
@@ -46,9 +47,9 @@ from flytekit.models.types import SimpleType
 def translate_inputs_to_literals(
     ctx: FlyteContext,
     incoming_values: Dict[str, Any],
-    flyte_interface_types: Dict[str, _interface_models.Variable],
+    flyte_interface_types: Dict[str, flyteidl.core.Variable],
     native_types: Dict[str, type],
-) -> Dict[str, _literals_models.Literal]:
+) -> Dict[str, flyteidl.core.Literal]:
     """
     The point of this function is to extract out Literals from a collection of either Python native values (which would
     be converted into Flyte literals) or Promises (the literals in which would just get extracted).
@@ -687,7 +688,7 @@ def create_task_output(
 
     # These should be OrderedDicts so it should be safe to iterate over the keys.
     if entity_interface:
-        variables = [k for k in entity_interface.outputs.keys()]
+        variables = [k for k in dict(entity_interface.outputs.variables).keys()]
 
     named_tuple_name = "DefaultNamedTupleOutput"
     if entity_interface and entity_interface.output_tuple_name:
@@ -1215,7 +1216,6 @@ def flyte_entity_call_handler(
             raise AssertionError(
                 f"Received unexpected keyword argument '{k}' in function '{cast(SupportsNodeCreation, entity).name}'"
             )
-
     ctx = FlyteContextManager.current_context()
     if ctx.execution_state and (
         ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -5,7 +5,7 @@ import re
 from abc import ABC
 from typing import Callable, Dict, List, Optional, TypeVar, Union
 
-from flyteidl.core import tasks_pb2
+import flyteidl_rust as flyteidl
 
 from flytekit.configuration import ImageConfig, SerializationSettings
 from flytekit.core.base_task import PythonTask, TaskMetadata, TaskResolverMixin
@@ -182,14 +182,14 @@ class PythonAutoContainerTask(PythonTask[T], ABC, metaclass=FlyteTrackedABC):
                 self.container_image.source_root = settings.source_root
         return get_registerable_container_image(self.container_image, settings.image_config)
 
-    def get_container(self, settings: SerializationSettings) -> _task_model.Container:
+    def get_container(self, settings: SerializationSettings) -> flyteidl.Container:
         # if pod_template is not None, return None here but in get_k8s_pod, return pod_template merged with container
         if self.pod_template is not None:
             return None
         else:
             return self._get_container(settings)
 
-    def _get_container(self, settings: SerializationSettings) -> _task_model.Container:
+    def _get_container(self, settings: SerializationSettings) -> flyteidl.Container:
         env = {}
         for elem in (settings.env, self.environment):
             if elem:
@@ -227,14 +227,14 @@ class PythonAutoContainerTask(PythonTask[T], ABC, metaclass=FlyteTrackedABC):
             return {}
         return {_PRIMARY_CONTAINER_NAME_FIELD: self.pod_template.primary_container_name}
 
-    def get_extended_resources(self, settings: SerializationSettings) -> Optional[tasks_pb2.ExtendedResources]:
+    def get_extended_resources(self, settings: SerializationSettings) -> Optional[flyteidl.ExtendedResources]:
         """
         Returns the extended resources to allocate to the task on hosted Flyte.
         """
         if self.accelerator is None:
             return None
 
-        return tasks_pb2.ExtendedResources(gpu_accelerator=self.accelerator.to_flyte_idl())
+        return flyteidl.ExtendedResources(gpu_accelerator=self.accelerator.to_flyte_idl())
 
 
 class DefaultTaskResolver(TrackedInstance, TaskResolverMixin):

--- a/flytekit/core/reference_entity.py
+++ b/flytekit/core/reference_entity.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple, Type, Union
 
+import flyteidl_rust as flyteidl
+
 from flytekit.core.context_manager import BranchEvalMode, ExecutionState, FlyteContext
 from flytekit.core.interface import Interface, transform_interface_to_typed_interface
 from flytekit.core.promise import (
@@ -15,7 +17,6 @@ from flytekit.core.promise import (
 from flytekit.core.type_engine import TypeEngine
 from flytekit.exceptions import user as _user_exceptions
 from flytekit.loggers import logger
-from flytekit.models import interface as _interface_models
 from flytekit.models import literals as _literal_models
 from flytekit.models.core import identifier as _identifier_model
 from flytekit.models.core import workflow as _workflow_model
@@ -92,7 +93,7 @@ class ReferenceEntity(object):
         return self._native_interface
 
     @property
-    def interface(self) -> _interface_models.TypedInterface:
+    def interface(self) -> flyteidl.core.TypedInterface:
         return self._interface
 
     @property

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -305,7 +305,7 @@ class SimpleTransformer(TypeTransformer[T]):
 
     def guess_python_type(self, literal_type: flyteidl.core.LiteralType) -> Type[T]:
         # In order to compare literal types,
-        # Since we've add __repr__ magic fucntion for enum type to show as int string, we can use `int(str(literal_type.type))`.
+        # Since we've add __repr__ magic function for enum type to show as int string, we can use `int(str(literal_type.type))`.
         """rust
         #[pymethods]
         impl literal_type::Type {
@@ -2124,7 +2124,7 @@ def _register_default_type_transformers():
                 hash="",
                 metadata={},
             ),
-            # Origianl: `x.scalar.primitive.integer`
+            # Original: `x.scalar.primitive.integer`
             lambda x: x.value[0].value[0].value[0],
         )
     )
@@ -2161,7 +2161,7 @@ def _register_default_type_transformers():
                 hash="",
                 metadata={},
             ),
-            # Origianl: `x.scalar.primitive.boolean`
+            # Original: `x.scalar.primitive.boolean`
             lambda x: x.value[0].value[0].value[0],
         )
     )
@@ -2182,11 +2182,12 @@ def _register_default_type_transformers():
                 hash="",
                 metadata={},
             ),
-            # Origianl: `x.scalar.primitive.string`
+            # Original: `x.scalar.primitive.string`
             lambda x: x.value[0].value[0].value[0],
         )
     )
 
+    # TODO(WIP): refactor to `flyteidl-rust`
     # TypeEngine.register(
     #     SimpleTransformer(
     #         "datetime",
@@ -2359,11 +2360,11 @@ class LiteralsResolver(collections.UserDict):
             if attr in self._type_hints:
                 as_type = self._type_hints[attr]
             else:
-                if self.variable_map and attr in self.variable_map.variables:
+                if self.variable_map and attr in self.variable_map.variables:  # type: ignore
                     try:
-                        as_type = TypeEngine.guess_python_type(self.variable_map.variables[attr].type)
+                        as_type = TypeEngine.guess_python_type(self.variable_map.variables[attr].type)  # type: ignore
                     except ValueError as e:
-                        logger.error(f"Could not guess a type for Variable {self.variable_map.variables[attr]}")
+                        logger.error(f"Could not guess a type for Variable {self.variable_map.variables[attr]}")  # type: ignore
                         raise e
                 else:
                     raise ValueError("as_type argument not supplied and Variable map not specified in LiteralsResolver")

--- a/flytekit/core/utils.py
+++ b/flytekit/core/utils.py
@@ -18,6 +18,8 @@ from flytekit.loggers import logger
 if TYPE_CHECKING:
     from flytekit.models import task as task_models
 
+import flyteidl_rust as flyteidl
+
 
 def _dnsify(value: str) -> str:
     """
@@ -80,9 +82,6 @@ def _get_container_definition(
     gpu_request = gpu_request
     memory_limit = memory_limit
     memory_request = memory_request
-
-    # from flytekit.models import task as task_models
-    import flyteidl_rust as flyteidl
 
     # TODO: Use convert_resources_to_resource_model instead of manually fixing the resources.
     requests = []

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -8,6 +8,8 @@ from enum import Enum
 from functools import update_wrapper
 from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple, Type, Union, cast, overload
 
+import flyteidl_rust as flyteidl
+
 from flytekit.core import constants as _common_constants
 from flytekit.core import launch_plan as _annotated_launch_plan
 from flytekit.core.base_task import PythonTask, Task
@@ -44,7 +46,6 @@ from flytekit.core.type_engine import TypeEngine
 from flytekit.exceptions import scopes as exception_scopes
 from flytekit.exceptions.user import FlyteValidationException, FlyteValueException
 from flytekit.loggers import logger
-from flytekit.models import interface as _interface_models
 from flytekit.models import literals as _literal_models
 from flytekit.models.core import workflow as _workflow_model
 from flytekit.models.documentation import Description, Documentation
@@ -240,7 +241,7 @@ class WorkflowBase(object):
         return self._python_interface
 
     @property
-    def interface(self) -> _interface_models.TypedInterface:
+    def interface(self) -> flyteidl.TypedInterface:
         return self._interface
 
     @property

--- a/flytekit/interaction/string_literals.py
+++ b/flytekit/interaction/string_literals.py
@@ -1,62 +1,61 @@
-import base64
 import typing
 
-from google.protobuf.json_format import MessageToDict
+import flyteidl_rust as flyteidl
 
-from flytekit.models.literals import Literal, LiteralMap, Primitive, Scalar
+from flytekit.models.literals import Literal
 
 
-def primitive_to_string(primitive: Primitive) -> typing.Any:
+def primitive_to_string(primitive: flyteidl.core.Primitive) -> typing.Any:
     """
     This method is used to convert a primitive to a string representation.
     """
-    if primitive.integer is not None:
-        return primitive.integer
-    if primitive.float_value is not None:
-        return primitive.float_value
-    if primitive.boolean is not None:
-        return primitive.boolean
-    if primitive.string_value is not None:
-        return primitive.string_value
-    if primitive.datetime is not None:
-        return primitive.datetime.isoformat()
-    if primitive.duration is not None:
-        return primitive.duration.total_seconds()
+    # if primitive.integer is not None:
+    #     return primitive.integer
+    # if primitive.float_value is not None:
+    #     return primitive.float_value
+    # if primitive.boolean is not None:
+    #     return primitive.boolean
+    if isinstance(primitive.value, flyteidl.primitive.Value.StringValue):
+        return primitive.value
+    # if primitive.datetime is not None:
+    #     return primitive.datetime.isoformat()
+    # if primitive.duration is not None:
+    #     return primitive.duration.total_seconds()
     raise ValueError(f"Unknown primitive type {primitive}")
 
 
-def scalar_to_string(scalar: Scalar) -> typing.Any:
+def scalar_to_string(scalar: flyteidl.core.Scalar) -> typing.Any:
     """
     This method is used to convert a scalar to a string representation.
     """
-    if scalar.primitive:
-        return primitive_to_string(scalar.primitive)
-    if scalar.none_type:
-        return None
-    if scalar.error:
-        return scalar.error.message
-    if scalar.structured_dataset:
-        return scalar.structured_dataset.uri
-    if scalar.schema:
-        return scalar.schema.uri
-    if scalar.blob:
-        return scalar.blob.uri
-    if scalar.binary:
-        return base64.b64encode(scalar.binary.value)
-    if scalar.generic:
-        return MessageToDict(scalar.generic)
-    if scalar.union:
-        return literal_string_repr(scalar.union.value)
+    if scalar[0].value:
+        return primitive_to_string(scalar[0].value[0])
+    # if scalar.none_type:
+    #     return None
+    # if scalar.error:
+    #     return scalar.error.message
+    # if scalar.structured_dataset:
+    #     return scalar.structured_dataset.uri
+    # if scalar.schema:
+    #     return scalar.schema.uri
+    # if scalar.blob:
+    #     return scalar.blob.uri
+    # if scalar.binary:
+    #     return base64.b64encode(scalar.binary.value)
+    # if scalar.generic:
+    #     return MessageToDict(scalar.generic)
+    # if scalar.union:
+    #     return literal_string_repr(scalar.union.value)
     raise ValueError(f"Unknown scalar type {scalar}")
 
 
-def literal_string_repr(lit: Literal) -> typing.Any:
+def literal_string_repr(lit: flyteidl.core.Literal) -> typing.Any:
     """
     This method is used to convert a literal to a string representation. This is useful in places, where we need to
     use a shortened string representation of a literal, especially a FlyteFile, FlyteDirectory, or StructuredDataset.
     """
-    if lit.scalar:
-        return scalar_to_string(lit.scalar)
+    if lit.value:
+        return scalar_to_string(lit.value)
     if lit.collection:
         return [literal_string_repr(i) for i in lit.collection.literals]
     if lit.map:
@@ -64,11 +63,13 @@ def literal_string_repr(lit: Literal) -> typing.Any:
     raise ValueError(f"Unknown literal type {lit}")
 
 
-def literal_map_string_repr(lm: typing.Union[LiteralMap, typing.Dict[str, Literal]]) -> typing.Dict[str, typing.Any]:
+def literal_map_string_repr(
+    lm: typing.Union[flyteidl.core.LiteralMap, typing.Dict[str, Literal]],
+) -> typing.Dict[str, typing.Any]:
     """
     This method is used to convert a literal map to a string representation.
     """
     lmd = lm
-    if isinstance(lm, LiteralMap):
+    if isinstance(lm, flyteidl.core.LiteralMap):
         lmd = lm.literals
     return {k: literal_string_repr(v) for k, v in lmd.items()}

--- a/flytekit/interaction/string_literals.py
+++ b/flytekit/interaction/string_literals.py
@@ -5,14 +5,15 @@ import flyteidl_rust as flyteidl
 from flytekit.models.literals import Literal
 
 
+# TODO(WIP):
 def primitive_to_string(primitive: flyteidl.core.Primitive) -> typing.Any:
     """
     This method is used to convert a primitive to a string representation.
     """
-    # if primitive.integer is not None:
-    #     return primitive.integer
-    # if primitive.float_value is not None:
-    #     return primitive.float_value
+    if isinstance(primitive.value, flyteidl.primitive.Value.Integer):
+        return primitive.integer
+    if isinstance(primitive.value, flyteidl.primitive.Value.FloatValue):
+        return primitive.value
     # if primitive.boolean is not None:
     #     return primitive.boolean
     if isinstance(primitive.value, flyteidl.primitive.Value.StringValue):
@@ -24,6 +25,7 @@ def primitive_to_string(primitive: flyteidl.core.Primitive) -> typing.Any:
     raise ValueError(f"Unknown primitive type {primitive}")
 
 
+# TODO(WIP):
 def scalar_to_string(scalar: flyteidl.core.Scalar) -> typing.Any:
     """
     This method is used to convert a scalar to a string representation.

--- a/flytekit/remote/entities.py
+++ b/flytekit/remote/entities.py
@@ -52,6 +52,7 @@ class FlyteTask(hash_mixin.HashOnReferenceMixin, RemoteEntity):
         config=None,
         should_register: bool = False,
     ):
+        # TODO(WIP): use PyO3 function signature to make flyteidl.admin.TaskSpec accept *args and **kwargs.
         # super(FlyteTask, self).__init__(
         self.template = flyteidl.core.TaskTemplate(
             id=id,
@@ -202,7 +203,7 @@ class FlyteTaskNode:
     """A class encapsulating a task that a Flyte node needs to execute."""
 
     def __init__(self, flyte_task: FlyteTask):
-        # super().__init__(None)
+        # super(FlyteTaskNode, self).__init__(None)
         self._flyte_task = flyte_task
 
     @property
@@ -221,14 +222,6 @@ class FlyteTaskNode:
         and returns the hydrated Flytekit object for it by fetching it with the FlyteTask control plane.
         """
         return cls(flyte_task=task)
-
-    # @classmethod
-    # def promote_from_rust_binding(cls, task: FlyteTask) -> FlyteTaskNode:
-    #     """
-    #     Takes the idl wrapper for a TaskNode,
-    #     and returns the hydrated Flytekit object for it by fetching it with the FlyteTask control plane.
-    #     """
-    #     return cls(flyte_task=task)
 
 
 class FlyteWorkflowNode(_workflow_model.WorkflowNode):
@@ -413,6 +406,7 @@ class FlyteNode(_hash_mixin.HashOnReferenceMixin):
         else:
             self._flyte_entity = branch_node or gate_node or array_node
 
+        # TODO(WIP): use PyO3 function signature to make flyteidl.core.Node accept *args and **kwargs.
         # super(FlyteNode, self).__init__(
         self.id = id
         self.metadata = metadata

--- a/flytekit/remote/executions.py
+++ b/flytekit/remote/executions.py
@@ -13,7 +13,6 @@ from flytekit.models import node_execution as node_execution_models
 from flytekit.models.interface import TypedInterface
 from flytekit.remote.entities import FlyteTask, FlyteWorkflow
 
-import flyteidl_rust as flyteidl
 
 class RemoteExecutionBase(object):
     def __init__(self, *args, **kwargs):
@@ -53,6 +52,7 @@ class FlyteTaskExecution(RemoteExecutionBase, flyteidl.admin.TaskExecution):
     """A class encapsulating a task execution being run on a Flyte remote backend."""
 
     def __init__(self, *args, **kwargs):
+        # TODO(WIP): use PyO3 function signature to make flyteidl.admin.TaskExecution accept *args and **kwargs.
         # super(RemoteExecutionBase).__init__(*args, **kwargs)
         self._inputs = None
         self._outputs = None
@@ -69,11 +69,6 @@ class FlyteTaskExecution(RemoteExecutionBase, flyteidl.admin.TaskExecution):
     @property
     def is_done(self) -> bool:
         """Whether or not the execution is complete."""
-        # return self.closure.phase in {
-        #     core_execution_models.TaskExecutionPhase.ABORTED,
-        #     core_execution_models.TaskExecutionPhase.FAILED,
-        #     core_execution_models.TaskExecutionPhase.SUCCEEDED,
-        # }
         return int(self.closure.phase) in {
             int(flyteidl.task_execution.Phase.Aborted),
             int(flyteidl.task_execution.Phase.Failed),
@@ -117,12 +112,8 @@ class FlyteWorkflowExecution(RemoteExecutionBase, flyteidl.admin.Execution):
     """A class encapsulating a workflow execution being run on a Flyte remote backend."""
 
     def __init__(self, *args, **kwargs):
+        # TODO(WIP): use PyO3 function signature to make flyteidl.admin.Execution accept *args and **kwargs.
         # super(FlyteWorkflowExecution, self).__init__(*args, **kwargs)
-        # id = id,
-        # spec = spec,
-        # closure = closure,
-
-        # self.closure = kwargs['closure']
 
         self._node_executions = None
         self._flyte_workflow: Optional[FlyteWorkflow] = None
@@ -169,14 +160,6 @@ class FlyteWorkflowExecution(RemoteExecutionBase, flyteidl.admin.Execution):
             id=base_model.id,
             spec=base_model.spec,
         )
-    
-    @classmethod
-    def promote_from_rust_binding(cls, base_model: flyteidl.Execution) -> "FlyteWorkflowExecution":
-        return cls(
-            closure=base_model.closure,
-            id=base_model.id,
-            spec=base_model.spec,
-        )
 
     @classmethod
     def promote_from_rust_binding(cls, base_model: flyteidl.admin.Execution) -> "FlyteWorkflowExecution":
@@ -191,6 +174,7 @@ class FlyteNodeExecution(RemoteExecutionBase, flyteidl.admin.NodeExecution):
     """A class encapsulating a node execution being run on a Flyte remote backend."""
 
     def __init__(self, *args, **kwargs):
+        # TODO(WIP): use PyO3 function signature to make flyteidl.admin.TaskSpec accept *args and **kwargs.
         # super(FlyteNodeExecution, self).__init__(*args, **kwargs)
         self._task_executions = None
         self._workflow_executions = []

--- a/flytekit/remote/interface.py
+++ b/flytekit/remote/interface.py
@@ -1,9 +1,17 @@
-from flytekit.models import interface as _interface_models
+import flyteidl_rust as flyteidl
 
 
-class TypedInterface(_interface_models.TypedInterface):
+class TypedInterface(flyteidl.core.TypedInterface):
     @classmethod
     def promote_from_model(cls, model):
+        """
+        :param flytekit.models.interface.TypedInterface model:
+        :rtype: TypedInterface
+        """
+        return cls(model.inputs, model.outputs)
+
+    @classmethod
+    def promote_from_rust_binding(cls, model):
         """
         :param flytekit.models.interface.TypedInterface model:
         :rtype: TypedInterface

--- a/flytekit/remote/remote_fs.py
+++ b/flytekit/remote/remote_fs.py
@@ -19,7 +19,8 @@ from flytekit.loggers import logger
 from flytekit.tools.script_mode import hash_file
 
 if typing.TYPE_CHECKING:
-    from flytekit.remote.remote import FlyteRemote
+    # from flytekit.remote.remote import FlyteRemote
+    from flytekit.remote.remote_rs import FlyteRemote
 
 _DEFAULT_CALLBACK = NoOpCallback()
 _PREFIX_KEY = "upload_prefix"

--- a/flytekit/remote/remote_rs.py
+++ b/flytekit/remote/remote_rs.py
@@ -1,0 +1,1531 @@
+"""
+This module provides the ``FlyteRemote`` object, which is the end-user's main starting point for interacting
+with a Flyte backend in an interactive and programmatic way. This of this experience as kind of like the web UI
+but in Python object form.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import configparser
+import functools
+import hashlib
+import os
+import pathlib
+import tempfile
+import time
+import typing
+import uuid
+from base64 import b64encode
+from collections import OrderedDict
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Dict
+
+import flyteidl_rust as flyteidl
+import cloudpickle
+import fsspec
+import requests
+
+from flytekit import ImageSpec
+from flytekit.clients.helpers import iterate_node_executions, iterate_task_executions
+from flytekit.configuration import Config, FastSerializationSettings, ImageConfig, SerializationSettings
+from flytekit.core import constants, utils
+from flytekit.core.artifact import Artifact
+from flytekit.core.base_task import PythonTask
+from flytekit.core.context_manager import FlyteContext, FlyteContextManager
+from flytekit.core.data_persistence import FileAccessProvider
+from flytekit.core.launch_plan import LaunchPlan, ReferenceLaunchPlan
+from flytekit.core.python_auto_container import PythonAutoContainerTask
+from flytekit.core.reference_entity import ReferenceSpec
+from flytekit.core.task import ReferenceTask
+from flytekit.core.tracker import extract_task_module
+from flytekit.core.type_engine import LiteralsResolver, TypeEngine
+from flytekit.core.workflow import ReferenceWorkflow, WorkflowBase
+from flytekit.exceptions import user as user_exceptions
+from flytekit.exceptions.user import (
+    FlyteEntityAlreadyExistsException,
+    FlyteValueException,
+)
+from flytekit.loggers import logger
+from flytekit.models import common as common_models
+from flytekit.models import launch_plan as launch_plan_models
+from flytekit.models.admin import common as admin_common_models
+from flytekit.models.admin import workflow as admin_workflow_models
+from flytekit.models.admin.common import Sort
+from flytekit.models.core import workflow as workflow_model
+from flytekit.models.core.identifier import Identifier, ResourceType
+from flytekit.models.execution import (
+    NodeExecutionGetDataResponse,
+    NotificationList,
+    WorkflowExecutionGetDataResponse,
+)
+from flytekit.models.launch_plan import LaunchPlanState
+from flytekit.remote.entities import FlyteLaunchPlan, FlyteNode, FlyteTask, FlyteWorkflow
+from flytekit.remote.executions import FlyteNodeExecution, FlyteTaskExecution, FlyteWorkflowExecution
+from flytekit.remote.interface import TypedInterface
+from flytekit.remote.remote_callable import RemoteEntity
+from flytekit.remote.remote_fs import get_flyte_fs
+from flytekit.tools.fast_registration import FastPackageOptions, fast_package
+from flytekit.tools.script_mode import _find_project_root, compress_scripts, hash_file
+from flytekit.tools.translator import (
+    FlyteControlPlaneEntity,
+    FlyteLocalEntity,
+    Options,
+    get_serializable,
+    get_serializable_launch_plan,
+)
+
+if typing.TYPE_CHECKING:
+    try:
+        from IPython.core.display import HTML
+    except ImportError:
+        ...
+
+ExecutionDataResponse = typing.Union[WorkflowExecutionGetDataResponse, NodeExecutionGetDataResponse]
+
+MOST_RECENT_FIRST = admin_common_models.Sort("created_at", admin_common_models.Sort.Direction.DESCENDING)
+
+
+class RegistrationSkipped(Exception):
+    """
+    RegistrationSkipped error is raised when trying to register an entity that is not registrable.
+    """
+
+    pass
+
+
+@dataclass
+class ResolvedIdentifiers:
+    project: str
+    domain: str
+    name: str
+    version: str
+
+
+def _get_latest_version(list_entities_method: typing.Callable, project: str, domain: str, name: str):
+    named_entity = common_models.NamedEntityIdentifier(project, domain, name)
+    entity_list, _ = list_entities_method(
+        named_entity,
+        limit=1,
+        sort_by=Sort("created_at", Sort.Direction.DESCENDING),
+    )
+    admin_entity = None if not entity_list else entity_list[0]
+    if not admin_entity:
+        raise user_exceptions.FlyteEntityNotExistException("Named entity {} not found".format(named_entity))
+    return admin_entity.id.version
+
+
+def _get_entity_identifier(
+    # list_entities_method: typing.Callable,
+    resource_type: int,  # from flytekit.models.core.identifier.ResourceType
+    project: str,
+    domain: str,
+    name: str,
+    version: typing.Optional[str] = None,
+    org: str = "",
+):
+    return flyteidl.core.Identifier(
+        resource_type,
+        project,
+        domain,
+        name,
+        version if version is not None else "",  # _get_latest_version(list_entities_method, project, domain, name),
+        org,
+    )
+
+
+def _get_git_repo_url(source_path):
+    """
+    Get git repo URL from remote.origin.url
+    """
+    try:
+        git_config = source_path / ".git" / "config"
+        if not git_config.exists():
+            raise ValueError(f"{source_path} is not a git repo")
+
+        config = configparser.ConfigParser()
+        config.read(git_config)
+        url = config['remote "origin"']["url"]
+
+        if url.startswith("git@"):
+            # url format: git@github.com:flytekit/flytekit.git
+            prefix_len, suffix_len = len("git@"), len(".git")
+            return url[prefix_len:-suffix_len].replace(":", "/")
+        elif url.startswith("https://"):
+            # url format: https://github.com/flytekit/flytekit
+            prefix_len = len("https://")
+            return url[prefix_len:]
+        elif url.startswith("http://"):
+            # url format: http://github.com/flytekit/flytekit
+            prefix_len = len("http://")
+            return url[prefix_len:]
+        else:
+            raise ValueError("Unable to parse url")
+
+    except Exception as e:
+        logger.debug(str(e))
+        return ""
+
+
+class FlyteRemote(object):
+    def __init__(
+        self,
+        config: Config,
+        default_project: typing.Optional[str] = None,
+        default_domain: typing.Optional[str] = None,
+        enable_rust: typing.Optional[bool] = False,
+        data_upload_location: str = "flyte://my-s3-bucket/",
+        **kwargs,
+    ):
+        if config is None or config.platform is None or config.platform.endpoint is None:
+            raise user_exceptions.FlyteAssertion("Flyte endpoint should be provided.")
+        if data_upload_location is None:
+            data_upload_location = FlyteContext.current_context().file_access.raw_output_prefix
+
+        self._kwargs = kwargs
+        self._client_initialized = False
+        if config.platform.insecure:
+            # currently only support insecure channel
+            self._admin_stub = flyteidl.AdminStub(f"http://{config.platform.endpoint}")
+            self._dataproxy_stub = flyteidl.DataProxyStub(f"http://{config.platform.endpoint}")
+
+        #
+
+        self._config = config
+
+        self._default_project = default_project
+        self._default_domain = default_domain
+
+        fsspec.register_implementation("flyte", get_flyte_fs(remote=self), clobber=True)
+
+        self._file_access = FileAccessProvider(
+            local_sandbox_dir=os.path.join(config.local_sandbox_path, "control_plane_metadata"),
+            raw_output_prefix=data_upload_location,
+            data_config=config.data_config,
+        )
+        self._ctx = FlyteContextManager.current_context().with_file_access(self._file_access).build()
+
+    @property
+    def context(self) -> FlyteContext:
+        return self._ctx
+
+    # @property
+    # def client(self) -> flyteidl.FlyteClient:
+    #     """Return a SynchronousFlyteClient for additional operations."""
+    #     if not self._client_initialized:
+    #         if self._config.platform.insecure:
+    #             self._client = flyteidl.FlyteClient(f"http://{self._config.platform.endpoint}")
+    #             self._client_initialized = True
+    #     return self._client
+
+    @property
+    def dataproxy_client(self) -> flyteidl.DataProxyClient:
+        """Return a SynchronousFlyteClient for additional operations."""
+        if not self._dataproxy_client_initialized:
+            if self._config.platform.insecure:
+                self._dataproxy_client = flyteidl.DataProxyClient(f"http://{self._config.platform.endpoint}")
+                self._dataproxy_client_initialized = True
+        return self._dataproxy_client
+
+    @property
+    def default_project(self) -> str:
+        """Default project to use when fetching or executing flyte entities."""
+        return self._default_project
+
+    @property
+    def default_domain(self) -> str:
+        """Default project to use when fetching or executing flyte entities."""
+        return self._default_domain
+
+    @property
+    def config(self) -> Config:
+        """Image config."""
+        return self._config
+
+    @property
+    def file_access(self) -> FileAccessProvider:
+        """File access provider to use for offloading non-literal inputs/outputs."""
+        return self._file_access
+
+    def remote_context(self):
+        """Context manager with remote-specific configuration."""
+        return FlyteContextManager.with_context(
+            FlyteContextManager.current_context().with_file_access(self.file_access)
+        )
+
+    def fetch_task(
+        self, project: str = None, domain: str = None, name: str = None, version: str = None, org: str = None
+    ) -> FlyteTask:
+        """Fetch a task entity from flyte admin.
+
+        :param project: fetch entity from this project. If None, uses the default_project attribute.
+        :param domain: fetch entity from this domain. If None, uses the default_domain attribute.
+        :param name: fetch entity with matching name.
+        :param version: fetch entity with matching version. If None, gets the latest version of the entity.
+        :returns: :class:`~flytekit.remote.tasks.task.FlyteTask`
+
+        :raises: FlyteAssertion if name is None
+        """
+        if name is None:
+            raise user_exceptions.FlyteAssertion("the 'name' argument must be specified.")
+        task_id = _get_entity_identifier(
+            # self.client.list_tasks_paginated,
+            int(flyteidl.core.ResourceType.Task),
+            project or self._default_project,
+            domain or self._default_domain,
+            name,
+            version,
+            org or "",
+        )
+        admin_task = self._admin_stub.get_task(flyteidl.admin.ObjectGetRequest(id=task_id))
+        flyte_task = FlyteTask.promote_from_rust_binding(admin_task.closure.compiled_task.template)
+        flyte_task.template.id = task_id
+        return flyte_task
+
+    def _resolve_identifier(self, t: int, name: str, version: str, ss: SerializationSettings) -> flyteidl.Identifier:
+        ident = _get_entity_identifier(
+            resource_type=t,
+            project=ss.project if ss and ss.project else self.default_project,
+            domain=ss.domain if ss and ss.domain else self.default_domain,
+            name=name,
+            version=version or ss.version,
+        )
+        if not ident.project or not ident.domain or not ident.name or not ident.version:
+            raise ValueError(
+                f"To register a new {ident.resource_type}, (project, domain, name, version) required, "
+                f"received ({ident.project}, {ident.domain}, {ident.name}, {ident.version})."
+            )
+        return ident
+
+    def raw_register(
+        self,
+        cp_entity: FlyteControlPlaneEntity,
+        settings: SerializationSettings,
+        version: str,
+        create_default_launchplan: bool = True,
+        options: Options = None,
+        og_entity: FlyteLocalEntity = None,
+    ) -> typing.Optional[flyteidl.Identifier]:
+        """
+        Raw register method, can be used to register control plane entities. Usually if you have a Flyte Entity like a
+        WorkflowBase, Task, LaunchPlan then use other methods. This should be used only if you have already serialized entities
+
+        :param cp_entity: The controlplane "serializable" version of a flyte entity. This is in the form that FlyteAdmin
+            understands.
+        :param settings: SerializationSettings to be used for registration - especially to identify the id
+        :param version: Version to be registered
+        :param create_default_launchplan: boolean that indicates if a default launch plan should be created
+        :param options: Options to be used if registering a default launch plan
+        :param og_entity: Pass in the original workflow (flytekit type) if create_default_launchplan is true
+        :return: Identifier of the created entity
+        """
+        if isinstance(cp_entity, RemoteEntity):
+            if isinstance(cp_entity, (FlyteWorkflow, FlyteTask)):
+                if not cp_entity.should_register:
+                    logger.debug(f"Skipping registration of remote entity: {cp_entity.name}")
+                    raise RegistrationSkipped(f"Remote task/Workflow {cp_entity.name} is not registrable.")
+            else:
+                logger.debug(f"Skipping registration of remote entity: {cp_entity.name}")
+                raise RegistrationSkipped(f"Remote task/Workflow {cp_entity.name} is not registrable.")
+
+        if isinstance(
+            cp_entity,
+            (
+                flyteidl.core.Node,
+                workflow_model.WorkflowNode,
+                workflow_model.BranchNode,
+                flyteidl.core.TaskNode,
+            ),
+        ):
+            logger.debug("Ignoring nodes for registration.")
+            return None
+
+        elif isinstance(cp_entity, ReferenceSpec):
+            logger.debug(f"Skipping registration of Reference entity, name: {cp_entity.template.id.name}")
+            return None
+
+        if isinstance(cp_entity, flyteidl.admin.TaskSpec):
+            if isinstance(cp_entity, FlyteTask):
+                version = cp_entity.id.version
+            ident = self._resolve_identifier(
+                int(flyteidl.core.ResourceType.Task), cp_entity.template.id.name, version, settings
+            )
+            try:
+                self._admin_stub.create_task(flyteidl.admin.TaskCreateRequest(id=ident, spec=cp_entity))
+            except FlyteEntityAlreadyExistsException:
+                logger.info(f" {ident} Already Exists!")
+            return ident
+
+        if isinstance(cp_entity, admin_workflow_models.WorkflowSpec):
+            if isinstance(cp_entity, FlyteWorkflow):
+                version = cp_entity.id.version
+            ident = self._resolve_identifier(ResourceType.WORKFLOW, cp_entity.template.id.name, version, settings)
+            try:
+                self.client.create_workflow(workflow_identifier=ident, workflow_spec=cp_entity)
+            except FlyteEntityAlreadyExistsException:
+                logger.info(f" {ident} Already Exists!")
+
+            if create_default_launchplan:
+                if not og_entity:
+                    raise user_exceptions.FlyteValueException(
+                        "To create default launch plan, please pass in the original flytekit workflow `og_entity`"
+                    )
+
+                # Let us also create a default launch-plan, ideally the default launchplan should be added
+                # to the orderedDict, but we do not.
+                self.file_access._get_upload_signed_url_fn = functools.partial(
+                    self.get_upload_signed_url, project=settings.project, domain=settings.domain
+                )
+                default_lp = LaunchPlan.get_default_launch_plan(self.context, og_entity)
+                lp_entity = get_serializable_launch_plan(
+                    OrderedDict(),
+                    settings,
+                    default_lp,
+                    recurse_downstream=False,
+                    options=options,
+                )
+                try:
+                    self.client.create_launch_plan(lp_entity.id, lp_entity.spec)
+                except FlyteEntityAlreadyExistsException:
+                    logger.info(f" {lp_entity.id} Already Exists!")
+            return ident
+
+        if isinstance(cp_entity, launch_plan_models.LaunchPlan):
+            ident = self._resolve_identifier(ResourceType.LAUNCH_PLAN, cp_entity.id.name, version, settings)
+            try:
+                self.client.create_launch_plan(launch_plan_identifer=ident, launch_plan_spec=cp_entity.spec)
+            except FlyteEntityAlreadyExistsException:
+                logger.info(f" {ident} Already Exists!")
+            return ident
+
+        raise AssertionError(f"Unknown entity of type {type(cp_entity)}")
+
+    async def _serialize_and_register(
+        self,
+        entity: FlyteLocalEntity,
+        settings: typing.Optional[SerializationSettings],
+        version: str,
+        options: typing.Optional[Options] = None,
+        create_default_launchplan: bool = True,
+    ) -> Identifier:
+        """
+        This method serializes and register the given Flyte entity
+        :return: Identifier of the registered entity
+        """
+        m = OrderedDict()
+        # Create dummy serialization settings for now.
+        # TODO: Clean this up by using lazy usage of serialization settings in translator.py
+        serialization_settings = settings
+        if not settings:
+            serialization_settings = SerializationSettings(
+                ImageConfig.auto_default_image(),
+                project=self.default_project,
+                domain=self.default_domain,
+                version=version,
+            )
+        if serialization_settings.version is None:
+            serialization_settings.version = version
+
+        _ = get_serializable(m, settings=serialization_settings, entity=entity, options=options)
+        # non-blocking register
+        cp_task_entity_map = OrderedDict(filter(lambda x: isinstance(x[1], flyteidl.admin.TaskSpec), m.items()))
+        tasks = []
+        loop = asyncio.get_event_loop()
+        for _entity, cp_entity in cp_task_entity_map.items():
+            tasks.append(
+                loop.run_in_executor(
+                    None,
+                    functools.partial(self.raw_register, cp_entity, serialization_settings, version, og_entity=_entity),
+                )
+            )
+        ident = []
+        ident.extend(await asyncio.gather(*tasks))
+        # blocking register
+        cp_other_entities = OrderedDict(filter(lambda x: not isinstance(x[1], flyteidl.admin.TaskSpec), m.items()))
+        for _entity, cp_entity in cp_other_entities.items():
+            ident.append(self.raw_register(cp_entity, serialization_settings, version, og_entity=_entity))
+        return ident[-1]
+
+    def register_task(
+        self,
+        entity: PythonTask,
+        serialization_settings: typing.Optional[SerializationSettings] = None,
+        version: typing.Optional[str] = None,
+    ) -> FlyteTask:
+        """
+        Register a qualified task (PythonTask) with Remote
+        For any conflicting parameters method arguments are regarded as overrides
+
+        :param entity: PythonTask can be either @task or a instance of a Task class
+        :param serialization_settings:  Settings that will be used to override various serialization parameters.
+        :param version: version that will be used to register. If not specified will default to using the serialization settings default
+        :return:
+        """
+        # Create a default serialization settings object if not provided
+        # It makes registration easier for the user
+        if serialization_settings is None:
+            _, _, _, module_file = extract_task_module(entity)
+            project_root = _find_project_root(module_file)
+            serialization_settings = SerializationSettings(
+                image_config=ImageConfig.auto_default_image(),
+                source_root=project_root,
+                project=self.default_project,
+                domain=self.default_domain,
+            )
+        if not serialization_settings.project:
+            serialization_settings.project = self.default_project
+        if not serialization_settings.domain:
+            serialization_settings.domain = self.default_domain
+
+        print(entity)
+        ident = asyncio.run(
+            self._serialize_and_register(entity=entity, settings=serialization_settings, version=version)
+        )
+
+        ft = self.fetch_task(
+            ident.project,
+            ident.domain,
+            ident.name,
+            ident.version,
+        )
+        ft._python_interface = entity.python_interface
+        return ft
+
+    def fast_package(
+        self,
+        root: os.PathLike,
+        deref_symlinks: bool = True,
+        output: str = None,
+        options: typing.Optional[FastPackageOptions] = None,
+    ) -> typing.Tuple[bytes, str]:
+        """
+        Packages the given paths into an installable zip and returns the md5_bytes and the URL of the uploaded location
+        :param root: path to the root of the package system that should be uploaded
+        :param output: output path. Optional, will default to a tempdir
+        :param deref_symlinks: if symlinks should be dereferenced. Defaults to True
+        :param options: additional options to customize fast_package behavior
+        :return: md5_bytes, url
+        """
+        # Create a zip file containing all the entries.
+        zip_file = fast_package(root, output, deref_symlinks, options)
+        # Upload zip file to Admin using FlyteRemote.
+        return self.upload_file(pathlib.Path(zip_file))
+
+    def upload_file(
+        self,
+        to_upload: pathlib.Path,
+        project: typing.Optional[str] = None,
+        domain: typing.Optional[str] = None,
+        filename_root: typing.Optional[str] = None,
+    ) -> typing.Tuple[bytes, str]:
+        """
+        Function will use remote's client to hash and then upload the file using Admin's data proxy service.
+
+        :param to_upload: Must be a single file
+        :param project: Project to upload under, if not supplied will use the remote's default
+        :param domain: Domain to upload under, if not specified will use the remote's default
+        :param filename_root: If provided will be used as the root of the filename. If not, Admin will use a hash
+        :return: The uploaded location.
+        """
+        if not to_upload.is_file():
+            raise ValueError(f"{to_upload} is not a single file, upload arg must be a single file.")
+        md5_bytes, str_digest, _ = hash_file(to_upload)
+        logger.debug(f"Text hash of file to upload is {str_digest}")
+
+        upload_location = self.get_upload_signed_url(
+            project=project or self.default_project,
+            domain=domain or self.default_domain,
+            content_md5=md5_bytes,
+            filename=to_upload.name,
+            filename_root=filename_root,
+        )
+
+        extra_headers = self.get_extra_headers_for_protocol(upload_location.native_url)
+        extra_headers.update(upload_location.headers)
+        encoded_md5 = b64encode(md5_bytes)
+        with open(str(to_upload), "+rb") as local_file:
+            content = local_file.read()
+            content_length = len(content)
+            headers = {"Content-Length": str(content_length), "Content-MD5": encoded_md5}
+            headers.update(extra_headers)
+            rsp = requests.put(
+                upload_location.signed_url,
+                data=content,
+                headers=headers,
+                verify=False
+                if self._config.platform.insecure_skip_verify is True
+                else self._config.platform.ca_cert_file_path,
+            )
+
+            # Check both HTTP 201 and 200, because some storage backends (e.g. Azure) return 201 instead of 200.
+            if rsp.status_code not in (requests.codes["OK"], requests.codes["created"]):
+                raise FlyteValueException(
+                    rsp.status_code,
+                    f"Request to send data {upload_location.signed_url} failed.\nResponse: {rsp.text}",
+                )
+
+        logger.debug(f"Uploading {to_upload} to {upload_location.signed_url} native url {upload_location.native_url}")
+
+        return md5_bytes, upload_location.native_url
+
+    def get_upload_signed_url(
+        self,
+        project: str,
+        domain: str,
+        content_md5: typing.Optional[bytes] = None,
+        filename: typing.Optional[str] = None,
+        expires_in: typing.Optional[datetime.timedelta] = None,
+        filename_root: typing.Optional[str] = None,
+        add_content_md5_metadata: bool = True,
+        org: str = None,
+    ) -> flyteidl.CreateUploadLocationResponse:
+        """
+        Get a signed url to be used during fast registration
+
+        :param project: Project to create the upload location for
+        :param domain: Domain to create the upload location for
+        :param content_md5: ContentMD5 restricts the upload location to the specific MD5 provided. The content_md5
+            will also appear in the generated path.
+        :param filename: If provided this specifies a desired suffix for the generated location
+        :param expires_in: If provided this defines a requested expiration duration for
+            the generated url
+        :param filename_root: If provided will be used as the root of the filename.  If not, Admin will use a hash
+          This option is useful when uploading a series of files that you want to be grouped together.
+        :param add_content_md5_metadata: If true, the content md5 will be added to the metadata in signed URL
+        :rtype: flyteidl.service.dataproxy_pb2.CreateUploadLocationResponse
+        """
+        try:
+            expires_in_pb = None
+            if expires_in:
+                expires_in_pb = flyteidl.Duration(
+                    seconds=(
+                        expires_in.days * 24 * 60 * 60 + expires_in.seconds + expires_in.microseconds // 1_000_000
+                    ),
+                    nanos=(expires_in.microseconds % 1_000_000 * 1_000),
+                )
+            return self._dataproxy_stub.create_upload_location(
+                flyteidl.CreateUploadLocationRequest(
+                    project=project,
+                    domain=domain,
+                    content_md5=content_md5,
+                    filename=filename,
+                    expires_in=expires_in_pb,
+                    filename_root=filename_root or "",
+                    add_content_md5_metadata=add_content_md5_metadata,
+                    org=org or "",
+                )
+            )
+        except Exception as e:
+            raise RuntimeError(f"Failed to get signed url for {filename}, reason: {e}")
+
+    @staticmethod
+    def get_extra_headers_for_protocol(native_url):
+        if native_url.startswith("abfs://"):
+            return {"x-ms-blob-type": "BlockBlob"}
+        return {}
+
+    @staticmethod
+    def _version_from_hash(
+        md5_bytes: bytes,
+        serialization_settings: SerializationSettings,
+        default_inputs: typing.Optional[Dict[str, typing.Any]] = None,
+        *additional_context: str,
+    ) -> str:
+        """
+        The md5 version that we send to S3/GCS has to match the file contents exactly,
+        but we don't have to use it when registering with the Flyte backend.
+        To avoid changes in the For that add the hash of the compilation settings to hash of file
+
+        :param md5_bytes:
+        :param serialization_settings:
+        :param additional_context: This is for additional context to factor into the version computation,
+          meant for objects (like Options for instance) that don't easily consistently stringify.
+        :return:
+        """
+        from flytekit import __version__
+
+        additional_context = additional_context or []
+
+        h = hashlib.md5(md5_bytes)
+        h.update(bytes(serialization_settings.to_json(), "utf-8"))
+        h.update(bytes(__version__, "utf-8"))
+
+        for s in additional_context:
+            h.update(bytes(s, "utf-8"))
+
+        if default_inputs:
+            try:
+                h.update(cloudpickle.dumps(default_inputs))
+            except TypeError:  # cannot pickle errors
+                logger.info("Skip pickling default inputs.")
+
+        # Omit the character '=' from the version as that's essentially padding used by the base64 encoding
+        # and does not increase entropy of the hash while making it very inconvenient to copy-and-paste.
+        return base64.urlsafe_b64encode(h.digest()).decode("ascii").rstrip("=")
+
+    def activate_launchplan(self, ident: Identifier):
+        """
+        Given a launchplan, activate it, all previous versions are deactivated.
+        """
+        self.client.update_launch_plan(id=ident, state=LaunchPlanState.ACTIVE)
+
+    def _execute(
+        self,
+        entity: typing.Union[FlyteTask, FlyteWorkflow, FlyteLaunchPlan],
+        inputs: typing.Dict[str, typing.Any],
+        project: str = None,
+        domain: str = None,
+        execution_name: typing.Optional[str] = None,
+        execution_name_prefix: typing.Optional[str] = None,
+        options: typing.Optional[Options] = None,
+        wait: bool = False,
+        type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
+        overwrite_cache: typing.Optional[bool] = None,
+        envs: typing.Optional[typing.Dict[str, str]] = None,
+        tags: typing.Optional[typing.List[str]] = None,
+        cluster_pool: typing.Optional[str] = None,
+        execution_cluster_label: typing.Optional[str] = None,
+    ) -> FlyteWorkflowExecution:
+        """Common method for execution across all entities.
+
+        :param flyte_id: entity identifier
+        :param inputs: dictionary mapping argument names to values
+        :param project: project on which to execute the entity referenced by flyte_id
+        :param domain: domain on which to execute the entity referenced by flyte_id
+        :param execution_name: name of the execution
+        :param wait: if True, waits for execution to complete
+        :param type_hints: map of python types to inputs so that the TypeEngine knows how to convert the input values
+          into Flyte Literals.
+        :param overwrite_cache: Allows for all cached values of a workflow and its tasks to be overwritten
+          for a single execution. If enabled, all calculations are performed even if cached results would
+          be available, overwriting the stored data once execution finishes successfully.
+        :param envs: Environment variables to set for the execution.
+        :param tags: Tags to set for the execution.
+        :param cluster_pool: Specify cluster pool on which newly created execution should be placed.
+        :returns: :class:`~flytekit.remote.workflow_execution.FlyteWorkflowExecution`
+        """
+        if execution_name is not None and execution_name_prefix is not None:
+            raise ValueError("Only one of execution_name and execution_name_prefix can be set, but got both set")
+        execution_name_prefix = execution_name_prefix + "-" if execution_name_prefix is not None else None
+        execution_name = execution_name or (execution_name_prefix or "f") + uuid.uuid4().hex[:19]
+        if not options:
+            options = Options()
+        if options.disable_notifications is not None:
+            if options.disable_notifications:
+                notifications = None
+            else:
+                notifications = NotificationList(options.notifications)
+        else:
+            notifications = NotificationList([])
+
+        type_hints = type_hints or {}
+        literal_map = {}
+        with self.remote_context() as ctx:
+            input_flyte_type_map = entity.interface.inputs
+            for k, v in inputs.items():
+                if input_flyte_type_map.variables.get(k) is None:
+                    raise user_exceptions.FlyteValueException(
+                        k, f"The {entity.__class__.__name__} doesn't have this input key."
+                    )
+                if isinstance(v, flyteidl.core.Literal):
+                    lit = v
+                elif isinstance(v, Artifact):
+                    raise user_exceptions.FlyteValueException(v, "Running with an artifact object is not yet possible.")
+                else:
+                    if k not in type_hints:
+                        try:
+                            type_hints[k] = TypeEngine.guess_python_type(input_flyte_type_map.variables[k].type)
+                        except ValueError:
+                            logger.debug(
+                                f"Could not guess type for {input_flyte_type_map.variables[k].type}, skipping..."
+                            )
+                    variable = entity.interface.inputs.variables.get(k)
+                    hint = type_hints[k]
+                    self.file_access._get_upload_signed_url_fn = functools.partial(
+                        self.get_upload_signed_url,
+                        project=project or self.default_project,
+                        domain=domain or self.default_domain,
+                    )
+                    lit = TypeEngine.to_literal(ctx, v, hint, variable.type)
+                literal_map[k] = lit
+
+            literal_inputs = flyteidl.core.LiteralMap(literals=literal_map)
+        try:
+            # Currently, this will only execute the flyte entity referenced by
+            # flyte_id in the same project and domain. However, it is possible to execute it in a different project
+            # and domain, which is specified in the first two arguments of client.create_execution. This is useful
+            # in the case that I want to use a flyte entity from e.g. project "A" but actually execute the entity on a
+            # different project "B". For now, this method doesn't support this use case.
+
+            exec_id = self._admin_stub.create_execution(
+                request=flyteidl.admin.ExecutionCreateRequest(
+                    project=project or self.default_project,
+                    domain=domain or self.default_domain,
+                    name=execution_name,
+                    spec=flyteidl.admin.ExecutionSpec(
+                        launch_plan=entity.id,
+                        metadata=flyteidl.admin.ExecutionMetadata(
+                            int(flyteidl.admin.ExecutionMode.Manual),
+                            "placeholder",  # Admin replaces this from oidc token if auth is enabled.
+                            0,
+                            [],  # artifact_ids
+                        ),
+                        overwrite_cache=overwrite_cache or True,
+                        notification_overrides=None,  # notifications,
+                        # disable_all=options.disable_notifications,
+                        labels=options.labels,
+                        annotations=options.annotations,
+                        raw_output_data_config=options.raw_output_data_config,
+                        auth_role=None,
+                        max_parallelism=options.max_parallelism or 25,
+                        security_context=options.security_context,
+                        envs=flyteidl.Envs(list(envs) or {}) if envs else None,
+                        tags=tags or [],
+                        cluster_assignment=flyteidl.ClusterAssignment(cluster_pool_name=cluster_pool or "")
+                        if cluster_pool
+                        else None,
+                        execution_cluster_label=flyteidl.ExecutionClusterLabel(execution_cluster_label or "")
+                        if execution_cluster_label
+                        else None,
+                        execution_env_assignments=[],
+                    ),
+                    inputs=literal_inputs,
+                    org="",
+                )
+            )
+            exec_id = exec_id.id
+        except user_exceptions.FlyteEntityAlreadyExistsException:
+            logger.warning(
+                f"Execution with Execution ID {execution_name} already exists. "
+                f"Assuming this is the same execution, returning!"
+            )
+            exec_id = flyteidl.core.WorkflowExecutionIdentifier(
+                project=project or self.default_project,
+                domain=domain or self.default_domain,
+                name=execution_name,
+                org="",
+            )
+
+        execution = FlyteWorkflowExecution.promote_from_rust_binding(
+            self._admin_stub.get_execution(flyteidl.admin.WorkflowExecutionGetRequest(id=exec_id))
+        )
+
+        if wait:
+            return self.wait(execution)
+        return execution
+
+    def execute(
+        self,
+        entity: typing.Union[FlyteTask, FlyteLaunchPlan, FlyteWorkflow, PythonTask, WorkflowBase, LaunchPlan],
+        inputs: typing.Dict[str, typing.Any],
+        project: str = None,
+        domain: str = None,
+        name: str = None,
+        version: str = None,
+        execution_name: typing.Optional[str] = None,
+        execution_name_prefix: typing.Optional[str] = None,
+        image_config: typing.Optional[ImageConfig] = None,
+        options: typing.Optional[Options] = None,
+        wait: bool = False,
+        type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
+        overwrite_cache: typing.Optional[bool] = None,
+        envs: typing.Optional[typing.Dict[str, str]] = None,
+        tags: typing.Optional[typing.List[str]] = None,
+        cluster_pool: typing.Optional[str] = None,
+    ) -> FlyteWorkflowExecution:
+        """
+        Execute a task, workflow, or launchplan, either something that's been declared locally, or a fetched entity.
+
+        This method supports:
+        - ``Flyte{Task, Workflow, LaunchPlan}`` remote module objects.
+        - ``@task``-decorated functions and ``TaskTemplate`` tasks.
+        - ``@workflow``-decorated functions.
+        - ``LaunchPlan`` objects.
+
+        For local entities, this code will attempt to find the entity first, and if missing, will compile and register
+        the object.
+
+        Not all arguments are relevant in all circumstances. For example, there's no reason to use the serialization
+        settings for entities that have already been registered on Admin.
+
+        :param options:
+        :param entity: entity to execute
+        :param inputs: dictionary mapping argument names to values
+        :param project: execute entity in this project. If entity doesn't exist in the project, register the entity
+            first before executing.
+        :param domain: execute entity in this domain. If entity doesn't exist in the domain, register the entity
+            first before executing.
+        :param name: execute entity using this name. If not None, use this value instead of ``entity.name``
+        :param version: execute entity using this version. If None, uses auto-generated value.
+        :param execution_name: name of the execution. If None, uses auto-generated value.
+        :param image_config:
+        :param wait: if True, waits for execution to complete
+        :param type_hints: Python types to be passed to the TypeEngine so that it knows how to properly convert the
+          input values for the execution into Flyte literals. If missing, will default to first guessing the type
+          using the type engine, and then to ``type(v)``. Providing the correct Python types is particularly important
+          if the inputs are containers like lists or maps, or if the Python type is one of the more complex Flyte
+          provided classes (like a StructuredDataset that's annotated with columns).
+        :param overwrite_cache: Allows for all cached values of a workflow and its tasks to be overwritten
+          for a single execution. If enabled, all calculations are performed even if cached results would
+          be available, overwriting the stored data once execution finishes successfully.
+        :param envs: Environment variables to be set for the execution.
+        :param tags: Tags to be set for the execution.
+        :param cluster_pool: Specify cluster pool on which newly created execution should be placed.
+
+        .. note:
+
+            The ``name`` and ``version`` arguments do not apply to ``FlyteTask``, ``FlyteLaunchPlan``, and
+            ``FlyteWorkflow`` entity inputs. These values are determined by referencing the entity identifier values.
+        """
+
+        if entity.python_interface:
+            type_hints = type_hints or entity.python_interface.inputs
+        if isinstance(entity, FlyteTask) or isinstance(entity, FlyteLaunchPlan):
+            return self.execute_remote_task_lp(
+                entity=entity,
+                inputs=inputs,
+                project=project,
+                domain=domain,
+                execution_name=execution_name,
+                execution_name_prefix=execution_name_prefix,
+                options=options,
+                wait=wait,
+                type_hints=type_hints,
+                overwrite_cache=overwrite_cache,
+                envs=envs,
+                tags=tags,
+                cluster_pool=cluster_pool,
+            )
+        if isinstance(entity, FlyteWorkflow):
+            return self.execute_remote_wf(
+                entity=entity,
+                inputs=inputs,
+                project=project,
+                domain=domain,
+                execution_name=execution_name,
+                execution_name_prefix=execution_name_prefix,
+                options=options,
+                wait=wait,
+                type_hints=type_hints,
+                overwrite_cache=overwrite_cache,
+                envs=envs,
+                tags=tags,
+                cluster_pool=cluster_pool,
+            )
+        if isinstance(entity, ReferenceTask):
+            return self.execute_reference_task(
+                entity=entity,
+                inputs=inputs,
+                execution_name=execution_name,
+                execution_name_prefix=execution_name_prefix,
+                options=options,
+                wait=wait,
+                type_hints=type_hints,
+                overwrite_cache=overwrite_cache,
+                envs=envs,
+                tags=tags,
+                cluster_pool=cluster_pool,
+            )
+        if isinstance(entity, ReferenceWorkflow):
+            return self.execute_reference_workflow(
+                entity=entity,
+                inputs=inputs,
+                execution_name=execution_name,
+                execution_name_prefix=execution_name_prefix,
+                options=options,
+                wait=wait,
+                type_hints=type_hints,
+                overwrite_cache=overwrite_cache,
+                envs=envs,
+                tags=tags,
+                cluster_pool=cluster_pool,
+            )
+        if isinstance(entity, ReferenceLaunchPlan):
+            return self.execute_reference_launch_plan(
+                entity=entity,
+                inputs=inputs,
+                execution_name=execution_name,
+                execution_name_prefix=execution_name_prefix,
+                options=options,
+                wait=wait,
+                type_hints=type_hints,
+                overwrite_cache=overwrite_cache,
+                envs=envs,
+                tags=tags,
+                cluster_pool=cluster_pool,
+            )
+        if isinstance(entity, PythonTask):
+            return self.execute_local_task(
+                entity=entity,
+                inputs=inputs,
+                project=project,
+                domain=domain,
+                name=name,
+                version=version,
+                execution_name=execution_name,
+                execution_name_prefix=execution_name_prefix,
+                image_config=image_config,
+                wait=wait,
+                overwrite_cache=overwrite_cache,
+                envs=envs,
+                tags=tags,
+                cluster_pool=cluster_pool,
+            )
+        if isinstance(entity, WorkflowBase):
+            return self.execute_local_workflow(
+                entity=entity,
+                inputs=inputs,
+                project=project,
+                domain=domain,
+                name=name,
+                version=version,
+                execution_name=execution_name,
+                execution_name_prefix=execution_name_prefix,
+                image_config=image_config,
+                options=options,
+                wait=wait,
+                overwrite_cache=overwrite_cache,
+                envs=envs,
+                tags=tags,
+                cluster_pool=cluster_pool,
+            )
+        if isinstance(entity, LaunchPlan):
+            return self.execute_local_launch_plan(
+                entity=entity,
+                inputs=inputs,
+                version=version,
+                project=project,
+                domain=domain,
+                name=name,
+                execution_name=execution_name,
+                execution_name_prefix=execution_name_prefix,
+                options=options,
+                wait=wait,
+                overwrite_cache=overwrite_cache,
+                envs=envs,
+                tags=tags,
+                cluster_pool=cluster_pool,
+            )
+        raise NotImplementedError(f"entity type {type(entity)} not recognized for execution")
+
+    def execute_remote_task_lp(
+        self,
+        entity: typing.Union[FlyteTask, FlyteLaunchPlan],
+        inputs: typing.Dict[str, typing.Any],
+        project: str = None,
+        domain: str = None,
+        execution_name: typing.Optional[str] = None,
+        execution_name_prefix: typing.Optional[str] = None,
+        options: typing.Optional[Options] = None,
+        wait: bool = False,
+        type_hints: typing.Optional[typing.Dict[str, typing.Type]] = None,
+        overwrite_cache: typing.Optional[bool] = None,
+        envs: typing.Optional[typing.Dict[str, str]] = None,
+        tags: typing.Optional[typing.List[str]] = None,
+        cluster_pool: typing.Optional[str] = None,
+    ) -> FlyteWorkflowExecution:
+        """Execute a FlyteTask, or FlyteLaunchplan.
+
+        NOTE: the name and version arguments are currently not used and only there consistency in the function signature
+        """
+
+        return self._execute(
+            entity,
+            inputs,
+            project=project,
+            domain=domain,
+            execution_name=execution_name,
+            execution_name_prefix=execution_name_prefix,
+            wait=wait,
+            options=options,
+            type_hints=type_hints,
+            overwrite_cache=overwrite_cache,
+            envs=envs,
+            tags=tags,
+            cluster_pool=cluster_pool,
+        )
+
+    def register_script(
+        self,
+        entity: typing.Union[WorkflowBase, PythonTask],
+        image_config: typing.Optional[ImageConfig] = None,
+        version: typing.Optional[str] = None,
+        project: typing.Optional[str] = None,
+        domain: typing.Optional[str] = None,
+        destination_dir: str = ".",
+        copy_all: bool = False,
+        default_launch_plan: bool = True,
+        options: typing.Optional[Options] = None,
+        source_path: typing.Optional[str] = None,
+        module_name: typing.Optional[str] = None,
+        envs: typing.Optional[typing.Dict[str, str]] = None,
+        fast_package_options: typing.Optional[FastPackageOptions] = None,
+    ) -> typing.Union[FlyteWorkflow, FlyteTask]:
+        """
+        Use this method to register a workflow via script mode.
+        :param destination_dir: The destination directory where the workflow will be copied to.
+        :param copy_all: If true, the entire source directory will be copied over to the destination directory.
+        :param domain: The domain to register the workflow in.
+        :param project: The project to register the workflow in.
+        :param image_config: The image config to use for the workflow.
+        :param version: version for the entity to be registered as
+        :param entity: The workflow to be registered or the task to be registered
+        :param default_launch_plan: This should be true if a default launch plan should be created for the workflow
+        :param options: Additional execution options that can be configured for the default launchplan
+        :param source_path: The root of the project path
+        :param module_name: the name of the module
+        :param envs: Environment variables to be passed to the serialization
+        :param fast_package_options: Options to customize copy_all behavior, ignored when copy_all is False.
+        :return:
+        """
+        if image_config is None:
+            image_config = ImageConfig.auto_default_image()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            if copy_all:
+                md5_bytes, upload_native_url = self.fast_package(
+                    pathlib.Path(source_path), False, tmp_dir, fast_package_options
+                )
+            else:
+                archive_fname = pathlib.Path(os.path.join(tmp_dir, "script_mode.tar.gz"))
+                compress_scripts(source_path, str(archive_fname), module_name)
+                md5_bytes, upload_native_url = self.upload_file(
+                    archive_fname, project or self.default_project, domain or self.default_domain
+                )
+
+        serialization_settings = SerializationSettings(
+            project=project,
+            domain=domain,
+            image_config=image_config,
+            git_repo=_get_git_repo_url(source_path),
+            env=envs,
+            fast_serialization_settings=FastSerializationSettings(
+                enabled=True,
+                destination_dir=destination_dir,
+                distribution_location=upload_native_url,
+            ),
+            source_root=source_path,
+        )
+
+        if version is None:
+
+            def _get_image_names(entity: typing.Union[PythonAutoContainerTask, WorkflowBase]) -> typing.List[str]:
+                if isinstance(entity, PythonAutoContainerTask) and isinstance(entity.container_image, ImageSpec):
+                    return [entity.container_image.image_name()]
+                if isinstance(entity, WorkflowBase):
+                    image_names = []
+                    for n in entity.nodes:
+                        image_names.extend(_get_image_names(n.flyte_entity))
+                    return image_names
+                return []
+
+            default_inputs = None
+            if isinstance(entity, WorkflowBase):
+                default_inputs = entity.python_interface.default_inputs_as_kwargs
+
+            # The md5 version that we send to S3/GCS has to match the file contents exactly,
+            # but we don't have to use it when registering with the Flyte backend.
+            # For that add the hash of the compilation settings to hash of file
+            version = self._version_from_hash(
+                md5_bytes, serialization_settings, default_inputs, *_get_image_names(entity)
+            )
+
+        if isinstance(entity, PythonTask):
+            return self.register_task(entity, serialization_settings, version)
+        fwf = self.register_workflow(entity, serialization_settings, version, default_launch_plan, options)
+        fwf._python_interface = entity.python_interface
+        return fwf
+
+    def generate_console_url(
+        self,
+        entity: typing.Union[
+            FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution, FlyteWorkflow, FlyteTask, FlyteLaunchPlan
+        ],
+    ):
+        """
+        Generate a Flyteconsole URL for the given Flyte remote endpoint.
+        This will automatically determine if this is an execution or an entity and change the type automatically
+        """
+        if isinstance(entity, (FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution)):
+            return f"{self.generate_console_http_domain()}/console/projects/{entity.id.project}/domains/{entity.id.domain}/executions/{entity.id.name}"  # noqa
+
+        if not isinstance(entity, (FlyteWorkflow, FlyteTask, FlyteLaunchPlan)):
+            raise ValueError(f"Only remote entities can be looked at in the console, got type {type(entity)}")
+        rt = "workflow"
+        if entity.id.resource_type == flyteidl.core.ResourceType.Task:
+            rt = "task"
+        elif entity.id.resource_type == flyteidl.core.ResourceType.LaunchPlan:
+            rt = "launch_plan"
+        return f"{self.generate_console_http_domain()}/console/projects/{entity.id.project}/domains/{entity.id.domain}/{rt}/{entity.name}/version/{entity.id.version}"  # noqa
+
+    def generate_console_http_domain(self) -> str:
+        """
+        This should generate the domain where console is hosted.
+
+        :return:
+        """
+        # If the console endpoint is explicitly set, return it, else derive it from the admin config
+        if self.config.platform.console_endpoint:
+            return self.config.platform.console_endpoint
+        protocol = "http" if self.config.platform.insecure else "https"
+        endpoint = self.config.platform.endpoint
+        # N.B.: this assumes that in case we have an identical configuration as the sandbox default config we are running single binary. The intent here is
+        # to ensure that the urls produced in the getting started guide point to the correct place.
+        if self.config.platform == Config.for_sandbox().platform:
+            endpoint = "localhost:30080"
+        return protocol + f"://{endpoint}"
+
+    def wait(
+        self,
+        execution: FlyteWorkflowExecution,
+        timeout: typing.Optional[timedelta] = None,
+        poll_interval: typing.Optional[timedelta] = None,
+        sync_nodes: bool = True,
+    ) -> FlyteWorkflowExecution:
+        """Wait for an execution to finish.
+
+        :param execution: execution object to wait on
+        :param timeout: maximum amount of time to wait
+        :param poll_interval: sync workflow execution at this interval
+        :param sync_nodes: passed along to the sync call for the workflow execution
+        """
+        poll_interval = poll_interval or timedelta(seconds=5)
+        time_to_give_up = datetime.max if timeout is None else datetime.now() + timeout
+
+        while datetime.now() < time_to_give_up:
+            execution = self.sync_execution(execution, sync_nodes=sync_nodes)
+            if execution.is_done:
+                return execution
+            time.sleep(poll_interval.total_seconds())
+
+        raise user_exceptions.FlyteTimeout(f"Execution {self} did not complete before timeout.")
+
+    def sync_execution(
+        self,
+        execution: FlyteWorkflowExecution,
+        entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None,
+        sync_nodes: bool = False,
+    ) -> FlyteWorkflowExecution:
+        """
+        Sync a FlyteWorkflowExecution object with its corresponding remote state.
+        """
+        if entity_definition is not None:
+            raise ValueError("Entity definition arguments aren't supported when syncing workflow executions")
+
+        # Update closure, and then data, because we don't want the execution to finish between when we get the data,
+        # and then for the closure to have is_done to be true.
+        execution._closure = self._admin_stub.get_execution(
+            flyteidl.admin.WorkflowExecutionGetRequest(id=execution.id)
+        ).closure
+
+        execution_data = self._admin_stub.get_execution_data(
+            flyteidl.admin.WorkflowExecutionGetDataRequest(id=execution.id)
+        )
+        lp_id = execution.spec.launch_plan
+        underlying_node_executions = []
+        # if sync_nodes:
+
+        #     underlying_node_executions = [
+        #         FlyteNodeExecution.promote_from_rust_binding(n) for n in iterate_node_executions(self._admin_stub, execution.id)
+        #     ]
+
+        # This condition is only true for single-task executions
+
+        if execution.spec.launch_plan.resource_type == int(flyteidl.core.ResourceType.Task):
+            flyte_entity = self.fetch_task(lp_id.project, lp_id.domain, lp_id.name, lp_id.version)
+            node_interface = flyte_entity.interface
+            # if sync_nodes:
+
+            #     # Need to construct the mapping. There should've been returned exactly three nodes, a start,
+            #     # an end, and a task node.
+            #     task_node_exec = [
+            #         x
+            #         for x in filter(
+            #             lambda x: x.id.node_id != constants.START_NODE_ID and x.id.node_id != constants.END_NODE_ID,
+            #             underlying_node_executions,
+            #         )
+            #     ]
+            #     # We need to manually make a map of the nodes since there is none for single task executions
+            #     # Assume the first one is the only one.
+            #     node_mapping = (
+            #         {
+            #             task_node_exec[0].id.node_id: FlyteNode(
+            #                 id=flyte_entity.id,
+            #                 upstream_nodes=[],
+            #                 bindings=[],
+            #                 metadata=NodeMetadata(name=""),
+            #                 task_node=FlyteTaskNode(flyte_entity),
+            #             )
+            #         }
+            #         if len(task_node_exec) >= 1
+            #         else {}  # This is for the case where node executions haven't appeared yet
+            #     )
+        # This is the default case, an execution of a normal workflow through a launch plan
+        else:
+            fetched_lp = self.fetch_launch_plan(lp_id.project, lp_id.domain, lp_id.name, lp_id.version)
+            node_interface = fetched_lp.flyte_workflow.interface
+            execution._flyte_workflow = fetched_lp.flyte_workflow
+            node_mapping = fetched_lp.flyte_workflow._node_map
+
+        # update node executions (if requested), and inputs/outputs
+        # if sync_nodes:
+        #     node_execs = {}
+        #     for n in underlying_node_executions:
+        #         node_execs[n.id.node_id] = self.sync_node_execution(n, node_mapping)  # noqa
+        #     execution._node_executions = node_execs
+
+        return self._assign_inputs_and_outputs(execution, execution_data, node_interface)
+
+    def sync_node_execution(
+        self,
+        execution: FlyteNodeExecution,
+        node_mapping: typing.Dict[str, FlyteNode],
+    ) -> FlyteNodeExecution:
+        """
+        Get data backing a node execution. These FlyteNodeExecution objects should've come from Admin with the model
+        fields already populated correctly. For purposes of the remote experience, we'd like to supplement the object
+        with some additional fields:
+        - inputs/outputs
+        - task/workflow executions, and/or underlying node executions in the case of parent nodes
+        - TypedInterface (remote wrapper type)
+
+        A node can have several different types of executions behind it. That is, the node could've run (perhaps
+        multiple times because of retries):
+        - A task
+        - A static subworkflow
+        - A dynamic subworkflow (which in turn may have run additional tasks, subwfs, and/or launch plans)
+        - A launch plan
+
+        The data model is complicated, so ascertaining which of these happened is a bit tricky. That logic is
+        encapsulated in this function.
+        """
+        # For single task execution - the metadata spec node id is missing. In these cases, revert to regular node id
+        node_id = execution.metadata.spec_node_id
+        # This case supports single-task execution compiled workflows.
+        if node_id and node_id not in node_mapping and execution.id.node_id in node_mapping:
+            node_id = execution.id.node_id
+            logger.debug(
+                f"Using node execution ID {node_id} instead of spec node id "
+                f"{execution.metadata.spec_node_id}, single-task execution likely."
+            )
+        # This case supports single-task execution compiled workflows with older versions of admin/propeller
+        if not node_id:
+            node_id = execution.id.node_id
+            logger.debug(f"No metadata spec_node_id found, using {node_id}")
+
+        # First see if it's a dummy node, if it is, we just skip it.
+        if constants.START_NODE_ID in node_id or constants.END_NODE_ID in node_id:
+            return execution
+
+        # Look for the Node object in the mapping supplied
+        if node_id in node_mapping:
+            execution._node = node_mapping[node_id]
+        else:
+            raise Exception(f"Missing node from mapping: {node_id}")
+
+        # Get the node execution data
+        node_execution_get_data_response = self._admin_stub.get_node_execution_data(
+            flyteidl.admin.NodeExecutionGetDataRequest(execution.id)
+        )
+
+        # Calling a launch plan directly case
+        # If a node ran a launch plan directly (i.e. not through a dynamic task or anything) then
+        # the closure should have a workflow_node_metadata populated with the launched execution id.
+        # The parent node flag should not be populated here
+        # This is the simplest case
+        if not execution.metadata.is_parent_node and isinstance(
+            execution.closure.target_metadata, flyteidl.node_execution_closure.TargetMetadata.WorkflowNodeMetadata
+        ):
+            launched_exec_id = execution.closure.target_metadata.execution_id
+            # This is a recursive call, basically going through the same process that brought us here in the first
+            # place, but on the launched execution.
+            launched_exec = self.fetch_execution(
+                project=launched_exec_id.project, domain=launched_exec_id.domain, name=launched_exec_id.name
+            )
+            self.sync_execution(launched_exec)
+
+            if launched_exec.is_done:
+                # The synced underlying execution should've had these populated.
+                execution._inputs = launched_exec.inputs
+                execution._outputs = launched_exec.outputs
+            execution._workflow_executions.append(launched_exec)
+            execution._interface = launched_exec._flyte_workflow.interface
+            return execution
+
+        # If a node ran a static subworkflow or a dynamic subworkflow then the parent flag will be set.
+        if execution.metadata.is_parent_node or execution.metadata.is_array:
+            # We'll need to query child node executions regardless since this is a parent node
+            child_node_executions = iterate_node_executions(
+                self._admin_stub,
+                workflow_execution_identifier=execution.id.execution_id,
+                unique_parent_id=execution.id.node_id,
+            )
+            child_node_executions = [x for x in child_node_executions]
+
+            # If this was a dynamic task, then there should be a CompiledWorkflowClosure inside the
+            # NodeExecutionGetDataResponse
+            if node_execution_get_data_response.dynamic_workflow is not None:
+                compiled_wf = node_execution_get_data_response.dynamic_workflow.compiled_workflow
+                node_launch_plans = {}
+                # TODO: Inspect branch nodes for launch plans
+                for node in FlyteWorkflow.get_non_system_nodes(compiled_wf.primary.template.nodes):
+                    if (
+                        node.workflow_node is not None
+                        and node.workflow_node.launchplan_ref is not None
+                        and node.workflow_node.launchplan_ref not in node_launch_plans
+                    ):
+                        node_launch_plans[node.workflow_node.launchplan_ref] = self.client.get_launch_plan(
+                            node.workflow_node.launchplan_ref
+                        ).spec
+
+                dynamic_flyte_wf = FlyteWorkflow.promote_from_closure(compiled_wf, node_launch_plans)
+                execution._underlying_node_executions = [
+                    self.sync_node_execution(
+                        FlyteNodeExecution.promote_from_rust_binding(cne), dynamic_flyte_wf._node_map
+                    )
+                    for cne in child_node_executions
+                ]
+                execution._task_executions = [
+                    node_exes.task_executions for node_exes in execution.subworkflow_node_executions.values()
+                ]
+
+                execution._interface = dynamic_flyte_wf.interface
+
+            # Handle the case where it's a static subworkflow
+            elif isinstance(execution._node.flyte_entity, FlyteWorkflow):
+                sub_flyte_workflow = execution._node.flyte_entity
+                sub_node_mapping = {n.id: n for n in sub_flyte_workflow.flyte_nodes}
+                execution._underlying_node_executions = [
+                    self.sync_node_execution(FlyteNodeExecution.promote_from_rust_binding(cne), sub_node_mapping)
+                    for cne in child_node_executions
+                ]
+                execution._interface = sub_flyte_workflow.interface
+
+            # Handle the case where it's a branch node
+            elif execution._node.branch_node is not None:
+                logger.info(
+                    "Skipping branch node execution for now - branch nodes will "
+                    "not have inputs and outputs filled in"
+                )
+                return execution
+            elif execution._node.array_node is not None:
+                # if there's a task node underneath the array node, let's fetch the interface for it
+                if execution._node.array_node.node.task_node is not None:
+                    tid = execution._node.array_node.node.task_node.reference_id
+                    t = self.fetch_task(tid.project, tid.domain, tid.name, tid.version)
+                    if t.interface:
+                        execution._interface = t.interface
+                    else:
+                        logger.error(f"Fetched map task does not have an interface, skipping i/o {t}")
+                        return execution
+                else:
+                    logger.error(f"Array node not over task, skipping i/o {t}")
+                    return execution
+            else:
+                logger.error(f"NE {execution} undeterminable, {type(execution._node)}, {execution._node}")
+                raise Exception(f"Node execution undeterminable, entity has type {type(execution._node)}")
+
+        # Handle the case for gate nodes
+        elif execution._node.gate_node is not None:
+            logger.info("Skipping gate node execution for now - gate nodes don't have inputs and outputs filled in")
+            return execution
+
+        # This is the plain ol' task execution case
+        else:
+            execution._task_executions = [
+                self.sync_task_execution(
+                    FlyteTaskExecution.promote_from_rust_binding(t), node_mapping[node_id].task_node.flyte_task
+                )
+                for t in iterate_task_executions(self._admin_stub, execution.id)
+            ]
+            execution._interface = execution._node.flyte_entity.interface
+
+        self._assign_inputs_and_outputs(
+            execution,
+            node_execution_get_data_response,
+            execution.interface,
+        )
+
+        return execution
+
+    def sync_task_execution(
+        self, execution: FlyteTaskExecution, entity_definition: typing.Optional[FlyteTask] = None
+    ) -> FlyteTaskExecution:
+        """Sync a FlyteTaskExecution object with its corresponding remote state."""
+        execution._closure = self._admin_stub.get_task_execution(
+            flyteidl.admin.TaskExecutionGetRequest(execution.id)
+        ).closure
+        execution_data = self._admin_stub.get_task_execution_data(
+            flyteidl.admin.TaskExecutionGetDataRequest(execution.id)
+        )
+        task_id = execution.id.task_id
+        if entity_definition is None:
+            entity_definition = self.fetch_task(task_id.project, task_id.domain, task_id.name, task_id.version)
+        return self._assign_inputs_and_outputs(execution, execution_data, entity_definition.interface)
+
+    def _assign_inputs_and_outputs(
+        self,
+        execution: typing.Union[FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution],
+        execution_data,
+        interface: TypedInterface,
+    ):
+        """Helper for assigning synced inputs and outputs to an execution object."""
+
+        input_literal_map = self._get_input_literal_map(execution_data)
+
+        execution._inputs = LiteralsResolver(input_literal_map.literals, interface.inputs, self.context)
+
+        if execution.is_done and not execution.error:
+            output_literal_map = self._get_output_literal_map(execution_data)
+            execution._outputs = LiteralsResolver(output_literal_map.literals, interface.outputs, self.context)
+        return execution
+
+    def _get_input_literal_map(self, execution_data: ExecutionDataResponse) -> flyteidl.core.LiteralMap:
+        # Inputs are returned inline unless they are too big, in which case a url blob pointing to them is returned.
+        if bool(execution_data.full_inputs.literals):
+            return execution_data.full_inputs
+        elif execution_data.inputs.bytes > 0:
+            with self.remote_context() as ctx:
+                tmp_name = os.path.join(ctx.file_access.local_sandbox_dir, "inputs.pb")
+                ctx.file_access.get_data(execution_data.inputs.url, tmp_name)
+                return utils.load_proto_from_file(flyteidl.core.LiteralMap, tmp_name)
+        return flyteidl.core.LiteralMap({})
+
+    def _get_output_literal_map(self, execution_data: ExecutionDataResponse) -> flyteidl.core.LiteralMap:
+        # Outputs are returned inline unless they are too big, in which case a url blob pointing to them is returned.
+        if bool(execution_data.full_outputs.literals):
+            return execution_data.full_outputs
+        elif execution_data.outputs.bytes > 0:
+            with self.remote_context() as ctx:
+                tmp_name = os.path.join(ctx.file_access.local_sandbox_dir, "outputs.pb")
+                ctx.file_access.get_data(execution_data.outputs.url, tmp_name)
+                return utils.load_proto_from_file(flyteidl.core.LiteralMap, tmp_name)
+        return flyteidl.core.LiteralMap({})
+
+    def fetch_execution(self, project: str = None, domain: str = None, name: str = None) -> FlyteWorkflowExecution:
+        """Fetch a workflow execution entity from flyte admin.
+
+        :param project: fetch entity from this project. If None, uses the default_project attribute.
+        :param domain: fetch entity from this domain. If None, uses the default_domain attribute.
+        :param name: fetch entity with matching name.
+        :returns: :class:`~flytekit.remote.workflow_execution.FlyteWorkflowExecution`
+
+        :raises: FlyteAssertion if name is None
+        """
+        if name is None:
+            raise user_exceptions.FlyteAssertion("the 'name' argument must be specified.")
+        execution = FlyteWorkflowExecution.promote_from_rust_binding(
+            self._admin_stub.get_execution(
+                request=flyteidl.admin.WorkflowExecutionGetRequest(
+                    id=flyteidl.core.WorkflowExecutionIdentifier(
+                        project or self.default_project,
+                        domain or self.default_domain,
+                        name,
+                        "",  # org
+                    )
+                )
+            )
+        )
+        return self.sync_execution(execution)

--- a/flytekit/remote/remote_rs.py
+++ b/flytekit/remote/remote_rs.py
@@ -23,8 +23,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Dict
 
-import flyteidl_rust as flyteidl
 import cloudpickle
+import flyteidl_rust as flyteidl
 import fsspec
 import requests
 
@@ -58,7 +58,6 @@ from flytekit.models.core import workflow as workflow_model
 from flytekit.models.core.identifier import Identifier, ResourceType
 from flytekit.models.execution import (
     NodeExecutionGetDataResponse,
-    NotificationList,
     WorkflowExecutionGetDataResponse,
 )
 from flytekit.models.launch_plan import LaunchPlanState
@@ -77,11 +76,11 @@ from flytekit.tools.translator import (
     get_serializable_launch_plan,
 )
 
-if typing.TYPE_CHECKING:
-    try:
-        from IPython.core.display import HTML
-    except ImportError:
-        ...
+# if typing.TYPE_CHECKING:
+#     try:
+#         from IPython.core.display import HTML
+#     except ImportError:
+#         ...
 
 ExecutionDataResponse = typing.Union[WorkflowExecutionGetDataResponse, NodeExecutionGetDataResponse]
 
@@ -712,13 +711,13 @@ class FlyteRemote(object):
         execution_name = execution_name or (execution_name_prefix or "f") + uuid.uuid4().hex[:19]
         if not options:
             options = Options()
-        if options.disable_notifications is not None:
-            if options.disable_notifications:
-                notifications = None
-            else:
-                notifications = NotificationList(options.notifications)
-        else:
-            notifications = NotificationList([])
+        # if options.disable_notifications is not None:
+        #     if options.disable_notifications:
+        #         notifications = None
+        #     else:
+        #         notifications = NotificationList(options.notifications)
+        # else:
+        #     notifications = NotificationList([])
 
         type_hints = type_hints or {}
         literal_map = {}
@@ -1224,7 +1223,7 @@ class FlyteRemote(object):
             flyteidl.admin.WorkflowExecutionGetDataRequest(id=execution.id)
         )
         lp_id = execution.spec.launch_plan
-        underlying_node_executions = []
+        # underlying_node_executions = []
         # if sync_nodes:
 
         #     underlying_node_executions = [
@@ -1263,11 +1262,11 @@ class FlyteRemote(object):
             #         else {}  # This is for the case where node executions haven't appeared yet
             #     )
         # This is the default case, an execution of a normal workflow through a launch plan
-        else:
-            fetched_lp = self.fetch_launch_plan(lp_id.project, lp_id.domain, lp_id.name, lp_id.version)
-            node_interface = fetched_lp.flyte_workflow.interface
-            execution._flyte_workflow = fetched_lp.flyte_workflow
-            node_mapping = fetched_lp.flyte_workflow._node_map
+        # else:
+        #     fetched_lp = self.fetch_launch_plan(lp_id.project, lp_id.domain, lp_id.name, lp_id.version)
+        #     node_interface = fetched_lp.flyte_workflow.interface
+        #     execution._flyte_workflow = fetched_lp.flyte_workflow
+        #     node_mapping = fetched_lp.flyte_workflow._node_map
 
         # update node executions (if requested), and inputs/outputs
         # if sync_nodes:

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -6,15 +6,14 @@ import tempfile
 import typing
 from pathlib import Path
 
-import flyteidl_rust as flyteidl
 import click
+import flyteidl_rust as flyteidl
 
 from flytekit.configuration import FastSerializationSettings, ImageConfig, SerializationSettings
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.loggers import logger
 from flytekit.models import launch_plan
 from flytekit.remote.remote import RegistrationSkipped, _get_git_repo_url
-
 from flytekit.remote.remote_rs import FlyteRemote
 from flytekit.tools import fast_registration, module_loader
 from flytekit.tools.script_mode import _find_project_root

--- a/flytekit/tools/serialize_helpers.py
+++ b/flytekit/tools/serialize_helpers.py
@@ -4,8 +4,8 @@ import sys
 import typing
 from collections import OrderedDict
 
-import flyteidl_rust as flyteidl
 import click
+import flyteidl_rust as flyteidl
 
 from flytekit import LaunchPlan
 from flytekit.core import context_manager as flyte_context

--- a/flytekit/tools/serialize_helpers.py
+++ b/flytekit/tools/serialize_helpers.py
@@ -4,6 +4,7 @@ import sys
 import typing
 from collections import OrderedDict
 
+import flyteidl_rust as flyteidl
 import click
 
 from flytekit import LaunchPlan
@@ -11,7 +12,6 @@ from flytekit.core import context_manager as flyte_context
 from flytekit.core.base_task import PythonTask
 from flytekit.core.workflow import WorkflowBase
 from flytekit.models import launch_plan as _launch_plan_models
-from flytekit.models import task as task_models
 from flytekit.models.admin import workflow as admin_workflow_models
 from flytekit.models.admin.workflow import WorkflowSpec
 from flytekit.models.task import TaskSpec
@@ -38,7 +38,7 @@ def _should_register_with_admin(entity) -> bool:
     that do not/should not be written to .pb file to send to admin. This function filters them out.
     """
     return isinstance(
-        entity, (task_models.TaskSpec, _launch_plan_models.LaunchPlan, admin_workflow_models.WorkflowSpec)
+        entity, (flyteidl.admin.TaskSpec, _launch_plan_models.LaunchPlan, admin_workflow_models.WorkflowSpec)
     ) and not isinstance(entity, RemoteEntity)
 
 

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -241,8 +241,6 @@ def get_serializable_task(
         task_type_version=entity.task_type_version,
         security_context=entity.security_context,
         config=merged_config,
-        # k8s_pod=pod,
-        # sql=entity.get_sql(settings),
         extended_resources=entity.get_extended_resources(settings),
     )
     if settings.should_fast_serialize() and isinstance(entity, PythonAutoContainerTask):

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Generator, Tuple
 from uuid import UUID
 
+import flyteidl_rust as flyteidl
 import fsspec
 from dataclasses_json import DataClassJsonMixin, config
 from fsspec.utils import get_protocol
@@ -486,10 +487,10 @@ class FlyteDirToMultipartBlobTransformer(TypeTransformer[FlyteDirectory]):
         fd._remote_source = uri
         return fd
 
-    def guess_python_type(self, literal_type: LiteralType) -> typing.Type[FlyteDirectory[typing.Any]]:
+    def guess_python_type(self, literal_type: flyteidl.LiteralType) -> typing.Type[FlyteDirectory[typing.Any]]:
         if (
-            literal_type.blob is not None
-            and literal_type.blob.dimensionality == _core_types.BlobType.BlobDimensionality.MULTIPART
+            literal_type.type is not None
+            and literal_type.type.dimensionality == flyteidl.Type.Blob.dimensionality.Multipart
         ):
             return FlyteDirectory.__class_getitem__(literal_type.blob.format)
         raise ValueError(f"Transformer {self} cannot reverse {literal_type}")

--- a/flytekit/types/error/error.py
+++ b/flytekit/types/error/error.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Type, TypeVar
 
+import flyteidl_rust as flyteidl
 from mashumaro.mixins.json import DataClassJSONMixin
 
 from flytekit.core.context_manager import FlyteContext
@@ -48,8 +49,8 @@ class ErrorTransformer(TypeTransformer[FlyteError]):
             raise TypeTransformerFailedError("Can only convert a generic literal to FlyteError")
         return FlyteError(message=lv.scalar.error.message, failed_node_id=lv.scalar.error.failed_node_id)
 
-    def guess_python_type(self, literal_type: LiteralType) -> Type[FlyteError]:
-        if literal_type.simple and literal_type.simple == _type_models.SimpleType.ERROR:
+    def guess_python_type(self, literal_type: flyteidl.core.LiteralType) -> Type[FlyteError]:
+        if literal_type.type and literal_type.type == _type_models.SimpleType.ERROR:
             return FlyteError
 
         raise ValueError(f"Transformer {self} cannot reverse {literal_type}")

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from urllib.parse import unquote
 
+import flyteidl_rust as flyteidl
 from dataclasses_json import config
 from marshmallow import fields
 from mashumaro.mixins.json import DataClassJSONMixin
@@ -525,13 +526,13 @@ class FlyteFilePathTransformer(TypeTransformer[FlyteFile]):
 
         return ff
 
-    def guess_python_type(self, literal_type: LiteralType) -> typing.Type[FlyteFile[typing.Any]]:
+    def guess_python_type(self, literal_type: flyteidl.LiteralType) -> typing.Type[FlyteFile[typing.Any]]:
         if (
-            literal_type.blob is not None
-            and literal_type.blob.dimensionality == BlobType.BlobDimensionality.SINGLE
-            and literal_type.blob.format != FlytePickleTransformer.PYTHON_PICKLE_FORMAT
+            literal_type.type is not None
+            and literal_type.type.dimensionality == BlobType.BlobDimensionality.SINGLE
+            and literal_type.type.format != FlytePickleTransformer.PYTHON_PICKLE_FORMAT
         ):
-            return FlyteFile.__class_getitem__(literal_type.blob.format)
+            return FlyteFile.__class_getitem__(literal_type.type.format)
 
         raise ValueError(f"Transformer {self} cannot reverse {literal_type}")
 

--- a/flytekit/types/iterator/json_iterator.py
+++ b/flytekit/types/iterator/json_iterator.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Type, Union
 
+import flyteidl_rust as flyteidl
 import jsonlines
 from typing_extensions import TypeAlias
 
@@ -100,11 +101,11 @@ class JSONIteratorTransformer(TypeTransformer[Iterator[JSON]]):
 
         return JSONIterator(reader)
 
-    def guess_python_type(self, literal_type: LiteralType) -> Type[Iterator[JSON]]:
+    def guess_python_type(self, literal_type: flyteidl.core.LiteralType) -> Type[Iterator[JSON]]:
         if (
-            literal_type.blob is not None
-            and literal_type.blob.dimensionality == _core_types.BlobType.BlobDimensionality.SINGLE
-            and literal_type.blob.format == self.JSON_ITERATOR_FORMAT
+            literal_type.type is not None
+            and literal_type.type.dimensionality == _core_types.BlobType.BlobDimensionality.SINGLE
+            and literal_type.type.format == self.JSON_ITERATOR_FORMAT
             and literal_type.metadata == {"format": self.JSON_ITERATOR_METADATA}
         ):
             return Iterator[JSON]  # type: ignore

--- a/flytekit/types/numpy/ndarray.py
+++ b/flytekit/types/numpy/ndarray.py
@@ -3,6 +3,7 @@ import typing
 from collections import OrderedDict
 from typing import Dict, Tuple, Type
 
+import flyteidl_rust as flyteidl
 import numpy as np
 from typing_extensions import Annotated, get_args, get_origin
 
@@ -78,11 +79,11 @@ class NumpyArrayTransformer(TypeTransformer[np.ndarray]):
             mmap_mode=metadata.get("mmap_mode"),  # type: ignore
         )
 
-    def guess_python_type(self, literal_type: LiteralType) -> typing.Type[np.ndarray]:
+    def guess_python_type(self, literal_type: flyteidl.core.LiteralType) -> typing.Type[np.ndarray]:
         if (
-            literal_type.blob is not None
-            and literal_type.blob.dimensionality == _core_types.BlobType.BlobDimensionality.SINGLE
-            and literal_type.blob.format == self.NUMPY_ARRAY_FORMAT
+            literal_type.type is not None
+            and literal_type.type.dimensionality == _core_types.BlobType.BlobDimensionality.SINGLE
+            and literal_type.type.format == self.NUMPY_ARRAY_FORMAT
         ):
             return np.ndarray
 

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -103,7 +103,7 @@ class FlytePickleTransformer(TypeTransformer[FlytePickle]):
 
     def guess_python_type(self, literal_type: LiteralType) -> typing.Type[FlytePickle[typing.Any]]:
         if (
-            literal_type.blob is not None
+            literal_type.type is not None
             and literal_type.blob.dimensionality == _core_types.BlobType.BlobDimensionality.SINGLE
             and literal_type.blob.format == FlytePickleTransformer.PYTHON_PICKLE_FORMAT
         ):

--- a/flytekit/types/schema/types.py
+++ b/flytekit/types/schema/types.py
@@ -9,6 +9,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Type
 
+import flyteidl_rust as flyteidl
 import numpy as _np
 from dataclasses_json import config
 from marshmallow import fields
@@ -418,8 +419,8 @@ class FlyteSchemaTransformer(TypeTransformer[FlyteSchema]):
             supported_mode=SchemaOpenMode.READ,
         )
 
-    def guess_python_type(self, literal_type: LiteralType) -> Type[FlyteSchema]:
-        if not literal_type.schema:
+    def guess_python_type(self, literal_type: flyteidl.LiteralType) -> Type[FlyteSchema]:
+        if not literal_type.type:
             raise ValueError(f"Cannot reverse {literal_type}")
         columns: typing.Dict[str, Type] = {}
         for literal_column in literal_type.schema.columns:

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -8,6 +8,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, is_dataclass
 from typing import Dict, Generator, Optional, Type, Union
 
+import flyteidl_rust as flyteidl
 from dataclasses_json import config
 from fsspec.utils import get_protocol
 from marshmallow import fields
@@ -881,10 +882,10 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
         """
         return LiteralType(structured_dataset_type=self._get_dataset_type(t))
 
-    def guess_python_type(self, literal_type: LiteralType) -> Type[StructuredDataset]:
+    def guess_python_type(self, literal_type: flyteidl.LiteralType) -> Type[StructuredDataset]:
         # todo: technically we should return the dataframe type specified in the constructor, but to do that,
         #   we'd have to store that, which we don't do today. See possibly #1363
-        if literal_type.structured_dataset_type is not None:
+        if literal_type.type is not None:
             return StructuredDataset
         raise ValueError(f"StructuredDatasetTransformerEngine cannot reverse {literal_type}")
 


### PR DESCRIPTION
## Tracking issue

As a result of the [initiative](https://github.com/flyteorg/flytekit/pull/2307), [issues](https://github.com/flyteorg/flyte/issues/5344), [discussions](https://github.com/flyteorg/flytekit/pull/2328) and serial trials and errors in `flyrs` branch  [1](https://github.com/flyteorg/flytekit/pull/2414) [2](https://github.com/flyteorg/flytekit/pull/2415) this PR aims to create another FlyteRemote in`remote/remote_rs.py` which  wrapping [`flyteidl-rust`](https://test.pypi.org/project/flyteidl-rust/)[^1] as its core. Python package,  `flyteidl-rust`, was built directly from Rust. With the helps of works in [flyte/flyteidl/lib.rs](), this PR eliminates the **protobuf objects serialization overhead**[^2] while calling gRPC services. Unlike the original approach in [`flyrs`](https://github.com/flyteorg/flytekit/tree/flyrs), this method optimizes performance and reduces the maintenance cost.

* Use case ( can work ):
  ```python
  from flytekit.remote.remote_rs import FlyteRemote
  
  def test_fetch_execute_sync_string_task(register):
      remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
      flyte_task = remote.fetch_task(name="basics.echo_string_task.test_echo_string_task", version=VERSION)
      # `wait` to sync execution
      execution = remote.execute(flyte_task, inputs={"s": "hey"}, wait=True)
      assert execution.is_done
      assert execution.outputs["o0"] == "hey"
  ```



[^1]: Temporarily registered in PyPI **test index** as test package that will not affect the real PyPI registry in production.
[^2]: In previous PRs, it serialize the python types into bytes string and pass into PyO3-exposed Rust functions.


## Why are the changes needed?

With `flyteidl-rust` Python bindings, Flytekit can get rid of **not only `grpc` but also `protobuf` Python dependencies**, ultimately **removing the `model` layer** between `protobuf` and `remote entities`. This approach leverages  Rust structures directly.

For Rust side, developers still can wrap `flyte/flytidl` as their remote gRPC clients or use its API directly.

For Python, developers can build another remote client by wrapping `flyteidl-rust` as its core.

## What changes were proposed in this pull request?

To this end, we have to replace all types import from `model` files to use `flyteidl-rust` package instead. Including, 
1. Modify remote entities to inherit from `flyteidl-rust` classes  instead of `model` files.
3. Refactor `type transoformers` in  `core/type_engine.py` and `get_serializable()` in `translator.py` to adapt with `flyteidl-rust` classes.

    * `get_serializable()` in `tools/translator.py`
        - [ ] `ReferenceEntity`
        - [X] `PythonTask`
        - [ ] `WorkflowBase`
        - [X] `Node`
        - [ ] `LaunchPlan`
        - [ ] `BranchNode`
        - [ ] `FlyteTask`
    * `SimpleTransformer` in `core/type_engine.py`
        - [X] `int`
        - [X] `float`
        - [X] `bool`
        - [X] `str`
        - [ ] `datetime`
        - [ ] `timedelta`
        - [ ] `date`
        - [ ] `none`
    * Other types' `Transformer` in `core/type_engine.py`

## How was this patch tested?

> [!WARNING] 
> For now, we havn't migrate the test cases to use `flyteidl-rust` and other type transformation still works in progress, so the CI must fail, don't run.
> 
> FlyteRemote only works in `Task` register / fetch / execute strictly with primitive python types, `Workflow` and `LaunchPlan` still works in progress.

### Setup process
1. Install `flyteidl-rust`
    `pip install -i https://test.pypi.org/simple/ flyteidl-rust`
     <img width="1280" alt="Screenshot 2024-06-27 at 7 11 54 PM" src="https://github.com/flyteorg/flytekit/assets/35886692/986d1d2d-ca5c-40be-8790-4d7ee95a19b6">

2. Run the tasks which only using string, integer, float as input or output. For example,
    * `pyflyte register ./echo_string_task.py` and run on web console, or
    * `pyflyte run --remote ./echo_string_task.py test_echo_string_task --s "hey"`

### Screenshots
* `pyflyte register` `echo_int` and `echo_float` task.
    <img width="1280" alt="Screenshot 2024-06-27 at 7 16 38 PM" src="https://github.com/flyteorg/flytekit/assets/35886692/c4585510-5f16-4e3f-a410-0281c29c39b4">
* re-run `echo_string` task from console.
    <img width="1280" alt="Screenshot 2024-06-27 at 7 15 25 PM" src="https://github.com/flyteorg/flytekit/assets/35886692/c2245c12-7552-4b5a-8dcf-e9433ea790ed">
* `pyflyte run --remote` 
    ```python
      from flytekit import task
      
      @task()
      def test_square_task(n: float) -> float:
          return n**2
    ```
    <img width="1280" alt="Screenshot 2024-06-27 at 7 24 05 PM" src="https://github.com/flyteorg/flytekit/assets/35886692/3adb2a8c-f105-46f6-97c6-47393e4a96da">
    <img width="1280" alt="Screenshot 2024-06-27 at 7 24 40 PM" src="https://github.com/flyteorg/flytekit/assets/35886692/29166028-42eb-441f-93ca-736b71f2a033">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

## Docs link

## Cross References

1. https://github.com/pydantic/pydantic-core
2. https://github.com/pola-rs/pyo3-polars/tree/main/pyo3-polars