### PR TITLE
Allow for flytekit version to be specified in default image builder

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -103,7 +103,9 @@ _PACKAGE_NAME_RE = re.compile(r"^[\w-]+")
 
 
 def _is_flytekit(package: str) -> bool:
-    """Return True if `package` is flytekit."""
+    """Return True if `package` is flytekit. `package` is expected to be a valid version
+    spec. i.e. `flytekit==1.12.3`, `flytekit`, `flytekit~=1.12.3`.
+    """
     m = _PACKAGE_NAME_RE.match(package)
     if not m:
         return False
@@ -137,7 +139,7 @@ def create_docker_context(image_spec: ImageSpec, tmp_dir: Path):
     if image_spec.packages:
         requirements.extend(image_spec.packages)
 
-    # Adds flytekit if if it is not specified
+    # Adds flytekit if it is not specified
     if not any(_is_flytekit(package) for package in requirements):
         requirements.append(get_flytekit_for_pypi())
 

--- a/tests/flytekit/unit/core/image_spec/test_default_builder.py
+++ b/tests/flytekit/unit/core/image_spec/test_default_builder.py
@@ -93,6 +93,10 @@ def test_create_docker_context_with_null_entrypoint(tmp_path):
     )
 
     create_docker_context(image_spec, docker_context_path)
+    dockerfile_path = docker_context_path / "Dockerfile"
+    assert dockerfile_path.exists()
+    dockerfile_content = dockerfile_path.read_text()
+    assert "ENTRYPOINT []" in dockerfile_content
 
 
 @pytest.mark.parametrize("flytekit_spec", [None, "flytekit>=1.12.3", "flytekit==1.12.3"])

--- a/tests/flytekit/unit/core/image_spec/test_default_builder.py
+++ b/tests/flytekit/unit/core/image_spec/test_default_builder.py
@@ -93,6 +93,7 @@ def test_create_docker_context_with_null_entrypoint(tmp_path):
     )
 
     create_docker_context(image_spec, docker_context_path)
+
     dockerfile_path = docker_context_path / "Dockerfile"
     assert dockerfile_path.exists()
     dockerfile_content = dockerfile_path.read_text()

--- a/tests/flytekit/unit/core/image_spec/test_default_builder.py
+++ b/tests/flytekit/unit/core/image_spec/test_default_builder.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+import flytekit
 from flytekit.image_spec import ImageSpec
 from flytekit.image_spec.default_builder import DefaultImageBuilder, create_docker_context
 
@@ -93,10 +94,40 @@ def test_create_docker_context_with_null_entrypoint(tmp_path):
 
     create_docker_context(image_spec, docker_context_path)
 
+
+@pytest.mark.parametrize("flytekit_spec", [None, "flytekit>=1.12.3", "flytekit==1.12.3"])
+def test_create_docker_context_with_flytekit(tmp_path, flytekit_spec, monkeypatch):
+
+    # pretend version is 1.13.0
+    mock_version = "1.13.0"
+    monkeypatch.setattr(flytekit, "__version__", mock_version)
+
+    docker_context_path = tmp_path / "builder_root"
+    docker_context_path.mkdir()
+
+    if flytekit_spec:
+        packages = [flytekit_spec]
+    else:
+        packages = []
+
+    image_spec = ImageSpec(
+        name="FLYTEKIT", packages=packages
+    )
+
+    create_docker_context(image_spec, docker_context_path)
+
     dockerfile_path = docker_context_path / "Dockerfile"
     assert dockerfile_path.exists()
-    dockerfile_content = dockerfile_path.read_text()
-    assert "ENTRYPOINT []" in dockerfile_content
+
+    requirements_path = docker_context_path / "requirements_uv.txt"
+    assert requirements_path.exists()
+
+    requirements_content = requirements_path.read_text()
+    if flytekit_spec:
+        flytekit_spec in requirements_content
+        assert f"flytekit=={mock_version}" not in requirements_content
+    else:
+        assert f"flytekit=={mock_version}" in requirements_content
 
 
 def test_create_docker_context_cuda(tmp_path):


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
With `1.13.0`, the default image builder does not allow `flytekit` to be specified to a specific version. For example, the following will fail:

```
from flytekit import ImageSpec, task

image1 = ImageSpec(
    packages=["numpy==1.26.4", "flytekit==1.12.3"],
    builder="default",
)


@task(container_image=image1)
def work():
    pass
```

```shell
 pyflyte build build_flyte.py work
```

with:

```
0.220   × No solution found when resolving dependencies:
0.221   ╰─▶ Because you require flytekit==1.13.0 and flytekit==1.12.3, we can
0.221       conclude that the requirements are unsatisfiable.
```

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
With this PR, we check for `flytekit` first. If it is not detected in `requirements`, then we inject `flytekit` into the requirements with the version used during registration.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test was added to this PR.