### PR TITLE
Removes isodate requirement

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -183,7 +183,6 @@ ipython==8.25.0
 isodate==0.6.1
     # via
     #   azure-storage-blob
-    #   flytekit
 jaraco-classes==3.4.0
     # via
     #   keyring

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "grpcio",
     "grpcio-status",
     "importlib-metadata",
-    "isodate",
     "jinja2",
     "joblib",
     "jsonlines",


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
`isodate` is not used anywhere in `flytekit`.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR removes `isodate` from `pyproject.toml`
