### PR TITLE
Support s3 path for click Dir param type

### DIFF
--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -80,13 +80,15 @@ class DirParamType(click.ParamType):
     ) -> typing.Any:
         if isinstance(value, ArtifactQuery):
             return value
-        p = pathlib.Path(value)
+
         # set remote_directory to false if running pyflyte run locally. This makes sure that the original
         # directory is used and not a random one.
         remote_directory = None if getattr(ctx.obj, "is_remote", False) else False
-        if p.exists() and p.is_dir():
-            return FlyteDirectory(path=value, remote_directory=remote_directory)
-        raise click.BadParameter(f"parameter should be a valid directory path, {value}")
+        if not FileAccessProvider.is_remote(value):
+            p = pathlib.Path(value)
+            if not p.exists() or not p.is_dir():
+                raise click.BadParameter(f"parameter should be a valid flytedirectory path, {value}")
+        return FlyteDirectory(path=value, remote_directory=remote_directory)
 
 
 class StructuredDatasetParamType(click.ParamType):

--- a/tests/flytekit/unit/interaction/test_click_types.py
+++ b/tests/flytekit/unit/interaction/test_click_types.py
@@ -28,6 +28,12 @@ from flytekit.interaction.click_types import (
 
 dummy_param = click.Option(["--dummy"], type=click.STRING, default="dummy")
 
+def test_dir_param():
+    m = mock.MagicMock()
+    l = DirParamType().convert("/tmp", m, m)
+    assert l.path == "/tmp"
+    r = DirParamType().convert("https://tmp/dir", m, m)
+    assert r.path == "https://tmp/dir"
 
 def test_file_param():
     m = mock.MagicMock()

--- a/tests/flytekit/unit/interaction/test_click_types.py
+++ b/tests/flytekit/unit/interaction/test_click_types.py
@@ -29,9 +29,11 @@ from flytekit.interaction.click_types import (
 dummy_param = click.Option(["--dummy"], type=click.STRING, default="dummy")
 
 def test_dir_param():
+    import os
     m = mock.MagicMock()
-    l = DirParamType().convert("/tmp", m, m)
-    assert l.path == "/tmp"
+    current_file_directory = os.path.dirname(os.path.abspath(__file__))
+    l = DirParamType().convert(current_file_directory, m, m)
+    assert l.path == current_file_directory
     r = DirParamType().convert("https://tmp/dir", m, m)
     assert r.path == "https://tmp/dir"
 


### PR DESCRIPTION
## Why are the changes needed?
We only support local directory for click Dir param type, now we want to support remote s3 path also. 

## What changes were proposed in this pull request?
Use `FileAccessProvider.is_remote` to check if the path is remote or not.

## How was this patch tested?
remote execution and unit test.

### Setup process
```python
import os

from flytekit import task, workflow
from flytekit.types.directory import FlyteDirectory
from flytekit.types.file import FlyteFile
from click.testing import CliRunner
from flytekit.clis.sdk_in_container import pyflyte


@task
def list_dir(d: FlyteDirectory):
    for fname in os.listdir(d):
        print(f"Found file {fname}")


@workflow
def dir_wf(d: FlyteDirectory):
    list_dir(d=d)

@task
def list_file(f: FlyteFile):
    print(f)
    with open(f, "r") as wf:
        print(wf.read())

@workflow
def file_wf(f: FlyteFile):
    list_file(f=f)


if __name__ == "__main__":
    runner = CliRunner()
    result = runner.invoke(pyflyte.main, ["run", "--remote", 
                                          "PR/s3-path-command-line/test.py", "dir_wf", "--d", "/Users/future-outlier/code/dev/PR/s3-path-command-line"])
    print(result.output)

    result = runner.invoke(pyflyte.main, ["run", "--remote", 
                                          "/Users/future-outlier/code/dev/PR/s3-path-command-line/test.py", "dir_wf", "--d", "s3://my-s3-bucket/a"])
    print(result.output)
```
### Screenshots
#### Terminal screenshots
```python
(DEV) future@outlier ~ % python PR/s3-path-command-line/test.py
Running Execution on Remote.

[✔] Go to http://localhost:30080/console/projects/flytesnacks/domains/development/executions/f45bc46a9b00c47239e8 to see execution in the console.

Running Execution on Remote.

[✔] Go to http://localhost:30080/console/projects/flytesnacks/domains/development/executions/f223ab0832cac4f058bd to see execution in the console.
```

#### use local dir
<img width="1085" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/8110927d-f970-4dbd-9bb9-164b54f22d24">
#### use remote dir
<img width="1081" alt="image" src="https://github.com/flyteorg/flytekit/assets/76461262/9cac4c0f-5b3e-43eb-9aee-f1404b2d4860">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

