### PR TITLE
validate idempotence token length in subsequent tasks

### DIFF
--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_mixin.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_mixin.py
@@ -68,7 +68,6 @@ def replace_placeholder(
     original_dict: str,
     placeholder: str,
     replacement: str,
-    idempotence_token: Optional[str],
 ) -> str:
     """
     Replace a placeholder in the original string and handle the specific logic for the sagemaker service and idempotence token.
@@ -79,7 +78,7 @@ def replace_placeholder(
         "idempotence_token",
     ]:
         if len(temp_dict) > 63:
-            truncated_token = idempotence_token[: 63 - len(original_dict.replace(f"{{{placeholder}}}", ""))]
+            truncated_token = replacement[: 63 - len(original_dict.replace(f"{{{placeholder}}}", ""))]
             return original_dict.replace(f"{{{placeholder}}}", truncated_token)
         else:
             return temp_dict
@@ -115,9 +114,9 @@ def update_dict_fn(
                 if f"{{{match}}}" == original_dict:
                     return nested_value
                 else:
-                    original_dict = replace_placeholder(service, original_dict, match, nested_value, idempotence_token)
+                    original_dict = replace_placeholder(service, original_dict, match, nested_value)
             elif match == "idempotence_token" and idempotence_token:
-                original_dict = replace_placeholder(service, original_dict, match, idempotence_token, idempotence_token)
+                original_dict = replace_placeholder(service, original_dict, match, idempotence_token)
         return original_dict
 
     if isinstance(original_dict, list):

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_mixin.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_mixin.py
@@ -97,6 +97,7 @@ def update_dict_fn(
     and update_dict is {"endpoint_config_name": "my-endpoint-config"},
     then the result will be {"EndpointConfigName": "my-endpoint-config"}.
 
+    :param service: The AWS service to use
     :param original_dict: The dictionary to update (in place)
     :param update_dict: The dictionary to use for updating
     :param idempotence_token: Hash of config -- this is to ensure the execution ID is deterministic

--- a/plugins/flytekit-aws-sagemaker/tests/test_boto3_mixin.py
+++ b/plugins/flytekit-aws-sagemaker/tests/test_boto3_mixin.py
@@ -51,6 +51,7 @@ def test_inputs():
     )
 
     result = update_dict_fn(
+        service="s3",
         original_dict=original_dict,
         update_dict={"inputs": literal_map_string_repr(inputs)},
     )
@@ -74,14 +75,16 @@ def test_container():
     original_dict = {"a": "{images.primary_container_image}"}
     images = {"primary_container_image": "cr.flyte.org/flyteorg/flytekit:py3.11-1.10.3"}
 
-    result = update_dict_fn(original_dict=original_dict, update_dict={"images": images})
+    result = update_dict_fn(
+        service="sagemaker", original_dict=original_dict, update_dict={"images": images}
+    )
 
     assert result == {"a": "cr.flyte.org/flyteorg/flytekit:py3.11-1.10.3"}
 
 
 @pytest.mark.asyncio
 @patch("flytekitplugins.awssagemaker_inference.boto3_mixin.aioboto3.Session")
-async def test_call(mock_session):
+async def test_call_with_no_idempotence_token(mock_session):
     mixin = Boto3AgentMixin(service="sagemaker")
 
     mock_client = AsyncMock()
@@ -118,3 +121,127 @@ async def test_call(mock_session):
 
     assert result == mock_method.return_value
     assert idempotence_token == ""
+
+
+@pytest.mark.asyncio
+@patch("flytekitplugins.awssagemaker_inference.boto3_mixin.aioboto3.Session")
+async def test_call_with_idempotence_token(mock_session):
+    mixin = Boto3AgentMixin(service="sagemaker")
+
+    mock_client = AsyncMock()
+    mock_session.return_value.client.return_value.__aenter__.return_value = mock_client
+    mock_method = mock_client.create_model
+
+    config = {
+        "ModelName": "{inputs.model_name}-{idempotence_token}",
+        "PrimaryContainer": {
+            "Image": "{images.image}",
+            "ModelDataUrl": "s3://sagemaker-agent-xgboost/model.tar.gz",
+        },
+    }
+    inputs = TypeEngine.dict_to_literal_map(
+        FlyteContext.current_context(),
+        {"model_name": "xgboost", "region": "us-west-2"},
+        {"model_name": str, "region": str},
+    )
+
+    result, idempotence_token = await mixin._call(
+        method="create_model",
+        config=config,
+        inputs=inputs,
+        images={"image": triton_image_uri(version="21.08")},
+    )
+
+    mock_method.assert_called_with(
+        ModelName="xgboost-23dba5d7c5aa79a8",
+        PrimaryContainer={
+            "Image": "301217895009.dkr.ecr.us-west-2.amazonaws.com/sagemaker-tritonserver:21.08-py3",
+            "ModelDataUrl": "s3://sagemaker-agent-xgboost/model.tar.gz",
+        },
+    )
+
+    assert result == mock_method.return_value
+    assert idempotence_token == "23dba5d7c5aa79a8"
+
+
+@pytest.mark.asyncio
+@patch("flytekitplugins.awssagemaker_inference.boto3_mixin.aioboto3.Session")
+async def test_call_with_truncated_idempotence_token(mock_session):
+    mixin = Boto3AgentMixin(service="sagemaker")
+
+    mock_client = AsyncMock()
+    mock_session.return_value.client.return_value.__aenter__.return_value = mock_client
+    mock_method = mock_client.create_model
+
+    config = {
+        "ModelName": "{inputs.model_name}-{idempotence_token}",
+        "PrimaryContainer": {
+            "Image": "{images.image}",
+            "ModelDataUrl": "s3://sagemaker-agent-xgboost/model.tar.gz",
+        },
+    }
+    inputs = TypeEngine.dict_to_literal_map(
+        FlyteContext.current_context(),
+        {
+            "model_name": "xgboost-random-string-1234567890123456789012345678",  # length=50
+            "region": "us-west-2",
+        },
+        {"model_name": str, "region": str},
+    )
+
+    result, idempotence_token = await mixin._call(
+        method="create_model",
+        config=config,
+        inputs=inputs,
+        images={"image": triton_image_uri(version="21.08")},
+    )
+
+    mock_method.assert_called_with(
+        ModelName="xgboost-random-string-1234567890123456789012345678-432aa64034f3",
+        PrimaryContainer={
+            "Image": "301217895009.dkr.ecr.us-west-2.amazonaws.com/sagemaker-tritonserver:21.08-py3",
+            "ModelDataUrl": "s3://sagemaker-agent-xgboost/model.tar.gz",
+        },
+    )
+
+    assert result == mock_method.return_value
+    assert idempotence_token == "432aa64034f37edb"
+
+
+@pytest.mark.asyncio
+@patch("flytekitplugins.awssagemaker_inference.boto3_mixin.aioboto3.Session")
+async def test_call_with_truncated_idempotence_token_as_input(mock_session):
+    mixin = Boto3AgentMixin(service="sagemaker")
+
+    mock_client = AsyncMock()
+    mock_session.return_value.client.return_value.__aenter__.return_value = mock_client
+    mock_method = mock_client.create_endpoint
+
+    config = {
+        "EndpointName": "{inputs.endpoint_name}-{idempotence_token}",
+        "EndpointConfigName": "{inputs.endpoint_config_name}-{inputs.idempotence_token}",
+    }
+    inputs = TypeEngine.dict_to_literal_map(
+        FlyteContext.current_context(),
+        {
+            "endpoint_name": "xgboost",
+            "endpoint_config_name": "xgboost-random-string-1234567890123456789012345678",  # length=50
+            "idempotence_token": "432aa64034f37edb",
+            "region": "us-west-2",
+        },
+        {"model_name": str, "region": str},
+    )
+
+    result, idempotence_token = await mixin._call(
+        method="create_endpoint",
+        config=config,
+        inputs=inputs,
+    )
+
+    mock_method.assert_called_with(
+        EndpointName="xgboost-ce735d6a183643f1",
+        EndpointConfigName="xgboost-random-string-1234567890123456789012345678-432aa64034f3",
+    )
+
+    assert result == mock_method.return_value
+    assert idempotence_token == "ce735d6a183643f1"


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?

To validate the idempotence token length in subsequent tasks in the SageMaker workflow.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

- Updates helper method in the mixin file to truncate idempotence token when the length exceeds 63.
- Adds additional test cases.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

Triggered a SageMaker deployment workflow locally.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
