### PR TITLE
add kubernetes package to official docker image again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ARG DOCKER_IMAGE
 RUN apt-get update && apt-get install build-essential -y \
     && pip install uv \
     && uv pip install --system --no-cache-dir -U flytekit==$VERSION \
+        kubernetes \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/ \


### PR DESCRIPTION
as it is needed in order to use pod templates.
This was indirectly removed with #2455

## Why are the changes needed?

needed to use pod templates with the official image

## What changes were proposed in this pull request?

install kubernetes package in image

