### PR TITLE
truncate sagemaker agent outputs and automate idempotence token handling

### DIFF
--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/agent.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/agent.py
@@ -109,10 +109,7 @@ class SageMakerEndpointAgent(Boto3AgentMixin, AsyncAgentBase):
 
         res = None
         if current_state == "InService":
-            res = {
-                "result": {"EndpointArn": endpoint_status.get("EndpointArn")},
-                "idempotence_token": idempotence_token,
-            }
+            res = {"result": {"EndpointArn": endpoint_status.get("EndpointArn")}}
 
         return Resource(phase=flyte_phase, outputs=res, message=message)
 

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/agent.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/agent.py
@@ -83,7 +83,7 @@ class SageMakerEndpointAgent(Boto3AgentMixin, AsyncAgentBase):
 
     async def get(self, resource_meta: SageMakerEndpointMetadata, **kwargs) -> Resource:
         try:
-            endpoint_status, idempotence_token = await self._call(
+            endpoint_status, _ = await self._call(
                 method="describe_endpoint",
                 config={"EndpointName": resource_meta.config.get("EndpointName")},
                 inputs=resource_meta.inputs,
@@ -97,7 +97,7 @@ class SageMakerEndpointAgent(Boto3AgentMixin, AsyncAgentBase):
             if error_code == "ValidationException" and "Could not find endpoint" in error_message:
                 raise Exception(
                     "This might be due to resource limits being exceeded, preventing the creation of a new endpoint. Please check your resource usage and limits."
-                ) from e
+                )
             raise e
 
         current_state = endpoint_status.get("EndpointStatus")

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_agent.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_agent.py
@@ -78,15 +78,16 @@ class BotoAgent(SyncAgentBase):
                     error_message,
                 ).group(0)
                 if arn:
+                    arn_result = None
                     if method == "create_model":
-                        result = {"ModelArn": arn}
+                        arn_result = {"ModelArn": arn}
                     elif method == "create_endpoint_config":
-                        result = {"EndpointConfigArn": arn}
+                        arn_result = {"EndpointConfigArn": arn}
 
                     return Resource(
                         phase=TaskExecution.SUCCEEDED,
                         outputs={
-                            "result": result,
+                            "result": arn_result if arn_result else {"result": f"Entity already exists {arn}."},
                             "idempotence_token": e.idempotence_token,
                         },
                     )

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_mixin.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_mixin.py
@@ -81,12 +81,12 @@ def update_dict_fn(
                         except Exception:
                             raise ValueError(f"Could not find the key {key} in {update_dict_copy}.")
 
-                    if len(matches) > 1:
-                        # Replace the placeholder in the original_dict
-                        original_dict = original_dict.replace(f"{{{match}}}", update_dict_copy)
-                    else:
+                    if f"{{{match}}}" == original_dict:
                         # If there's only one match, it needn't always be a string, so not replacing the original dict.
                         return update_dict_copy
+                    else:
+                        # Replace the placeholder in the original_dict
+                        original_dict = original_dict.replace(f"{{{match}}}", update_dict_copy)
                 elif match == "idempotence_token" and idempotence_token:
                     temp_dict = original_dict.replace(f"{{{match}}}", idempotence_token)
                     if len(temp_dict) > 63:

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/task.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/task.py
@@ -95,7 +95,7 @@ class SageMakerEndpointTask(AsyncAgentExecutorMixin, PythonTask):
         super().__init__(
             name=name,
             task_type=self._TASK_TYPE,
-            interface=Interface(inputs=inputs, outputs=kwtypes(result=dict, idempotence_token=str)),
+            interface=Interface(inputs=inputs, outputs=kwtypes(result=dict)),
             **kwargs,
         )
         self._config = config

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/workflow.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/workflow.py
@@ -81,19 +81,19 @@ def create_sagemaker_deployment(
         wf.add_workflow_input("region", str)
 
     if idempotence_token:
-        append_token(model_config, "ModelName", idempotence_token, name)
-        append_token(endpoint_config_config, "EndpointConfigName", idempotence_token, name)
+        append_token(model_config, "ModelName", "idempotence_token", name)
+        append_token(endpoint_config_config, "EndpointConfigName", "idempotence_token", name)
 
         if "ProductionVariants" in endpoint_config_config and endpoint_config_config["ProductionVariants"]:
             append_token(
                 endpoint_config_config["ProductionVariants"][0],
                 "ModelName",
-                inputs.idempotence_token,
+                "inputs.idempotence_token",
                 name,
             )
 
-        append_token(endpoint_config, "EndpointName", idempotence_token, name)
-        append_token(endpoint_config, "EndpointConfigName", inputs.idempotence_token, name)
+        append_token(endpoint_config, "EndpointName", "idempotence_token", name)
+        append_token(endpoint_config, "EndpointConfigName", "inputs.idempotence_token", name)
 
     inputs = {
         SageMakerModelTask: {

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/workflow.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/workflow.py
@@ -38,6 +38,13 @@ def create_deployment_task(
     )
 
 
+def append_token(config, key, token, name):
+    if key in config:
+        config[key] += f"-{{{token}}}"
+    else:
+        config[key] = f"{name}-{{{token}}}"
+
+
 def create_sagemaker_deployment(
     name: str,
     model_config: Dict[str, Any],
@@ -49,6 +56,7 @@ def create_sagemaker_deployment(
     endpoint_input_types: Optional[Dict[str, Type]] = None,
     region: Optional[str] = None,
     region_at_runtime: bool = False,
+    idempotence_token: bool = True,
 ) -> Workflow:
     """
     Creates SageMaker model, endpoint config and endpoint.
@@ -62,6 +70,7 @@ def create_sagemaker_deployment(
     :param endpoint_input_types: Mapping of SageMaker endpoint inputs to their types.
     :param region: The region for SageMaker API calls.
     :param region_at_runtime: Set this to True if you want to provide the region at runtime.
+    :param idempotence_token: Set this to False if you don't want the agent to automatically append a token/hash to the deployment names.
     """
     if not any((region, region_at_runtime)):
         raise ValueError("Region parameter is required.")
@@ -70,6 +79,21 @@ def create_sagemaker_deployment(
 
     if region_at_runtime:
         wf.add_workflow_input("region", str)
+
+    if idempotence_token:
+        append_token(model_config, "ModelName", idempotence_token, name)
+        append_token(endpoint_config_config, "EndpointConfigName", idempotence_token, name)
+
+        if "ProductionVariants" in endpoint_config_config and endpoint_config_config["ProductionVariants"]:
+            append_token(
+                endpoint_config_config["ProductionVariants"][0],
+                "ModelName",
+                inputs.idempotence_token,
+                name,
+            )
+
+        append_token(endpoint_config, "EndpointName", idempotence_token, name)
+        append_token(endpoint_config, "EndpointConfigName", inputs.idempotence_token, name)
 
     inputs = {
         SageMakerModelTask: {

--- a/plugins/flytekit-aws-sagemaker/tests/test_boto3_agent.py
+++ b/plugins/flytekit-aws-sagemaker/tests/test_boto3_agent.py
@@ -22,35 +22,44 @@ idempotence_token = "74443947857331f7"
 @pytest.mark.parametrize(
     "mock_return_value",
     [
-        ((
-            {
-                "EndpointConfigArn": "arn:aws:sagemaker:us-east-2:000000000:endpoint-config/sagemaker-xgboost-endpoint-config",
-            },
-            idempotence_token,
-        ), "create_endpoint_config"),
-        ((
-            {
-                "pickle_check": datetime(2024, 5, 5),
-                "Location": "http://examplebucket.s3.amazonaws.com/",
-            },
-            idempotence_token,
-        ), "create_bucket"),
+        (
+            (
+                {
+                    "EndpointConfigArn": "arn:aws:sagemaker:us-east-2:000000000:endpoint-config/sagemaker-xgboost-endpoint-config",
+                },
+                idempotence_token,
+            ),
+            "create_endpoint_config",
+        ),
+        (
+            (
+                {
+                    "pickle_check": datetime(2024, 5, 5),
+                    "Location": "http://examplebucket.s3.amazonaws.com/",
+                },
+                idempotence_token,
+            ),
+            "create_bucket",
+        ),
         ((None, idempotence_token), "create_endpoint_config"),
-        ((
-            CustomException(
-                message="An error occurred",
-                idempotence_token=idempotence_token,
-                original_exception=ClientError(
-                    error_response={
-                        "Error": {
-                            "Code": "ValidationException",
-                            "Message": "Cannot create already existing endpoint 'arn:aws:sagemaker:us-east-2:123456789:endpoint/stable-diffusion-endpoint-non-finetuned-06716dbe4b2c68e7'",
-                        }
-                    },
-                    operation_name="DescribeEndpoint",
-                ),
-            )
-        ), "create_endpoint_config"),
+        (
+            (
+                CustomException(
+                    message="An error occurred",
+                    idempotence_token=idempotence_token,
+                    original_exception=ClientError(
+                        error_response={
+                            "Error": {
+                                "Code": "ValidationException",
+                                "Message": "Cannot create already existing endpoint 'arn:aws:sagemaker:us-east-2:123456789:endpoint/stable-diffusion-endpoint-non-finetuned-06716dbe4b2c68e7'",
+                            }
+                        },
+                        operation_name="DescribeEndpoint",
+                    ),
+                )
+            ),
+            "create_endpoint_config",
+        ),
     ],
 )
 @mock.patch(

--- a/plugins/flytekit-aws-sagemaker/tests/test_boto3_agent.py
+++ b/plugins/flytekit-aws-sagemaker/tests/test_boto3_agent.py
@@ -22,43 +22,21 @@ idempotence_token = "74443947857331f7"
 @pytest.mark.parametrize(
     "mock_return_value",
     [
-        (
+        ((
             {
-                "ResponseMetadata": {
-                    "RequestId": "66f80391-348a-4ee0-9158-508914d16db2",
-                    "HTTPStatusCode": 200.0,
-                    "RetryAttempts": 0.0,
-                    "HTTPHeaders": {
-                        "content-type": "application/x-amz-json-1.1",
-                        "date": "Wed, 31 Jan 2024 16:43:52 GMT",
-                        "x-amzn-requestid": "66f80391-348a-4ee0-9158-508914d16db2",
-                        "content-length": "114",
-                    },
-                },
                 "EndpointConfigArn": "arn:aws:sagemaker:us-east-2:000000000:endpoint-config/sagemaker-xgboost-endpoint-config",
             },
             idempotence_token,
-        ),
-        (
+        ), "create_endpoint_config"),
+        ((
             {
-                "ResponseMetadata": {
-                    "RequestId": "66f80391-348a-4ee0-9158-508914d16db2",
-                    "HTTPStatusCode": 200.0,
-                    "RetryAttempts": 0.0,
-                    "HTTPHeaders": {
-                        "content-type": "application/x-amz-json-1.1",
-                        "date": "Wed, 31 Jan 2024 16:43:52 GMT",
-                        "x-amzn-requestid": "66f80391-348a-4ee0-9158-508914d16db2",
-                        "content-length": "114",
-                    },
-                },
                 "pickle_check": datetime(2024, 5, 5),
-                "EndpointConfigArn": "arn:aws:sagemaker:us-east-2:000000000:endpoint-config/sagemaker-xgboost-endpoint-config",
+                "Location": "http://examplebucket.s3.amazonaws.com/",
             },
             idempotence_token,
-        ),
-        (None, idempotence_token),
-        (
+        ), "create_bucket"),
+        ((None, idempotence_token), "create_endpoint_config"),
+        ((
             CustomException(
                 message="An error occurred",
                 idempotence_token=idempotence_token,
@@ -72,14 +50,14 @@ idempotence_token = "74443947857331f7"
                     operation_name="DescribeEndpoint",
                 ),
             )
-        ),
+        ), "create_endpoint_config"),
     ],
 )
 @mock.patch(
     "flytekitplugins.awssagemaker_inference.boto3_agent.Boto3AgentMixin._call",
 )
 async def test_agent(mock_boto_call, mock_return_value):
-    mock_boto_call.return_value = mock_return_value
+    mock_boto_call.return_value = mock_return_value[0]
 
     agent = AgentRegistry.get_agent("boto")
     task_id = Identifier(
@@ -106,7 +84,7 @@ async def test_agent(mock_boto_call, mock_return_value):
             },
         },
         "region": "us-east-2",
-        "method": "create_endpoint_config",
+        "method": mock_return_value[1],
         "images": None,
     }
     task_metadata = TaskMetadata(
@@ -149,8 +127,8 @@ async def test_agent(mock_boto_call, mock_return_value):
     ctx = FlyteContext.current_context()
     output_prefix = ctx.file_access.get_random_remote_directory()
 
-    if isinstance(mock_return_value, Exception):
-        mock_boto_call.side_effect = mock_return_value
+    if isinstance(mock_return_value[0], Exception):
+        mock_boto_call.side_effect = mock_return_value[0]
 
         resource = await agent.do(
             task_template=task_template,
@@ -158,7 +136,7 @@ async def test_agent(mock_boto_call, mock_return_value):
             output_prefix=output_prefix,
         )
         assert resource.outputs["result"] == {
-            "result": f"Entity already exists: arn:aws:sagemaker:us-east-2:123456789:endpoint/stable-diffusion-endpoint-non-finetuned-06716dbe4b2c68e7"
+            "EndpointConfigArn": "arn:aws:sagemaker:us-east-2:123456789:endpoint/stable-diffusion-endpoint-non-finetuned-06716dbe4b2c68e7"
         }
         assert resource.outputs["idempotence_token"] == idempotence_token
         return
@@ -169,9 +147,9 @@ async def test_agent(mock_boto_call, mock_return_value):
 
     assert resource.phase == TaskExecution.SUCCEEDED
 
-    if mock_return_value[0]:
+    if mock_return_value[0][0]:
         outputs = literal_map_string_repr(resource.outputs)
-        if "pickle_check" in mock_return_value[0]:
+        if "pickle_check" in mock_return_value[0][0]:
             assert "pickle_file" in outputs["result"]
         else:
             assert (
@@ -179,5 +157,5 @@ async def test_agent(mock_boto_call, mock_return_value):
                 == "arn:aws:sagemaker:us-east-2:000000000:endpoint-config/sagemaker-xgboost-endpoint-config"
             )
             assert outputs["idempotence_token"] == "74443947857331f7"
-    elif mock_return_value[0] is None:
+    elif mock_return_value[0][0] is None:
         assert resource.outputs["result"] == {"result": None}

--- a/plugins/flytekit-aws-sagemaker/tests/test_inference_agent.py
+++ b/plugins/flytekit-aws-sagemaker/tests/test_inference_agent.py
@@ -171,7 +171,6 @@ async def test_agent(mock_boto_call, mock_return_value):
         resource.outputs["result"]["EndpointArn"]
         == "arn:aws:sagemaker:us-east-2:1234567890:endpoint/sagemaker-xgboost-endpoint"
     )
-    assert resource.outputs["idempotence_token"] == idempotence_token
 
     # DELETE
     delete_response = await agent.delete(metadata)

--- a/plugins/flytekit-aws-sagemaker/tests/test_inference_task.py
+++ b/plugins/flytekit-aws-sagemaker/tests/test_inference_task.py
@@ -73,7 +73,7 @@ from flytekit.configuration import Image, ImageConfig, SerializationSettings
             kwtypes(endpoint_name=str, endpoint_config_name=str),
             None,
             2,
-            2,
+            1,
             "us-east-2",
             SageMakerEndpointTask,
         ),


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?

- To return the relevant outputs and discard the irrelevant entries from the output dictionary. 
- To make specifying the idempotence token optional in the config and delegate the heavy lifting to the plugin.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

This PR truncates the SageMaker agent outputs to only return the ARNs. It also adds a new `idempotence_token` parameter to the `create_sagemaker_deployment` function, which, when set to `True`, appends an idempotence token to the relevant fields.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

I've run the example locally. New output format: `[{'ModelArn': 'arn:aws:sagemaker:us-east-2:123456789:model/stable-diffusion-model-0b2634d258f999f6'}, {'EndpointConfigArn': 'arn:aws:sagemaker:us-east-2:123456789:endpoint-config/stable-diffusion-model-5825e66eb1014642'}, {'EndpointArn': 'arn:aws:sagemaker:us-east-2:123456789:endpoint/stable-diffusion-model-1-dc4144fef7e49561'}]`

New deployment workflow:
```python
sd_deployment = create_sagemaker_deployment(
    name="stable-diffusion",
    model_input_types=kwtypes(
        deployment_name=str, model_path=FlyteFile, execution_role_arn=str
    ),
    model_config={
        "ModelName": "{inputs.deployment_name}",
        "PrimaryContainer": {
            "Image": "{images.sd_deployment_image}",
            "ModelDataUrl": "{inputs.model_path}",
            "Environment": {
                "SAGEMAKER_TRITON_DEFAULT_MODEL_NAME": "pipeline",
                "SAGEMAKER_TRITON_LOG_INFO": "false --load-model=text_encoder --load-model=vae",
            },
        },
        "ExecutionRoleArn": "{inputs.execution_role_arn}",
    },
    endpoint_config_input_types=kwtypes(
        deployment_name=str,
        initial_instance_count=int,
        instance_type=str,
    ),
    endpoint_config_config={
        "ProductionVariants": [
            {
                "VariantName": "AllTraffic-2",
                "ModelName": "{inputs.deployment_name}",
                "InitialInstanceCount": "{inputs.initial_instance_count}",
                "InstanceType": "{inputs.instance_type}",
            },
        ],
    },
    endpoint_input_types=kwtypes(deployment_name=str),
    endpoint_config={
        "EndpointName": "{inputs.deployment_name}",
    },
    images={"sd_deployment_image": triton_image_uri(version="23.12")},
    region_at_runtime=True,
)
```
The `idempotence_token` is set to `True` by default, so the agent appends an idempotence token to model name, endpoint config name, and endpoint.

If the field value isn't provided, such as `ModelName`, the agent appends the idempotence token to the workflow name and uses that as the `ModelName`.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
