### PR TITLE
Improve jupyter repr and `__repr__` for Flyte models

### DIFF
--- a/flytekit/models/common.py
+++ b/flytekit/models/common.py
@@ -47,8 +47,7 @@ class FlyteType(FlyteABCMeta):
 def _repr_idl_yaml_like(idl, indent=0) -> str:
     """Formats an IDL into a YAML-like representation."""
     if not hasattr(idl, "ListFields"):
-        str_repr = shorten(str(idl).strip(), width=80)
-        return str_repr
+        return str(idl)
 
     with closing(StringIO()) as out:
         for descriptor, field in idl.ListFields():
@@ -60,6 +59,7 @@ def _repr_idl_yaml_like(idl, indent=0) -> str:
                     out.write(" " * indent + descriptor.name + ":" + os.linesep)
                     out.write(_repr_idl_yaml_like(field, indent + 2))
             except AttributeError:
+                # No ListFields -> Must be a scalar
                 str_repr = shorten(str(field).strip(), width=80)
                 if str_repr:
                     out.write(" " * indent + descriptor.name + ": " + str_repr + os.linesep)
@@ -106,7 +106,7 @@ class FlyteIdlEntity(object, metaclass=FlyteType):
         type_str = type(self).__name__
         idl = self.to_flyte_idl()
         str_repr = _repr_idl_yaml_like(idl)
-        return f"<h4>Flyte Serialized object of type: {type_str}</h4><pre>{str_repr}</pre>"
+        return f"<h4>{type_str}</h4><pre>{str_repr}</pre>"
 
     @property
     def is_empty(self):

--- a/flytekit/models/common.py
+++ b/flytekit/models/common.py
@@ -1,7 +1,6 @@
 import abc
 import json
 import os
-import re
 from contextlib import closing
 from io import StringIO
 from textwrap import shorten
@@ -87,9 +86,9 @@ class FlyteIdlEntity(object, metaclass=FlyteType):
         """
         :rtype: Text
         """
-        literal_str = re.sub(r"\s+", " ", str(self.to_flyte_idl())).strip()
+        str_repr = _repr_idl_yaml_like(self.to_flyte_idl(), indent=2).rstrip(os.linesep)
         type_str = type(self).__name__
-        return f"[Flyte Serialized object: Type: <{type_str}> Value: <{literal_str}>]"
+        return f"{type_str}:" + os.linesep + str_repr
 
     def verbose_string(self):
         """
@@ -105,7 +104,7 @@ class FlyteIdlEntity(object, metaclass=FlyteType):
         # `_repr_html_` is used by Jupyter to render objects
         type_str = type(self).__name__
         idl = self.to_flyte_idl()
-        str_repr = _repr_idl_yaml_like(idl)
+        str_repr = _repr_idl_yaml_like(idl).rstrip(os.linesep)
         return f"<h4>{type_str}</h4><pre>{str_repr}</pre>"
 
     @property

--- a/flytekit/models/common.py
+++ b/flytekit/models/common.py
@@ -88,7 +88,7 @@ class FlyteIdlEntity(object, metaclass=FlyteType):
         """
         str_repr = _repr_idl_yaml_like(self.to_flyte_idl(), indent=2).rstrip(os.linesep)
         type_str = type(self).__name__
-        return f"{type_str}:" + os.linesep + str_repr
+        return f"Flyte Serialized object ({type_str}):" + os.linesep + str_repr
 
     def verbose_string(self):
         """

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -250,7 +250,6 @@ def get_serializable_task(
         sql=entity.get_sql(settings),
         extended_resources=entity.get_extended_resources(settings),
     )
-    breakpoint()
     if settings.should_fast_serialize() and isinstance(entity, PythonAutoContainerTask):
         entity.reset_command_fn()
 

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -250,6 +250,7 @@ def get_serializable_task(
         sql=entity.get_sql(settings),
         extended_resources=entity.get_extended_resources(settings),
     )
+    breakpoint()
     if settings.should_fast_serialize() and isinstance(entity, PythonAutoContainerTask):
         entity.reset_command_fn()
 

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -88,7 +88,7 @@ def test_create_and_link_node_from_remote_ignore():
     # which is incorrect
     with pytest.raises(
         FlyteAssertion,
-        match=r"Missing input `i` type `LiteralType:",
+        match=r"Missing input `i` type `Flyte Serialized object \(LiteralType\):",
     ):
         create_and_link_node_from_remote(ctx, lp)
 

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -88,7 +88,7 @@ def test_create_and_link_node_from_remote_ignore():
     # which is incorrect
     with pytest.raises(
         FlyteAssertion,
-        match=r"Missing input `i` type `\[Flyte Serialized object: Type: <LiteralType> Value: <simple: INTEGER>\]`",
+        match=r"Missing input `i` type `LiteralType:",
     ):
         create_and_link_node_from_remote(ctx, lp)
 

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1706,7 +1706,7 @@ def test_union_type():
         match=re.escape(
             "Error encountered while executing 'wf2':\n"
             f"  Failed to convert inputs of task '{prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
-            '  Cannot convert from Literal:'
+            r'  Cannot convert from Flyte Serialized object (Literal):'
         ),
     ):
         assert wf2(a="2") == "2"

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1706,8 +1706,7 @@ def test_union_type():
         match=re.escape(
             "Error encountered while executing 'wf2':\n"
             f"  Failed to convert inputs of task '{prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
-            '  Cannot convert from [Flyte Serialized object: Type: <Literal> Value: <scalar { union { value { scalar { primitive { string_value: "2" } } } '
-            'type { simple: STRING structure { tag: "str" } } } }>] to typing.Union[float, dict] (using tag str)'
+            '  Cannot convert from Literal:'
         ),
     ):
         assert wf2(a="2") == "2"

--- a/tests/flytekit/unit/models/test_common.py
+++ b/tests/flytekit/unit/models/test_common.py
@@ -110,3 +110,11 @@ def test_short_string_raw_output_data_config():
     obj = _common.RawOutputDataConfig("s3://bucket")
     assert "Flyte Serialized object: Type: <RawOutputDataConfig> Value" in obj.short_string()
     assert "Flyte Serialized object: Type: <RawOutputDataConfig> Value" in repr(obj)
+
+
+def test_html_repr_data_config():
+    obj = _common.RawOutputDataConfig("s3://bucket")
+
+    out = obj._repr_html_()
+    assert "output_location_prefix: s3://bucket" in out
+    assert "<h4>RawOutputDataConfig</h4>" in out

--- a/tests/flytekit/unit/models/test_common.py
+++ b/tests/flytekit/unit/models/test_common.py
@@ -1,5 +1,17 @@
+import datetime
+from datetime import timezone, timedelta
+import textwrap
+
 from flytekit.models import common as _common
 from flytekit.models.core import execution as _execution
+
+from flytekit.models.execution import ExecutionClosure
+
+from flytekit.models.execution import LiteralMapBlob
+from flytekit.models.literals import LiteralMap, Scalar, Primitive, Literal, RetryStrategy
+from flytekit.models.core.execution import WorkflowExecutionPhase
+from flytekit.models.task import TaskMetadata, RuntimeMetadata
+from flytekit.models.project import Project
 
 
 def test_notification_email():
@@ -106,7 +118,6 @@ def test_auth_role_empty():
 
 
 def test_short_string_raw_output_data_config():
-    """"""
     obj = _common.RawOutputDataConfig("s3://bucket")
     assert "Flyte Serialized object (RawOutputDataConfig):" in obj.short_string()
     assert "Flyte Serialized object (RawOutputDataConfig):" in repr(obj)
@@ -118,3 +129,92 @@ def test_html_repr_data_config():
     out = obj._repr_html_()
     assert "output_location_prefix: s3://bucket" in out
     assert "<h4>RawOutputDataConfig</h4>" in out
+
+
+def test_short_string_entities_ExecutionClosure():
+    _OUTPUT_MAP = LiteralMap(
+        {"b": Literal(scalar=Scalar(primitive=Primitive(integer=2)))}
+    )
+
+    test_datetime = datetime.datetime(year=2022, month=1, day=1, tzinfo=timezone.utc)
+    test_timedelta = datetime.timedelta(seconds=10)
+    test_outputs = LiteralMapBlob(values=_OUTPUT_MAP, uri="http://foo/")
+
+    obj = ExecutionClosure(
+        phase=WorkflowExecutionPhase.SUCCEEDED,
+        started_at=test_datetime,
+        duration=test_timedelta,
+        outputs=test_outputs,
+        created_at=None,
+        updated_at=test_datetime,
+    )
+    expected_result = textwrap.dedent("""\
+    Flyte Serialized object (ExecutionClosure):
+      outputs:
+        uri: http://foo/
+      phase: 4
+      started_at:
+        seconds: 1640995200
+      duration:
+        seconds: 10
+      updated_at:
+        seconds: 1640995200""")
+
+    assert repr(obj) == expected_result
+    assert obj.short_string() == expected_result
+
+
+def test_short_string_entities_Primitive():
+    obj = Primitive(integer=1)
+    expected_result = textwrap.dedent("""\
+    Flyte Serialized object (Primitive):
+      integer: 1""")
+
+    assert repr(obj) == expected_result
+    assert obj.short_string() == expected_result
+
+
+def test_short_string_entities_TaskMetadata():
+    obj = TaskMetadata(
+        True,
+        RuntimeMetadata(RuntimeMetadata.RuntimeType.FLYTE_SDK, "1.0.0", "python"),
+        timedelta(days=1),
+        RetryStrategy(3),
+        True,
+        "0.1.1b0",
+        "This is deprecated!",
+        True,
+        "A",
+        (),
+    )
+
+    expected_result = textwrap.dedent("""\
+    Flyte Serialized object (TaskMetadata):
+      discoverable: True
+      runtime:
+        type: 1
+        version: 1.0.0
+        flavor: python
+      timeout:
+        seconds: 86400
+      retries:
+        retries: 3
+      discovery_version: 0.1.1b0
+      deprecated_error_message: This is deprecated!
+      interruptible: True
+      cache_serializable: True
+      pod_template_name: A""")
+    assert repr(obj) == expected_result
+    assert obj.short_string() == expected_result
+
+
+def test_short_string_entities_Project():
+    obj = Project("project_id", "project_name", "project_description")
+    expected_result = textwrap.dedent("""\
+    Flyte Serialized object (Project):
+      id: project_id
+      name: project_name
+      description: project_description""")
+
+    assert repr(obj) == expected_result
+    assert obj.short_string() == expected_result

--- a/tests/flytekit/unit/models/test_common.py
+++ b/tests/flytekit/unit/models/test_common.py
@@ -108,8 +108,8 @@ def test_auth_role_empty():
 def test_short_string_raw_output_data_config():
     """"""
     obj = _common.RawOutputDataConfig("s3://bucket")
-    assert "RawOutputDataConfig:" in obj.short_string()
-    assert "RawOutputDataConfig:" in repr(obj)
+    assert "Flyte Serialized object (RawOutputDataConfig):" in obj.short_string()
+    assert "Flyte Serialized object (RawOutputDataConfig):" in repr(obj)
 
 
 def test_html_repr_data_config():

--- a/tests/flytekit/unit/models/test_common.py
+++ b/tests/flytekit/unit/models/test_common.py
@@ -108,8 +108,8 @@ def test_auth_role_empty():
 def test_short_string_raw_output_data_config():
     """"""
     obj = _common.RawOutputDataConfig("s3://bucket")
-    assert "Flyte Serialized object: Type: <RawOutputDataConfig> Value" in obj.short_string()
-    assert "Flyte Serialized object: Type: <RawOutputDataConfig> Value" in repr(obj)
+    assert "RawOutputDataConfig:" in obj.short_string()
+    assert "RawOutputDataConfig:" in repr(obj)
 
 
 def test_html_repr_data_config():


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
Improves jupyter repr for `flytekit.models`.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR adds a `_repr_html_` that generically renders any `flytekit.model`. Internally it uses `_repr_idl_yaml_like` that renders any flyteidl as a yaml like repr.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I added a simple unit test.

### Screenshots

#### This PR

![Screenshot 2024-08-02 at 10 25 00 PM](https://github.com/user-attachments/assets/810ef504-2119-42fa-9e4d-b330cdf3f3ec)

#### Current


![Screenshot 2024-08-02 at 10 26 28 PM](https://github.com/user-attachments/assets/1f30327c-0f46-42fa-8a2f-71fc805a25e2)

