### PR TITLE
Improved date parsing in CLI with meta variables

### DIFF
--- a/tests/flytekit/unit/interaction/test_click_types.py
+++ b/tests/flytekit/unit/interaction/test_click_types.py
@@ -139,15 +139,48 @@ def test_duration_type():
         t.convert(None, None, None)
 
 
+# write a helper function that calls convert and checks the result
+def _datetime_helper(t: click.ParamType, value: str, expected: datetime):
+    v = t.convert(value, None, None)
+    assert v.day == expected.day
+    assert v.month == expected.month
+
+
 def test_datetime_type():
     t = DateTimeType()
 
     assert t.convert("2020-01-01", None, None) == datetime(2020, 1, 1)
 
     now = datetime.now()
-    v = t.convert("now", None, None)
-    assert v.day == now.day
-    assert v.month == now.month
+    _datetime_helper(t, "now", now)
+
+    today = datetime.today()
+    _datetime_helper(t, "today", today)
+
+    add = datetime.now() + timedelta(days=1)
+    _datetime_helper(t, "now + 1d", add)
+
+    sub = datetime.now() - timedelta(days=1)
+    _datetime_helper(t, "now - 1d", sub)
+
+    fmt_v = "2020-01-01T10:10:00"
+    d = t.convert(fmt_v, None, None)
+    _datetime_helper(t, fmt_v, d)
+
+    _datetime_helper(t, f"{fmt_v} + 1d", d + timedelta(days=1))
+
+    with pytest.raises(click.BadParameter):
+        t.convert("now-1d", None, None)
+
+    with pytest.raises(click.BadParameter):
+        t.convert("now + 1", None, None)
+
+    with pytest.raises(click.BadParameter):
+        t.convert("now + 1abc", None, None)
+
+    with pytest.raises(click.BadParameter):
+        t.convert("aaa + 1d", None, None)
+
 
 
 def test_json_type():


### PR DESCRIPTION
## Why are the changes needed?
Improves the Parsing system for CLI when using datetime or date

## What changes were proposed in this pull request?
```
(flytekit) ➜  flytekit git:(cli-date-support) ✗ pyflyte run test.py foo --x today                                                                                                                                                
Running Execution on local.
2024-07-21
```

```
(flytekit) ➜  flytekit git:(cli-date-support) ✗ pyflyte run test.py foo --x "today + 10d"                                                                                                                                         
Running Execution on local.
2024-07-31
```

```
(flytekit) ➜  flytekit git:(cli-date-support) ✗ pyflyte run test.py foo --x now                                                                                                                                                  
Running Execution on local.
2024-07-21
```

## How was this patch tested?

Unit tested and local testing


### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
