### PR TITLE
Make elastic timeout configurable for HorovovJob.

### DIFF
--- a/plugins/flytekit-kf-mpi/flytekitplugins/kfmpi/task.py
+++ b/plugins/flytekit-kf-mpi/flytekitplugins/kfmpi/task.py
@@ -233,6 +233,7 @@ class HorovodJob(object):
         verbose: Optional flag indicating whether to enable verbose logging (default: False).
         log_level: Optional string specifying the log level (default: "INFO").
         discovery_script_path: Path to the discovery script used for host discovery (default: "/etc/mpi/discover_hosts.sh").
+        elastic_timeout: horovod eslastic timeout in second (default: 1200).
         num_launcher_replicas: [DEPRECATED] The number of launcher server replicas to use. This argument is deprecated. Please use launcher.replicas instead.
         num_workers: [DEPRECATED] The number of worker replicas to spawn in the cluster for this job. Please use worker.replicas instead.
     """
@@ -244,6 +245,7 @@ class HorovodJob(object):
     verbose: Optional[bool] = False
     log_level: Optional[str] = "INFO"
     discovery_script_path: Optional[str] = "/etc/mpi/discover_hosts.sh"
+    elastic_timeout: Optional[int] = 1200
     # Support v0 config for backwards compatibility
     num_launcher_replicas: Optional[int] = None
     num_workers: Optional[int] = None
@@ -287,6 +289,8 @@ class HorovodFunctionTask(MPIFunctionTask):
             f"{self.task_config.slots}",
             "--host-discovery-script",
             self.task_config.discovery_script_path,
+            "--elastic-timeout",
+            f"{self.task_config.elastic_timeout}",
         ]
         if self.task_config.verbose:
             base_cmd.append("--verbose")


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?
The default elastic timeout to wait for worker pod to be ready is 60s https://github.com/horovod/horovod/blob/55a73d4f662bf637f6994a61f62b517ad9554dc1/horovod/runner/launch.py#L452C32-L452C51

Sometimes it is taking longer than 10 min to pull the image since the openconnect image is large. 

example failure: 
https://observe.prod.linkedin.com/g/d/b8d1d3e1-b5f8-4814-9e56-89ed6370ea39/kingkong-job-execution?orgId=1&var-executionId=1029478&var-Cluster=grid1-k8s-0&refresh=1h


<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Changes:
* Increased elastic_timeout to 20 min;
* make elastic_timeout configurable by user
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ X ] I updated the documentation accordingly.
- [ X ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
