### PR TITLE
Don't check the return statement for reference_launch_plan

### DIFF
--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -509,7 +509,7 @@ def reference_launch_plan(
     """
 
     def wrapper(fn) -> ReferenceLaunchPlan:
-        interface = transform_function_to_interface(fn)
+        interface = transform_function_to_interface(fn, is_reference_entity=True)
         return ReferenceLaunchPlan(project, domain, name, version, interface.inputs, interface.outputs)
 
     return wrapper

--- a/tests/flytekit/unit/core/test_references.py
+++ b/tests/flytekit/unit/core/test_references.py
@@ -408,7 +408,7 @@ def test_lp_from_ref_wf():
 def test_ref_lp_from_decorator():
     @reference_launch_plan(project="project", domain="domain", name="name", version="version")
     def ref_lp1(p1: str, p2: str) -> int:
-        return 0
+        ...
 
     assert ref_lp1.id.name == "name"
     assert ref_lp1.id.project == "project"
@@ -422,7 +422,7 @@ def test_ref_lp_from_decorator_with_named_outputs():
     nt = typing.NamedTuple("RefLPOutput", [("o1", int), ("o2", str)])
     @reference_launch_plan(project="project", domain="domain", name="name", version="version")
     def ref_lp1(p1: str, p2: str) -> nt:
-        return nt(o1=1, o2="2")
+        ...
 
     assert ref_lp1.python_interface.outputs == {"o1": int, "o2": str}
 
@@ -470,7 +470,7 @@ def test_ref_dynamic_lp():
     def my_subwf(a: int) -> typing.List[int]:
         @reference_launch_plan(project="project", domain="domain", name="name", version="version")
         def ref_lp1(p1: str, p2: str) -> int:
-            return 1
+            ...
 
         s = []
         for i in range(a):


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
can not register a reference LP because it doesn't have `return` statement
```
@reference_task(
    project="flyte-conformance",
    domain="development",
    name="flytesnacks.examples.basics.basics.workflow.slope",
    version="e2ZYwgh3ZzI7Q56rJjSN1g",
)
def ref_basic(x: typing.List[int], y: typing.List[int]) -> float:
    ...
```

## What changes were proposed in this pull request?
Don't check the return statement for reference_launch_plan

## How was this patch tested?
unit test/pyflyte run

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA
## Docs link
NA
