### PR TITLE
Replace super(AsyncAgentBase) with super(DatabricksAgent)

### DIFF
--- a/plugins/flytekit-spark/flytekitplugins/spark/agent.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/agent.py
@@ -126,7 +126,7 @@ class DatabricksAgentV2(DatabricksAgent):
     """
 
     def __init__(self):
-        super(AsyncAgentBase, self).__init__(task_type_name="databricks", metadata_type=DatabricksJobMetadata)
+        super(DatabricksAgent, self).__init__(task_type_name="databricks", metadata_type=DatabricksJobMetadata)
 
 
 def get_header() -> typing.Dict[str, str]:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -145,9 +145,14 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
                     self._default_applications_path or "local:///usr/local/bin/entrypoint.py"
                 )
 
+        if isinstance(task_config, DatabricksV2):
+            task_type = "databricks"
+        else:
+            task_type = "spark"
+
         super(PysparkFunctionTask, self).__init__(
             task_config=task_config,
-            task_type=self._SPARK_TASK_TYPE,
+            task_type=task_type,
             task_function=task_function,
             container_image=container_image,
             **kwargs,


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
DatabricksAgentV2 is calling the wrong parent class

## What changes were proposed in this pull request?
Replace super(AsyncAgentBase) with super(DatabricksAgent)

## How was this patch tested?
remote

### Setup process

### Screenshots
<img width="1714" alt="Screenshot 2024-07-19 at 8 56 39 AM" src="https://github.com/user-attachments/assets/554a82dd-a2a7-482d-91ee-ac9031e551e2">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
