### PR TITLE
Enable Ray Fast Register

### DIFF
--- a/plugins/flytekit-ray/flytekitplugins/ray/task.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/task.py
@@ -1,16 +1,22 @@
 import base64
 import json
+import os
 import typing
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
-
+import os
 import yaml
-from flytekitplugins.ray.models import HeadGroupSpec, RayCluster, RayJob, WorkerGroupSpec
+from flytekitplugins.ray.models import (
+    HeadGroupSpec,
+    RayCluster,
+    RayJob,
+    WorkerGroupSpec,
+)
 from google.protobuf.json_format import MessageToDict
 
 from flytekit import lazy_module
 from flytekit.configuration import SerializationSettings
-from flytekit.core.context_manager import ExecutionParameters
+from flytekit.core.context_manager import ExecutionParameters, FlyteContextManager
 from flytekit.core.python_function_task import PythonFunctionTask
 from flytekit.extend import TaskPlugins
 
@@ -40,6 +46,7 @@ class RayJobConfig:
     address: typing.Optional[str] = None
     shutdown_after_job_finishes: bool = False
     ttl_seconds_after_finished: typing.Optional[int] = None
+    excludes_working_dir: typing.Optional[typing.List[str]] = None
 
 
 class RayFunctionTask(PythonFunctionTask):
@@ -50,29 +57,65 @@ class RayFunctionTask(PythonFunctionTask):
     _RAY_TASK_TYPE = "ray"
 
     def __init__(self, task_config: RayJobConfig, task_function: Callable, **kwargs):
-        super().__init__(task_config=task_config, task_type=self._RAY_TASK_TYPE, task_function=task_function, **kwargs)
+        super().__init__(
+            task_config=task_config,
+            task_type=self._RAY_TASK_TYPE,
+            task_function=task_function,
+            **kwargs,
+        )
         self._task_config = task_config
 
     def pre_execute(self, user_params: ExecutionParameters) -> ExecutionParameters:
-        ray.init(address=self._task_config.address)
+        init_params = {"address": self._task_config.address}
+
+        ctx = FlyteContextManager.current_context()
+        if not ctx.execution_state.is_local_execution():
+            working_dir = os.getcwd()
+            init_params["runtime_env"] = {"working_dir": working_dir}
+
+            cfg = self._task_config
+            if cfg.excludes_working_dir:
+                init_params["runtime_env"]["excludes"] = cfg.excludes_working_dir
+
+            # fast register data with timestamp mtime=0 will be zipped and uploaded to ray gcs
+            # zip does not support timestamps before 1980 -> hacky workaround of touching all the files
+            os.system(f"touch `find {working_dir} -type f`")
+
+        ray.init(**init_params)
         return user_params
 
     def get_custom(self, settings: SerializationSettings) -> Optional[Dict[str, Any]]:
         cfg = self._task_config
 
         # Deprecated: runtime_env is removed KubeRay >= 1.1.0. It is replaced by runtime_env_yaml
-        runtime_env = base64.b64encode(json.dumps(cfg.runtime_env).encode()).decode() if cfg.runtime_env else None
+        runtime_env = (
+            base64.b64encode(json.dumps(cfg.runtime_env).encode()).decode()
+            if cfg.runtime_env
+            else None
+        )
 
         runtime_env_yaml = yaml.dump(cfg.runtime_env) if cfg.runtime_env else None
 
         ray_job = RayJob(
             ray_cluster=RayCluster(
-                head_group_spec=HeadGroupSpec(cfg.head_node_config.ray_start_params) if cfg.head_node_config else None,
+                head_group_spec=(
+                    HeadGroupSpec(cfg.head_node_config.ray_start_params)
+                    if cfg.head_node_config
+                    else None
+                ),
                 worker_group_spec=[
-                    WorkerGroupSpec(c.group_name, c.replicas, c.min_replicas, c.max_replicas, c.ray_start_params)
+                    WorkerGroupSpec(
+                        c.group_name,
+                        c.replicas,
+                        c.min_replicas,
+                        c.max_replicas,
+                        c.ray_start_params,
+                    )
                     for c in cfg.worker_node_config
                 ],
-                enable_autoscaling=cfg.enable_autoscaling if cfg.enable_autoscaling else False,
+                enable_autoscaling=(
+                    cfg.enable_autoscaling if cfg.enable_autoscaling else False
+                ),
             ),
             runtime_env=runtime_env,
             runtime_env_yaml=runtime_env_yaml,

--- a/plugins/flytekit-ray/flytekitplugins/ray/task.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/task.py
@@ -87,20 +87,14 @@ class RayFunctionTask(PythonFunctionTask):
         cfg = self._task_config
 
         # Deprecated: runtime_env is removed KubeRay >= 1.1.0. It is replaced by runtime_env_yaml
-        runtime_env = (
-            base64.b64encode(json.dumps(cfg.runtime_env).encode()).decode()
-            if cfg.runtime_env
-            else None
-        )
+        runtime_env = base64.b64encode(json.dumps(cfg.runtime_env).encode()).decode() if cfg.runtime_env else None
 
         runtime_env_yaml = yaml.dump(cfg.runtime_env) if cfg.runtime_env else None
 
         ray_job = RayJob(
             ray_cluster=RayCluster(
                 head_group_spec=(
-                    HeadGroupSpec(cfg.head_node_config.ray_start_params)
-                    if cfg.head_node_config
-                    else None
+                    HeadGroupSpec(cfg.head_node_config.ray_start_params) if cfg.head_node_config else None
                 ),
                 worker_group_spec=[
                     WorkerGroupSpec(
@@ -112,9 +106,7 @@ class RayFunctionTask(PythonFunctionTask):
                     )
                     for c in cfg.worker_node_config
                 ],
-                enable_autoscaling=(
-                    cfg.enable_autoscaling if cfg.enable_autoscaling else False
-                ),
+                enable_autoscaling=(cfg.enable_autoscaling if cfg.enable_autoscaling else False),
             ),
             runtime_env=runtime_env,
             runtime_env_yaml=runtime_env_yaml,

--- a/plugins/flytekit-ray/flytekitplugins/ray/task.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/task.py
@@ -80,10 +80,6 @@ class RayFunctionTask(PythonFunctionTask):
             if cfg.excludes_working_dir:
                 init_params["runtime_env"]["excludes"].extend(cfg.excludes_working_dir)
 
-            # fast register data with timestamp mtime=0 will be zipped and uploaded to ray gcs
-            # zip does not support timestamps before 1980 -> hacky workaround of touching all the files
-            # os.system(f"touch `find {working_dir} -type f`")
-
         ray.init(**init_params)
         return user_params
 

--- a/plugins/flytekit-ray/flytekitplugins/ray/task.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/task.py
@@ -4,7 +4,7 @@ import os
 import typing
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
-import os
+
 import yaml
 from flytekitplugins.ray.models import (
     HeadGroupSpec,

--- a/plugins/flytekit-ray/flytekitplugins/ray/task.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/task.py
@@ -78,7 +78,7 @@ class RayFunctionTask(PythonFunctionTask):
 
             cfg = self._task_config
             if cfg.excludes_working_dir:
-                init_params["runtime_env"]["excludes"].append(cfg.excludes_working_dir)
+                init_params["runtime_env"]["excludes"].extend(cfg.excludes_working_dir)
 
             # fast register data with timestamp mtime=0 will be zipped and uploaded to ray gcs
             # zip does not support timestamps before 1980 -> hacky workaround of touching all the files

--- a/plugins/flytekit-ray/flytekitplugins/ray/task.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/task.py
@@ -88,20 +88,14 @@ class RayFunctionTask(PythonFunctionTask):
         cfg = self._task_config
 
         # Deprecated: runtime_env is removed KubeRay >= 1.1.0. It is replaced by runtime_env_yaml
-        runtime_env = (
-            base64.b64encode(json.dumps(cfg.runtime_env).encode()).decode()
-            if cfg.runtime_env
-            else None
-        )
+        runtime_env = base64.b64encode(json.dumps(cfg.runtime_env).encode()).decode() if cfg.runtime_env else None
 
         runtime_env_yaml = yaml.dump(cfg.runtime_env) if cfg.runtime_env else None
 
         ray_job = RayJob(
             ray_cluster=RayCluster(
                 head_group_spec=(
-                    HeadGroupSpec(cfg.head_node_config.ray_start_params)
-                    if cfg.head_node_config
-                    else None
+                    HeadGroupSpec(cfg.head_node_config.ray_start_params) if cfg.head_node_config else None
                 ),
                 worker_group_spec=[
                     WorkerGroupSpec(
@@ -113,9 +107,7 @@ class RayFunctionTask(PythonFunctionTask):
                     )
                     for c in cfg.worker_node_config
                 ],
-                enable_autoscaling=(
-                    cfg.enable_autoscaling if cfg.enable_autoscaling else False
-                ),
+                enable_autoscaling=(cfg.enable_autoscaling if cfg.enable_autoscaling else False),
             ),
             runtime_env=runtime_env,
             runtime_env_yaml=runtime_env_yaml,


### PR DESCRIPTION
## Why are the changes needed?
Today, when launching a Ray job in Flyte only the Head Node is retrieving fast register data - no applying for Ray Worker Nodes. This results in the need for the user of copy the source code into the containers working dir & rebuilding the container image for every change on the ray user code.

This PR utilizes rays functionality of adding files to the ray job on runtime passing the `runtime_env {"working_dir":"some_path"}`.

⚠️ There is an ray gcs storage limit of 500MiB. Thats why ray supports adding an `excludes` variable along with `working_dir` which functions as a .ignore file. This PR introduces a `excludes_working_dir` to the RayJobConfig, which allows control over what files to upload to the ray cluster.

## What changes were proposed in this pull request?
- Adding `working_dir` & `excludes` init parameter when running remotely
- Docs on what this [parameter](https://docs.ray.io/en/latest/ray-core/handling-dependencies.html#api-reference) is doing
- TLDR: after head node downloads fast register data -> `ray.init("working_dir"="/root", excludes=["data"])` zips all fast register data, takes `excludes` into account and uploads to ray gcs -> ray worker nodes downloads zips from ray gcs and unzips
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
- Running the following workflow with Imagespec works:
``` python
from flytekit import ImageSpec, Resources, task, workflow, PodTemplate
from flytekitplugins.ray import HeadNodeConfig, RayJobConfig, WorkerNodeConfig
from ray.util.multiprocessing import Pool

import time
import math
import random

container_image = ImageSpec(
    name="rayworkerlove",
    apt_packages=["git", "wget"],
    packages=[
        "git+https://github.com/flyteorg/flytekit.git@d5549cee2a9bef8338bd9e94aa23397631386c10#subdirectory=plugins/flytekit-ray"
    ],
    registry="ghcr.io/fiedlerNr9",
)


def sample(num_samples):
    num_inside = 0
    for _ in range(num_samples):
        x, y = random.uniform(-1, 1), random.uniform(-1, 1)
        if math.hypot(x, y) <= 1:
            num_inside += 1
    return num_inside


ray_config = RayJobConfig(
    head_node_config=HeadNodeConfig(
        ray_start_params={"log-color": "True", "num-cpus": "1"}
    ),
    worker_node_config=[
        WorkerNodeConfig(
            group_name="ray-group", replicas=3, min_replicas=1, max_replicas=4
        )
    ],
    shutdown_after_job_finishes=True,
    ttl_seconds_after_finished=120,
    enable_autoscaling=False,
    excludes_working_dir=["micromamba"],
)


@task(
    task_config=ray_config,
    requests=Resources(mem="2Gi", cpu="1"),
    container_image=container_image,
)
def approximate_pi_distributed(num_samples: int):

    pool = Pool()

    start = time.time()
    num_inside = 0
    sample_batch_size = 100000
    for result in pool.map(
        sample, [sample_batch_size for _ in range(num_samples // sample_batch_size)]
    ):
        num_inside += result

    print("pi ~= {}".format((4 * num_inside) / num_samples))
    print("Finished in: {:.2f}s".format(time.time() - start))


@workflow
def wf(n: int = 60000000):
    approximate_pi_distributed(num_samples=n)

```
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots
<img width="1130" alt="image" src="https://github.com/user-attachments/assets/cf87563c-e534-4574-8ae2-223749b1d197">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.
