### PR TITLE
Update error message for TypeTransformerFailedError

### DIFF
--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -292,7 +292,7 @@ class Task(object):
         except TypeTransformerFailedError as exc:
             msg = f"Failed to convert inputs of task '{self.name}':\n  {exc}"
             logger.error(msg)
-            raise TypeError(msg) from exc
+            raise TypeError(msg) from None
         input_literal_map = _literal_models.LiteralMap(literals=literals)
 
         # if metadata.cache is set, check memoized version
@@ -724,7 +724,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
             except Exception as exc:
                 msg = f"Failed to convert inputs of task '{self.name}':\n  {exc}"
                 logger.error(msg)
-                raise type(exc)(msg) from exc
+                raise type(exc)(msg) from None
 
             # TODO: Logger should auto inject the current context information to indicate if the task is running within
             #   a workflow or a subworkflow etc

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -94,7 +94,7 @@ def translate_inputs_to_literals(
                 v = resolve_attr_path_in_promise(v)
             result[k] = TypeEngine.to_literal(ctx, v, t, var.type)
         except TypeTransformerFailedError as exc:
-            raise TypeTransformerFailedError(f"Failed argument '{k}': {exc}") from exc
+            raise TypeTransformerFailedError(f"Failed argument '{k}': {exc}") from None
 
     return result
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -240,8 +240,9 @@ class SimpleTransformer(TypeTransformer[T]):
                 f"Cannot convert to type {expected_python_type}, only {self._type} is supported"
             )
 
-        if isinstance(None, expected_python_type) and lv.scalar.none_type is None:
-            raise TypeTransformerFailedError(f"Cannot convert literal {lv} to None")
+        if isinstance(None, expected_python_type):
+            if lv.scalar.none_type is None:
+                raise TypeTransformerFailedError(f"Cannot convert literal {lv} to None")
         elif lv.scalar.primitive is None:
             raise TypeTransformerFailedError(f"Cannot convert literal {lv} to {self._type}")
         else:

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -240,14 +240,30 @@ class SimpleTransformer(TypeTransformer[T]):
                 f"Cannot convert to type {expected_python_type}, only {self._type} is supported"
             )
 
-        try:  # todo(maximsmol): this is quite ugly and each transformer should really check their Literal
-            res = self._from_literal_transformer(lv)
-            if type(res) != self._type:
-                raise TypeTransformerFailedError(f"Cannot convert literal {lv} to {self._type}")
-            return res
-        except AttributeError:
-            # Assume that this is because a property on `lv` was None
+        if isinstance(None, expected_python_type) and lv.scalar.none_type is None:
+            raise TypeTransformerFailedError(f"Cannot convert literal {lv} to None")
+        elif lv.scalar.primitive is None:
             raise TypeTransformerFailedError(f"Cannot convert literal {lv} to {self._type}")
+        else:
+            if expected_python_type is int and lv.scalar.primitive.integer is None:
+                raise TypeTransformerFailedError(f"Cannot convert literal {lv} to int")
+            elif expected_python_type is float and lv.scalar.primitive.float_value is None:
+                raise TypeTransformerFailedError(f"Cannot convert literal {lv} to float")
+            elif expected_python_type is bool and lv.scalar.primitive.boolean is None:
+                raise TypeTransformerFailedError(f"Cannot convert literal {lv} to bool")
+            elif expected_python_type is str and lv.scalar.primitive.string_value is None:
+                raise TypeTransformerFailedError(f"Cannot convert literal {lv} to str")
+            elif expected_python_type is datetime.datetime and lv.scalar.primitive.datetime is None:
+                raise TypeTransformerFailedError(f"Cannot convert literal {lv} to datetime")
+            elif expected_python_type is datetime.timedelta and lv.scalar.primitive.duration is None:
+                raise TypeTransformerFailedError(f"Cannot convert literal {lv} to timedelta")
+            elif expected_python_type is datetime.date and lv.scalar.primitive.datetime is None:
+                raise TypeTransformerFailedError(f"Cannot convert literal {lv} to date")
+
+        res = self._from_literal_transformer(lv)
+        if type(res) != self._type:
+            raise TypeTransformerFailedError(f"Cannot convert literal {lv} to {self._type}")
+        return res
 
     def guess_python_type(self, literal_type: LiteralType) -> Type[T]:
         if literal_type.simple is not None and literal_type.simple == self._lt.simple:

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -247,7 +247,11 @@ class SimpleTransformer(TypeTransformer[T]):
         else:
             if expected_python_type is int and lv.scalar.primitive.integer is None:
                 raise TypeTransformerFailedError(f"Cannot convert literal {lv} to int")
-            elif expected_python_type is float and lv.scalar.primitive.float_value is None:
+            elif (
+                expected_python_type is float
+                and lv.scalar.primitive.float_value is None
+                and lv.scalar.primitive.integer is None
+            ):
                 raise TypeTransformerFailedError(f"Cannot convert literal {lv} to float")
             elif expected_python_type is bool and lv.scalar.primitive.boolean is None:
                 raise TypeTransformerFailedError(f"Cannot convert literal {lv} to bool")


### PR DESCRIPTION
## Tracking issue
Related to flyteorg/flyte#5353
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?
1. To raise `TypeTransformerFailedError` directly and provide clearer feedback on unsupported type transformations instead of internal `AttributeError` messages like `AttributeError: 'NoneType' object has no attribute 'string_value'`.
2. To validate the literal for each registered SimpleTransformer, ensuring more robust type handling.

## What changes were proposed in this pull request?
1. Remove the try-except code block that raises an `AttributeError` when a SimpleTransformer receives an incorrect literal format.
2. Add individual checks for each SimpleTransformer currently supported by flytekit.

## How was this patch tested?
Executed unit tests using:
```bash
pytest /flytekit/tests/flytekit/unit/core/test_type_engine.py
```

### Screenshots
#### Running the above unit test on the master branch:
![Master branch test](https://github.com/user-attachments/assets/df942a26-b705-457a-8199-6c61bc31fb38)

#### Running the above unit test on this new branch: `fix-check-simpletransformer-get-union-type-error`
![New branch test](https://github.com/user-attachments/assets/fe730f52-fd49-4497-9cdc-e4e4a80ecb82)

-> No additional errors occur.

## Check all the applicable boxes
- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
N/A

## Docs link
N/A