### PR TITLE
[FlyteSchema] Fix numpy problems

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1495,6 +1495,7 @@ class UnionTransformer(TypeTransformer[T]):
         is_ambiguous = False
         res = None
         res_type = None
+        t = None
         for i in range(len(get_args(python_type))):
             try:
                 t = get_args(python_type)[i]
@@ -1504,8 +1505,8 @@ class UnionTransformer(TypeTransformer[T]):
                 if found_res:
                     is_ambiguous = True
                 found_res = True
-            except Exception:
-                logger.debug(f"Failed to convert from {python_val} to {t}", exc_info=True)
+            except Exception as e:
+                logger.debug(f"Failed to convert from {python_val} to {t} with error: {e}", exc_info=True)
                 continue
 
         if is_ambiguous:

--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -175,7 +175,7 @@ class DateTimeType(click.DateTime):
         if isinstance(value, ArtifactQuery):
             return value
 
-        if " " in value:
+        if isinstance(value, str) and " " in value:
             import re
 
             m = re.match(self._FLOATING_FORMAT_PATTERN, value)

--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -193,7 +193,9 @@ class DateTimeType(click.DateTime):
                 if parts[1] == "-":
                     return dt - delta
                 return dt + delta
-            raise click.BadParameter(f"Expected format {self.formats}, got {value}")
+            else:
+                value = datetime.datetime.fromisoformat(value)
+
         return self._datetime_from_format(value, param, ctx)
 
 

--- a/plugins/flytekit-envd/tests/test_image_spec.py
+++ b/plugins/flytekit-envd/tests/test_image_spec.py
@@ -37,7 +37,7 @@ def test_image_spec():
         apt_packages=["git"],
         python_version="3.8",
         base_image=base_image,
-        pip_index="https://private-pip-index/simple",
+        pip_index="https://pypi.python.org/simple",
         source_root=os.path.dirname(os.path.realpath(__file__)),
     )
 
@@ -58,7 +58,7 @@ def build():
     install.python_packages(name=["pandas"])
     install.apt_packages(name=["git"])
     runtime.environ(env={{'PYTHONPATH': '/root:', '_F_IMG_ID': '{image_name}'}}, extra_path=['/root'])
-    config.pip_index(url="https://private-pip-index/simple")
+    config.pip_index(url="https://pypi.python.org/simple")
     install.python(version="3.8")
     io.copy(source="./", target="/root")
 """

--- a/tests/flytekit/unit/core/test_dataclass.py
+++ b/tests/flytekit/unit/core/test_dataclass.py
@@ -904,7 +904,7 @@ def test_numpy_import_issue_from_flyte_schema_in_dataclass():
 
     @task
     def my_flyte_task(inputs: list[MyDataClass | None]) -> bool:
-        return inputs and inputs[0] is not None
+        return inputs and (inputs[0] is not None) # type: ignore
 
     @workflow
     def main_flyte_workflow(b: bool = False) -> bool:

--- a/tests/flytekit/unit/core/test_dataclass.py
+++ b/tests/flytekit/unit/core/test_dataclass.py
@@ -2,6 +2,7 @@ import pytest
 from dataclasses_json import DataClassJsonMixin
 from mashumaro.mixins.json import DataClassJSONMixin
 import os
+import sys
 import tempfile
 from dataclasses import dataclass
 from typing import Annotated, List, Dict, Optional
@@ -882,3 +883,33 @@ def test_get_literal_type_data_class_json_fail_but_mashumaro_works():
     transformer = DataclassTransformer()
     lt = transformer.get_literal_type(NestedFlyteTypesWithDataClassJson)
     assert lt.metadata is not None
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Requires Python 3.10 or higher")
+def test_numpy_import_issue_from_flyte_schema_in_dataclass():
+    from dataclasses import dataclass
+
+    from flytekit import task, workflow
+    from flytekit.types.directory import FlyteDirectory
+    from flytekit.types.file import FlyteFile
+
+    @dataclass
+    class MyDataClass:
+        output_file: FlyteFile
+        output_directory: FlyteDirectory
+
+    @task
+    def my_flyte_workflow(b: bool) -> list[MyDataClass | None]:
+        if b:
+            return [MyDataClass(__file__, ".")]
+        return [None]
+
+    @task
+    def my_flyte_task(inputs: list[MyDataClass | None]) -> bool:
+        return inputs and inputs[0] is not None
+
+    @workflow
+    def main_flyte_workflow(b: bool = False) -> bool:
+        inputs = my_flyte_workflow(b=b)
+        return my_flyte_task(inputs=inputs)
+
+    assert main_flyte_workflow(b=True) == True
+    assert main_flyte_workflow(b=False) == False

--- a/tests/flytekit/unit/interaction/test_click_types.py
+++ b/tests/flytekit/unit/interaction/test_click_types.py
@@ -181,6 +181,9 @@ def test_datetime_type():
     with pytest.raises(click.BadParameter):
         t.convert("aaa + 1d", None, None)
 
+    fmt_v = "2024-07-29 13:47:07.643004+00:00"
+    d = t.convert(fmt_v, None, None)
+    _datetime_helper(t, fmt_v, d)
 
 
 def test_json_type():


### PR DESCRIPTION
## Tracking issue


## Why are the changes needed?
If we import `FlyteSchema` when using flytekit, we don't want to import `numpy`.
We have to do it by `try ... catch`

## What changes were proposed in this pull request?



## How was this patch tested?
Unit Tests, local execution and remote execution.

### Setup process
```python
from dataclasses import dataclass
from typing import Union, List
from flytekit import task, workflow, ImageSpec
from flytekit.types.directory import FlyteDirectory
from flytekit.types.file import FlyteFile

flytekit_hash = "8a982ccae43c2ce7e08b36af883c81eb080b9712"
flytekit = f"git+https://github.com/flyteorg/flytekit.git@{flytekit_hash}"

image = ImageSpec(
    # python_version="3.9",
    python_version="3.10",
    # python_version="3.11",
    # python_version="3.12",
    packages=[flytekit],
    apt_packages=["git"],
    registry="localhost:30000",
)
# image = "cr.flyte.org/flyteorg/flytekit:py3.12-1.13.1a3"
@dataclass
class MyDataClass:
    output_file: FlyteFile
    output_directory: FlyteDirectory

@task(container_image=image)
def my_flyte_workflow(b: bool) -> List[Union[MyDataClass, None]]:
    if b:
        return [MyDataClass(output_file=__file__, output_directory=".")]
    return [None]

@task(container_image=image)
def my_flyte_task(inputs: List[Union[MyDataClass, None]]) -> bool:
    print(inputs)
    return inputs and inputs[0] is not None

@workflow
def main_flyte_workflow(b: bool = False) -> bool:
    inputs = my_flyte_workflow(b=b)
    return my_flyte_task(inputs=inputs)

if __name__ == "__main__":
    print(f"Running {__file__} main...")
    print(f"Running {main_flyte_workflow(b=True)}")
    print(f"Done running {__file__} main...")
```
### Screenshots
#### local execution
<img width="985" alt="image" src="https://github.com/user-attachments/assets/3205eb9d-ade2-4a8c-a707-51fa41084636">

#### remote execution
python 3.9 to python 3.12

<img width="1221" alt="image" src="https://github.com/user-attachments/assets/60138190-7f23-4409-af2b-e14403f541e7">



## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
