### PR TITLE
fix datetime in eager workflow

### DIFF
--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -180,7 +180,7 @@ class AsyncEntity:
 
         poll_interval = self._poll_interval or timedelta(seconds=30)
         time_to_give_up = (
-            (datetime.max - timedelta(days=2)).astimezone(timezone.utc)
+            (datetime.max.replace(tzinfo=timezone.utc))
             if self._timeout is None
             else datetime.now(timezone.utc) + self._timeout
         )
@@ -213,7 +213,7 @@ class AsyncEntity:
 
             poll_interval = self._poll_interval or timedelta(seconds=6)
             time_to_give_up = (
-                (datetime.max - timedelta(days=2)).astimezone(timezone.utc)
+                (datetime.max.replace(tzinfo=timezone.utc))
                 if self._timeout is None
                 else datetime.now(timezone.utc) + self._timeout
             )

--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -179,7 +179,7 @@ class AsyncEntity:
         self.async_stack.set_node(node)
 
         poll_interval = self._poll_interval or timedelta(seconds=30)
-        time_to_give_up = datetime.max if self._timeout is None else datetime.now(timezone.utc) + self._timeout
+        time_to_give_up = (datetime.max - timedelta(days=2)).astimezone(timezone.utc) if self._timeout is None else datetime.now(timezone.utc) + self._timeout
 
         while datetime.now(timezone.utc) < time_to_give_up:
             execution = self.remote.sync(execution)
@@ -208,7 +208,7 @@ class AsyncEntity:
             )
 
             poll_interval = self._poll_interval or timedelta(seconds=6)
-            time_to_give_up = datetime.max if self._timeout is None else datetime.now(timezone.utc) + self._timeout
+            time_to_give_up = (datetime.max - timedelta(days=2)).astimezone(timezone.utc) if self._timeout is None else datetime.now(timezone.utc) + self._timeout
 
             while datetime.now(timezone.utc) < time_to_give_up:
                 execution = self.remote.sync(execution)

--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -179,7 +179,11 @@ class AsyncEntity:
         self.async_stack.set_node(node)
 
         poll_interval = self._poll_interval or timedelta(seconds=30)
-        time_to_give_up = (datetime.max - timedelta(days=2)).astimezone(timezone.utc) if self._timeout is None else datetime.now(timezone.utc) + self._timeout
+        time_to_give_up = (
+            (datetime.max - timedelta(days=2)).astimezone(timezone.utc)
+            if self._timeout is None
+            else datetime.now(timezone.utc) + self._timeout
+        )
 
         while datetime.now(timezone.utc) < time_to_give_up:
             execution = self.remote.sync(execution)
@@ -208,7 +212,11 @@ class AsyncEntity:
             )
 
             poll_interval = self._poll_interval or timedelta(seconds=6)
-            time_to_give_up = (datetime.max - timedelta(days=2)).astimezone(timezone.utc) if self._timeout is None else datetime.now(timezone.utc) + self._timeout
+            time_to_give_up = (
+                (datetime.max - timedelta(days=2)).astimezone(timezone.utc)
+                if self._timeout is None
+                else datetime.now(timezone.utc) + self._timeout
+            )
 
             while datetime.now(timezone.utc) < time_to_give_up:
                 execution = self.remote.sync(execution)


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

```python=
[3/3] currentAttempt done. Last Error: SYSTEM::Traceback (most recent call last):
  File "/flytekit/flytekit/bin/entrypoint.py", line 103, in _dispatch_execute
    outputs = asyncio.run(outputs)
  File "/usr/local/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/flytekit/flytekit/core/base_task.py", line 666, in _async_execute
    native_outputs = await native_outputs
  File "/flytekit/flytekit/experimental/eager_function.py", line 517, in wrapper
    out = await _fn(*args, **kws)
  File "/root/test_async.py", line 68, in simple_async_workflow
    res = await coro
  File "/flytekit/flytekit/experimental/eager_function.py", line 184, in __call__
    while datetime.now(timezone.utc) < time_to_give_up:
TypeError: can't compare offset-naive and offset-aware datetimes
```

datetime comparison is wrong when using eager_workflows

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

changed datetime.max as timezone-aware datetime and prevented timestamp overflow by subtracting 2 days. 

## How was this patch tested?

`pytest --pdb -x tests/flytekit/unit/experimental/test_eager_workflows.py  -s`
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
