### PR TITLE
Fix: Set OMP_NUM_THREADS by default in Elastic

### DIFF
--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -122,6 +122,10 @@ class Elastic(object):
     Single-node elastic training is executed in a k8s pod when `nnodes` is set to 1.
     Multi-node training is executed otherwise using a `Pytorch Job <https://github.com/kubeflow/training-operator>`_.
 
+    Like `torchrun`, this plugin sets the environment variable `OMP_NUM_THREADS` to 1 if it is not set.
+    Please see https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html for potential performance improvements.
+    To change `OMP_NUM_THREADS`, specify it in the environment dict of the flytekit task decorator or via `pyflyte run --env`.
+
     Args:
         nnodes (Union[int, str]): Number of nodes, or the range of nodes in form <minimum_nodes>:<maximum_nodes>.
         nproc_per_node (str): Number of workers per node.

--- a/plugins/flytekit-kf-pytorch/tests/test_pytorch_task.py
+++ b/plugins/flytekit-kf-pytorch/tests/test_pytorch_task.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from flytekitplugins.kfpytorch.task import CleanPodPolicy, Master, PyTorch, RestartPolicy, RunPolicy, Worker
 
@@ -16,7 +17,6 @@ def serialization_settings() -> SerializationSettings:
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
     return settings
-
 
 def test_pytorch_task(serialization_settings: SerializationSettings):
     @task(

--- a/plugins/flytekit-kf-pytorch/tests/test_pytorch_task.py
+++ b/plugins/flytekit-kf-pytorch/tests/test_pytorch_task.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 from flytekitplugins.kfpytorch.task import CleanPodPolicy, Master, PyTorch, RestartPolicy, RunPolicy, Worker
 
@@ -17,6 +16,7 @@ def serialization_settings() -> SerializationSettings:
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
     )
     return settings
+
 
 def test_pytorch_task(serialization_settings: SerializationSettings):
     @task(


### PR DESCRIPTION
## Why are the changes needed?

`torchrun` sets the environment variable `OMP_NUM_THREADS` automatically if not specified ([code](https://github.com/pytorch/pytorch/blob/main/torch/distributed/run.py#L791)). If it is not set, we saw some special cases in which our experiments were stuck for several minutes with high CPU load.

Also see https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html#utilize-openmp for more details.

To make `Elastic` tasks behave the same as executions started with `torchrun`, I would propose copying this behavior over to flytekit.

## What changes were proposed in this pull request?

See above

## How was this patch tested?

1. Added unit tests
2. Tested with internal workflows to check the behavior of `OMP_NUM_THREADS`.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
