### PR TITLE
Handle common cases of mutable default arguments explicitly

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -5,7 +5,7 @@ import inspect
 import typing
 from copy import deepcopy
 from enum import Enum
-from typing import Any, Coroutine, Dict, Hashable, List, Optional, Set, Tuple, Union, cast, get_args
+from typing import Any, Coroutine, Dict, List, Optional, Set, Tuple, Union, cast, get_args
 
 from google.protobuf import struct_pb2 as _struct
 from typing_extensions import Protocol
@@ -1116,8 +1116,13 @@ def create_and_link_node(
                 or UnionTransformer.is_optional_type(interface.inputs_with_defaults[k][0])
             ):
                 default_val = interface.inputs_with_defaults[k][1]
-                if not isinstance(default_val, Hashable):
-                    raise _user_exceptions.FlyteAssertion("Cannot use non-hashable object as default argument")
+                # Common cases of mutable default arguments, as described in https://www.pullrequest.com/blog/python-pitfalls-the-perils-of-using-lists-and-dicts-as-default-arguments/
+                # or https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil, are not supported.
+                # As of 2024-08-05, Python native sets are not supported in Flytekit. However, they are included here for completeness.
+                if isinstance(default_val, list) or isinstance(default_val, dict) or isinstance(default_val, set):
+                    raise _user_exceptions.FlyteAssertion(
+                        f"Argument {k} for function {entity.name} is a mutable default argument, which is a python anti-pattern and not supported in flytekit tasks"
+                    )
                 kwargs[k] = default_val
             else:
                 error_msg = f"Input {k} of type {interface.inputs[k]} was not specified for function {entity.name}"

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -1,3 +1,4 @@
+import re
 import os
 import typing
 from collections import OrderedDict
@@ -775,7 +776,10 @@ def test_default_args_task_list_type():
     def wf_with_input() -> typing.List[int]:
         return t1(a=input_val)
 
-    with pytest.raises(FlyteAssertion, match="Cannot use non-hashable object as default argument"):
+    with pytest.raises(
+        FlyteAssertion,
+        match=r"Argument a for function .*test_serialization\.t1 is a mutable default argument, which is a python anti-pattern and not supported in flytekit tasks"
+    ):
         get_serializable(OrderedDict(), serialization_settings, wf_no_input)
 
     wf_with_input_spec = get_serializable(OrderedDict(), serialization_settings, wf_with_input)
@@ -810,7 +814,10 @@ def test_default_args_task_dict_type():
     def wf_with_input() -> typing.Dict[str, int]:
         return t1(a=input_val)
 
-    with pytest.raises(FlyteAssertion, match="Cannot use non-hashable object as default argument"):
+    with pytest.raises(
+        FlyteAssertion,
+        match=r"Argument a for function .*test_serialization\.t1 is a mutable default argument, which is a python anti-pattern and not supported in flytekit tasks"
+    ):
         get_serializable(OrderedDict(), serialization_settings, wf_no_input)
 
     wf_with_input_spec = get_serializable(OrderedDict(), serialization_settings, wf_with_input)
@@ -910,7 +917,10 @@ def test_default_args_task_optional_list_type_default_list():
     def wf_with_input() -> typing.Optional[typing.List[int]]:
         return t1(a=input_val)
 
-    with pytest.raises(FlyteAssertion, match="Cannot use non-hashable object as default argument"):
+    with pytest.raises(
+        FlyteAssertion,
+        match=r"Argument a for function .*test_serialization\.t1 is a mutable default argument, which is a python anti-pattern and not supported in flytekit tasks"
+    ):
         get_serializable(OrderedDict(), serialization_settings, wf_no_input)
 
     wf_with_input_spec = get_serializable(OrderedDict(), serialization_settings, wf_with_input)


### PR DESCRIPTION
## Why are the changes needed?
In https://github.com/flyteorg/flytekit/pull/2401 we added a check against mutable default arguments where we simply confirmed that the object was hashable. This works, but it's too restrictive as it prevents other commonly used objects (e.g. dataclasses) from being used as default values.

Even sophisticated linters like ruff only detect mutable default arguments for lists, dictionaries, and sets. For example, this sample code:
```
from dataclasses import dataclass
from mashumaro import DataClassDictMixin

@dataclass
class DC(DataClassDictMixin):
    a: int
    b: str

def f(dc: DC = DC(42, "43"), xs: list[int] = [1,2], d: dict[str, int] = {"abc": 42}, s: set(int) = set([1,2,3])):
    ...
```
returns this error in ruff:
```
❯ ruff check example
example/dc.py:9:46: B006 Do not use mutable data structures for argument defaults
   |
 7 |     b: str
 8 |
 9 | def f(dc: DC = DC(42, "43"), xs: list[int] = [1,2], d: dict[str, int] = {"abc": 42}, s: set(int) = set([1,2,3])):
   |                                              ^^^^^ B006
10 |     ...
   |
   = help: Replace with `None`; initialize within function

example/dc.py:9:73: B006 Do not use mutable data structures for argument defaults
   |
 7 |     b: str
 8 |
 9 | def f(dc: DC = DC(42, "43"), xs: list[int] = [1,2], d: dict[str, int] = {"abc": 42}, s: set(int) = set([1,2,3])):
   |                                                                         ^^^^^^^^^^^ B006
10 |     ...
   |
   = help: Replace with `None`; initialize within function

example/dc.py:9:100: B006 Do not use mutable data structures for argument defaults
   |
 7 |     b: str
 8 |
 9 | def f(dc: DC = DC(42, "43"), xs: list[int] = [1,2], d: dict[str, int] = {"abc": 42}, s: set(int) = set([1,2,3])):
   |                                                                                                    ^^^^^^^^^^^^ B006
10 |     ...
   |
   = help: Replace with `None`; initialize within function

Found 3 errors.
No fixes available (3 hidden fixes can be enabled with the `--unsafe-fixes` option).
```
Notice how the dataclass is not classified as a mutable default arg.

## What changes were proposed in this pull request?
We handle the 3 common cases explicitly instead of checking if the object is hashable.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
unit tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
