### PR TITLE
Add upper bound for pandera plugin

### DIFF
--- a/plugins/flytekit-pandera/setup.py
+++ b/plugins/flytekit-pandera/setup.py
@@ -4,6 +4,7 @@ PLUGIN_NAME = "pandera"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
+# TODO: remove upper bound. https://github.com/flyteorg/flyte/issues/5531
 plugin_requires = ["flytekit>=1.3.0b2,<2.0.0", "pandera>=0.7.1,<=0.19.3", "pandas"]
 
 __version__ = "0.0.0+develop"

--- a/plugins/flytekit-pandera/setup.py
+++ b/plugins/flytekit-pandera/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "pandera"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.3.0b2,<2.0.0", "pandera>=0.7.1", "pandas"]
+plugin_requires = ["flytekit>=1.3.0b2,<2.0.0", "pandera>=0.7.1,<=0.19.3", "pandas"]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
unit test is failing
```
FAILED tests/test_plugin.py::test_pandera_dataframe_type_hints - AttributeError: module 'pandera' has no attribute 'SchemaModel'
```

## What changes were proposed in this pull request?
add upper bound

## How was this patch tested?
unit test

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
