### PR TITLE
Return explicit task execution code not found

### DIFF
--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -55,6 +55,11 @@ class FlyteValueException(FlyteUserException, ValueError):
         super(FlyteValueException, self).__init__(self._create_verbose_message(received_value, error_message))
 
 
+class FlyteDataNotFoundException(FlyteValueException):
+    def __init__(self, path: str):
+        super(FlyteDataNotFoundException, self).__init__(path, "File not found")
+
+
 class FlyteAssertion(FlyteUserException, AssertionError):
     _ERROR_CODE = "USER:AssertionError"
 

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -15,6 +15,7 @@ import click
 
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.utils import timeit
+from flytekit.exceptions.user import FlyteDataNotFoundException
 from flytekit.loggers import logger
 from flytekit.tools.ignore import DockerIgnore, FlyteIgnore, GitIgnore, Ignore, IgnoreGroup, StandardIgnore
 from flytekit.tools.script_mode import tar_strip_file_attributes
@@ -146,7 +147,12 @@ def download_distribution(additional_distribution: str, destination: str):
     # NOTE the os.path.join(destination, ''). This is to ensure that the given path is in fact a directory and all
     # downloaded data should be copied into this directory. We do this to account for a difference in behavior in
     # fsspec, which requires a trailing slash in case of pre-existing directory.
-    FlyteContextManager.current_context().file_access.get_data(additional_distribution, os.path.join(destination, ""))
+    try:
+        FlyteContextManager.current_context().file_access.get_data(
+            additional_distribution, os.path.join(destination, "")
+        )
+    except FlyteDataNotFoundException as ex:
+        raise RuntimeError("task execution code was not found") from ex
     tarfile_name = os.path.basename(additional_distribution)
     if not tarfile_name.endswith(".tar.gz"):
         raise RuntimeError("Unrecognized additional distribution format for {}".format(additional_distribution))

--- a/tests/flytekit/unit/core/test_checkpoint.py
+++ b/tests/flytekit/unit/core/test_checkpoint.py
@@ -5,7 +5,7 @@ import pytest
 
 import flytekit
 from flytekit.core.checkpointer import SyncCheckpoint
-from flytekit.exceptions.user import FlyteAssertion
+from flytekit.exceptions.user import FlyteDataNotFoundException
 
 
 def test_sync_checkpoint_write(tmpdir):
@@ -90,10 +90,10 @@ def test_sync_checkpoint_restore_corrupt(tmpdir):
     prev.unlink()
     src.rmdir()
 
-    with pytest.raises(FlyteAssertion):
+    with pytest.raises(FlyteDataNotFoundException):
         cp.restore(user_dest)
 
-    with pytest.raises(FlyteAssertion):
+    with pytest.raises(FlyteDataNotFoundException):
         cp.restore(user_dest)
 
 


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?

If data stored in S3 bucket is deleted, we want flytekit to handle not found error in a more explicit and self-descriptive way.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

Tested against local sandbox setup and got following task output
```python
[1/1] currentAttempt done. Last Error: USER::
[al2j8c22ppzrgd924jqk-n0-0] terminated with exit code (1). Reason [Error]. Message: 
 in fun
    return caller(func, *(extras + args), **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/flytekit/flytekit/core/data_persistence.py", line 122, in retry_request
    raise e
  File "/flytekit/flytekit/core/data_persistence.py", line 115, in retry_request
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/flytekit/flytekit/core/data_persistence.py", line 303, in get
    raise FlyteDataNotFoundException(from_path)
flytekit.exceptions.user.FlyteDataNotFoundException: USER:ValueError: error=Value error!  Received: s3://my-s3-bucket/flytesnacks/development/W4S5AAPUOZIDDPCM7BI7TEDDP4======/script_mode.tar.gz. File not found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/bin/pyflyte-fast-execute", line 8, in <module>
    sys.exit(fast_execute_task_cmd())
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/flytekit/flytekit/bin/entrypoint.py", line 534, in fast_execute_task_cmd
    _download_distribution(additional_distribution, dest_dir)
  File "/flytekit/flytekit/core/utils.py", line 308, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/flytekit/flytekit/tools/fast_registration.py", line 155, in download_distribution
    raise RuntimeError("task execution code was not found") from ex
RuntimeError: task execution code was not found
.
```
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
