### PR TITLE
refactor(core): Enhance return type extraction logic

### DIFF
--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -507,7 +507,9 @@ def extract_return_annotation(return_annotation: Union[Type, Tuple, None]) -> Di
 
     # This statement results in true for typing.Namedtuple, single and void return types, so this
     # handles Options 1, 2. Even though NamedTuple for us is multi-valued, it's a single value for Python
-    if isinstance(return_annotation, Type) or isinstance(return_annotation, TypeVar):  # type: ignore
+    if hasattr(return_annotation, "__bases__") and (
+        isinstance(return_annotation, Type) or isinstance(return_annotation, TypeVar)
+    ):  # type: ignore
         # isinstance / issubclass does not work for Namedtuple.
         # Options 1 and 2
         bases = return_annotation.__bases__  # type: ignore

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -508,8 +508,8 @@ def extract_return_annotation(return_annotation: Union[Type, Tuple, None]) -> Di
     # This statement results in true for typing.Namedtuple, single and void return types, so this
     # handles Options 1, 2. Even though NamedTuple for us is multi-valued, it's a single value for Python
     if hasattr(return_annotation, "__bases__") and (
-        isinstance(return_annotation, Type) or isinstance(return_annotation, TypeVar)
-    ):  # type: ignore
+        isinstance(return_annotation, Type) or isinstance(return_annotation, TypeVar)  # type: ignore
+    ):
         # isinstance / issubclass does not work for Namedtuple.
         # Options 1 and 2
         bases = return_annotation.__bases__  # type: ignore

--- a/tests/flytekit/unit/core/test_interface.py
+++ b/tests/flytekit/unit/core/test_interface.py
@@ -4,7 +4,7 @@ import typing
 from typing import Dict, List
 
 import pytest
-from typing_extensions import Annotated  # type: ignore
+from typing_extensions import Annotated, TypeVar  # type: ignore
 
 from flytekit import map_task, task
 from flytekit.core import context_manager
@@ -95,6 +95,15 @@ def test_extract_only():
     return_type = extract_return_annotation(typing.get_type_hints(t).get("return", None))
     assert len(return_type) == 1
     assert return_type["o0"] == Dict[str, int]
+
+    VST = TypeVar("VST")
+
+    def t(a: int, b: str) -> VST:
+        ...
+
+    return_type = extract_return_annotation(typing.get_type_hints(t).get("return", None))
+    assert len(return_type) == 1
+    assert return_type["o0"] == VST
 
 
 def test_named_tuples():

--- a/tests/flytekit/unit/core/test_interface.py
+++ b/tests/flytekit/unit/core/test_interface.py
@@ -98,7 +98,7 @@ def test_extract_only():
 
     VST = TypeVar("VST")
 
-    def t(a: int, b: str) -> VST:
+    def t(a: int, b: str) -> VST:  # type: ignore
         ...
 
     return_type = extract_return_annotation(typing.get_type_hints(t).get("return", None))


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Got the below error
```
│   397 │   │   outputs[k] = v  # type: ignore                                                     │
│   398 │   inputs: Dict[str, Tuple[Type, Any]] = OrderedDict()                                    │
│                                                                                                  │
│ /Users/kevin/git/flytekit/flytekit/core/interface.py:515 in extract_return_annotation            │
│                                                                                                  │
│   512 │   ):  # type: ignore                                                                     │
│   513 │   │   # isinstance / issubclass does not work for Namedtuple.                            │
│   514 │   │   # Options 1 and 2                                                                  │
│ ❱ 515 │   │   bases = return_annotation.__bases__  # type: ignore                                │
│   516 │   │   if len(bases) == 1 and bases[0] == tuple and hasattr(return_annotation, "_fields   │
│   517 │   │   │   logger.debug(f"Task returns named tuple {return_annotation}")                  │
│   518 │   │   │   return dict(get_type_hints(cast(Type, return_annotation), include_extras=Tru   │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'TypeVar' object has no attribute '__bases__'
```

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
check if `return_annotation` has `__bases__` attribute

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
