### PR TITLE
Replace Exceptions with specific errors

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -366,7 +366,7 @@ def _execute_task(
     :return:
     """
     if len(resolver_args) < 1:
-        raise Exception("cannot be <1")
+        raise ValueError("cannot be <1")
 
     with setup_execution(
         raw_output_data_prefix,
@@ -419,7 +419,7 @@ def _execute_map_task(
     :return:
     """
     if len(resolver_args) < 1:
-        raise Exception(f"Resolver args cannot be <1, got {resolver_args}")
+        raise ValueError(f"Resolver args cannot be <1, got {resolver_args}")
 
     with setup_execution(
         raw_output_data_prefix, checkpoint_path, prev_checkpoint, dynamic_addl_distro, dynamic_dest_dir

--- a/flytekit/clients/auth/auth_client.py
+++ b/flytekit/clients/auth/auth_client.py
@@ -332,7 +332,7 @@ class AuthorizationClient(metaclass=_SingletonPerEndpoint):
         if resp.status_code != _StatusCodes.OK:
             # TODO: handle expected (?) error cases:
             #  https://auth0.com/docs/flows/guides/device-auth/call-api-device-auth#token-responses
-            raise Exception(
+            raise RuntimeError(
                 "Failed to request access token with response: [{}] {}".format(resp.status_code, resp.content)
             )
         return self._credentials_from_response(resp)

--- a/flytekit/core/array_node.py
+++ b/flytekit/core/array_node.py
@@ -77,9 +77,9 @@ class ArrayNode:
                 if isinstance(metadata, _workflow_model.NodeMetadata):
                     self.metadata = metadata
                 else:
-                    raise Exception("Invalid metadata for LaunchPlan. Should be NodeMetadata.")
+                    raise TypeError("Invalid metadata for LaunchPlan. Should be NodeMetadata.")
         else:
-            raise Exception("Only LaunchPlans are supported for now.")
+            raise ValueError(f"Only LaunchPlans are supported for now, but got {type(target)}")
 
     def construct_node_metadata(self) -> _workflow_model.NodeMetadata:
         # Part of SupportsNodeCreation interface

--- a/flytekit/core/base_sql_task.py
+++ b/flytekit/core/base_sql_task.py
@@ -48,7 +48,7 @@ class SQLTask(PythonTask[T]):
         return self._query_template
 
     def execute(self, **kwargs) -> Any:
-        raise Exception("Cannot run a SQL Task natively, please mock.")
+        raise NotImplementedError("Cannot run a SQL Task natively, please mock.")
 
     def get_query(self, **kwargs) -> str:
         return self.interpolate_query(self.query_template, **kwargs)

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -358,7 +358,7 @@ class Task(object):
         return flyte_entity_call_handler(self, *args, **kwargs)  # type: ignore
 
     def compile(self, ctx: FlyteContext, *args, **kwargs):
-        raise Exception("not implemented")
+        raise NotImplementedError
 
     def get_container(self, settings: SerializationSettings) -> Optional[_task_model.Container]:
         """

--- a/flytekit/core/class_based_resolver.py
+++ b/flytekit/core/class_based_resolver.py
@@ -38,6 +38,6 @@ class ClassStorageTaskResolver(TrackedInstance, TaskResolverMixin):
         This is responsible for turning an instance of a task into args that the load_task function can reconstitute.
         """
         if t not in self.mapping:
-            raise Exception("no such task")
+            raise ValueError("no such task")
 
         return [f"{self.mapping.index(t)}"]

--- a/flytekit/core/node_creation.py
+++ b/flytekit/core/node_creation.py
@@ -137,7 +137,7 @@ def create_node(
 
         if ctx.execution_state.branch_eval_mode == BranchEvalMode.BRANCH_SKIPPED:
             logger.warning(f"Manual node creation cannot be used in branch logic {entity.name}")
-            raise Exception("Being more restrictive for now and disallowing manual node creation in branch logic")
+            raise RuntimeError("Being more restrictive for now and disallowing manual node creation in branch logic")
 
         # This the output of __call__ under local execute conditions which means this is the output of local_execute
         # which means this is the output of create_task_output with Promises containing values (or a VoidPromise)
@@ -152,7 +152,7 @@ def create_node(
         output_names = entity.python_interface.output_names  # type: ignore
 
         if not output_names:
-            raise Exception(f"Non-VoidPromise received {results} but interface for {entity.name} doesn't have outputs")
+            raise ValueError(f"Non-VoidPromise received {results} but interface for {entity.name} doesn't have outputs")
 
         if len(output_names) == 1:
             # See explanation above for why we still tupletize a single element.
@@ -161,4 +161,4 @@ def create_node(
         return entity.python_interface.output_tuple(*results)  # type: ignore
 
     else:
-        raise Exception(f"Cannot use explicit run to call Flyte entities {entity.name}")
+        raise RuntimeError(f"Cannot use explicit run to call Flyte entities {entity.name}")

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -667,7 +667,7 @@ def create_task_output(
         return promises
 
     if len(promises) == 0:
-        raise Exception(
+        raise ValueError(
             "This function should not be called with an empty list. It should have been handled with a"
             "VoidPromise at this function's call-site."
         )
@@ -1265,7 +1265,7 @@ def flyte_entity_call_handler(
             if result is None or isinstance(result, VoidPromise):
                 return None
             else:
-                raise Exception(f"Received an output when workflow local execution expected None. Received: {result}")
+                raise ValueError(f"Received an output when workflow local execution expected None. Received: {result}")
 
         if inspect.iscoroutine(result):
             return result

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -267,7 +267,7 @@ class DefaultTaskResolver(TrackedInstance, TaskResolverMixin):
         return ["task-module", m, "task-name", t]
 
     def get_all_tasks(self) -> List[PythonAutoContainerTask]:  # type: ignore
-        raise Exception("should not be needed")
+        raise NotImplementedError
 
 
 default_task_resolver = DefaultTaskResolver()

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -269,7 +269,7 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):  # type: ignore
                 # require a network call to flyteadmin to populate the TaskTemplate
                 # model
                 if isinstance(entity, ReferenceTask):
-                    raise Exception("Reference tasks are currently unsupported within dynamic tasks")
+                    raise ValueError("Reference tasks are currently unsupported within dynamic tasks")
 
                 if not isinstance(model, task_models.TaskSpec):
                     raise TypeError(

--- a/flytekit/core/reference_entity.py
+++ b/flytekit/core/reference_entity.py
@@ -79,13 +79,13 @@ class ReferenceEntity(object):
             and not isinstance(reference, TaskReference)
             and not isinstance(reference, LaunchPlanReference)
         ):
-            raise Exception("Must be one of task, workflow, or launch plan")
+            raise ValueError(f"Must be one of task, workflow, or launch plan, but got {type(reference)}")
         self._reference = reference
         self._native_interface = Interface(inputs=inputs, outputs=outputs)
         self._interface = transform_interface_to_typed_interface(self._native_interface)
 
     def execute(self, **kwargs) -> Any:
-        raise Exception("Remote reference entities cannot be run locally. You must mock this out.")
+        raise NotImplementedError("Remote reference entities cannot be run locally. You must mock this out.")
 
     @property
     def python_interface(self) -> Interface:

--- a/flytekit/core/testing.py
+++ b/flytekit/core/testing.py
@@ -33,7 +33,7 @@ def task_mock(t: PythonTask) -> typing.Generator[MagicMock, None, None]:
     """
 
     if not isinstance(t, PythonTask) and not isinstance(t, WorkflowBase) and not isinstance(t, ReferenceEntity):
-        raise Exception("Can only be used for tasks")
+        raise ValueError(f"Can only be used for tasks, but got {type(t)}")
 
     m = MagicMock()
 
@@ -56,7 +56,7 @@ def patch(target: Union[PythonTask, WorkflowBase, ReferenceEntity]):
         and not isinstance(target, WorkflowBase)
         and not isinstance(target, ReferenceEntity)
     ):
-        raise Exception("Can only use mocks on tasks/workflows declared in Python.")
+        raise ValueError(f"Can only use mocks on tasks/workflows declared in Python, but got {type(target)}")
 
     logger.info(
         "When using this patch function on Flyte entities, please be aware weird issues may arise if also"

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -300,7 +300,7 @@ class WorkflowBase(object):
             raise exc
 
     def execute(self, **kwargs):
-        raise Exception("Should not be called")
+        raise NotImplementedError
 
     def compile(self, **kwargs):
         pass
@@ -530,7 +530,7 @@ class ImperativeWorkflow(WorkflowBase):
     def create_conditional(self, name: str) -> ConditionalSection:
         ctx = FlyteContext.current_context()
         if ctx.compilation_state is not None:
-            raise Exception("Can't already be compiling")
+            raise RuntimeError("Can't already be compiling")
         FlyteContextManager.with_context(ctx.with_compilation_state(self.compilation_state))
         return conditional(name=name)
 
@@ -543,7 +543,7 @@ class ImperativeWorkflow(WorkflowBase):
 
         ctx = FlyteContext.current_context()
         if ctx.compilation_state is not None:
-            raise Exception("Can't already be compiling")
+            raise RuntimeError("Can't already be compiling")
         with FlyteContextManager.with_context(ctx.with_compilation_state(self.compilation_state)) as ctx:
             n = create_node(entity=entity, **kwargs)
 
@@ -605,7 +605,7 @@ class ImperativeWorkflow(WorkflowBase):
 
         ctx = FlyteContext.current_context()
         if ctx.compilation_state is not None:
-            raise Exception("Can't already be compiling")
+            raise RuntimeError("Can't already be compiling")
         with FlyteContextManager.with_context(ctx.with_compilation_state(self.compilation_state)) as ctx:
             b, _ = binding_from_python_std(
                 ctx, output_name, expected_literal_type=flyte_type, t_value=p, t_value_type=python_type
@@ -767,7 +767,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
             if not isinstance(workflow_outputs, tuple):
                 raise AssertionError("The Workflow specification indicates multiple return values, received only one")
             if len(output_names) != len(workflow_outputs):
-                raise Exception(f"Length mismatch {len(output_names)} vs {len(workflow_outputs)}")
+                raise ValueError(f"Length mismatch {len(output_names)} vs {len(workflow_outputs)}")
             for i, out in enumerate(output_names):
                 if isinstance(workflow_outputs[i], ConditionalSection):
                     raise AssertionError("A Conditional block (if-else) should always end with an `else_()` clause")

--- a/flytekit/extras/tasks/shell.py
+++ b/flytekit/extras/tasks/shell.py
@@ -101,10 +101,10 @@ def subproc_execute(command: typing.Union[List[str], str], **kwargs) -> ProcessR
         return ProcessResult(result.returncode, result.stdout, result.stderr)
 
     except subprocess.CalledProcessError as e:
-        raise Exception(f"Command: {e.cmd}\nFailed with return code {e.returncode}:\n{e.stderr}")
+        raise RuntimeError(f"Command: {e.cmd}\nFailed with return code {e.returncode}:\n{e.stderr}")
 
     except FileNotFoundError as e:
-        raise Exception(
+        raise RuntimeError(
             f"""Process failed because the executable could not be found.
             Did you specify a container image in the task definition if using
             custom dependencies?\n{e}"""

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2093,7 +2093,7 @@ class FlyteRemote(object):
         if node_id in node_mapping:
             execution._node = node_mapping[node_id]
         else:
-            raise Exception(f"Missing node from mapping: {node_id}")
+            raise ValueError(f"Missing node from mapping: {node_id}")
 
         # Get the node execution data
         node_execution_get_data_response = self.client.get_node_execution_data(execution.id)
@@ -2188,7 +2188,7 @@ class FlyteRemote(object):
                     return execution
             else:
                 logger.error(f"NE {execution} undeterminable, {type(execution._node)}, {execution._node}")
-                raise Exception(f"Node execution undeterminable, entity has type {type(execution._node)}")
+                raise ValueError(f"Node execution undeterminable, entity has type {type(execution._node)}")
 
         # Handle the case for gate nodes
         elif execution._node.gate_node is not None:

--- a/flytekit/tools/subprocess.py
+++ b/flytekit/tools/subprocess.py
@@ -23,7 +23,7 @@ def check_call(cmd_args, **kwargs):
                 err_str = std_err.read()
                 logger.error("Error from command '{}':\n{}\n".format(cmd_args, err_str))
 
-                raise Exception(
+                raise RuntimeError(
                     "Called process exited with error code: {}.  Stderr dump:\n\n{}".format(ret_code, err_str)
                 )
 

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -280,7 +280,7 @@ def get_serializable_workflow(
             # require a network call to flyteadmin to populate the WorkflowTemplate
             # object
             if isinstance(n.flyte_entity, ReferenceWorkflow):
-                raise Exception(
+                raise ValueError(
                     "Reference sub-workflows are currently unsupported. Use reference launch plans instead."
                 )
             sub_wf_spec = get_serializable(entity_mapping, settings, n.flyte_entity, options)
@@ -440,7 +440,7 @@ def get_serializable_node(
     options: Optional[Options] = None,
 ) -> workflow_model.Node:
     if entity.flyte_entity is None:
-        raise Exception(f"Node {entity.id} has no flyte entity")
+        raise ValueError(f"Node {entity.id} has no flyte entity")
 
     upstream_nodes = [
         get_serializable(entity_mapping, settings, n, options=options)
@@ -466,7 +466,7 @@ def get_serializable_node(
         elif ref_template.resource_type == _identifier_model.ResourceType.LAUNCH_PLAN:
             node_model._workflow_node = workflow_model.WorkflowNode(launchplan_ref=ref_template.id)
         else:
-            raise Exception(
+            raise TypeError(
                 f"Unexpected resource type for reference entity {entity.flyte_entity}: {ref_template.resource_type}"
             )
         return node_model
@@ -622,7 +622,7 @@ def get_serializable_node(
             workflow_node=workflow_model.WorkflowNode(launchplan_ref=entity.flyte_entity.id),
         )
     else:
-        raise Exception(f"Node contained non-serializable entity {entity._flyte_entity}")
+        raise ValueError(f"Node contained non-serializable entity {entity._flyte_entity}")
 
     return node_model
 
@@ -821,7 +821,7 @@ def get_serializable(
         cp_entity = get_serializable_array_node(entity_mapping, settings, entity, options)
 
     else:
-        raise Exception(f"Non serializable type found {type(entity)} Entity {entity}")
+        raise ValueError(f"Non serializable type found {type(entity)} Entity {entity}")
 
     if isinstance(entity, TaskSpec) or isinstance(entity, WorkflowSpec):
         # 1. Check if the size of long description exceeds 16KB

--- a/plugins/flytekit-airflow/flytekitplugins/airflow/task.py
+++ b/plugins/flytekit-airflow/flytekitplugins/airflow/task.py
@@ -73,7 +73,7 @@ class AirflowTaskResolver(TrackedInstance, TaskResolverMixin):
         ]
 
     def get_all_tasks(self) -> typing.List[PythonAutoContainerTask]:  # type: ignore
-        raise Exception("should not be needed")
+        raise NotImplementedError
 
 
 airflow_task_resolver = AirflowTaskResolver()

--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/agent.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/agent.py
@@ -95,7 +95,7 @@ class SageMakerEndpointAgent(Boto3AgentMixin, AsyncAgentBase):
             error_message = original_exception.response["Error"]["Message"]
 
             if error_code == "ValidationException" and "Could not find endpoint" in error_message:
-                raise Exception(
+                raise RuntimeError(
                     "This might be due to resource limits being exceeded, preventing the creation of a new endpoint. Please check your resource usage and limits."
                 )
             raise e

--- a/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
+++ b/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
@@ -99,7 +99,7 @@ def create_envd_config(image_spec: ImageSpec) -> str:
     base_image = DefaultImages.default_image() if image_spec.base_image is None else image_spec.base_image
     if image_spec.cuda:
         if image_spec.python_version is None:
-            raise Exception("python_version is required when cuda and cudnn are specified")
+            raise ValueError("python_version is required when cuda and cudnn are specified")
         base_image = "ubuntu20.04"
 
     python_packages = _create_str_from_package_list(image_spec.packages)

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -446,7 +446,7 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
             launcher_args = ()
 
         else:
-            raise Exception("Bad start method")
+            raise ValueError("Bad start method")
 
         from torch.distributed.elastic.multiprocessing.api import SignalException
         from torch.distributed.elastic.multiprocessing.errors import ChildFailedError


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
We raise `Exception` in many places, which does not allow users to catch specific errors from Flytekit."

```python
try:
  import flytekit
  ...
except RuntimeError:
  ...
except ValueError:
  ...
```

## What changes were proposed in this pull request?
Replace `Exceptions` with specific errors

## How was this patch tested?
unit test

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
