### PR TITLE
Add support imageSpec chaining

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -76,7 +76,6 @@ class ImageSpec:
         self._is_force_push = os.environ.get(FLYTE_FORCE_PUSH_IMAGE_SPEC, False)  # False by default
         if self.registry:
             self.registry = self.registry.lower()
-        self._prev: ImageSpec = None
 
     def image_name(self) -> str:
         """Full image name with tag."""

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -76,6 +76,7 @@ class ImageSpec:
         self._is_force_push = os.environ.get(FLYTE_FORCE_PUSH_IMAGE_SPEC, False)  # False by default
         if self.registry:
             self.registry = self.registry.lower()
+        self._prev: ImageSpec = None
 
     def image_name(self) -> str:
         """Full image name with tag."""
@@ -164,46 +165,31 @@ class ImageSpec:
         """
         Builder that returns a new image spec with an additional list of commands that will be executed during the building process.
         """
-        new_image_spec = copy.deepcopy(self)
-        if new_image_spec.commands is None:
-            new_image_spec.commands = []
-
-        if isinstance(commands, List):
-            new_image_spec.commands.extend(commands)
-        else:
-            new_image_spec.commands.append(commands)
-
-        return new_image_spec
+        return ImageSpec(
+            commands=commands if isinstance(commands, List) else [commands],
+            base_image=self,
+            registry=self.registry,
+        )
 
     def with_packages(self, packages: Union[str, List[str]]) -> "ImageSpec":
         """
         Builder that returns a new image speck with additional python packages that will be installed during the building process.
         """
-        new_image_spec = copy.deepcopy(self)
-        if new_image_spec.packages is None:
-            new_image_spec.packages = []
-
-        if isinstance(packages, List):
-            new_image_spec.packages.extend(packages)
-        else:
-            new_image_spec.packages.append(packages)
-
-        return new_image_spec
+        return ImageSpec(
+            packages=packages if isinstance(packages, List) else [packages],
+            base_image=self,
+            registry=self.registry,
+        )
 
     def with_apt_packages(self, apt_packages: Union[str, List[str]]) -> "ImageSpec":
         """
-        Builder that returns a new image spec with additional list of apt packages that will be executed during the building process.
+        Builder that returns a new image spec with an additional list of apt packages that will be executed during the building process.
         """
-        new_image_spec = copy.deepcopy(self)
-        if new_image_spec.apt_packages is None:
-            new_image_spec.apt_packages = []
-
-        if isinstance(apt_packages, List):
-            new_image_spec.apt_packages.extend(apt_packages)
-        else:
-            new_image_spec.apt_packages.append(apt_packages)
-
-        return new_image_spec
+        return ImageSpec(
+            apt_packages=apt_packages if isinstance(apt_packages, List) else [apt_packages],
+            base_image=self,
+            registry=self.registry,
+        )
 
     def force_push(self) -> "ImageSpec":
         """


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Cannot control the order of the docker command

## What changes were proposed in this pull request?
`.with_packages` will return a new ImageSpec. In this new ImageSpec, the base image will be the current image, and packages will be the input of `with_packages`. Therefore, the new imageSpec will build and push the base image, and another new imageSpec will be built with new packages.

```python
ImageSpec(registry="ghcr.io/flyteorg", packages=["tensorflow"])  # build and push image 1
         .with_pacakges("wget")  # build and push image 2 (base_image is image 1)
         .with_apt_packages("numpy")  -> build image  # build and push image 3 (base image is image 2)
```

## How was this patch tested?
```python
from flytekit import task, workflow, ImageSpec

custom_image = ImageSpec(
    registry="ghcr.io/flyteorg",
    packages=["tensorflow"],
    apt_packages=["wget"],
    commands=["echo 6"]
).with_apt_packages("wget").with_packages("numpy")


@task(container_image=custom_image)
def t1(a: int) -> int:
    return a + 1


@workflow
def wf() -> int:
    return t1(a=3)
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
