### PR TITLE
Fix Get Agent Secret Using Key

### DIFF
--- a/flytekit/extend/backend/utils.py
+++ b/flytekit/extend/backend/utils.py
@@ -39,7 +39,7 @@ def is_terminal_phase(phase: TaskExecution.Phase) -> bool:
 
 
 def get_agent_secret(secret_key: str) -> str:
-    return flytekit.current_context().secrets.get(secret_key)
+    return flytekit.current_context().secrets.get(key=secret_key)
 
 
 def render_task_template(tt: TaskTemplate, file_prefix: str) -> TaskTemplate:


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/3936


## Why are the changes needed?
If we install union sdk, when using `get_agent_secret`, we will ignore the group, and right now we use `group` to retrieve the agent's secret.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
