### PR TITLE
return exceptions when gathering

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -773,10 +773,10 @@ class FlyteRemote(object):
         identifiers_or_exceptions.extend(await asyncio.gather(*tasks, return_exceptions=True))
         # Check to make sure any exceptions are just registration skipped exceptions
         for ie in identifiers_or_exceptions:
+            if isinstance(ie, RegistrationSkipped):
+                logger.info(f"Skipping registration... {ie}")
+                continue
             if isinstance(ie, Exception):
-                if isinstance(ie, RegistrationSkipped):
-                    logger.info(f"Skipping registration... {ie}")
-                    continue
                 raise ie
         # serial register
         cp_other_entities = OrderedDict(filter(lambda x: not isinstance(x[1], task_models.TaskSpec), m.items()))

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -658,7 +658,7 @@ class FlyteRemote(object):
                     raise RegistrationSkipped(f"Remote task/Workflow {cp_entity.name} is not registrable.")
             else:
                 logger.debug(f"Skipping registration of remote entity: {cp_entity.name}")
-                raise RegistrationSkipped(f"Remote task/Workflow {cp_entity.name} is not registrable.")
+                raise RegistrationSkipped(f"Remote entity {cp_entity.name} is not registrable.")
 
         if isinstance(
             cp_entity,
@@ -768,13 +768,23 @@ class FlyteRemote(object):
                     functools.partial(self.raw_register, cp_entity, serialization_settings, version, og_entity=entity),
                 )
             )
-        ident = []
-        ident.extend(await asyncio.gather(*tasks))
+
+        identifiers_or_exceptions = []
+        identifiers_or_exceptions.extend(await asyncio.gather(*tasks, return_exceptions=True))
+        # Check to make sure any exceptions are just registration skipped exceptions
+        for ie in identifiers_or_exceptions:
+            if isinstance(ie, Exception):
+                if isinstance(ie, RegistrationSkipped):
+                    logger.info(f"Skipping registration... {ie}")
+                    continue
+                raise ie
         # serial register
         cp_other_entities = OrderedDict(filter(lambda x: not isinstance(x[1], task_models.TaskSpec), m.items()))
         for entity, cp_entity in cp_other_entities.items():
-            ident.append(self.raw_register(cp_entity, serialization_settings, version, og_entity=entity))
-        return ident[-1]
+            identifiers_or_exceptions.append(
+                self.raw_register(cp_entity, serialization_settings, version, og_entity=entity)
+            )
+        return identifiers_or_exceptions[-1]
 
     def register_task(
         self,


### PR DESCRIPTION
## Tracking issue
https://flyte-org.slack.com/archives/CP2HDHKE1/p1722624663458609

## What changes were proposed in this pull request?
If an exception is encountered while registering tasks, continue to register launch plans/workflows if all the exceptions were just Registration Skipped.

## How was this patch tested?
Tested locally by recreating the community provided example.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
