### PR TITLE
update markdown renderer to create tables

### DIFF
--- a/flytekit/deck/renderer.py
+++ b/flytekit/deck/renderer.py
@@ -55,7 +55,8 @@ class MarkdownRenderer:
     """Convert a markdown string to HTML and return HTML as a unicode string."""
 
     def to_html(self, text: str) -> str:
-        return MarkdownIt().render(text)
+        md = MarkdownIt("gfm-like").enable('table')  # enable table plugin
+        return md.render(text)
 
 
 class SourceCodeRenderer:


### PR DESCRIPTION
## Why are the changes needed?

It would be nice to render pandas dataframes as tables in decks using markdown (`df.to_markdown()`). To do this we need to the `table` plugin of `markdown-it-py` enabled.

## What changes were proposed in this pull request?

Enable `table` plugin for `markdown-it-py`.

## How was this patch tested?

```python
data = {
    'id': np.arange(1, 11),
    'name': [f'Item {i}' for i in range(1, 11)],
    'value': np.random.rand(10) * 100,
    'category': np.random.choice(['A', 'B', 'C'], size=10),
    'timestamp': pd.date_range('2023-01-01', periods=10, freq='D')
}
df = pd.DataFrame(data)
md_df = df.to_markdown()
flytekit.current_context().default_deck.append(
        MarkdownRenderer().to_html(md_df)
    )
```

### html before change:
<img width="1696" alt="image" src="https://github.com/user-attachments/assets/9976166e-c1bf-442c-b063-aac8b691d89d">


### html after change:
<img width="360" alt="image" src="https://github.com/user-attachments/assets/6c847336-1ee5-4cd2-b7d0-c3c8e187c68e">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Docs link

Link to the markdown-it-py docs: https://markdown-it-py.readthedocs.io/en/latest/using.html#the-parser
