### PR TITLE
[fix] Validate interface variable names are python-valid

### DIFF
--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import collections
 import copy
 import inspect
-import re
 import typing
 from collections import OrderedDict
 from typing import Any, Dict, Generator, List, Optional, Tuple, Type, TypeVar, Union, cast

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections
 import copy
 import inspect
+import re
 import typing
 from collections import OrderedDict
 from typing import Any, Dict, Generator, List, Optional, Tuple, Type, TypeVar, Union, cast
@@ -70,6 +71,8 @@ class Interface(object):
         self._inputs: Union[Dict[str, Tuple[Type, Any]], Dict[str, Type]] = {}  # type: ignore
         if inputs:
             for k, v in inputs.items():
+                if not k.isidentifier():
+                    raise ValueError(f'Input name must be valid Python identifier: {k!r}')
                 if type(v) is tuple and len(cast(Tuple, v)) > 1:
                     self._inputs[k] = v  # type: ignore
                 else:

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -71,7 +71,7 @@ class Interface(object):
         if inputs:
             for k, v in inputs.items():
                 if not k.isidentifier():
-                    raise ValueError(f'Input name must be valid Python identifier: {k!r}')
+                    raise ValueError(f"Input name must be valid Python identifier: {k!r}")
                 if type(v) is tuple and len(cast(Tuple, v)) > 1:
                     self._inputs[k] = v  # type: ignore
                 else:

--- a/tests/flytekit/unit/core/test_interface.py
+++ b/tests/flytekit/unit/core/test_interface.py
@@ -320,6 +320,16 @@ def test_transform_interface_to_typed_interface_with_docstring():
     assert typed_interface.outputs.get("y_int").description == "description for y_int"
 
 
+def test_init_interface_with_invalid_parameters():
+    from flytekit.core.interface import Interface
+
+    with pytest.raises(ValueError, match=r"Input name must be valid Python identifier:"):
+        _ = Interface({"my.input": int}, {})
+
+    with pytest.raises(ValueError, match=r"Type names and field names must be valid identifiers:"):
+        _ = Interface({}, {"my.output": int})
+
+
 def test_parameter_change_to_pickle_type():
     ctx = context_manager.FlyteContext.current_context()
 


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5511

## Why are the changes needed?

Rationale: flyte inputs names are "like" python variable names, which should not use special characters like . (see my.value in the repro code

Expected behavior: The workflow should actually fail at compile time at step 1. (e.g. perform extra validation)

## What changes were proposed in this pull request?

Workflow should fail at compile time at step 1, when python-invalid variable name is used like "my.value".

## How was this patch tested?

### Setup process

```
import logging

from flytekit import ContainerTask, kwtypes, task, workflow

logger = logging.getLogger(__file__)

calculate_ellipse_area_shell = ContainerTask(
    name="ellipse-area-metadata-shell",
    input_data_dir="/var/inputs",
    output_data_dir="/var/outputs",
    inputs=kwtypes(**{"my.value": float, "c": float}),
    outputs=kwtypes(area=float, metadata=str),
    image="ghcr.io/flyteorg/rawcontainers-shell:v2",
    command=[
        "./calculate-ellipse-area.sh"
    ],
)

@task
def report_all_calculated_areas(
    area_shell: float,
    metadata_shell: str,
):
    logger.info(f"shell: area={area_shell}, metadata={metadata_shell}")

@workflow
def wf(a: float, b: float):
    area_shell, metadata_shell = calculate_ellipse_area_shell(**{"my.value": a, "c": b})

    # Report on all results in a single task to simplify comparison
    report_all_calculated_areas(
        area_shell=area_shell,
        metadata_shell=metadata_shell,
    )
```

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
