### PR TITLE
Remove use of multiprocessing from the OAuth client

### DIFF
--- a/flytekit/clients/auth/auth_client.py
+++ b/flytekit/clients/auth/auth_client.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from http import HTTPStatus as _StatusCodes
 from multiprocessing import get_context
 from urllib.parse import urlencode as _urlencode
+from queue import Queue
 
 import click
 import requests
@@ -124,7 +125,7 @@ class OAuthHTTPServer(_BaseHTTPServer.HTTPServer):
         request_handler_class: typing.Type[_BaseHTTPServer.BaseHTTPRequestHandler],
         bind_and_activate: bool = True,
         redirect_path: str = None,
-        queue: multiprocessing.Queue = None,
+        queue: Queue = None,
     ):
         _BaseHTTPServer.HTTPServer.__init__(self, server_address, request_handler_class, bind_and_activate)
         self._redirect_path = redirect_path
@@ -142,9 +143,8 @@ class OAuthHTTPServer(_BaseHTTPServer.HTTPServer):
 
     def handle_authorization_code(self, auth_code: str):
         self._queue.put(auth_code)
-        self.server_close()
 
-    def handle_request(self, queue: multiprocessing.Queue = None) -> typing.Any:
+    def handle_request(self, queue: Queue = None) -> typing.Any:
         self._queue = queue
         return super().handle_request()
 
@@ -345,26 +345,21 @@ class AuthorizationClient(metaclass=_SingletonPerEndpoint):
         retrieve credentials
         """
         # In the absence of globally-set token values, initiate the token request flow
-        ctx = get_context("fork")
-        q = ctx.Queue()
+        q = Queue()
 
         # First prepare the callback server in the background
         server = self._create_callback_server()
 
-        server_process = ctx.Process(target=server.handle_request, args=(q,))
-        server_process.daemon = True
+        self._request_authorization_code()
 
-        try:
-            server_process.start()
+        server.handle_request(q)
+        server.server_close()
 
-            # Send the call to request the authorization code in the background
-            self._request_authorization_code()
+        # Send the call to request the authorization code in the background
 
-            # Request the access token once the auth code has been received.
-            auth_code = q.get()
-            return self._request_access_token(auth_code)
-        finally:
-            server_process.terminate()
+        # Request the access token once the auth code has been received.
+        auth_code = q.get()
+        return self._request_access_token(auth_code)
 
     def refresh_access_token(self, credentials: Credentials) -> Credentials:
         if credentials.refresh_token is None:

--- a/flytekit/clients/auth/auth_client.py
+++ b/flytekit/clients/auth/auth_client.py
@@ -4,7 +4,6 @@ import base64
 import hashlib
 import http.server as _BaseHTTPServer
 import logging
-import multiprocessing
 import os
 import re
 import typing
@@ -12,9 +11,8 @@ import urllib.parse as _urlparse
 import webbrowser
 from dataclasses import dataclass
 from http import HTTPStatus as _StatusCodes
-from multiprocessing import get_context
-from urllib.parse import urlencode as _urlencode
 from queue import Queue
+from urllib.parse import urlencode as _urlencode
 
 import click
 import requests


### PR DESCRIPTION
## Why are the changes needed?

Multiprocessing in Python is a bit fraught with issues, as it requires that every dependency in the transitive dependency tree of your project supports multiprocessing. We've noticed issues with the way that this code interacts with concurrent task registration that results in trying to open multiple instances of the server, which fails due to listening on the same port.

## What changes were proposed in this pull request?

The multiprocessing usage here didn't actually bring any real benefit, as the intended use was to simply block the requestor's control flow anyways with the use of a queue. This retains the same behavior without the use of any multiprocessing.

## How was this patch tested?

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.