### PR TITLE
[Artifacts/Elastic] Skip partitions

### DIFF
--- a/flytekit/core/artifact.py
+++ b/flytekit/core/artifact.py
@@ -319,7 +319,6 @@ class Partitions(object):
 
     def __getattr__(self, item):
         if item == "partitions" or item == "_partitions":
-            print("PARTITIONS: I'm in an uninitialized state!!!!!!!!!!!!", flush=True)
             raise AttributeError("Partitions in an uninitialized state, skipping partitions")
         if self.partitions and item in self.partitions:
             return self.partitions[item]
@@ -469,7 +468,6 @@ class Artifact(object):
                 ...
                 return RideCountData.create_from(df, time_partition=datetime.datetime.now())
         """
-        print(f"ARTFOMT: 1", flush=True)
         omt = FlyteContextManager.current_context().output_metadata_tracker
         additional = [card]
         additional.extend(args)
@@ -493,7 +491,6 @@ class Artifact(object):
                     additional_items=filtered_additional if filtered_additional else None,
                 ),
             )
-            print(f"OMT: ")
         return o
 
     def query(

--- a/flytekit/core/artifact.py
+++ b/flytekit/core/artifact.py
@@ -318,6 +318,9 @@ class Partitions(object):
                 p.reference_artifact = artifact
 
     def __getattr__(self, item):
+        if item == "partitions" or item == "_partitions":
+            print("PARTITIONS: I'm in an uninitialized state!!!!!!!!!!!!", flush=True)
+            raise AttributeError("Partitions in an uninitialized state, skipping partitions")
         if self.partitions and item in self.partitions:
             return self.partitions[item]
         raise AttributeError(f"Partition {item} not found in {self}")
@@ -466,6 +469,7 @@ class Artifact(object):
                 ...
                 return RideCountData.create_from(df, time_partition=datetime.datetime.now())
         """
+        print(f"ARTFOMT: 1", flush=True)
         omt = FlyteContextManager.current_context().output_metadata_tracker
         additional = [card]
         additional.extend(args)
@@ -489,6 +493,7 @@ class Artifact(object):
                     additional_items=filtered_additional if filtered_additional else None,
                 ),
             )
+            print(f"OMT: ")
         return o
 
     def query(

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -447,12 +447,10 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
         from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
 
         try:
-            print("Here+++++++++++++++++++++++++ 1")
             out = elastic_launch(
                 config=config,
                 entrypoint=launcher_target_func,
             )(*launcher_args)
-            print("Here+++++++++++++++++++++++++ 2")
         except ChildFailedError as e:
             _, first_failure = e.get_first_failure()
             if is_recoverable_worker_error(first_failure):

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -241,7 +241,7 @@ class ElasticWorkerResult(NamedTuple):
 
     return_value: Any
     decks: List[flytekit.Deck]
-    om: Optional[OutputMetadata]
+    om: Optional[OutputMetadata] = None
 
 
 def spawn_helper(

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -241,7 +241,7 @@ class ElasticWorkerResult(NamedTuple):
 
     return_value: Any
     decks: List[flytekit.Deck]
-    om: OutputMetadata
+    om: Optional[OutputMetadata]
 
 
 def spawn_helper(
@@ -435,7 +435,7 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
                     if isinstance(e, FlyteRecoverableException):
                         create_recoverable_error_file()
                     raise
-                return ElasticWorkerResult(return_value=return_val, decks=flytekit.current_context().decks)
+                return ElasticWorkerResult(return_value=return_val, decks=flytekit.current_context().decks, om=None)
 
             launcher_target_func = fn_partial
             launcher_args = ()
@@ -447,10 +447,12 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
         from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
 
         try:
+            print("Here+++++++++++++++++++++++++ 1")
             out = elastic_launch(
                 config=config,
                 entrypoint=launcher_target_func,
             )(*launcher_args)
+            print("Here+++++++++++++++++++++++++ 2")
         except ChildFailedError as e:
             _, first_failure = e.get_first_failure()
             if is_recoverable_worker_error(first_failure):

--- a/tests/flytekit/unit/core/test_artifacts.py
+++ b/tests/flytekit/unit/core/test_artifacts.py
@@ -619,3 +619,15 @@ def test_lims():
     # test an artifact with 11 partition keys
     with pytest.raises(ValueError):
         Artifact(name="test artifact", time_partitioned=True, partition_keys=[f"key_{i}" for i in range(11)])
+
+
+def test_cloudpickle():
+    a1_b = Artifact(name="my_data", partition_keys=["b"])
+
+    spec = a1_b(b="my_b_value")
+    import cloudpickle
+
+    d = cloudpickle.dumps(spec)
+    spec2 = cloudpickle.loads(d)
+
+    assert spec2.partitions.b.value.static_value == "my_b_value"


### PR DESCRIPTION
## Why are the changes needed?
This relates to an issue we found when using the artifact class with Elastic while also specifying partitions.

As far as I can tell, what's happening is that the kfpytorch plugin [serializes](https://github.com/flyteorg/flytekit/blob/5bc5d5c0db193fdeea1bcaa2af6ee1af2316499c/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py#L408), using cloud pickle, and then [deserializes](https://github.com/flyteorg/flytekit/blob/5bc5d5c0db193fdeea1bcaa2af6ee1af2316499c/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py#L276) within the worker.  Because of how cloudpickle works, this was causing an infinite recursion in the `__getattr__` call of the partitions object.  Basically the getattr function is called only if the field is missing from the object, but cloudpickle doesn't run the init function for the object, which leads to an infinite recursion.  (The added unit test fails with infinite recursion if the code change to getattr is removed.)  (See more background [here.](https://nedbatchelder.com/blog/201010/surprising_getattr_recursion.html))

```
  File "/Users/ytong/go/src/github.com/flyteorg/flytekit/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py", line 276, in spawn_helper
    fn = cloudpickle.loads(fn)
         ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ytong/go/src/github.com/flyteorg/flytekit/flytekit/core/artifact.py", line 321, in __getattr__
    if self.partitions and item in self.partitions:
       ^^^^^^^^^^^^^^^
  File "/Users/ytong/go/src/github.com/flyteorg/flytekit/flytekit/core/artifact.py", line 312, in partitions
    return self._partitions
           ^^^^^^^^^^^^^^^^
  File "/Users/ytong/go/src/github.com/flyteorg/flytekit/flytekit/core/artifact.py", line 321, in __getattr__
    if self.partitions and item in self.partitions:
       ^^^^^^^^^^^^^^^
```

This was hard to find because the exception was getting swallowed by Elastic somewhere.  This stack trace was taken from a file which looks something like `/var/folders/jx/54tww2ls58n8qtlp9k31nbd80000gp/T/torchelastic_wg0jjz6j/local_r5pr8f9n/attempt_0/0/error.json`.  The behavior of the pytorch plugin is such that this just hangs (at least until some timeout), rather than failing even though there is an error.json.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Tested locally.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
