### PR TITLE
Update env variables and runtime name for default image buidler

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -24,14 +24,14 @@ RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
     --mount=from=uv,source=/uv,target=/usr/bin/uv \
     --mount=type=bind,target=requirements_uv.txt,src=requirements_uv.txt \
     /usr/bin/uv \
-    pip install --python /opt/micromamba/envs/dev/bin/python $PIP_EXTRA \
+    pip install --python /opt/micromamba/envs/runtime/bin/python $PIP_EXTRA \
     --requirement requirements_uv.txt
 """)
 
 PIP_PYTHON_INSTALL_COMMAND_TEMPLATE = Template("""\
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/pip,id=pip \
     --mount=type=bind,target=requirements_pip.txt,src=requirements_pip.txt \
-    /opt/micromamba/envs/dev/bin/python -m pip install $PIP_EXTRA \
+    /opt/micromamba/envs/runtime/bin/python -m pip install $PIP_EXTRA \
     --requirement requirements_pip.txt
 """)
 
@@ -61,7 +61,7 @@ RUN chown -R flytekit /root && chown -R flytekit /home
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/opt/micromamba/pkgs,\
 id=micromamba \
     --mount=from=micromamba,source=/usr/bin/micromamba,target=/usr/bin/micromamba \
-    /usr/bin/micromamba create -n dev --root-prefix /opt/micromamba \
+    /usr/bin/micromamba create -n runtime --root-prefix /opt/micromamba \
     -c conda-forge $CONDA_CHANNELS \
     python=$PYTHON_VERSION $CONDA_PACKAGES
 
@@ -69,8 +69,12 @@ $UV_PYTHON_INSTALL_COMMAND
 $PIP_PYTHON_INSTALL_COMMAND
 
 # Configure user space
-ENV PATH="/opt/micromamba/envs/dev/bin:$$PATH"
-ENV FLYTE_SDK_RICH_TRACEBACKS=0 SSL_CERT_DIR=/etc/ssl/certs $ENV
+ENV PATH="/opt/micromamba/envs/runtime/bin:$$PATH" \
+    UV_LINK_MODE=copy \
+    UV_PRERELEASE=allow \
+    FLYTE_SDK_RICH_TRACEBACKS=0 \
+    SSL_CERT_DIR=/etc/ssl/certs \
+    $ENV
 
 # Adds nvidia just in case it exists
 ENV PATH="$$PATH:/usr/local/nvidia/bin:/usr/local/cuda/bin" \


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
--> 
Small adjustments to the default image builder to extend support for prerelease wheels.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
The changes are:

- Add `UV_LINK_MODE=copy` which removes a warning from `uv`. In a docker env, it needs to copy over files from the uv cache into the image.
- `UV_PRERELEASE=allow` allows for prerelease builds to be included.
- Change the environment name to "runtime".

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I ran:

```bash
export _FLYTEKIT_TEST_DEFAULT_BUILDER=1
pytest tests/flytekit/unit/core/image_spec/test_default_builder.py::test_build
```

and also ran workflows with the builder.