### PR TITLE
Fix overriding of loader_args task resolver in papermill plugin

### DIFF
--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -202,15 +202,21 @@ class NotebookTask(PythonInstanceTask[T]):
         # Always extract the module from the notebook task, no matter what _config_task_instance is.
         _, m, t, _ = extract_task_module(self)
         loader_args = ["task-module", m, "task-name", t]
+        previous_loader_args = self._config_task_instance.task_resolver.loader_args
         self._config_task_instance.task_resolver.loader_args = lambda ss, task: loader_args
-        return self._config_task_instance.get_container(settings)
+        container = self._config_task_instance.get_container(settings)
+        self._config_task_instance.task_resolver.loader_args = previous_loader_args
+        return container
 
     def get_k8s_pod(self, settings: SerializationSettings) -> task_models.K8sPod:
         # Always extract the module from the notebook task, no matter what _config_task_instance is.
         _, m, t, _ = extract_task_module(self)
         loader_args = ["task-module", m, "task-name", t]
+        previous_loader_args = self._config_task_instance.task_resolver.loader_args
         self._config_task_instance.task_resolver.loader_args = lambda ss, task: loader_args
-        return self._config_task_instance.get_k8s_pod(settings)
+        k8s_pod = self._config_task_instance.get_k8s_pod(settings)
+        self._config_task_instance.task_resolver.loader_args = previous_loader_args
+        return k8s_pod
 
     def get_config(self, settings: SerializationSettings) -> typing.Dict[str, str]:
         return {**super().get_config(settings), **self._config_task_instance.get_config(settings)}

--- a/plugins/flytekit-papermill/tests/test_task.py
+++ b/plugins/flytekit-papermill/tests/test_task.py
@@ -4,8 +4,10 @@ import shutil
 import tempfile
 import typing
 from unittest import mock
+import pytest
 
 import pandas as pd
+from flytekit.core.pod_template import PodTemplate
 from click.testing import CliRunner
 from flytekitplugins.awsbatch import AWSBatchConfig
 from flytekitplugins.papermill import NotebookTask
@@ -147,16 +149,27 @@ def generate_por_spec_for_task():
     return pod_spec
 
 
-nb = NotebookTask(
+nb_pod = NotebookTask(
     name="test",
     task_config=Pod(pod_spec=generate_por_spec_for_task(), primary_container_name="primary"),
     notebook_path=_get_nb_path("nb-simple", abs=False),
     inputs=kwtypes(h=str, n=int, w=str),
     outputs=kwtypes(h=str, w=PythonNotebook, x=X),
 )
+nb_pod_template = NotebookTask(
+    name="test",
+    pod_template=PodTemplate(pod_spec=generate_por_spec_for_task(), primary_container_name="primary"),
+    notebook_path=_get_nb_path("nb-simple", abs=False),
+    inputs=kwtypes(h=str, n=int, w=str),
+    outputs=kwtypes(h=str, w=PythonNotebook, x=X),
+)
 
 
-def test_notebook_pod_task():
+@pytest.mark.parametrize("nb_task", [
+    nb_pod,
+    nb_pod_template,
+])
+def test_notebook_pod_task(nb_task):
     serialization_settings = flytekit.configuration.SerializationSettings(
         project="project",
         domain="domain",
@@ -165,12 +178,92 @@ def test_notebook_pod_task():
         image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
     )
 
-    assert nb.get_container(serialization_settings) is None
-    assert nb.get_config(serialization_settings)["primary_container_name"] == "primary"
+    assert nb_task.get_container(serialization_settings) is None
+    assert nb_task.get_config(serialization_settings)["primary_container_name"] == "primary"
     assert (
-        nb.get_command(serialization_settings)
-        == nb.get_k8s_pod(serialization_settings).pod_spec["containers"][0]["args"]
+        nb_task.get_command(serialization_settings)
+        == nb_task.get_k8s_pod(serialization_settings).pod_spec["containers"][0]["args"]
     )
+
+
+@pytest.mark.parametrize("nb_task, name", [
+    (nb_pod, "nb_pod"),
+    (nb_pod_template, "nb_pod_template"),
+])
+def test_notebook_pod_override(nb_task, name):
+    serialization_settings = flytekit.configuration.SerializationSettings(
+        project="project",
+        domain="domain",
+        version="version",
+        env=None,
+        image_config=ImageConfig(Image(name="name", fqn="image", tag="name")),
+    )
+
+    @task
+    def t1():
+        ...
+
+    assert t1.get_container(serialization_settings).args == [
+        "pyflyte-execute",
+        "--inputs",
+        "{{.input}}",
+        "--output-prefix",
+        "{{.outputPrefix}}",
+        "--raw-output-data-prefix",
+        "{{.rawOutputDataPrefix}}",
+        "--checkpoint-path",
+        "{{.checkpointOutputPrefix}}",
+        "--prev-checkpoint",
+        "{{.prevCheckpointPrefix}}",
+        "--resolver",
+        "flytekit.core.python_auto_container.default_task_resolver",
+        "--",
+        "task-module",
+        "tests.test_task",
+        "task-name",
+        "t1",
+    ]
+    assert nb_task.get_k8s_pod(serialization_settings).pod_spec["containers"][0]["args"] == [
+        "pyflyte-execute",
+        "--inputs",
+        "{{.input}}",
+        "--output-prefix",
+        "{{.outputPrefix}}",
+        "--raw-output-data-prefix",
+        "{{.rawOutputDataPrefix}}",
+        "--checkpoint-path",
+        "{{.checkpointOutputPrefix}}",
+        "--prev-checkpoint",
+        "{{.prevCheckpointPrefix}}",
+        "--resolver",
+        "flytekit.core.python_auto_container.default_task_resolver",
+        "--",
+        "task-module",
+        "tests.test_task",
+        "task-name",
+        f"{name}",
+    ]
+    assert t1.get_container(serialization_settings).args == [
+        "pyflyte-execute",
+        "--inputs",
+        "{{.input}}",
+        "--output-prefix",
+        "{{.outputPrefix}}",
+        "--raw-output-data-prefix",
+        "{{.rawOutputDataPrefix}}",
+        "--checkpoint-path",
+        "{{.checkpointOutputPrefix}}",
+        "--prev-checkpoint",
+        "{{.prevCheckpointPrefix}}",
+        "--resolver",
+        "flytekit.core.python_auto_container.default_task_resolver",
+        "--",
+        "task-module",
+        "tests.test_task",
+        "task-name",
+        # Confirm that task name is correctly pointing to t1
+        "t1",
+    ]
 
 
 nb_batch = NotebookTask(
@@ -210,7 +303,7 @@ def test_notebook_batch_task():
     ]
 
 
-def test_repro_papermill_overriding_task_resolver_loader_args():
+def test_overriding_task_resolver_loader_args():
     serialization_settings = flytekit.configuration.SerializationSettings(
         project="project",
         domain="domain",
@@ -243,7 +336,6 @@ def test_repro_papermill_overriding_task_resolver_loader_args():
         "task-name",
         "t1",
     ]
-
     assert nb_batch.get_container(serialization_settings).args == [
         "pyflyte-execute",
         "--inputs",
@@ -260,8 +352,6 @@ def test_repro_papermill_overriding_task_resolver_loader_args():
         "task-name",
         "nb_batch",
     ]
-
-    # Call t1.get_container again and confirm that task-name is now wrong
     assert t1.get_container(serialization_settings).args == [
         "pyflyte-execute",
         "--inputs",
@@ -280,7 +370,7 @@ def test_repro_papermill_overriding_task_resolver_loader_args():
         "task-module",
         "tests.test_task",
         "task-name",
-        # Note that the task name is now `nb_batch`
+        # Confirm that task name is correctly pointing to t1
         "t1",
     ]
 


### PR DESCRIPTION
## Why are the changes needed?
In https://github.com/flyteorg/flytekit/pull/1859/ (which was released in flytekitplugins-papermill 1.10.0) we ended up overriding the task resolver's `loader_args` method in order to generate the correct `NotebookTask` container arguments. However we never restored that function to its original value, which has the side effect that in the case of shared task resolvers (e.g. the `default_task_resolver` used for regular tasks) we end up reusing the last `NotebookTask` registered as the task name.

## What changes were proposed in this pull request?
This PR restores the loader_args in papermill plugin's `get_container` and `get_k8s_pod`.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
