### PR TITLE
Default image builder: Creates HOME if it does not exists

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -83,7 +83,8 @@ WORKDIR /root
 SHELL ["/bin/bash", "-c"]
 
 USER flytekit
-RUN echo "export PATH=$$PATH" >> $$HOME/.profile
+RUN mkdir -p $$HOME && \
+    echo "export PATH=$$PATH" >> $$HOME/.profile
 """
 )
 

--- a/tests/flytekit/unit/core/image_spec/test_default_builder.py
+++ b/tests/flytekit/unit/core/image_spec/test_default_builder.py
@@ -44,6 +44,7 @@ def test_create_docker_context(tmp_path):
     assert "COPY --chown=flytekit ./src /root" in dockerfile_content
     assert "RUN mkdir my_dir" in dockerfile_content
     assert "ENTRYPOINT [\"/bin/bash\"]" in dockerfile_content
+    assert "mkdir -p $HOME" in dockerfile_content
 
     requirements_path = docker_context_path / "requirements_uv.txt"
     assert requirements_path.exists()


### PR DESCRIPTION
## Why are the changes needed?

For some images, the $HOME directory does not exists yet. With this PR, it gets created. For example, if one specifies the normal flyte base image, it'll fail to build.

```
from flytekit import ImageSpec, task

image = ImageSpec(
    base_image="ghcr.io/flyteorg/flytekit:py3.12-1.13.0",
    packages=["pandas==2.2.2"],
    registry="localhost:30000",
)

@task(container_image=image)
def get():
    return
```

Note that the default image builder does not use the python environment from the `base_image` and creates its own Python environment.

## How was this patch tested?
Unit test was updated in this PR.