### PR TITLE
Removes jinja2 dependency

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -20,7 +20,6 @@ IPython
 keyrings.alt
 setuptools_scm
 pytest-icdiff
-jinja2
 
 # Tensorflow is not available for python 3.12 yet: https://github.com/tensorflow/tensorflow/issues/62003
 tensorflow; python_version<'3.12'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -196,10 +196,6 @@ jaraco-functools==4.0.1
     # via keyring
 jedi==0.19.1
     # via ipython
-jinja2==3.1.4
-    # via
-    #   -r dev-requirements.in
-    #   flytekit
 jmespath==1.0.1
     # via botocore
 joblib==1.4.2
@@ -221,8 +217,6 @@ markdown-it-py==3.0.0
     # via
     #   flytekit
     #   rich
-markupsafe==2.1.5
-    # via jinja2
 marshmallow==3.21.2
     # via
     #   dataclasses-json

--- a/flytekit/deck/deck.py
+++ b/flytekit/deck/deck.py
@@ -1,6 +1,8 @@
 import enum
 import os
 import typing
+from html import escape
+from string import Template
 from typing import Optional
 
 from flytekit.core.context_manager import ExecutionParameters, ExecutionState, FlyteContext, FlyteContextManager
@@ -153,8 +155,16 @@ def _get_deck(
     If ignore_jupyter is set to True, then it will return a str even in a jupyter environment.
     """
     deck_map = {deck.name: deck.html for deck in new_user_params.decks}
+    nav_htmls = []
+    body_htmls = []
 
-    raw_html = get_deck_template().render(metadata=deck_map)
+    for key, value in deck_map.items():
+        nav_htmls.append(f'<li onclick="handleLinkClick(this)">{escape(key)}</li>')
+        # Can not escape here because this is HTML. Escaping it will present the HTML as text.
+        # The renderer must ensure that the HTML is safe.
+        body_htmls.append(f'<div>{value}</div>')
+
+    raw_html = get_deck_template().substitute(NAV_HTML="".join(nav_htmls), BODY_HTML="".join(body_htmls))
     if not ignore_jupyter and ipython_check():
         try:
             from IPython.core.display import HTML
@@ -184,18 +194,9 @@ def _output_deck(task_name: str, new_user_params: ExecutionParameters):
         logger.error(f"Failed to write flyte deck html with error {e}.")
 
 
-def get_deck_template() -> "Template":
-    from jinja2 import Environment, FileSystemLoader, select_autoescape
-
+def get_deck_template() -> Template:
     root = os.path.dirname(os.path.abspath(__file__))
-    templates_dir = os.path.join(root, "html")
-    env = Environment(
-        loader=FileSystemLoader(templates_dir),
-        # 🔥 include autoescaping for security purposes
-        # sources:
-        # - https://jinja.palletsprojects.com/en/3.0.x/api/#autoescaping
-        # - https://stackoverflow.com/a/38642558/8474894 (see in comments)
-        # - https://stackoverflow.com/a/68826578/8474894
-        autoescape=select_autoescape(enabled_extensions=("html",)),
-    )
-    return env.get_template("template.html")
+    templates_dir = os.path.join(root, "html", "template.html")
+    with open(templates_dir, "r") as f:
+        template_content = f.read()
+    return Template(template_content)

--- a/flytekit/deck/html/template.html
+++ b/flytekit/deck/html/template.html
@@ -69,20 +69,14 @@
 
 </head>
 <body>
-    <!---{#% autoescape true %#}--->
     <nav id="flyte-frame-nav">
         <ul id="flyte-frame-tabs">
-            {% for key, value in metadata.items() %}
-                <li onclick="handleLinkClick(this)">{{ key | safe }}</li>
-            {% endfor %}
+            $NAV_HTML
         </ul>
     </nav>
     <div id="flyte-frame-container">
-        {% for key, value in metadata.items() %}
-            <div>{{ value | safe }}</div>
-        {% endfor %}
+        $BODY_HTML
     </div>
-    <!---{#% autoescape %#}--->
 </body>
 <script>
     const setTabs = index => {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "grpcio-status",
     "importlib-metadata",
     "isodate",
-    "jinja2",
     "joblib",
     "jsonlines",
     "jsonpickle",


### PR DESCRIPTION
## Tracking issue
Related to https://github.com/flyteorg/flyte/issues/4418 and https://github.com/flyteorg/flytekit/pull/2413

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
This PR reduces the number of dependencies in `flytekit`.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This removes the Jinja2 dependency from flytekit and uses the `strings` instead.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I build an image with `make build-dev` and confirmed that the deck renders.