### PR TITLE
Make `openai_organization` Optional in OpenAI plugins

### DIFF
--- a/plugins/flytekit-openai/flytekitplugins/openai/batch/task.py
+++ b/plugins/flytekit-openai/flytekitplugins/openai/batch/task.py
@@ -33,7 +33,7 @@ class BatchEndpointTask(AsyncAgentExecutorMixin, PythonTask):
         self,
         name: str,
         config: Dict[str, Any],
-        openai_organization: Optional[str] = "",
+        openai_organization: Optional[str] = None,
         **kwargs,
     ):
         super().__init__(
@@ -71,7 +71,7 @@ class OpenAIFileDefaultImages(DefaultImages):
 @dataclass
 class OpenAIFileConfig:
     secret: Secret
-    openai_organization: Optional[str] = ""
+    openai_organization: Optional[str] = None
 
     def _secret_to_dict(self) -> Dict[str, Optional[str]]:
         return {

--- a/plugins/flytekit-openai/flytekitplugins/openai/batch/task.py
+++ b/plugins/flytekit-openai/flytekitplugins/openai/batch/task.py
@@ -32,8 +32,8 @@ class BatchEndpointTask(AsyncAgentExecutorMixin, PythonTask):
     def __init__(
         self,
         name: str,
-        openai_organization: str,
         config: Dict[str, Any],
+        openai_organization: Optional[str] = "",
         **kwargs,
     ):
         super().__init__(
@@ -70,8 +70,8 @@ class OpenAIFileDefaultImages(DefaultImages):
 
 @dataclass
 class OpenAIFileConfig:
-    openai_organization: str
     secret: Secret
+    openai_organization: Optional[str] = ""
 
     def _secret_to_dict(self) -> Dict[str, Optional[str]]:
         return {

--- a/plugins/flytekit-openai/flytekitplugins/openai/batch/workflow.py
+++ b/plugins/flytekit-openai/flytekitplugins/openai/batch/workflow.py
@@ -17,7 +17,7 @@ from .task import (
 def create_batch(
     name: str,
     secret: Secret,
-    openai_organization: Optional[str] = "",
+    openai_organization: Optional[str] = None,
     config: Optional[Dict[str, Any]] = None,
     is_json_iterator: bool = True,
     file_upload_mem: str = "700Mi",

--- a/plugins/flytekit-openai/flytekitplugins/openai/batch/workflow.py
+++ b/plugins/flytekit-openai/flytekitplugins/openai/batch/workflow.py
@@ -16,8 +16,8 @@ from .task import (
 
 def create_batch(
     name: str,
-    openai_organization: str,
     secret: Secret,
+    openai_organization: Optional[str] = "",
     config: Optional[Dict[str, Any]] = None,
     is_json_iterator: bool = True,
     file_upload_mem: str = "700Mi",

--- a/plugins/flytekit-openai/flytekitplugins/openai/chatgpt/task.py
+++ b/plugins/flytekit-openai/flytekitplugins/openai/chatgpt/task.py
@@ -13,7 +13,7 @@ class ChatGPTTask(SyncAgentExecutorMixin, PythonTask):
 
     _TASK_TYPE = "chatgpt"
 
-    def __init__(self, name: str, chatgpt_config: Dict[str, Any], openai_organization: Optional[str] = "", **kwargs):
+    def __init__(self, name: str, chatgpt_config: Dict[str, Any], openai_organization: Optional[str] = None, **kwargs):
         """
         Args:
             name: Name of this task, should be unique in the project

--- a/plugins/flytekit-openai/flytekitplugins/openai/chatgpt/task.py
+++ b/plugins/flytekit-openai/flytekitplugins/openai/chatgpt/task.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from flytekit.configuration import SerializationSettings
 from flytekit.core.base_task import PythonTask
@@ -13,7 +13,7 @@ class ChatGPTTask(SyncAgentExecutorMixin, PythonTask):
 
     _TASK_TYPE = "chatgpt"
 
-    def __init__(self, name: str, openai_organization: str, chatgpt_config: Dict[str, Any], **kwargs):
+    def __init__(self, name: str, chatgpt_config: Dict[str, Any], openai_organization: Optional[str] = "", **kwargs):
         """
         Args:
             name: Name of this task, should be unique in the project


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936

## Why are the changes needed?
It's optional now.

## How was this patch tested?
chatgpt agent: unit test, local execution, and single binary remote execution
batch agent: unit test

## Help
I can't run the batch agent task in my local execution.
It will start an infinite event loop.

<img width="807" alt="image" src="https://github.com/user-attachments/assets/58ab253f-5b36-4e74-96ae-fa60a712ca93">

```python
import os
from typing import Iterator

from flytekit import Secret, workflow
from flytekit.types.file import JSONLFile
from flytekit.types.iterator import JSON
from flytekitplugins.openai import BatchResult, create_batch



def jsons():
    for x in [
        {
            "custom_id": "request-1",
            "method": "POST",
            "url": "/v1/chat/completions",
            "body": {
                "model": "gpt-3.5-turbo",
                "messages": [
                    {"role": "system", "content": "You are a helpful assistant."},
                    {"role": "user", "content": "What is 2+2?"},
                ],
            },
        },
        {
            "custom_id": "request-2",
            "method": "POST",
            "url": "/v1/chat/completions",
            "body": {
                "model": "gpt-3.5-turbo",
                "messages": [
                    {"role": "system", "content": "You are a helpful assistant."},
                    {"role": "user", "content": "Who won the world series in 2020?"},
                ],
            },
        },
    ]:
        yield x

#
#
# iterator_batch = create_batch(
#     name="gpt-3.5-turbo-iterator",
#     # openai_organization="your-org",
#     secret=Secret(group="openai", key="api_key"),
# )
#
#
#
# @workflow
# def json_iterator_wf(json_vals: Iterator[JSON] = jsons()) -> BatchResult:
#     return iterator_batch(jsonl_in=json_vals)
#
#
# if __name__ == "__main__":
#     print(f"Running {__file__} main...")
#     print(f"Running json_iterator_wf() {json_iterator_wf()}")

it_batch = create_batch(
    name="gpt-3.5-turbo",
    secret=Secret(group="openai", key="api_key"),
)

file_batch = create_batch(

    name="gpt-3.5-turbo",
    openai_organization="org-NayNG68kGnVXMJ8Ak4PMgQv7",
    secret=Secret(group="openai", key="api_key"),
    is_json_iterator=False,

)


@workflow
def json_iterator_wf(json_vals: Iterator[JSON] = jsons()) -> BatchResult:

    return it_batch(jsonl_in=json_vals)


@workflow
def jsonl_wf(jsonl_file: JSONLFile = "build/data.jsonl") -> BatchResult:

    return file_batch(jsonl_in=jsonl_file)

if __name__ == "__main__":
    print(f"Running {__file__} main...")
    print(f"Running json_iterator_wf() {json_iterator_wf()}")
    print(f"Running jsonl_wf() {jsonl_wf()}")
```

## Screenshots
chatgpt local execution and remote execution

<img width="903" alt="image" src="https://github.com/user-attachments/assets/a350803c-7acf-4352-ba16-841ab74efac4">

<img width="1687" alt="image" src="https://github.com/user-attachments/assets/d8d8257b-e06b-4a84-a87f-ba3b1e791569">
