### PR TITLE
Set default width if fail to get terminal size

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1650,7 +1650,7 @@ class UnionTransformer(TypeTransformer[T]):
                 res_tag = trans.name
                 found_res = True
             except Exception as e:
-                logger.debug(f"Failed to convert from {lv} to {v}", e)
+                logger.debug(f"Failed to convert from {lv} to {v} with error: {e}")
 
         if is_ambiguous:
             raise TypeError(

--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -140,13 +140,19 @@ def upgrade_to_rich_logging(log_level: typing.Optional[int] = logging.WARNING):
 
     import flytekit
 
+    try:
+        width = os.get_terminal_size().columns
+    except Exception as e:
+        logger.debug(f"Failed to get terminal size: {e}")
+        width = 80
+
     handler = RichHandler(
         tracebacks_suppress=[click, flytekit],
         rich_tracebacks=True,
         omit_repeated_times=False,
         show_path=False,
         log_time_format="%H:%M:%S.%f",
-        console=Console(width=os.get_terminal_size().columns),
+        console=Console(width=width),
     )
 
     formatter = logging.Formatter(fmt="%(filename)s:%(lineno)d - %(message)s")

--- a/tests/flytekit/loggers.py
+++ b/tests/flytekit/loggers.py
@@ -1,0 +1,11 @@
+import sys
+from subprocess import run
+
+
+def test_error(tmp_path):
+    EXAMPLE = "import flytekit"
+
+    script_path = tmp_path / "script.py"
+    script_path.write_text(EXAMPLE)
+    out = run([sys.executable, script_path], text=True, capture_output=True)
+    assert out.stderr == ""

--- a/tests/flytekit/unit/test_translator.py
+++ b/tests/flytekit/unit/test_translator.py
@@ -166,3 +166,4 @@ def test_launch_plan_with_fixed_input():
     assert len(task_spec.template.interface.outputs) == 1
     assert len(task_spec.template.nodes) == 1
     assert len(task_spec.template.nodes[0].inputs) == 2
+

--- a/tests/flytekit/unit/test_translator.py
+++ b/tests/flytekit/unit/test_translator.py
@@ -166,4 +166,3 @@ def test_launch_plan_with_fixed_input():
     assert len(task_spec.template.interface.outputs) == 1
     assert len(task_spec.template.nodes) == 1
     assert len(task_spec.template.nodes[0].inputs) == 2
-


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Cannot get the terminal size in the subprocess

## What changes were proposed in this pull request?
Set default width if fail to get terminal size

## How was this patch tested?
unit test

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
