### PR TITLE
Modify test_array_node.py to support running in python 3.8

### DIFF
--- a/tests/flytekit/unit/core/test_array_node.py
+++ b/tests/flytekit/unit/core/test_array_node.py
@@ -37,7 +37,7 @@ lp = LaunchPlan.get_default_launch_plan(current_context(), parent_wf)
 
 
 @workflow
-def grandparent_wf() -> list[int]:
+def grandparent_wf() -> typing.List[int]:
     return array_node(lp, concurrency=10, min_success_ratio=0.9)(a=[1, 3, 5], b=[2, 4, 6])
 
 
@@ -86,7 +86,7 @@ def test_local_exec_lp_min_successes(min_successes, min_success_ratio, should_ra
     ex_lp = LaunchPlan.get_default_launch_plan(current_context(), ex_wf)
 
     @workflow
-    def grandparent_ex_wf() -> list[typing.Optional[int]]:
+    def grandparent_ex_wf() -> typing.List[typing.Optional[int]]:
         return array_node(ex_lp, min_successes=min_successes, min_success_ratio=min_success_ratio)(val=[1, 2, 3, 4])
 
     if should_raise_error:


### PR DESCRIPTION
## Why are the changes needed?
We run nightly tests in all supported python versions (e.g. https://github.com/flyteorg/flytekit/actions/runs/10249523395), but tests have been failing in python 3.8. This PR fixes the remaining ones.

## What changes were proposed in this pull request?
Use the deprecated `typing.List` to define a list. Once we [drop support for python 3.8](https://github.com/flyteorg/flyte/issues/5633) later in the year we can go back to using the native collections everywhere in the codebase.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Ran tests locally using python 3.8.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
