### PR TITLE
[wip] Refactor to use binding `flyteidl-rust`'s `RawSynchronousFlyteClient`

### DIFF
--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -1,6 +1,7 @@
 import datetime
 import typing
 
+import flyteidl_rust as flyteidl
 from flyteidl.admin import common_pb2 as _common_pb2
 from flyteidl.admin import execution_pb2 as _execution_pb2
 from flyteidl.admin import launch_plan_pb2 as _launch_plan_pb2
@@ -9,13 +10,11 @@ from flyteidl.admin import node_execution_pb2 as _node_execution_pb2
 from flyteidl.admin import project_domain_attributes_pb2 as _project_domain_attributes_pb2
 from flyteidl.admin import project_pb2 as _project_pb2
 from flyteidl.admin import task_execution_pb2 as _task_execution_pb2
-from flyteidl.admin import task_pb2 as _task_pb2
 from flyteidl.admin import workflow_attributes_pb2 as _workflow_attributes_pb2
 from flyteidl.admin import workflow_pb2 as _workflow_pb2
 from flyteidl.service import dataproxy_pb2 as _data_proxy_pb2
 from google.protobuf.duration_pb2 import Duration
 
-from flytekit.clients.raw import RawSynchronousFlyteClient as _RawSynchronousFlyteClient
 from flytekit.models import common as _common
 from flytekit.models import execution as _execution
 from flytekit.models import filters as _filters
@@ -29,7 +28,7 @@ from flytekit.models.admin import workflow as _workflow
 from flytekit.models.core import identifier as _identifier
 
 
-class SynchronousFlyteClient(_RawSynchronousFlyteClient):
+class SynchronousFlyteClient(flyteidl.RawSynchronousFlyteClient):
     """
     This is a low-level client that users can use to make direct gRPC service calls to the control plane. See the
     :std:doc:`service spec <idl:protos/docs/service/index>`. This is more user-friendly interface than the
@@ -75,7 +74,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         :raises grpc.RpcError:
         """
         super(SynchronousFlyteClient, self).create_task(
-            _task_pb2.TaskCreateRequest(id=task_identifer.to_flyte_idl(), spec=task_spec.to_flyte_idl())
+            flyteidl.admin.TaskCreateRequest(id=task_identifer.to_flyte_idl(), spec=task_spec.to_flyte_idl())
         )
 
     def list_task_ids_paginated(self, project, domain, limit=100, token=None, sort_by=None):
@@ -173,7 +172,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         :rtype: flytekit.models.task.Task
         """
         return _task.Task.from_flyte_idl(
-            super(SynchronousFlyteClient, self).get_task(_common_pb2.ObjectGetRequest(id=id.to_flyte_idl()))
+            super(SynchronousFlyteClient, self).get_task(flyteidl.admin.ObjectGetRequest(id=id.to_flyte_idl()))
         )
 
     ####################################################################################################################
@@ -551,12 +550,13 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         return _identifier.WorkflowExecutionIdentifier.from_flyte_idl(
             super(SynchronousFlyteClient, self)
             .create_execution(
-                _execution_pb2.ExecutionCreateRequest(
+                flyteidl.admin.ExecutionCreateRequest(
                     project=project,
                     domain=domain,
                     name=name,
                     spec=execution_spec.to_flyte_idl(),
                     inputs=inputs.to_flyte_idl(),
+                    org="",
                 )
             )
             .id
@@ -582,7 +582,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         """
         return _execution.Execution.from_flyte_idl(
             super(SynchronousFlyteClient, self).get_execution(
-                _execution_pb2.WorkflowExecutionGetRequest(id=id.to_flyte_idl())
+                flyteidl.admin.WorkflowExecutionGetRequest(id=id.to_flyte_idl())
             )
         )
 
@@ -595,7 +595,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         """
         return _execution.WorkflowExecutionGetDataResponse.from_flyte_idl(
             super(SynchronousFlyteClient, self).get_execution_data(
-                _execution_pb2.WorkflowExecutionGetDataRequest(id=id.to_flyte_idl())
+                flyteidl.admin.WorkflowExecutionGetDataRequest(id=id.to_flyte_idl())
             )
         )
 
@@ -677,7 +677,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         """
         return _node_execution.NodeExecution.from_flyte_idl(
             super(SynchronousFlyteClient, self).get_node_execution(
-                _node_execution_pb2.NodeExecutionGetRequest(id=node_execution_identifier.to_flyte_idl())
+                flyteidl.admin.NodeExecutionGetRequest(id=node_execution_identifier.to_flyte_idl())
             )
         )
 
@@ -689,7 +689,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         """
         return _execution.NodeExecutionGetDataResponse.from_flyte_idl(
             super(SynchronousFlyteClient, self).get_node_execution_data(
-                _node_execution_pb2.NodeExecutionGetDataRequest(id=node_execution_identifier.to_flyte_idl())
+                flyteidl.admin.NodeExecutionGetDataRequest(id=node_execution_identifier.to_flyte_idl())
             )
         )
 
@@ -715,7 +715,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         :rtype: list[flytekit.models.node_execution.NodeExecution], Text
         """
         exec_list = super(SynchronousFlyteClient, self).list_node_executions_paginated(
-            _node_execution_pb2.NodeExecutionListRequest(
+            flyteidl.admin.NodeExecutionListRequest(
                 workflow_execution_id=workflow_execution_identifier.to_flyte_idl(),
                 limit=limit,
                 token=token,
@@ -775,7 +775,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         """
         return _task_execution.TaskExecution.from_flyte_idl(
             super(SynchronousFlyteClient, self).get_task_execution(
-                _task_execution_pb2.TaskExecutionGetRequest(id=id.to_flyte_idl())
+                flyteidl.admin.TaskExecutionGetRequest(id=id.to_flyte_idl())
             )
         )
 
@@ -788,7 +788,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         """
         return _execution.TaskExecutionGetDataResponse.from_flyte_idl(
             super(SynchronousFlyteClient, self).get_task_execution_data(
-                _task_execution_pb2.TaskExecutionGetDataRequest(id=task_execution_identifier.to_flyte_idl())
+                flyteidl.admin.TaskExecutionGetDataRequest(id=task_execution_identifier.to_flyte_idl())
             )
         )
 
@@ -1010,14 +1010,15 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
                 expires_in_pb = Duration()
                 expires_in_pb.FromTimedelta(expires_in)
             return super(SynchronousFlyteClient, self).create_upload_location(
-                _data_proxy_pb2.CreateUploadLocationRequest(
+                flyteidl.service.CreateUploadLocationRequest(
                     project=project,
                     domain=domain,
                     content_md5=content_md5,
                     filename=filename,
                     expires_in=expires_in_pb,
-                    filename_root=filename_root,
+                    filename_root=filename_root or "",
                     add_content_md5_metadata=add_content_md5_metadata,
+                    org="",
                 )
             )
         except Exception as e:

--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -326,12 +326,12 @@ def literal_type_to_click_type(lt: LiteralType, python_type: typing.Type) -> cli
     Converts a Flyte LiteralType given a python_type to a click.ParamType
     """
     if lt.simple:
-        if lt.simple == SimpleType.STRUCT:
+        if int(str(lt.simple)) == SimpleType.STRUCT:
             ct = JsonParamType(python_type)
             ct.name = f"JSON object {python_type.__name__}"
             return ct
-        if lt.simple in SIMPLE_TYPE_CONVERTER:
-            return SIMPLE_TYPE_CONVERTER[lt.simple]
+        if int(str(lt.simple)) in SIMPLE_TYPE_CONVERTER:
+            return SIMPLE_TYPE_CONVERTER[int(str(lt.simple))]
         raise NotImplementedError(f"Type {lt.simple} is not supported in pyflyte run")
 
     if lt.enum_type:

--- a/flytekit/models/annotation.py
+++ b/flytekit/models/annotation.py
@@ -1,9 +1,8 @@
 import json
 from typing import Any, Dict
 
-from flyteidl.core import types_pb2 as _types_pb2
+import flyteidl_rust as flyteidl
 from google.protobuf import json_format as _json_format
-from google.protobuf import struct_pb2 as _struct
 
 
 class TypeAnnotation:
@@ -19,17 +18,16 @@ class TypeAnnotation:
         """
         return self._annotations
 
-    def to_flyte_idl(self) -> _types_pb2.TypeAnnotation:
+    def to_flyte_idl(self) -> flyteidl.core.TypeAnnotation:
         """
         :rtype: flyteidl.core.types_pb2.TypeAnnotation
         """
-
         if self._annotations is not None:
-            annotations = _json_format.Parse(json.dumps(self.annotations), _struct.Struct())
+            annotations = _json_format.Parse(json.dumps(self.annotations), flyteidl.wkt.Struct())
         else:
             annotations = None
 
-        return _types_pb2.TypeAnnotation(
+        return flyteidl.core.TypeAnnotation(
             annotations=annotations,
         )
 

--- a/flytekit/models/common.py
+++ b/flytekit/models/common.py
@@ -3,8 +3,8 @@ import json
 import re
 from typing import Dict
 
+import flyteidl_rust as flytedidl
 from flyteidl.admin import common_pb2 as _common_pb2
-from flyteidl.core import literals_pb2 as _literals_pb2
 from google.protobuf import json_format as _json_format
 from google.protobuf import struct_pb2 as _struct
 
@@ -302,11 +302,20 @@ class Notification(FlyteIdlEntity):
         """
         :rtype: flyteidl.admin.common_pb2.Notification
         """
-        return _common_pb2.Notification(
+        _type = None
+        if self.email:
+            _type = flytedidl.notification.Type.Email(self.email)
+        elif self.pager_duty:
+            _type = flytedidl.notification.Type.PagerDuty(self.pager_duty)
+        elif self.slack:
+            _type = flytedidl.notification.Type.Slack(self.slack)
+
+        return flytedidl.notification.Type(
             phases=self.phases,
-            email=self.email.to_flyte_idl() if self.email else None,
-            pager_duty=self.pager_duty.to_flyte_idl() if self.pager_duty else None,
-            slack=self.slack.to_flyte_idl() if self.slack else None,
+            type=_type,
+            # email=self.email.to_flyte_idl() if self.email else None,
+            # pager_duty=self.pager_duty.to_flyte_idl() if self.pager_duty else None,
+            # slack=self.slack.to_flyte_idl() if self.slack else None,
         )
 
     @classmethod
@@ -340,7 +349,7 @@ class Labels(FlyteIdlEntity):
         """
         :rtype: dict[Text, Text]
         """
-        return _common_pb2.Labels(values={k: v for k, v in self.values.items()})
+        return flytedidl.admin.Labels(values={k: v for k, v in self.values.items()})
 
     @classmethod
     def from_flyte_idl(cls, pb2_object):
@@ -368,7 +377,7 @@ class Annotations(FlyteIdlEntity):
         """
         :rtype: _common_pb2.Annotations
         """
-        return _common_pb2.Annotations(values={k: v for k, v in self.values.items()})
+        return flytedidl.admin.Annotations(values={k: v for k, v in self.values.items()})
 
     @classmethod
     def from_flyte_idl(cls, pb2_object):
@@ -451,9 +460,9 @@ class AuthRole(FlyteIdlEntity):
         """
         :rtype: flyteidl.admin.launch_plan_pb2.Auth
         """
-        return _common_pb2.AuthRole(
-            assumable_iam_role=self.assumable_iam_role if self.assumable_iam_role else None,
-            kubernetes_service_account=self.kubernetes_service_account if self.kubernetes_service_account else None,
+        return flytedidl.admin.AuthRole(
+            assumable_iam_role=self.assumable_iam_role or "",
+            kubernetes_service_account=self.kubernetes_service_account or "",
         )
 
     @classmethod
@@ -483,7 +492,7 @@ class RawOutputDataConfig(FlyteIdlEntity):
         """
         :rtype: flyteidl.admin.common_pb2.Auth
         """
-        return _common_pb2.RawOutputDataConfig(output_location_prefix=self.output_location_prefix)
+        return flytedidl.admin.RawOutputDataConfig(output_location_prefix=self.output_location_prefix)
 
     @classmethod
     def from_flyte_idl(cls, pb2):
@@ -498,8 +507,8 @@ class Envs(FlyteIdlEntity):
     def envs(self) -> Dict[str, str]:
         return self._envs
 
-    def to_flyte_idl(self) -> _common_pb2.Envs:
-        return _common_pb2.Envs(values=[_literals_pb2.KeyValuePair(key=k, value=v) for k, v in self.envs.items()])
+    def to_flyte_idl(self) -> flytedidl.admin.Envs:
+        return flytedidl.admin.Envs(values=[flytedidl.core.KeyValuePair(key=k, value=v) for k, v in self.envs.items()])
 
     @classmethod
     def from_flyte_idl(cls, pb2: _common_pb2.Envs) -> _common_pb2.Envs:

--- a/flytekit/models/core/identifier.py
+++ b/flytekit/models/core/identifier.py
@@ -1,13 +1,14 @@
+import flyteidl_rust as flyteidl
 from flyteidl.core import identifier_pb2 as identifier_pb2
 
 from flytekit.models import common as _common_models
 
 
 class ResourceType(object):
-    UNSPECIFIED = identifier_pb2.UNSPECIFIED
-    TASK = identifier_pb2.TASK
-    WORKFLOW = identifier_pb2.WORKFLOW
-    LAUNCH_PLAN = identifier_pb2.LAUNCH_PLAN
+    UNSPECIFIED = int(flyteidl.core.ResourceType.Unspecified)
+    TASK = int(flyteidl.core.ResourceType.Task)
+    WORKFLOW = int(flyteidl.core.ResourceType.Workflow)
+    LAUNCH_PLAN = int(flyteidl.core.ResourceType.LaunchPlan)
 
 
 class Identifier(_common_models.FlyteIdlEntity):
@@ -24,6 +25,7 @@ class Identifier(_common_models.FlyteIdlEntity):
         self._domain = domain
         self._name = name
         self._version = version
+        self._org = ""
 
     @property
     def resource_type(self):
@@ -64,16 +66,24 @@ class Identifier(_common_models.FlyteIdlEntity):
         """
         return self._version
 
+    @property
+    def org(self):
+        """
+        :rtype: Text
+        """
+        return self._org
+
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.core.identifier_pb2.Identifier
         """
-        return identifier_pb2.Identifier(
+        return flyteidl.core.Identifier(
             resource_type=self.resource_type,
             project=self.project,
             domain=self.domain,
             name=self.name,
             version=self.version,
+            org=self.org,
         )
 
     @classmethod
@@ -107,6 +117,7 @@ class WorkflowExecutionIdentifier(_common_models.FlyteIdlEntity):
         self._project = project
         self._domain = domain
         self._name = name
+        self._org = ""
 
     @property
     def project(self):
@@ -129,14 +140,22 @@ class WorkflowExecutionIdentifier(_common_models.FlyteIdlEntity):
         """
         return self._name
 
+    @property
+    def org(self):
+        """
+        :rtype: Text
+        """
+        return self._org
+
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.core.identifier_pb2.WorkflowExecutionIdentifier
         """
-        return identifier_pb2.WorkflowExecutionIdentifier(
+        return flyteidl.core.WorkflowExecutionIdentifier(
             project=self.project,
             domain=self.domain,
             name=self.name,
+            org=self.org,
         )
 
     @classmethod
@@ -179,7 +198,7 @@ class NodeExecutionIdentifier(_common_models.FlyteIdlEntity):
         """
         :rtype: flyteidl.core.identifier_pb2.NodeExecutionIdentifier
         """
-        return identifier_pb2.NodeExecutionIdentifier(
+        return flyteidl.core.NodeExecutionIdentifier(
             node_id=self.node_id,
             execution_id=self.execution_id.to_flyte_idl(),
         )

--- a/flytekit/models/documentation.py
+++ b/flytekit/models/documentation.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
+import flyteidl_rust as flyteidl
 from flyteidl.admin import description_entity_pb2
 
 from flytekit.models import common as _common_models
@@ -27,11 +28,16 @@ class Description(_common_models.FlyteIdlEntity):
     format: DescriptionFormat = DescriptionFormat.RST
 
     def to_flyte_idl(self):
-        return description_entity_pb2.Description(
-            value=self.value if self.value else None,
-            uri=self.uri if self.uri else None,
+        return flyteidl.admin.Description(
+            content=flyteidl.description.Content.Value(self.value)
+            if self.value
+            else flyteidl.description.Content.Uri(self.uri)
+            if self.uri
+            else None,
+            # value=self.value if self.value else None,
+            # uri=self.uri if self.uri else None,
             format=self.format.value,
-            icon_link=self.icon_link,
+            icon_link=self.icon_link or "",
         )
 
     @classmethod
@@ -76,10 +82,11 @@ class Documentation(_common_models.FlyteIdlEntity):
     source_code: Optional[SourceCode] = None
 
     def to_flyte_idl(self):
-        return description_entity_pb2.DescriptionEntity(
-            short_description=self.short_description,
+        return flyteidl.admin.DescriptionEntity(
+            short_description=self.short_description or "",
             long_description=self.long_description.to_flyte_idl() if self.long_description else None,
             source_code=self.source_code.to_flyte_idl() if self.source_code else None,
+            tags=[],
         )
 
     @classmethod

--- a/flytekit/models/interface.py
+++ b/flytekit/models/interface.py
@@ -1,5 +1,6 @@
 import typing
 
+import flyteidl_rust as flyteidl
 from flyteidl.core import artifact_id_pb2 as art_id
 from flyteidl.core import interface_pb2 as _interface_pb2
 
@@ -57,7 +58,7 @@ class Variable(_common.FlyteIdlEntity):
         """
         :rtype: flyteidl.core.interface_pb2.Variable
         """
-        return _interface_pb2.Variable(
+        return flyteidl.core.Variable(
             type=self.type.to_flyte_idl(),
             description=self.description,
             artifact_partial_id=self.artifact_partial_id,
@@ -65,17 +66,15 @@ class Variable(_common.FlyteIdlEntity):
         )
 
     @classmethod
-    def from_flyte_idl(cls, variable_proto) -> _interface_pb2.Variable:
+    def from_flyte_idl(cls, variable_proto) -> flyteidl.core.Variable:
         """
         :param flyteidl.core.interface_pb2.Variable variable_proto:
         """
         return cls(
             type=_types.LiteralType.from_flyte_idl(variable_proto.type),
             description=variable_proto.description,
-            artifact_partial_id=variable_proto.artifact_partial_id
-            if variable_proto.HasField("artifact_partial_id")
-            else None,
-            artifact_tag=variable_proto.artifact_tag if variable_proto.HasField("artifact_tag") else None,
+            artifact_partial_id=variable_proto.artifact_partial_id or None,
+            artifact_tag=variable_proto.artifact_tag or None,
         )
 
 
@@ -130,10 +129,10 @@ class TypedInterface(_common.FlyteIdlEntity):
     def outputs(self) -> typing.Dict[str, Variable]:
         return self._outputs
 
-    def to_flyte_idl(self) -> _interface_pb2.TypedInterface:
-        return _interface_pb2.TypedInterface(
-            inputs=_interface_pb2.VariableMap(variables={k: v.to_flyte_idl() for k, v in self.inputs.items()}),
-            outputs=_interface_pb2.VariableMap(variables={k: v.to_flyte_idl() for k, v in self.outputs.items()}),
+    def to_flyte_idl(self) -> flyteidl.core.TypedInterface:
+        return flyteidl.core.TypedInterface(
+            inputs=flyteidl.core.VariableMap(variables={k: v.to_flyte_idl() for k, v in self.inputs.items()}),
+            outputs=flyteidl.core.VariableMap(variables={k: v.to_flyte_idl() for k, v in self.outputs.items()}),
         )
 
     @classmethod

--- a/flytekit/models/literals.py
+++ b/flytekit/models/literals.py
@@ -2,6 +2,7 @@ from datetime import datetime as _datetime
 from datetime import timezone as _timezone
 from typing import Dict, Optional
 
+import flyteidl_rust as flyteidl
 from flyteidl.core import literals_pb2 as _literals_pb2
 from google.protobuf.struct_pb2 import Struct
 
@@ -34,7 +35,7 @@ class RetryStrategy(_common.FlyteIdlEntity):
         """
         :rtype: flyteidl.core.literals_pb2.RetryStrategy
         """
-        return _literals_pb2.RetryStrategy(retries=self.retries)
+        return flyteidl.core.RetryStrategy(retries=self.retries)
 
     @classmethod
     def from_flyte_idl(cls, pb2_object):
@@ -141,11 +142,21 @@ class Primitive(_common.FlyteIdlEntity):
         """
         :rtype: flyteidl.core.literals_pb2.Primitive
         """
-        primitive = _literals_pb2.Primitive(
-            integer=self.integer,
-            float_value=self.float_value,
-            string_value=self.string_value,
-            boolean=self.boolean,
+        value = None
+        if self.string_value:
+            value = flyteidl.primitive.Value.StringValue(self.string_value)
+        elif self.integer:
+            value = flyteidl.primitive.Value.Integer(self.integer)
+        elif self.float_value:
+            value = flyteidl.primitive.Value.FloatValue(self.float_value)
+        elif self.boolean:
+            value = flyteidl.primitive.Value.Boolean(self.string_value)
+        primitive = flyteidl.core.Primitive(
+            value
+            # integer=self.integer,
+            # float_value=self.float_value,
+            # string_value=self.string_value,
+            # boolean=self.boolean,
         )
         if self.datetime is not None:
             # Convert to UTC and remove timezone so protobuf behaves.
@@ -689,7 +700,7 @@ class LiteralMap(_common.FlyteIdlEntity):
         """
         :rtype: flyteidl.core.literals_pb2.LiteralMap
         """
-        return _literals_pb2.LiteralMap(literals={k: v.to_flyte_idl() for k, v in self.literals.items()})
+        return flyteidl.core.LiteralMap(literals={k: v.to_flyte_idl() for k, v in self.literals.items()})
 
     @classmethod
     def from_flyte_idl(cls, pb2_object):
@@ -818,16 +829,22 @@ class Scalar(_common.FlyteIdlEntity):
         """
         :rtype: flyteidl.core.literals_pb2.Scalar
         """
-        return _literals_pb2.Scalar(
-            primitive=self.primitive.to_flyte_idl() if self.primitive is not None else None,
-            blob=self.blob.to_flyte_idl() if self.blob is not None else None,
-            binary=self.binary.to_flyte_idl() if self.binary is not None else None,
-            schema=self.schema.to_flyte_idl() if self.schema is not None else None,
-            union=self.union.to_flyte_idl() if self.union is not None else None,
-            none_type=self.none_type.to_flyte_idl() if self.none_type is not None else None,
-            error=self.error.to_flyte_idl() if self.error is not None else None,
-            generic=self.generic,
-            structured_dataset=self.structured_dataset.to_flyte_idl() if self.structured_dataset is not None else None,
+        return flyteidl.literal.Value.Scalar(
+            flyteidl.core.Scalar(
+                flyteidl.scalar.Value.Primitive(
+                    self.primitive.to_flyte_idl() if self.primitive is not None else None,
+                    # TODO:
+                    # primitive=self.primitive.to_flyte_idl() if self.primitive is not None else None,
+                    # blob=self.blob.to_flyte_idl() if self.blob is not None else None,
+                    # binary=self.binary.to_flyte_idl() if self.binary is not None else None,
+                    # schema=self.schema.to_flyte_idl() if self.schema is not None else None,
+                    # union=self.union.to_flyte_idl() if self.union is not None else None,
+                    # none_type=self.none_type.to_flyte_idl() if self.none_type is not None else None,
+                    # error=self.error.to_flyte_idl() if self.error is not None else None,
+                    # generic=self.generic,
+                    # structured_dataset=self.structured_dataset.to_flyte_idl() if self.structured_dataset is not None else None,
+                )
+            )
         )
 
     @classmethod
@@ -836,9 +853,9 @@ class Scalar(_common.FlyteIdlEntity):
         :param flyteidl.core.literals_pb2.Scalar pb2_object:
         :rtype: flytekit.models.literals.Scalar
         """
-        # todo finish
         return cls(
-            primitive=Primitive.from_flyte_idl(pb2_object.primitive) if pb2_object.HasField("primitive") else None,
+            # TODO:
+            primitive=Primitive.from_flyte_idl(pb2_object.primitive) if pb2_object.primitive else None,
             blob=Blob.from_flyte_idl(pb2_object.blob) if pb2_object.HasField("blob") else None,
             binary=Binary.from_flyte_idl(pb2_object.binary) if pb2_object.HasField("binary") else None,
             schema=Schema.from_flyte_idl(pb2_object.schema) if pb2_object.HasField("schema") else None,
@@ -929,12 +946,13 @@ class Literal(_common.FlyteIdlEntity):
         """
         :rtype: flyteidl.core.literals_pb2.Literal
         """
-        return _literals_pb2.Literal(
-            scalar=self.scalar.to_flyte_idl() if self.scalar is not None else None,
-            collection=self.collection.to_flyte_idl() if self.collection is not None else None,
-            map=self.map.to_flyte_idl() if self.map is not None else None,
-            hash=self.hash,
-            metadata=self.metadata,
+        return flyteidl.core.Literal(
+            value=self.scalar.to_flyte_idl() if self.scalar is not None else None,
+            # scalar=self.scalar.to_flyte_idl() if self.scalar is not None else None,
+            # collection=self.collection.to_flyte_idl() if self.collection is not None else None,
+            # map=self.map.to_flyte_idl() if self.map is not None else None,
+            hash=self.hash or "",
+            metadata=self.metadata or {},
         )
 
     @classmethod

--- a/flytekit/models/matchable_resource.py
+++ b/flytekit/models/matchable_resource.py
@@ -1,3 +1,4 @@
+import flyteidl_rust as flyteidl
 from flyteidl.admin import matchable_resource_pb2 as _matchable_resource
 
 from flytekit.models import common as _common
@@ -143,7 +144,7 @@ class ExecutionClusterLabel(_common.FlyteIdlEntity):
         """
         :rtype: flyteidl.admin.matchable_resource_pb2.ExecutionClusterLabel
         """
-        return _matchable_resource.ExecutionClusterLabel(
+        return flyteidl.admin.ExecutionClusterLabel(
             value=self.value,
         )
 

--- a/flytekit/models/security.py
+++ b/flytekit/models/security.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional
 
+import flyteidl_rust as flyteidl
 from flyteidl.core import security_pb2 as _sec
 
 from flytekit.models import common as _common
@@ -162,21 +163,22 @@ class SecurityContext(_common.FlyteIdlEntity):
         if self.tokens and not isinstance(self.tokens, list):
             self.tokens = [self.tokens]
 
-    def to_flyte_idl(self) -> _sec.SecurityContext:
+    def to_flyte_idl(self) -> flyteidl.core.SecurityContext:
         if self.run_as is None and self.secrets is None and self.tokens is None:
             return None
-        return _sec.SecurityContext(
+        return flyteidl.core.SecurityContext(
             run_as=self.run_as.to_flyte_idl() if self.run_as else None,
             secrets=[s.to_flyte_idl() for s in self.secrets] if self.secrets else None,
             tokens=[t.to_flyte_idl() for t in self.tokens] if self.tokens else None,
         )
 
     @classmethod
-    def from_flyte_idl(cls, pb2_object: _sec.SecurityContext) -> "SecurityContext":
+    def from_flyte_idl(cls, pb2_object: flyteidl.core.SecurityContext) -> "flyteidl.core.SecurityContext":
+        # TODO:
         return cls(
-            run_as=Identity.from_flyte_idl(pb2_object.run_as)
-            if pb2_object.run_as and pb2_object.run_as.ByteSize() > 0
-            else None,
-            secrets=[Secret.from_flyte_idl(s) for s in pb2_object.secrets] if pb2_object.secrets else None,
-            tokens=[OAuth2TokenRequest.from_flyte_idl(t) for t in pb2_object.tokens] if pb2_object.tokens else None,
+            run_as=None,  # Identity.from_flyte_idl(pb2_object.run_as)
+            # if pb2_object.run_as and pb2_object.run_as.ByteSize() > 0
+            # else None,
+            secrets=[],  # [Secret.from_flyte_idl(s) for s in pb2_object.secrets] if pb2_object.secrets else None,
+            tokens=[],  # [OAuth2TokenRequest.from_flyte_idl(t) for t in pb2_object.tokens] if pb2_object.tokens else None,
         )

--- a/flytekit/remote/entities.py
+++ b/flytekit/remote/entities.py
@@ -174,7 +174,7 @@ class FlyteTask(hash_mixin.HashOnReferenceMixin, RemoteEntity, TaskSpec):
             task_type_version=base_model.task_type_version,
         )
         # Override the newly generated name if one exists in the base model
-        if not base_model.id.is_empty:
+        if len(str(base_model.id)) > 0:  # not is_empty
             t._id = base_model.id
 
         return t

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -241,7 +241,7 @@ class FlyteRemote(object):
     def client(self) -> SynchronousFlyteClient:
         """Return a SynchronousFlyteClient for additional operations."""
         if not self._client_initialized:
-            self._client = SynchronousFlyteClient(self.config.platform, **self._kwargs)
+            self._client = SynchronousFlyteClient(self.config.platform.endpoint, **self._kwargs)
             self._client_initialized = True
         return self._client
 
@@ -351,6 +351,8 @@ class FlyteRemote(object):
             version,
         )
         admin_task = self.client.get_task(task_id)
+        admin_task = self.client.get_task(task_id)
+
         flyte_task = FlyteTask.promote_from_model(admin_task.closure.compiled_task.template)
         flyte_task.template._id = task_id
         return flyte_task


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?

Retain model layer overhead from this PR https://github.com/flyteorg/flytekit/pull/2536, and directly inherit  class`RawSynchronousFlyteClient` from binding https://test.pypi.org/project/flyteidl-rust/  in current `SynchronousFlyteClient` at `friendly.py`. The end game is replacing `raw.py` with fully functioned, auth-included, rust `RawSynchronousFlyteClient` pyhton binding.

## What changes were proposed in this pull request?

## How was this patch tested?

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [X] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flytekit/pull/2536

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
