### PR TITLE
Fix FlyteDirectory docs rendering

### DIFF
--- a/docs/source/_templates/file_types.rst
+++ b/docs/source/_templates/file_types.rst
@@ -2,7 +2,7 @@
 
 .. currentmodule:: {{ module }}
 
-{% if objname == 'FlyteFile' %}
+{% if objname == 'FlyteFile' or  objname == 'FlyteDirectory' %}
 
 .. autoclass:: {{ objname }}
 


### PR DESCRIPTION
## Tracking issue
https://linear.app/unionai/issue/DOC-480/fix-rendering-of-flytedirectory-api-doc-page-in-flyte-docs

## Why are the changes needed?

[FlyteDirectory API docs page](https://docs.flyte.org/en/latest/api/flytekit/generated/flytekit.types.directory.FlyteDirectory.html) is rendering incorrectly

## What changes were proposed in this pull request?

Adding FlyteDirectory to the if then logic of the template that produces the rendered page

## How was this patch tested?

Local build

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
Equivalent in flyte repo:
https://github.com/flyteorg/flyte/pull/5564

