### PR TITLE
Copy user files that were imported by workflow in pyflyte run

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -44,7 +44,7 @@ from flytekit.models.types import SimpleType
 from flytekit.remote import FlyteLaunchPlan, FlyteRemote, FlyteTask, FlyteWorkflow, remote_fs
 from flytekit.remote.executions import FlyteWorkflowExecution
 from flytekit.tools import module_loader
-from flytekit.tools.script_mode import _find_project_root, compress_scripts
+from flytekit.tools.script_mode import _find_project_root, compress_scripts, get_all_modules
 from flytekit.tools.translator import Options
 
 
@@ -493,7 +493,8 @@ def _update_flyte_context(params: RunLevelParams) -> FlyteContext.Builder:
     if output_prefix and ctx.file_access.is_remote(output_prefix):
         with tempfile.TemporaryDirectory() as tmp_dir:
             archive_fname = pathlib.Path(os.path.join(tmp_dir, "script_mode.tar.gz"))
-            compress_scripts(params.computed_params.project_root, str(archive_fname), list(sys.modules.values()))
+            modules = get_all_modules(params.computed_params.project_root, params.computed_params.module)
+            compress_scripts(params.computed_params.project_root, str(archive_fname), modules)
             remote_dir = file_access.get_random_remote_directory()
             remote_archive_fname = f"{remote_dir}/script_mode.tar.gz"
             file_access.put_data(str(archive_fname), remote_archive_fname)

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -493,7 +493,7 @@ def _update_flyte_context(params: RunLevelParams) -> FlyteContext.Builder:
     if output_prefix and ctx.file_access.is_remote(output_prefix):
         with tempfile.TemporaryDirectory() as tmp_dir:
             archive_fname = pathlib.Path(os.path.join(tmp_dir, "script_mode.tar.gz"))
-            compress_scripts(params.computed_params.project_root, str(archive_fname), params.computed_params.module)
+            compress_scripts(params.computed_params.project_root, str(archive_fname), list(sys.modules.values()))
             remote_dir = file_access.get_random_remote_directory()
             remote_archive_fname = f"{remote_dir}/script_mode.tar.gz"
             file_access.put_data(str(archive_fname), remote_archive_fname)

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -88,7 +88,7 @@ from flytekit.remote.remote_callable import RemoteEntity
 from flytekit.remote.remote_fs import get_flyte_fs
 from flytekit.tools.fast_registration import FastPackageOptions, fast_package
 from flytekit.tools.interactive import ipython_check
-from flytekit.tools.script_mode import _find_project_root, compress_scripts, hash_file
+from flytekit.tools.script_mode import _find_project_root, compress_scripts, hash_file, get_all_modules
 from flytekit.tools.translator import (
     FlyteControlPlaneEntity,
     FlyteLocalEntity,
@@ -1021,7 +1021,7 @@ class FlyteRemote(object):
                 )
             else:
                 archive_fname = pathlib.Path(os.path.join(tmp_dir, "script_mode.tar.gz"))
-                compress_scripts(source_path, str(archive_fname), list(sys.modules.values()))
+                compress_scripts(source_path, str(archive_fname), get_all_modules(source_path, module_name))
                 md5_bytes, upload_native_url = self.upload_file(
                     archive_fname, project or self.default_project, domain or self.default_domain
                 )

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -13,6 +13,7 @@ import functools
 import hashlib
 import os
 import pathlib
+import sys
 import tempfile
 import time
 import typing
@@ -1020,7 +1021,7 @@ class FlyteRemote(object):
                 )
             else:
                 archive_fname = pathlib.Path(os.path.join(tmp_dir, "script_mode.tar.gz"))
-                compress_scripts(source_path, str(archive_fname), module_name)
+                compress_scripts(source_path, str(archive_fname), list(sys.modules.values()))
                 md5_bytes, upload_native_url = self.upload_file(
                     archive_fname, project or self.default_project, domain or self.default_domain
                 )

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -13,7 +13,6 @@ import functools
 import hashlib
 import os
 import pathlib
-import sys
 import tempfile
 import time
 import typing
@@ -88,7 +87,7 @@ from flytekit.remote.remote_callable import RemoteEntity
 from flytekit.remote.remote_fs import get_flyte_fs
 from flytekit.tools.fast_registration import FastPackageOptions, fast_package
 from flytekit.tools.interactive import ipython_check
-from flytekit.tools.script_mode import _find_project_root, compress_scripts, hash_file, get_all_modules
+from flytekit.tools.script_mode import _find_project_root, compress_scripts, get_all_modules, hash_file
 from flytekit.tools.translator import (
     FlyteControlPlaneEntity,
     FlyteLocalEntity,

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -9,7 +9,7 @@ import tempfile
 import typing
 from pathlib import Path
 from types import ModuleType
-from typing import List
+from typing import List, Optional
 
 
 def compress_scripts(source_path: str, destination: str, modules: List[ModuleType]):
@@ -140,10 +140,10 @@ def add_imported_modules_from_source(source_path: str, destination: str, modules
         shutil.copy(mod_file, new_destination)
 
 
-def get_all_modules(source_path: str, module_name: str) -> List[ModuleType]:
+def get_all_modules(source_path: str, module_name: Optional[str]) -> List[ModuleType]:
     """Import python file with module_name in source_path and return all modules."""
     sys_modules = list(sys.modules.values())
-    if module_name in sys.modules:
+    if module_name is None or module_name in sys.modules:
         # module already exists, there is no need to import it again
         return sys_modules
 

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -12,7 +12,7 @@ from types import ModuleType
 from typing import List
 
 
-def compress_scripts(source_path: str, destination: str, module_name: str):
+def compress_scripts(source_path: str, destination: str, modules: List[ModuleType]):
     """
     Compresses the single script while maintaining the folder structure for that file.
 
@@ -24,25 +24,27 @@ def compress_scripts(source_path: str, destination: str, module_name: str):
     │       ├── example.py
     │       ├── another_example.py
     │       ├── yet_another_example.py
+    │       ├── unused_example.py
     │       └── __init__.py
 
-    Let's say you want to compress `example.py`. In that case we specify the the full module name as
-    flyte.workflows.example and that will produce a tar file that contains only that file alongside
-    with the folder structure, i.e.:
+    Let's say you want to compress `example.py` imports `another_example.py`. And `another_example.py`
+    imports on `yet_another_example.py`. This will  produce a tar file that contains only that
+    file alongside with the folder structure, i.e.:
 
     .
     ├── flyte
     │   ├── __init__.py
     │   └── workflows
     │       ├── example.py
+    │       ├── another_example.py
+    │       ├── yet_another_example.py
     │       └── __init__.py
-
-    Note: If `example.py` didn't import tasks or workflows from `another_example.py` and `yet_another_example.py`, these files were not copied to the destination..
 
     """
     with tempfile.TemporaryDirectory() as tmp_dir:
         destination_path = os.path.join(tmp_dir, "code")
-        add_imported_modules_from_source(source_path, destination_path, list(sys.modules.values()))
+        os.mkdir(destination_path)
+        add_imported_modules_from_source(source_path, destination_path, modules)
 
         tar_path = os.path.join(tmp_dir, "tmp.tar")
         with tarfile.open(tar_path, "w") as tar:

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -155,6 +155,9 @@ def add_imported_modules_from_source(source_path: str, destination: str, modules
         if mod_file is None:
             continue
 
+        # Check to see if mod_file is in site_packages of bin_directory, which are
+        # installed packages & libraries that are not user files. This happens when
+        # there is a virtualenv like `.venv` in the working directory.
         try:
             if os.path.commonpath(site_packages + [mod_file]) in site_packages_set:
                 # Do not upload files from site-packages
@@ -166,7 +169,7 @@ def add_imported_modules_from_source(source_path: str, destination: str, modules
 
         except ValueError:
             # ValueError is raised by windows if the paths are not from the same drive
-            # If the files are not in the same drive, then the mod_file is not
+            # If the files are not in the same drive, then mod_file is not
             # in the site-packages or bin directory.
             pass
 

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -155,13 +155,20 @@ def add_imported_modules_from_source(source_path: str, destination: str, modules
         if mod_file is None:
             continue
 
-        if os.path.commonpath(site_packages + [mod_file]) in site_packages_set:
-            # Do not upload files from site-packages
-            continue
+        try:
+            if os.path.commonpath(site_packages + [mod_file]) in site_packages_set:
+                # Do not upload files from site-packages
+                continue
 
-        if os.path.commonpath([bin_directory, mod_file]) == bin_directory:
-            # Do not upload from the bin directory
-            continue
+            if os.path.commonpath([bin_directory, mod_file]) == bin_directory:
+                # Do not upload from the bin directory
+                continue
+
+        except ValueError:
+            # ValueError is raised by windows if the paths are not from the sae drive
+            # If the files are not in the same drive, then the mod_file is not
+            # in the site-packages or bin directory.
+            pass
 
         common_path = os.path.commonpath([mod_file, source_path])
         if common_path != source_path:

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -1,6 +1,5 @@
 import gzip
 import hashlib
-import importlib
 import os
 import shutil
 import site
@@ -11,10 +10,6 @@ import typing
 from pathlib import Path
 from types import ModuleType
 from typing import List
-
-from flytekit import PythonFunctionTask
-from flytekit.core.tracker import get_full_module_path
-from flytekit.core.workflow import ImperativeWorkflow, WorkflowBase
 
 
 def compress_scripts(source_path: str, destination: str, module_name: str):

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -165,14 +165,20 @@ def add_imported_modules_from_source(source_path: str, destination: str, modules
                 continue
 
         except ValueError:
-            # ValueError is raised by windows if the paths are not from the sae drive
+            # ValueError is raised by windows if the paths are not from the same drive
             # If the files are not in the same drive, then the mod_file is not
             # in the site-packages or bin directory.
             pass
 
-        common_path = os.path.commonpath([mod_file, source_path])
-        if common_path != source_path:
-            # Do not upload files that do not share a common directory with the source
+        try:
+            common_path = os.path.commonpath([mod_file, source_path])
+            if common_path != source_path:
+                # Do not upload files that do not share a common directory with the source
+                continue
+        except ValueError:
+            # ValueError is raised by windows if the paths are not from the same drive
+            # If they are not in the same directory, then they do not share a common path,
+            # so we do not upload the file.
             continue
 
         relative_path = os.path.relpath(mod_file, start=source_path)

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -103,7 +103,7 @@ def add_imported_modules_from_source(source_path: str, destination: str, modules
         if mod_file is None:
             continue
 
-        # Check to see if mod_file is in site_packages of bin_directory, which are
+        # Check to see if mod_file is in site_packages or bin_directory, which are
         # installed packages & libraries that are not user files. This happens when
         # there is a virtualenv like `.venv` in the working directory.
         try:

--- a/tests/flytekit/unit/tools/test_script_mode.py
+++ b/tests/flytekit/unit/tools/test_script_mode.py
@@ -75,14 +75,20 @@ def test_deterministic_hash(tmp_path):
 
     destination = tmp_path / "destination"
 
-    sys.path.append(str(workflows_dir.parent))
-    compress_scripts(str(workflows_dir.parent), str(destination), "workflows.hello_world")
+    modules = [
+        import_module_from_file("workflows.hello_world", os.fspath(workflow_file)),
+        import_module_from_file("workflows.imperative_wf", os.fspath(workflow_file)),
+        import_module_from_file("wf1.test", os.fspath(t1_file)),
+        import_module_from_file("wf2.test", os.fspath(t2_file))
+    ]
+
+    compress_scripts(str(workflows_dir.parent), str(destination), modules)
 
     digest, hex_digest, _ = hash_file(destination)
 
     # Try again to assert digest determinism
     destination2 = tmp_path / "destination2"
-    compress_scripts(str(workflows_dir.parent), str(destination2), "workflows.hello_world")
+    compress_scripts(str(workflows_dir.parent), str(destination2), modules)
     digest2, hex_digest2, _ = hash_file(destination)
 
     assert digest == digest2


### PR DESCRIPTION
## Tracking issue
Related to https://github.com/flyteorg/flyte/issues/5343

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, `pyflyte run` requires `--copy-all` when the workflow imports files from other directories. This is a common gotcha because `pyflyte run workflow.py` works, but `pyflyte run --remote workflow.py` does not.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
With this PR:
- We look at all the modules in `sys.modules` and copy over all files that are necessary for the workflow to run.
- This way `pyflyte run --remote workflow.py` will work out of the box most of the time.
- Less copying than `--copy-all` because it only copies over the required files. If you have a project with tests or docs, it will not be copied.

I think the new coping mechanism does what `copy_module_to_destination` does, but I did not want to adjust it just in case I break anything. I added a new `add_imported_modules_from_source` to additionally copy over files. 

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I added unit tests to make sure the copying works. I also had a project with this structure:

```
.
└── workflows
    ├── __init__.py
    ├── another_module
    │   └── wow.py
    ├── main.py
    └── util.py
```

and ran `pyflyte run --remote workflows/main.py` and everything copies correctly. Simple workflow in the root directory also works:

```
.
├── main.py
└── util.py
```