### PR TITLE
Use logging level in env for default dev logger

### DIFF
--- a/flytekit/loggers.py
+++ b/flytekit/loggers.py
@@ -135,7 +135,7 @@ def initialize_global_loggers():
 
     set_flytekit_log_properties(handler, None, _get_env_logging_level())
     set_user_logger_properties(handler, None, logging.INFO)
-    set_developer_properties(handler, None, logging.INFO)
+    set_developer_properties(handler, None, _get_dev_env_logging_level())
 
 
 def is_rich_logging_enabled() -> bool:


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use logging level in env for dev logger by default. If it's None, use level.info by default.
