### PR TITLE
[fix] Validate workflow input name is lowercase

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -379,6 +379,10 @@ def to_click_option(
     This handles converting workflow input types to supported click parameters with callbacks to initialize
     the input values to their expected types.
     """
+    if input_name != input_name.lower():
+        # Click does not support uppercase option names: https://github.com/pallets/click/issues/837
+        raise ValueError(f"Workflow input name must be lowercase: {input_name!r}")
+
     run_level_params: RunLevelParams = ctx.obj
 
     literal_converter = FlyteLiteralConverter(

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -78,7 +78,10 @@ class Interface(object):
         if inputs:
             for k, v in inputs.items():
                 if not k.isidentifier():
-                    raise ValueError(f"Input name must be valid Python identifier: {k!r}")
+                    raise ValueError(f"Input name must be a valid Python identifier: {k!r}")
+                if k != k.lower():
+                    # Click does not support uppercase option names: https://github.com/pallets/click/issues/837
+                    raise ValueError(f"Input name must be lowercase: {k!r}")
                 if type(v) is tuple and len(cast(Tuple, v)) > 1:
                     self._inputs[k] = v  # type: ignore
                 else:

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -79,9 +79,6 @@ class Interface(object):
             for k, v in inputs.items():
                 if not k.isidentifier():
                     raise ValueError(f"Input name must be a valid Python identifier: {k!r}")
-                if k != k.lower():
-                    # Click does not support uppercase option names: https://github.com/pallets/click/issues/837
-                    raise ValueError(f"Input name must be lowercase: {k!r}")
                 if type(v) is tuple and len(cast(Tuple, v)) > 1:
                     self._inputs[k] = v  # type: ignore
                 else:

--- a/tests/flytekit/unit/core/test_interface.py
+++ b/tests/flytekit/unit/core/test_interface.py
@@ -332,11 +332,14 @@ def test_transform_interface_to_typed_interface_with_docstring():
 def test_init_interface_with_invalid_parameters():
     from flytekit.core.interface import Interface
 
-    with pytest.raises(ValueError, match=r"Input name must be valid Python identifier:"):
+    with pytest.raises(ValueError, match=r"Input name must be a valid Python identifier:"):
         _ = Interface({"my.input": int}, {})
 
     with pytest.raises(ValueError, match=r"Type names and field names must be valid identifiers:"):
         _ = Interface({}, {"my.output": int})
+
+    with pytest.raises(ValueError, match=r"Input name must be lowercase:"):
+        _ = Interface({"A": int}, {})
 
 
 def test_parameter_change_to_pickle_type():

--- a/tests/flytekit/unit/core/test_interface.py
+++ b/tests/flytekit/unit/core/test_interface.py
@@ -338,9 +338,6 @@ def test_init_interface_with_invalid_parameters():
     with pytest.raises(ValueError, match=r"Type names and field names must be valid identifiers:"):
         _ = Interface({}, {"my.output": int})
 
-    with pytest.raises(ValueError, match=r"Input name must be lowercase:"):
-        _ = Interface({"A": int}, {})
-
 
 def test_parameter_change_to_pickle_type():
     ctx = context_manager.FlyteContext.current_context()


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5640

## Why are the changes needed?

Click does not support uppercase in option names: https://github.com/pallets/click/issues/837

This causes an unintuitive error in flytekit when uppercase is used in task input names:
```
$ pyflyte run --remote wf.py wf --A 1
Failed with Unknown Exception <class 'flytekit.core.type_engine.TypeTransformerFailedError'>
Reason: Python value cannot be None, expected <class 'int'>/<FlyteLiteral(LiteralType) simple: INTEGER>
```

This PR aims to improve the error message. A long-term fix might be to support uppercase in workflow input names, but this seems to be incompatible with the click.Option implementation. Lowercase+snake_case is a convention that click aims to follow.

## What changes were proposed in this pull request?

Add validation against the workflow input names to ensure it is lowercase.

## How was this patch tested?

New error is improved:
```
$ pyflyte run --remote wf.py wf --A 1
Failed with Unknown Exception <class 'ValueError'> Reason: Workflow input name must be lowercase: 'A'
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
