### PR TITLE
Richer printing for some artifact objects

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -2023,8 +2023,6 @@ class LiteralsResolver(collections.UserDict):
     LiteralsResolver is a helper class meant primarily for use with the FlyteRemote experience or any other situation
     where you might be working with LiteralMaps. This object allows the caller to specify the Python type that should
     correspond to an element of the map.
-
-    TODO: Consider inheriting from collections.UserDict instead of manually having the _native_values cache
     """
 
     def __init__(

--- a/flytekit/models/types.py
+++ b/flytekit/models/types.py
@@ -283,11 +283,37 @@ class LiteralType(_common.FlyteIdlEntity):
         self._enum_type = enum_type
         self._union_type = union_type
         self._structured_dataset_type = structured_dataset_type
-        self._metadata = metadata
         self._structure = structure
         self._structured_dataset_type = structured_dataset_type
         self._metadata = metadata
         self._annotation = annotation
+
+    def __rich_repr__(self):
+        if self.simple:
+            yield "Simple"
+        elif self.schema:
+            yield "Schema"
+        elif self.collection_type:
+            sub = next(self.collection_type.__rich_repr__())
+            yield f"List[{sub}]"
+        elif self.map_value_type:
+            sub = next(self.map_value_type.__rich_repr__())
+            yield f"Dict[str, {sub}]"
+        elif self.blob:
+            if self.blob.dimensionality == _types_pb2.BlobType.BlobDimensionality.SINGLE:
+                yield "File"
+            elif self.blob.dimensionality == _types_pb2.BlobType.BlobDimensionality.MULTIPART:
+                yield "Directory"
+            else:
+                yield "Unknown Blob Type"
+        elif self.enum_type:
+            yield "Enum"
+        elif self.union_type:
+            yield "Union"
+        elif self.structured_dataset_type:
+            yield f"StructuredDataset(format={self.structured_dataset_type.format})"
+        else:
+            yield "Unknown Type"
 
     @property
     def simple(self) -> SimpleType:

--- a/tests/flytekit/unit/core/test_artifacts.py
+++ b/tests/flytekit/unit/core/test_artifacts.py
@@ -615,6 +615,27 @@ def test_tp_math():
     assert tp2 is not tp
 
 
+def test_tp_printing():
+    d = datetime.datetime(2063, 4, 5, 0, 0)
+    pt = Timestamp()
+    pt.FromDatetime(d)
+    tp = TimePartition(value=art_id.LabelValue(time_value=pt), granularity=Granularity.HOUR)
+    txt = "".join([str(x) for x in tp.__rich_repr__()])
+    # should show something like ('Time Partition', '2063-04-05 00:00:00')
+    # just check that we don't accidentally fail to evaluate a generator
+    assert "generator" not in txt
+
+
+def test_partition_printing():
+    a1_b = Artifact(name="my_data", partition_keys=["b"])
+    spec = a1_b(b="my_b_value")
+    ps = spec.partitions
+    txt = "".join([str(x) for x in ps.__rich_repr__()])
+    # should look something like ('Partitions', '(\'b\', static_value: "my_b_value"\n)')
+    # just check that we don't accidentally fail to evaluate a generator
+    assert "generator" not in txt
+
+
 def test_lims():
     # test an artifact with 11 partition keys
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Why are the changes needed?
Just improving the experience.

## What changes were proposed in this pull request?
Adding  `__rich_repr__` and `_repr_html_` to TimePartition, Partition, and Partitions objects.
Also adding `__rich_repr__` to LiteralType.

## How was this patch tested?
Tested in jupyter locally, along with the corresponding change, it now looks like
![image](https://github.com/user-attachments/assets/1eed64b7-5508-4101-b577-ccc8d2efed87)


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
