### PR TITLE
Deprecate scopes

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -184,16 +184,16 @@ def get_traceback_str(e: Exception) -> str:
     if isinstance(e, FlyteUserRuntimeException):
         # If the exception is a user exception, we want to capture the traceback of the exception that was raised by the
         # user code, not the Flyte internals.
-        err = e.__cause__ if e.__cause__ else e
+        tb = e.__cause__.__traceback__ if e.__cause__ else e.__traceback__
     else:
-        err = e
-    tb = e.__traceback__
+        tb = e.__traceback__
     lines = traceback.format_tb(tb)
     lines = [line.rstrip() for line in lines]
     tb_str = "\n    ".join(lines)
     format_str = "Traceback (most recent call last):\n" "\n    {traceback}\n" "\n" "Message:\n" "\n" "    {message}"
 
-    return format_str.format(traceback=tb_str, message=f"{type(err).__name__}: {err}")
+    value = e.value if isinstance(e, FlyteUserRuntimeException) else e
+    return format_str.format(traceback=tb_str, message=f"{type(value).__name__}: {value}")
 
 
 def get_one_of(*args) -> str:

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -184,9 +184,8 @@ def get_traceback_str(e: Exception) -> str:
     tb = e.__cause__.__traceback__ if e.__cause__ else e.__traceback__
     lines = traceback.format_tb(tb)
     lines = [line.rstrip() for line in lines]
-    lines = "\n".join(lines).split("\n")
-    tb_str = "\n    ".join([""] + lines)
-    format_str = "Traceback (most recent call last):\n" "{traceback}\n" "\n" "Message:\n" "\n" "    {message}"
+    tb_str = "\n    ".join(lines)
+    format_str = "Traceback (most recent call last):\n" "\n    {traceback}\n" "\n" "Message:\n" "\n" "    {message}"
 
     value = e.value if isinstance(e, FlyteUserRuntimeException) else e
     return format_str.format(traceback=tb_str, message=f"{type(value)}: {value}")

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -34,8 +34,7 @@ from flytekit.core.context_manager import (
 from flytekit.core.data_persistence import FileAccessProvider
 from flytekit.core.promise import VoidPromise
 from flytekit.deck.deck import _output_deck
-from flytekit.exceptions import scopes as _scoped_exceptions
-from flytekit.exceptions import scopes as _scopes
+from flytekit.exceptions.user import FlyteUserRuntimeException
 from flytekit.interfaces.stats.taggable import get_stats as _get_stats
 from flytekit.loggers import logger, user_space_logger
 from flytekit.models import dynamic_job as _dynamic_job
@@ -54,7 +53,6 @@ def get_version_message():
 
 
 def _compute_array_job_index():
-    # type () -> int
     """
     Computes the absolute index of the current array job. This is determined by summing the compute-environment-specific
     environment variable and the offset (if one's set). The offset will be set and used when the user request that the
@@ -96,7 +94,7 @@ def _dispatch_execute(
         # Step2
         # Decorate the dispatch execute function before calling it, this wraps all exceptions into one
         # of the FlyteScopedExceptions
-        outputs = _scoped_exceptions.system_entry_point(task_def.dispatch_execute)(ctx, idl_input_literals)
+        outputs = task_def.dispatch_execute(ctx, idl_input_literals)
         if inspect.iscoroutine(outputs):
             # Handle eager-mode (async) tasks
             logger.info("Output is a coroutine")
@@ -122,48 +120,37 @@ def _dispatch_execute(
             )
 
     # Handle user-scoped errors
-    except _scoped_exceptions.FlyteScopedUserException as e:
+    except FlyteUserRuntimeException as e:
         if isinstance(e.value, IgnoreOutputs):
             logger.warning(f"User-scoped IgnoreOutputs received! Outputs.pb will not be uploaded. reason {e}!!")
             return
-        output_file_dict[_constants.ERROR_FILE_NAME] = _error_models.ErrorDocument(
-            _error_models.ContainerError(
-                e.error_code, e.verbose_message, e.kind, _execution_models.ExecutionError.ErrorKind.USER
-            )
-        )
-        logger.error("!! Begin User Error Captured by Flyte !!")
-        logger.error(e.verbose_message)
-        logger.error("!! End Error Captured by Flyte !!")
-
-    # Handle system-scoped errors
-    except _scoped_exceptions.FlyteScopedSystemException as e:
-        if isinstance(e.value, IgnoreOutputs):
-            logger.warning(f"System-scoped IgnoreOutputs received! Outputs.pb will not be uploaded. reason {e}!!")
-            return
-        output_file_dict[_constants.ERROR_FILE_NAME] = _error_models.ErrorDocument(
-            _error_models.ContainerError(
-                e.error_code, e.verbose_message, e.kind, _execution_models.ExecutionError.ErrorKind.SYSTEM
-            )
-        )
-        logger.error("!! Begin System Error Captured by Flyte !!")
-        logger.error(e.verbose_message)
-        logger.error("!! End Error Captured by Flyte !!")
-
-    # Interpret all other exceptions (some of which may be caused by the code in the try block outside of
-    # dispatch_execute) as recoverable system exceptions.
-    except Exception as e:
-        # Step 3c
         exc_str = traceback.format_exc()
         output_file_dict[_constants.ERROR_FILE_NAME] = _error_models.ErrorDocument(
             _error_models.ContainerError(
-                "SYSTEM:Unknown",
+                "USER",
+                exc_str,
+                _error_models.ContainerError.Kind.NON_RECOVERABLE,
+                _execution_models.ExecutionError.ErrorKind.USER,
+            )
+        )
+        logger.error(f"Exception when executing task {task_def.name}, reason {str(e)}")
+        logger.error("!! Begin User Error Captured by Flyte !!")
+        logger.error(exc_str)
+        logger.error("!! End Error Captured by Flyte !!")
+
+    # All the Non-user errors are captured here, and are considered system errors
+    except Exception as e:
+        exc_str = traceback.format_exc()
+        output_file_dict[_constants.ERROR_FILE_NAME] = _error_models.ErrorDocument(
+            _error_models.ContainerError(
+                "SYSTEM",
                 exc_str,
                 _error_models.ContainerError.Kind.RECOVERABLE,
                 _execution_models.ExecutionError.ErrorKind.SYSTEM,
             )
         )
-        logger.error(f"Exception when executing task {task_def.name or task_def.id.name}, reason {str(e)}")
-        logger.error("!! Begin Unknown System Error Captured by Flyte !!")
+        logger.error(f"Exception when executing task {task_def.name}, reason {str(e)}")
+        logger.error("!! Begin System Error Captured by Flyte !!")
         logger.error(exc_str)
         logger.error("!! End Error Captured by Flyte !!")
 
@@ -329,7 +316,6 @@ def _handle_annotated_task(
     _dispatch_execute(ctx, task_def, inputs, output_prefix)
 
 
-@_scopes.system_entry_point
 def _execute_task(
     inputs: str,
     output_prefix: str,
@@ -387,7 +373,6 @@ def _execute_task(
         _handle_annotated_task(ctx, _task_def, inputs, output_prefix)
 
 
-@_scopes.system_entry_point
 def _execute_map_task(
     inputs,
     output_prefix,

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -150,7 +150,10 @@ def _dispatch_execute(
                 _execution_models.ExecutionError.ErrorKind.USER,
             )
         )
-        logger.error(f"Exception when executing task {task_def.name}, reason {str(e)}")
+        if task_def is not None:
+            logger.error(f"Exception when executing task {task_def.name or task_def.id.name}, reason {str(e)}")
+        else:
+            logger.error(f"Exception when loading_task, reason {str(e)}")
         logger.error("!! Begin User Error Captured by Flyte !!")
         logger.error(exc_str)
         logger.error("!! End Error Captured by Flyte !!")
@@ -166,10 +169,6 @@ def _dispatch_execute(
                 _execution_models.ExecutionError.ErrorKind.SYSTEM,
             )
         )
-        if task_def is not None:
-            logger.error(f"Exception when executing task {task_def.name or task_def.id.name}, reason {str(e)}")
-        else:
-            logger.error(f"Exception when loading_task, reason {str(e)}")
 
         logger.error("!! Begin Unknown System Error Captured by Flyte !!")
         logger.error(exc_str)

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -124,7 +124,8 @@ def _dispatch_execute(
         if isinstance(e.value, IgnoreOutputs):
             logger.warning(f"User-scoped IgnoreOutputs received! Outputs.pb will not be uploaded. reason {e}!!")
             return
-        exc_str = traceback.format_exc()
+        format_str = "Traceback (most recent call last):\n" "{traceback}\n" "\n" "Message:\n" "\n" "    {message}"
+        exc_str = format_str.format(traceback=e.__cause__, message=f"{type(e.value)}: {e.value}")
         output_file_dict[_constants.ERROR_FILE_NAME] = _error_models.ErrorDocument(
             _error_models.ContainerError(
                 "USER",

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -130,7 +130,7 @@ def _dispatch_execute(
             kind = _error_models.ContainerError.Kind.NON_RECOVERABLE
 
         format_str = "Traceback (most recent call last):\n" "{traceback}\n" "\n" "Message:\n" "\n" "    {message}"
-        tb_str = e.__cause__.__traceback__.__str__()
+        tb_str = traceback.format_tb(e.__cause__.__traceback__)
         exc_str = format_str.format(traceback=tb_str, message=f"{type(e.value)}: {e.value}")
         output_file_dict[_constants.ERROR_FILE_NAME] = _error_models.ErrorDocument(
             _error_models.ContainerError(

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -140,7 +140,7 @@ def _dispatch_execute(
                 _execution_models.ExecutionError.ErrorKind.USER,
             )
         )
-        logger.error(f"Exception when executing task {task_def.name or task_def.id.name}, reason {str(e)}")
+        logger.error(f"Exception when executing task {task_def.name}, reason {str(e)}")
         logger.error("!! Begin User Error Captured by Flyte !!")
         logger.error(exc_str)
         logger.error("!! End Error Captured by Flyte !!")

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -184,16 +184,16 @@ def get_traceback_str(e: Exception) -> str:
     if isinstance(e, FlyteUserRuntimeException):
         # If the exception is a user exception, we want to capture the traceback of the exception that was raised by the
         # user code, not the Flyte internals.
-        tb = e.__cause__.__traceback__ if e.__cause__ else e.__traceback__
+        err = e.__cause__ if e.__cause__ else e
     else:
-        tb = e.__traceback__
+        err = e
+    tb = e.__traceback__
     lines = traceback.format_tb(tb)
     lines = [line.rstrip() for line in lines]
     tb_str = "\n    ".join(lines)
     format_str = "Traceback (most recent call last):\n" "\n    {traceback}\n" "\n" "Message:\n" "\n" "    {message}"
 
-    value = e.value if isinstance(e, FlyteUserRuntimeException) else e
-    return format_str.format(traceback=tb_str, message=f"{type(value).__name__}: {value}")
+    return format_str.format(traceback=tb_str, message=f"{type(err).__name__}: {err}")
 
 
 def get_one_of(*args) -> str:

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -188,7 +188,7 @@ def get_traceback_str(e: Exception) -> str:
     format_str = "Traceback (most recent call last):\n" "\n    {traceback}\n" "\n" "Message:\n" "\n" "    {message}"
 
     value = e.value if isinstance(e, FlyteUserRuntimeException) else e
-    return format_str.format(traceback=tb_str, message=f"{type(value)}: {value}")
+    return format_str.format(traceback=tb_str, message=f"{type(value).__name__}: {value}")
 
 
 def get_one_of(*args) -> str:

--- a/flytekit/clis/sdk_in_container/serialize.py
+++ b/flytekit/clis/sdk_in_container/serialize.py
@@ -8,7 +8,6 @@ import rich_click as click
 from flytekit.clis.sdk_in_container import constants
 from flytekit.clis.sdk_in_container.constants import CTX_PACKAGES
 from flytekit.configuration import FastSerializationSettings, ImageConfig, SerializationSettings
-from flytekit.exceptions.scopes import system_entry_point
 from flytekit.interaction.click_types import key_value_callback
 from flytekit.tools.fast_registration import fast_package
 from flytekit.tools.repo import serialize_to_folder
@@ -25,7 +24,6 @@ class SerializationMode(Enum):
     FAST = 1
 
 
-@system_entry_point
 def serialize_all(
     pkgs: typing.List[str] = None,
     local_source_root: typing.Optional[str] = None,

--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -20,7 +20,6 @@ from flytekit.core.launch_plan import LaunchPlan
 from flytekit.core.python_function_task import PythonFunctionTask, PythonInstanceTask
 from flytekit.core.type_engine import TypeEngine, is_annotated
 from flytekit.core.utils import timeit
-from flytekit.exceptions import scopes as exception_scopes
 from flytekit.loggers import logger
 from flytekit.models import literals as _literal_models
 from flytekit.models.array_job import ArrayJob
@@ -258,7 +257,7 @@ class ArrayNodeMapTask(PythonTask):
     def execute(self, **kwargs) -> Any:
         ctx = FlyteContextManager.current_context()
         if ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
-            return exception_scopes.user_entry_point(self.python_function_task.execute)(**kwargs)
+            return self.python_function_task.execute(**kwargs)
 
         return self._raw_execute(**kwargs)
 
@@ -335,7 +334,7 @@ class ArrayNodeMapTask(PythonTask):
                 else:
                     single_instance_inputs[k] = kwargs[k]
             try:
-                o = exception_scopes.user_entry_point(self._run_task.execute)(**single_instance_inputs)
+                o = self._run_task.execute(**single_instance_inputs)
                 if outputs_expected:
                     outputs.append(o)
             except Exception as exc:

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -710,6 +710,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
           may be none
         * ``DynamicJobSpec`` is returned when a dynamic workflow is executed
         """
+        raise RuntimeError("failed to upload flyte decks")
         if DeckField.TIMELINE.value in self.deck_fields and ctx.user_space_params is not None:
             ctx.user_space_params.decks.append(ctx.user_space_params.timeline_deck)
         # Invoked before the task is executed

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -741,7 +741,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                         # If the task is being executed locally, we want to raise the original exception
                         e.args = (f"Error encountered while executing '{self.name}':\n  {e.args[0]}",)
                         raise
-                    raise FlyteUserRuntimeException("flytekit runtime error. Original error message: {e}") from e
+                    raise FlyteUserRuntimeException(e) from e
 
             if inspect.iscoroutine(native_outputs):
                 # If native outputs is a coroutine, then this is an eager workflow.

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -710,7 +710,6 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
           may be none
         * ``DynamicJobSpec`` is returned when a dynamic workflow is executed
         """
-        raise RuntimeError("failed to upload flyte decks")
         if DeckField.TIMELINE.value in self.deck_fields and ctx.user_space_params is not None:
             ctx.user_space_params.decks.append(ctx.user_space_params.timeline_deck)
         # Invoked before the task is executed

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -44,7 +44,6 @@ from typing import (
 from flyteidl.core import artifact_id_pb2 as art_id
 from flyteidl.core import tasks_pb2
 
-import flytekit
 from flytekit.configuration import LocalConfig, SerializationSettings
 from flytekit.core.artifact_utils import (
     idl_partitions_from_dict,
@@ -737,7 +736,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 try:
                     native_outputs = self.execute(**native_inputs)
                 except Exception as e:
-                    if flytekit.FlyteContextManager().current_context().execution_state.is_local_execution():
+                    if FlyteContextManager().current_context().execution_state.is_local_execution():
                         # If the task is being executed locally, we want to raise the original exception
                         e.args = (f"Error encountered while executing '{self.name}':\n  {e.args[0]}",)
                         raise

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -73,6 +73,7 @@ from flytekit.core.type_engine import TypeEngine, TypeTransformerFailedError
 from flytekit.core.utils import timeit
 from flytekit.deck import DeckField
 from flytekit.exceptions.scopes import FlyteScopedUserException
+from flytekit.exceptions.user import FlyteUserRuntimeException
 from flytekit.loggers import logger
 from flytekit.models import dynamic_job as _dynamic_job
 from flytekit.models import interface as _interface_models
@@ -738,8 +739,8 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
             with timeit("Execute user level code"):
                 try:
                     native_outputs = self.execute(**native_inputs)
-                except Exception:
-                    raise FlyteScopedUserException(*exc_info())
+                except Exception as e:
+                    raise FlyteUserRuntimeException("Failed to execute user code") from e
 
             if inspect.iscoroutine(native_outputs):
                 # If native outputs is a coroutine, then this is an eager workflow.

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -741,7 +741,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                         # If the task is being executed locally, we want to raise the original exception
                         e.args = (f"Error encountered while executing '{self.name}':\n  {e.args[0]}",)
                         raise
-                    raise FlyteUserRuntimeException(e) from e
+                    raise FlyteUserRuntimeException("flytekit runtime error. Original error message: {e}") from e
 
             if inspect.iscoroutine(native_outputs):
                 # If native outputs is a coroutine, then this is an eager workflow.

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -740,7 +740,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 try:
                     native_outputs = self.execute(**native_inputs)
                 except Exception as e:
-                    raise FlyteUserRuntimeException("Failed to execute user code") from e
+                    raise FlyteUserRuntimeException(e)
 
             if inspect.iscoroutine(native_outputs):
                 # If native outputs is a coroutine, then this is an eager workflow.

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -736,7 +736,8 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 try:
                     native_outputs = self.execute(**native_inputs)
                 except Exception as e:
-                    if FlyteContextManager().current_context().execution_state.is_local_execution():
+                    ctx = FlyteContextManager().current_context()
+                    if ctx.execution_state and ctx.execution_state.is_local_execution():
                         # If the task is being executed locally, we want to raise the original exception
                         e.args = (f"Error encountered while executing '{self.name}':\n  {e.args[0]}",)
                         raise

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -292,7 +292,7 @@ class Task(object):
                 native_types=self.get_input_types(),  # type: ignore
             )
         except TypeTransformerFailedError as exc:
-            exc.args = (f"Error encountered while converting inputs of '{self.name}':\n  {exc.args[0]}",)
+            exc.args = (f"Failed to convert inputs of task '{self.name}':\n  {exc.args[0]}",)
             raise
         input_literal_map = _literal_models.LiteralMap(literals=literals)
 

--- a/flytekit/core/legacy_map_task.py
+++ b/flytekit/core/legacy_map_task.py
@@ -21,7 +21,6 @@ from flytekit.core.interface import transform_interface_to_list_interface
 from flytekit.core.python_function_task import PythonFunctionTask, PythonInstanceTask
 from flytekit.core.tracker import TrackedInstance
 from flytekit.core.utils import timeit
-from flytekit.exceptions import scopes as exception_scopes
 from flytekit.loggers import logger
 from flytekit.models.array_job import ArrayJob
 from flytekit.models.interface import Variable
@@ -254,7 +253,7 @@ class MapPythonTask(PythonTask):
                 map_task_inputs[k] = v[task_index]
             else:
                 map_task_inputs[k] = v
-        return exception_scopes.user_entry_point(self._run_task.execute)(**map_task_inputs)
+        return self._run_task.execute(**map_task_inputs)
 
     def _raw_execute(self, **kwargs) -> Any:
         """
@@ -288,7 +287,7 @@ class MapPythonTask(PythonTask):
                 else:
                     single_instance_inputs[k] = kwargs[k]
             try:
-                o = exception_scopes.user_entry_point(self._run_task.execute)(**single_instance_inputs)
+                o = self._run_task.execute(**single_instance_inputs)
                 if outputs_expected:
                     outputs.append(o)
             except Exception as exc:

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -94,7 +94,8 @@ def translate_inputs_to_literals(
                 v = resolve_attr_path_in_promise(v)
             result[k] = TypeEngine.to_literal(ctx, v, t, var.type)
         except TypeTransformerFailedError as exc:
-            raise TypeTransformerFailedError(f"Failed argument '{k}': {exc}") from None
+            exc.args = (f"Failed argument '{k}': {exc.args[0]}",)
+            raise
 
     return result
 

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -39,7 +39,6 @@ from flytekit.core.workflow import (
     WorkflowMetadata,
     WorkflowMetadataDefaults,
 )
-from flytekit.exceptions import scopes as exception_scopes
 from flytekit.exceptions.user import FlyteValueException
 from flytekit.loggers import logger
 from flytekit.models import dynamic_job as _dynamic_job
@@ -196,12 +195,12 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):  # type: ignore
         handle dynamic tasks or you will no longer be able to use the task as a dynamic task generator.
         """
         if self.execution_mode == self.ExecutionBehavior.DEFAULT:
-            return exception_scopes.user_entry_point(self._task_function)(**kwargs)
+            return self._task_function(**kwargs)
         elif self.execution_mode == self.ExecutionBehavior.EAGER:
             # if the task is a coroutine function, inject the context object so that the async_entity
             # has access to the FlyteContext.
             kwargs["async_ctx"] = FlyteContextManager.current_context()
-            return exception_scopes.user_entry_point(self._task_function)(**kwargs)
+            return self._task_function(**kwargs)
         elif self.execution_mode == self.ExecutionBehavior.DYNAMIC:
             return self.dynamic_execute(self._task_function, **kwargs)
 
@@ -346,7 +345,7 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):  # type: ignore
             return self.compile_into_workflow(ctx, task_function, **kwargs)
 
         if ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.LOCAL_TASK_EXECUTION:
-            return exception_scopes.user_entry_point(task_function)(**kwargs)
+            return task_function(**kwargs)
 
         raise ValueError(f"Invalid execution provided, execution state: {ctx.execution_state}")
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1155,7 +1155,8 @@ class TypeEngine(typing.Generic[T]):
             try:
                 kwargs[k] = TypeEngine.to_python_value(ctx, lm.literals[k], python_interface_inputs[k])
             except TypeTransformerFailedError as exc:
-                raise TypeTransformerFailedError(f"Error converting input '{k}' at position {i}:\n  {exc}") from None
+                exc.args = (f"Error converting input '{k}' at position {i}:\n  {exc.args[0]}",)
+                raise
         return kwargs
 
     @classmethod

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -748,7 +748,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
                     logger.debug(f"WF {self.name} saving task {n.flyte_entity.name}")
                     self.add(n.flyte_entity)
 
-            self._validate_add_on_failure_handler(comp_ctx, comp_ctx.compilation_state.exec_prefix + "f", input_kwargs)
+            self._validate_add_on_failure_handler(comp_ctx, comp_ctx.compilation_state.prefix + "f", input_kwargs)
 
         # Iterate through the workflow outputs
         bindings = []

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -46,7 +46,6 @@ from flytekit.core.python_auto_container import PythonAutoContainerTask
 from flytekit.core.reference_entity import ReferenceEntity, WorkflowReference
 from flytekit.core.tracker import extract_task_module
 from flytekit.core.type_engine import TypeEngine
-from flytekit.exceptions import scopes as exception_scopes
 from flytekit.exceptions.user import FlyteValidationException, FlyteValueException
 from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
@@ -690,7 +689,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
             # Now lets compile the failure-node if it exists
             if self.on_failure:
                 c = wf_args.copy()
-                exception_scopes.user_entry_point(self.on_failure)(**c)
+                self.on_failure(**c)
                 inner_nodes = None
                 if inner_comp_ctx.compilation_state and inner_comp_ctx.compilation_state.nodes:
                     inner_nodes = inner_comp_ctx.compilation_state.nodes
@@ -717,7 +716,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
             # Construct the default input promise bindings, but then override with the provided inputs, if any
             input_kwargs = construct_input_promises([k for k in self.interface.inputs.keys()])
             input_kwargs.update(kwargs)
-            workflow_outputs = exception_scopes.user_entry_point(self._workflow_function)(**input_kwargs)
+            workflow_outputs = self._workflow_function(**input_kwargs)
             all_nodes.extend(comp_ctx.compilation_state.nodes)
 
             # This little loop was added as part of the task resolver change. The task resolver interface itself is
@@ -800,7 +799,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
         call execute from dispatch_execute which is in local_execute, workflows should also call an execute inside
         local_execute. This makes mocking cleaner.
         """
-        return exception_scopes.user_entry_point(self._workflow_function)(**kwargs)
+        return self._workflow_function(**kwargs)
 
 
 @overload

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -748,7 +748,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
                     logger.debug(f"WF {self.name} saving task {n.flyte_entity.name}")
                     self.add(n.flyte_entity)
 
-            self._validate_add_on_failure_handler(comp_ctx, comp_ctx.compilation_state.prefix + "f", input_kwargs)
+            self._validate_add_on_failure_handler(comp_ctx, comp_ctx.compilation_state.exec_prefix + "f", input_kwargs)
 
         # Iterate through the workflow outputs
         bindings = []

--- a/flytekit/exceptions/scopes.py
+++ b/flytekit/exceptions/scopes.py
@@ -4,6 +4,7 @@ import traceback
 from functools import wraps as _wraps
 from sys import exc_info as _exc_info
 from traceback import format_tb as _format_tb
+from warnings import warn
 
 import flytekit
 from flytekit.exceptions import base as _base_exceptions
@@ -15,6 +16,7 @@ from flytekit.models.core import errors as _error_model
 
 class FlyteScopedException(Exception):
     def __init__(self, context, exc_type, exc_value, exc_tb, top_trim=0, bottom_trim=0, kind=None):
+        warn(f"{self.__class__.__name__} is deprecated.", DeprecationWarning, stacklevel=2)
         self._exc_type = exc_type
         self._exc_value = exc_value
         self._exc_tb = exc_tb
@@ -100,6 +102,7 @@ class FlyteScopedException(Exception):
 
 class FlyteScopedSystemException(FlyteScopedException):
     def __init__(self, exc_type, exc_value, exc_tb, **kwargs):
+        warn(f"{self.__class__.__name__} is deprecated.", DeprecationWarning, stacklevel=2)
         super(FlyteScopedSystemException, self).__init__("SYSTEM", exc_type, exc_value, exc_tb, **kwargs)
 
     @property
@@ -114,6 +117,7 @@ class FlyteScopedSystemException(FlyteScopedException):
 
 class FlyteScopedUserException(FlyteScopedException):
     def __init__(self, exc_type, exc_value, exc_tb, **kwargs):
+        warn(f"{self.__class__.__name__} is deprecated.", DeprecationWarning, stacklevel=2)
         super(FlyteScopedUserException, self).__init__("USER", exc_type, exc_value, exc_tb, **kwargs)
 
     @property
@@ -168,6 +172,7 @@ def system_entry_point(wrapped, args, kwargs):
     user -- allowing them to know if they should take action themselves or pass on to the platform owners.
     We will dispatch metrics and such appropriately.
     """
+    warn("This method is deprecated.", DeprecationWarning, stacklevel=2)
     try:
         _CONTEXT_STACK.append(_SYSTEM_CONTEXT)
         if _is_base_context():
@@ -208,6 +213,7 @@ def user_entry_point(wrapped, args, kwargs):
     we create here will only be handled within our system code so we don't need to worry about leaking weird exceptions
     to the user.
     """
+    warn("This method is deprecated.", DeprecationWarning, stacklevel=2)
     try:
         _CONTEXT_STACK.append(_USER_CONTEXT)
         if _is_base_context():

--- a/flytekit/exceptions/scopes.py
+++ b/flytekit/exceptions/scopes.py
@@ -42,7 +42,6 @@ class FlyteScopedException(Exception):
 
         lines = _format_tb(top_tb, limit=limit)
         lines = [line.rstrip() for line in lines]
-        lines = "\n".join(lines).split("\n")
         traceback_str = "\n    ".join([""] + lines)
 
         format_str = "Traceback (most recent call last):\n" "{traceback}\n" "\n" "Message:\n" "\n" "    {message}"

--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -14,9 +14,10 @@ class FlyteUserRuntimeException(_FlyteException):
     def __init__(self, exc_value):
         """
         FlyteUserRuntimeException is thrown when a user code raises an exception.
-        @param exc_type: The exception that was raised from user code.
+        @param exc_value: The exception that was raised from user code.
         """
         self._exc_value = exc_value
+        super(FlyteUserRuntimeException, self).__init__(str(exc_value))
 
     @property
     def value(self):

--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -11,6 +11,17 @@ class FlyteUserException(_FlyteException):
 class FlyteUserRuntimeException(_FlyteException):
     _ERROR_CODE = "USER:RuntimeError"
 
+    def __init__(self, exc_value):
+        """
+        FlyteUserRuntimeException is thrown when a user code raises an exception.
+        @param exc_type: The exception that was raised from user code.
+        """
+        self._exc_value = exc_value
+
+    @property
+    def value(self):
+        return self._exc_value
+
 
 class FlyteTypeException(FlyteUserException, TypeError):
     _ERROR_CODE = "USER:TypeError"

--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -17,7 +17,7 @@ class FlyteUserRuntimeException(_FlyteException):
         @param exc_value: The exception that was raised from user code.
         """
         self._exc_value = exc_value
-        super(FlyteUserRuntimeException, self).__init__(str(exc_value))
+        super().__init__(str(exc_value))
 
     @property
     def value(self):

--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -8,6 +8,23 @@ class FlyteUserException(_FlyteException):
     _ERROR_CODE = "USER:Unknown"
 
 
+class FlyteUserRuntimeException(_FlyteException):
+    _ERROR_CODE = "USER:RuntimeError"
+
+    def __init__(self, exc_type, exc_value, exc_tb, **kwargs):
+        """
+        FlyteUserRuntimeException is thrown when a user code raises an exception.
+        @param exc_type: The exception that was raised from user code.
+        @param exc_value: The exception that was raised from user code.
+        @param exc_tb: The exception that was raised from user code.
+        """
+        self._exc_value = exc_value
+
+    @property
+    def value(self):
+        return self._exc_value
+
+
 class FlyteTypeException(FlyteUserException, TypeError):
     _ERROR_CODE = "USER:TypeError"
 

--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -11,19 +11,6 @@ class FlyteUserException(_FlyteException):
 class FlyteUserRuntimeException(_FlyteException):
     _ERROR_CODE = "USER:RuntimeError"
 
-    def __init__(self, exc_type, exc_value, exc_tb, **kwargs):
-        """
-        FlyteUserRuntimeException is thrown when a user code raises an exception.
-        @param exc_type: The exception that was raised from user code.
-        @param exc_value: The exception that was raised from user code.
-        @param exc_tb: The exception that was raised from user code.
-        """
-        self._exc_value = exc_value
-
-    @property
-    def value(self):
-        return self._exc_value
-
 
 class FlyteTypeException(FlyteUserException, TypeError):
     _ERROR_CODE = "USER:TypeError"

--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -15,6 +15,19 @@ class FlyteUserException(_FlyteException):
 class FlyteUserRuntimeException(_FlyteException):
     _ERROR_CODE = "USER:RuntimeError"
 
+    def __init__(self, exc_value: Exception):
+        """
+        FlyteUserRuntimeException is thrown when a user code raises an exception.
+
+        :param exc_value: The exception that was raised from user code.
+        """
+        self._exc_value = exc_value
+        super().__init__(str(exc_value))
+
+    @property
+    def value(self):
+        return self._exc_value
+
 
 class FlyteTypeException(FlyteUserException, TypeError):
     _ERROR_CODE = "USER:TypeError"

--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -15,19 +15,6 @@ class FlyteUserException(_FlyteException):
 class FlyteUserRuntimeException(_FlyteException):
     _ERROR_CODE = "USER:RuntimeError"
 
-    def __init__(self, exc_value: Exception):
-        """
-        FlyteUserRuntimeException is thrown when a user code raises an exception.
-
-        :param exc_value: The exception that was raised from user code.
-        """
-        self._exc_value = exc_value
-        super().__init__(str(exc_value))
-
-    @property
-    def value(self):
-        return self._exc_value
-
 
 class FlyteTypeException(FlyteUserException, TypeError):
     _ERROR_CODE = "USER:TypeError"

--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -11,10 +11,11 @@ class FlyteUserException(_FlyteException):
 class FlyteUserRuntimeException(_FlyteException):
     _ERROR_CODE = "USER:RuntimeError"
 
-    def __init__(self, exc_value):
+    def __init__(self, exc_value: Exception):
         """
         FlyteUserRuntimeException is thrown when a user code raises an exception.
-        @param exc_value: The exception that was raised from user code.
+
+        :param exc_value: The exception that was raised from user code.
         """
         self._exc_value = exc_value
         super().__init__(str(exc_value))

--- a/flytekit/extend/backend/base_agent.py
+++ b/flytekit/extend/backend/base_agent.py
@@ -272,7 +272,8 @@ class SyncAgentExecutorMixin:
                 agent.do, task_template=template, inputs=literal_map, output_prefix=output_prefix
             )
         except Exception as e:
-            raise FlyteUserException(f"Failed to run the task {self.name} with error: {e}") from None
+            e.args = (f"Failed to run the task {self.name} with error: {e.args[0]}",)
+            raise
 
 
 class AsyncAgentExecutorMixin:

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -488,9 +488,8 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
 
         Handles the exception scope for the `_execute` method.
         """
-        from flytekit.exceptions import scopes as exception_scopes
 
-        return exception_scopes.user_entry_point(self._execute)(**kwargs)
+        return self._execute(**kwargs)
 
     def get_custom(self, settings: SerializationSettings) -> Optional[Dict[str, Any]]:
         if self.task_config.nnodes == 1:

--- a/plugins/flytekit-pandera/tests/test_plugin.py
+++ b/plugins/flytekit-pandera/tests/test_plugin.py
@@ -1,3 +1,5 @@
+import os
+
 import pandas
 import pandera
 import pytest
@@ -70,9 +72,13 @@ def test_pandera_dataframe_type_hints():
     def wf_invalid_output(df: pandera.typing.DataFrame[InSchema]) -> pandera.typing.DataFrame[OutSchema]:
         return transform2_noop(df=transform1(df=df))
 
+    # pytest-xdist uses `__channelexec__` as the top-level module
+    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
+    prefix = "__channelexec__." if running_xdist else ""
+
     with pytest.raises(
         TypeError,
-        match="Failed to convert outputs of task 'test_plugin.transform2_noop' at position 0.\nFailed to convert type <class 'pandas.core.frame.DataFrame'> to type pandera.typing.pandas.DataFrame",
+        match=f"Failed to convert outputs of task '{prefix}test_plugin.transform2_noop' at position 0.\nFailed to convert type <class 'pandas.core.frame.DataFrame'> to type pandera.typing.pandas.DataFrame",
     ):
         wf_invalid_output(df=valid_df)
 

--- a/plugins/flytekit-pandera/tests/test_plugin.py
+++ b/plugins/flytekit-pandera/tests/test_plugin.py
@@ -72,7 +72,7 @@ def test_pandera_dataframe_type_hints():
 
     with pytest.raises(
         TypeError,
-        match="Error encountered while executing 'wf_invalid_output':\n" "  Failed to convert outputs of task",
+        match="Failed to convert outputs of task 'test_plugin.transform2_noop' at position 0.\nFailed to convert type <class 'pandas.core.frame.DataFrame'> to type pandera.typing.pandas.DataFrame",
     ):
         wf_invalid_output(df=valid_df)
 

--- a/plugins/flytekit-pandera/tests/test_plugin.py
+++ b/plugins/flytekit-pandera/tests/test_plugin.py
@@ -72,13 +72,9 @@ def test_pandera_dataframe_type_hints():
     def wf_invalid_output(df: pandera.typing.DataFrame[InSchema]) -> pandera.typing.DataFrame[OutSchema]:
         return transform2_noop(df=transform1(df=df))
 
-    # pytest-xdist uses `__channelexec__` as the top-level module
-    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
-    prefix = "__channelexec__." if running_xdist else ""
-
     with pytest.raises(
         TypeError,
-        match=f"Failed to convert outputs of task '{prefix}test_plugin.transform2_noop' at position 0.\nFailed to convert type <class 'pandas.core.frame.DataFrame'> to type pandera.typing.pandas.DataFrame",
+        match=f"Failed to convert type <class 'pandas.core.frame.DataFrame'> to type pandera.typing.pandas.DataFrame",
     ):
         wf_invalid_output(df=valid_df)
 

--- a/tests/flytekit/conftest.py
+++ b/tests/flytekit/conftest.py
@@ -16,10 +16,3 @@ def configure_plugin():
 @pytest.fixture(scope="module", autouse=True)
 def set_default_envs():
     os.environ["FLYTE_EXIT_ON_USER_EXCEPTION"] = "0"
-
-
-@pytest.fixture(scope="module")
-def pytest_prefix():
-    # pytest-xdist uses `__channelexec__` as the top-level module
-    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
-    return "__channelexec__." if running_xdist else ""

--- a/tests/flytekit/conftest.py
+++ b/tests/flytekit/conftest.py
@@ -16,3 +16,10 @@ def configure_plugin():
 @pytest.fixture(scope="module", autouse=True)
 def set_default_envs():
     os.environ["FLYTE_EXIT_ON_USER_EXCEPTION"] = "0"
+
+
+@pytest.fixture(scope="module")
+def pytest_prefix():
+    # pytest-xdist uses `__channelexec__` as the top-level module
+    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
+    return "__channelexec__." if running_xdist else ""

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -17,6 +17,7 @@ from flytekit.core.task import task
 from flytekit.core.type_engine import TypeEngine
 from flytekit.exceptions import user as user_exceptions
 from flytekit.exceptions.scopes import system_entry_point
+from flytekit.exceptions.user import FlyteUserRuntimeException
 from flytekit.models import literals as _literal_models
 from flytekit.models.core import errors as error_models
 from flytekit.models.core import execution as execution_models
@@ -68,7 +69,7 @@ def test_dispatch_execute_ignore(mock_write_to_file, mock_upload_dir, mock_get_d
         )
     ) as ctx:
         python_task = mock.MagicMock()
-        python_task.dispatch_execute.side_effect = IgnoreOutputs()
+        python_task.dispatch_execute.side_effect = FlyteUserRuntimeException(IgnoreOutputs())
 
         empty_literal_map = _literal_models.LiteralMap({}).to_flyte_idl()
         mock_load_proto.return_value = empty_literal_map

--- a/tests/flytekit/unit/conftest.py
+++ b/tests/flytekit/unit/conftest.py
@@ -20,3 +20,10 @@ settings.register_profile("ci", max_examples=5, deadline=100_000)
 settings.register_profile("dev", max_examples=10, deadline=10_000)
 
 settings.load_profile(os.getenv("FLYTEKIT_HYPOTHESIS_PROFILE", "dev"))
+
+
+@pytest.fixture()
+def exec_prefix():
+    # pytest-xdist uses `__channelexec__` as the top-level module
+    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
+    return "__channelexec__." if running_xdist else ""

--- a/tests/flytekit/unit/core/test_conditions.py
+++ b/tests/flytekit/unit/core/test_conditions.py
@@ -119,7 +119,7 @@ def test_condition_sub_workflows():
     assert y == 1
 
 
-def test_condition_tuple_branches():
+def test_condition_tuple_branches(exec_prefix):
     @task
     def sum_sub(a: int, b: int) -> typing.NamedTuple("Outputs", sum=int, sub=int):
         return a + b, a - b
@@ -140,15 +140,11 @@ def test_condition_tuple_branches():
     assert x == 5
     assert y == 1
 
-    # pytest-xdist uses `__channelexec__` as the top-level module
-    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
-    prefix = "__channelexec__." if running_xdist else ""
-
     wf_spec = get_serializable(OrderedDict(), serialization_settings, math_ops)
     assert len(wf_spec.template.nodes) == 1
     assert (
         wf_spec.template.nodes[0].branch_node.if_else.case.then_node.task_node.reference_id.name
-        == f"{prefix}tests.flytekit.unit.core.test_conditions.sum_sub"
+        == f"{exec_prefix}tests.flytekit.unit.core.test_conditions.sum_sub"
     )
 
 

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1688,7 +1688,7 @@ def test_failure_node():
 
 
 @pytest.mark.skipif("pandas" not in sys.modules, reason="Pandas is not installed.")
-def test_union_type():
+def test_union_type(pytest_prefix):
     import pandas as pd
 
     from flytekit.types.schema import FlyteSchema
@@ -1722,14 +1722,10 @@ def test_union_type():
     def wf2(a: typing.Union[int, str]) -> typing.Union[int, str]:
         return t2(a=a)
 
-    # pytest-xdist uses `__channelexec__` as the top-level module
-    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
-    prefix = "__channelexec__." if running_xdist else ""
-
     with pytest.raises(
         TypeError,
         match=re.escape(
-            f"Error encountered while converting inputs of '{prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
+            f"Error encountered while converting inputs of '{pytest_prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
             '  Cannot convert from [Flyte Serialized object: Type: <Literal> Value: <scalar { union { value { scalar { primitive { string_value: "2" } } } '
             'type { simple: STRING structure { tag: "str" } } } }>] to typing.Union[float, dict] (using tag str)'
         ),

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1688,7 +1688,7 @@ def test_failure_node():
 
 
 @pytest.mark.skipif("pandas" not in sys.modules, reason="Pandas is not installed.")
-def test_union_type(pytest_prefix):
+def test_union_type():
     import pandas as pd
 
     from flytekit.types.schema import FlyteSchema
@@ -1722,10 +1722,14 @@ def test_union_type(pytest_prefix):
     def wf2(a: typing.Union[int, str]) -> typing.Union[int, str]:
         return t2(a=a)
 
+    # pytest-xdist uses `__channelexec__` as the top-level module
+    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
+    prefix = "__channelexec__." if running_xdist else ""
+
     with pytest.raises(
         TypeError,
         match=re.escape(
-            f"Error encountered while converting inputs of '{pytest_prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
+            f"Error encountered while converting inputs of '{prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
             '  Cannot convert from [Flyte Serialized object: Type: <Literal> Value: <scalar { union { value { scalar { primitive { string_value: "2" } } } '
             'type { simple: STRING structure { tag: "str" } } } }>] to typing.Union[float, dict] (using tag str)'
         ),

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1753,20 +1753,8 @@ def test_union_type(exec_prefix):
     with pytest.raises(
         TypeError,
         match=re.escape(
-<<<<<<< HEAD
             f"Error encountered while converting inputs of '{exec_prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
-            '  Cannot convert from [Flyte Serialized object: Type: <Literal> Value: <scalar { union { value { scalar { primitive { string_value: "2" } } } '
-            'type { simple: STRING structure { tag: "str" } } } }>] to typing.Union[float, dict] (using tag str)'
-||||||| e28c8bf29
-            "Error encountered while executing 'wf2':\n"
-            f"  Failed to convert inputs of task '{prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
-            '  Cannot convert from [Flyte Serialized object: Type: <Literal> Value: <scalar { union { value { scalar { primitive { string_value: "2" } } } '
-            'type { simple: STRING structure { tag: "str" } } } }>] to typing.Union[float, dict] (using tag str)'
-=======
-            "Error encountered while executing 'wf2':\n"
-            f"  Failed to convert inputs of task '{prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
             r'  Cannot convert from Flyte Serialized object (Literal):'
->>>>>>> fdb2d7911ef907e248b1bc8a43cab11d794da325
         ),
     ):
         assert wf2(a="2") == "2"

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1729,8 +1729,7 @@ def test_union_type():
     with pytest.raises(
         TypeError,
         match=re.escape(
-            "Error encountered while executing 'wf2':\n"
-            f"  Failed to convert inputs of task '{prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
+            f"Error encountered while converting inputs of '{prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
             '  Cannot convert from [Flyte Serialized object: Type: <Literal> Value: <scalar { union { value { scalar { primitive { string_value: "2" } } } '
             'type { simple: STRING structure { tag: "str" } } } }>] to typing.Union[float, dict] (using tag str)'
         ),

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1635,6 +1635,7 @@ def test_error_messages():
     ):
         foo4()
 
+
 def test_failure_node():
     @task
     def run(a: int, b: str) -> typing.Tuple[int, str]:

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1567,7 +1567,7 @@ def test_guess_dict4():
     assert output_lm.literals["o0"].scalar.generic == expected_struct
 
 
-def test_error_messages():
+def test_error_messages(exec_prefix):
     @dataclass
     class DC1:
         a: int
@@ -1595,14 +1595,10 @@ def test_error_messages():
     def foo4(input: DC1=DC1(1, 'a')) -> DC2:
         return input  # type: ignore
 
-    # pytest-xdist uses `__channelexec__` as the top-level module
-    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
-    prefix = "__channelexec__." if running_xdist else ""
-
     with pytest.raises(
         TypeError,
         match=(
-            f"Failed to convert inputs of task '{prefix}tests.flytekit.unit.core.test_type_hints.foo':\n"
+            f"Failed to convert inputs of task '{exec_prefix}tests.flytekit.unit.core.test_type_hints.foo':\n"
             "  Failed argument 'a': Expected value of type <class 'int'> but got 'hello' of type <class 'str'>"
         ),
     ):
@@ -1611,7 +1607,7 @@ def test_error_messages():
     with pytest.raises(
         TypeError,
         match=(
-            f"Failed to convert outputs of task '{prefix}tests.flytekit.unit.core.test_type_hints.foo2' at position 0.\n"
+            f"Failed to convert outputs of task '{exec_prefix}tests.flytekit.unit.core.test_type_hints.foo2' at position 0.\n"
             f"Failed to convert type <class 'str'> to type <class 'int'>.\n"
             "Error Message: Expected value of type <class 'int'> but got 'hello' of type <class 'str'>."
         ),
@@ -1620,7 +1616,7 @@ def test_error_messages():
 
     with pytest.raises(
         TypeError,
-        match=f"Failed to convert inputs of task '{prefix}tests.flytekit.unit.core.test_type_hints.foo3':\n  "
+        match=f"Failed to convert inputs of task '{exec_prefix}tests.flytekit.unit.core.test_type_hints.foo3':\n  "
         f"Failed argument 'a': Expected a dict",
     ):
         foo3(a=[{"hello": 2}])
@@ -1628,7 +1624,7 @@ def test_error_messages():
     with pytest.raises(
         TypeError,
         match=(
-            f"Failed to convert outputs of task '{prefix}tests.flytekit.unit.core.test_type_hints.foo4' at position 0.\n"
+            f"Failed to convert outputs of task '{exec_prefix}tests.flytekit.unit.core.test_type_hints.foo4' at position 0.\n"
             f"Failed to convert type <class 'tests.flytekit.unit.core.test_type_hints.test_error_messages.<locals>.DC1'> to type <class 'tests.flytekit.unit.core.test_type_hints.test_error_messages.<locals>.DC2'>.\n"
             "Error Message: 'DC1' object has no attribute 'c'."
         ),
@@ -1687,7 +1683,7 @@ def test_failure_node():
         assert wf2.failure_node.flyte_entity == failure_handler
 
 
-def test_failure_node_mismatch_inputs():
+def test_failure_node_mismatch_inputs(exec_prefix):
     @task()
     def t1(a: int) -> int:
         return a + 3
@@ -1696,14 +1692,10 @@ def test_failure_node_mismatch_inputs():
     def wf1(a: int = 3, b: str = "hello"):
         t1(a=a)
 
-    # pytest-xdist uses `__channelexec__` as the top-level module
-    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
-    prefix = "__channelexec__." if running_xdist else ""
-
     with pytest.raises(
         FlyteFailureNodeInputMismatchException,
         match="Mismatched Inputs Detected\n"
-              f"The failure node `{prefix}tests.flytekit.unit.core.test_type_hints.t1` has "
+              f"The failure node `{exec_prefix}tests.flytekit.unit.core.test_type_hints.t1` has "
               "inputs that do not align with those expected by the workflow `tests.flytekit.unit.core.test_type_hints.wf1`.\n"
               "Failure Node's Inputs: {'a': <class 'int'>}\n"
               "Workflow's Inputs: {'a': <class 'int'>, 'b': <class 'str'>}\n"
@@ -1724,7 +1716,7 @@ def test_failure_node_mismatch_inputs():
 
 
 @pytest.mark.skipif("pandas" not in sys.modules, reason="Pandas is not installed.")
-def test_union_type():
+def test_union_type(exec_prefix):
     import pandas as pd
 
     from flytekit.types.schema import FlyteSchema
@@ -1758,14 +1750,10 @@ def test_union_type():
     def wf2(a: typing.Union[int, str]) -> typing.Union[int, str]:
         return t2(a=a)
 
-    # pytest-xdist uses `__channelexec__` as the top-level module
-    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
-    prefix = "__channelexec__." if running_xdist else ""
-
     with pytest.raises(
         TypeError,
         match=re.escape(
-            f"Error encountered while converting inputs of '{prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
+            f"Error encountered while converting inputs of '{exec_prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
             '  Cannot convert from [Flyte Serialized object: Type: <Literal> Value: <scalar { union { value { scalar { primitive { string_value: "2" } } } '
             'type { simple: STRING structure { tag: "str" } } } }>] to typing.Union[float, dict] (using tag str)'
         ),

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -290,7 +290,7 @@ def test_wf_no_output():
     assert no_outputs_wf() is None
 
 
-def test_wf_nested_comp():
+def test_wf_nested_comp(exec_prefix):
     @task
     def t1(a: int) -> int:
         a = a + 5
@@ -314,14 +314,10 @@ def test_wf_nested_comp():
     assert len(model_wf.template.nodes) == 2
     assert model_wf.template.nodes[1].workflow_node is not None
 
-    # pytest-xdist uses `__channelexec__` as the top-level module
-    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
-    prefix = "__channelexec__." if running_xdist else ""
-
     sub_wf = model_wf.sub_workflows[0]
     assert len(sub_wf.nodes) == 1
     assert sub_wf.nodes[0].id == "n0"
-    assert sub_wf.nodes[0].task_node.reference_id.name == f"{prefix}tests.flytekit.unit.core.test_workflows.t1"
+    assert sub_wf.nodes[0].task_node.reference_id.name == f"{exec_prefix}tests.flytekit.unit.core.test_workflows.t1"
 
 
 @task
@@ -471,7 +467,7 @@ def test_compile_wf_at_compile_time():
 
 
 @patch("builtins.print")
-def test_failure_node_local_execution(mock_print):
+def test_failure_node_local_execution(mock_print, exec_prefix):
     @task
     def clean_up(name: str, err: typing.Optional[FlyteError] = None):
         print(f"Deleting cluster {name} due to {err}")
@@ -501,13 +497,9 @@ def test_failure_node_local_execution(mock_print):
     with pytest.raises(ValueError):
         wf()
 
-    # pytest-xdist uses `__channelexec__` as the top-level module
-    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
-    prefix = "__channelexec__." if running_xdist else ""
-
     # Adjusted the error message to match the one in the failure
     expected_error_message = str(
-        FlyteError(message=f"Error encountered while executing '{prefix}tests.flytekit.unit.core.test_workflows.t1':\n  Fail!", failed_node_id="fn0")
+        FlyteError(message=f"Error encountered while executing '{exec_prefix}tests.flytekit.unit.core.test_workflows.t1':\n  Fail!", failed_node_id="fn0")
     )
 
     assert mock_print.call_count > 0

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -503,7 +503,7 @@ def test_failure_node_local_execution(mock_print):
 
     # Adjusted the error message to match the one in the failure
     expected_error_message = str(
-        FlyteError(message="Error encountered while executing 'wf':\n  Fail!", failed_node_id="fn0")
+        FlyteError(message="Error encountered while executing 'tests.flytekit.unit.core.test_workflows.t1':\n  Fail!", failed_node_id="fn0")
     )
 
     assert mock_print.call_count > 0

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -501,9 +501,13 @@ def test_failure_node_local_execution(mock_print):
     with pytest.raises(ValueError):
         wf()
 
+    # pytest-xdist uses `__channelexec__` as the top-level module
+    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
+    prefix = "__channelexec__." if running_xdist else ""
+
     # Adjusted the error message to match the one in the failure
     expected_error_message = str(
-        FlyteError(message="Error encountered while executing 'tests.flytekit.unit.core.test_workflows.t1':\n  Fail!", failed_node_id="fn0")
+        FlyteError(message=f"Error encountered while executing '{prefix}tests.flytekit.unit.core.test_workflows.t1':\n  Fail!", failed_node_id="fn0")
     )
 
     assert mock_print.call_count > 0


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Error messages are not clear in both remote and local execution.

## What changes were proposed in this pull request?
- Add `FlyteUserRuntimeException`. it is thrown when a user code raises an exception.
- Non-FlyteUserRuntimeException errros are system errors
- remove `system_entry_point` and `user_entry_point` in the code
- deprecate FlyteScopedException

## How was this patch tested?
unit test / remote


### Setup process

```python
from flytekit import task, workflow, ImageSpec

new_flytekit = "git+https://github.com/flyteorg/flytekit@14ab38ca17d3b9a5bb70e5ae9a61955b01f573e4"

sd_finetuning_image = ImageSpec(
    registry="pingsutw",
    apt_packages=["git"],
    packages=[
        new_flytekit,
    ],
    builder="envd",
)


@task(enable_deck=True, container_image=sd_finetuning_image)
def t1(a: int) -> int:
    raise ValueError("error")
    return a + 1


@workflow
def wf() -> int:
    return t1(a=3)
```

### Screenshots
Before:
- User error
<img width="1138" alt="Screenshot 2024-08-10 at 12 35 01 AM" src="https://github.com/user-attachments/assets/b15342a6-f40f-4509-bd66-d9ebb4387356">

- System error
<img width="1152" alt="Screenshot 2024-08-10 at 2 50 54 AM" src="https://github.com/user-attachments/assets/f6a19359-664c-4ade-b465-c240a256c057">


- Local error
<img width="1242" alt="Screenshot 2024-08-10 at 2 33 12 AM" src="https://github.com/user-attachments/assets/5445691f-1d85-4264-99f7-0055e307c586">

- User error
<img width="1055" alt="Screenshot 2024-08-10 at 2 14 31 AM" src="https://github.com/user-attachments/assets/9d8b056f-a47d-4021-b565-768991fe993d">

- System error
<img width="1147" alt="Screenshot 2024-08-10 at 2 47 06 AM" src="https://github.com/user-attachments/assets/6bf24b3a-759c-4720-af14-b5803f4744a2">

- Local error
<img width="1242" alt="Screenshot 2024-08-10 at 2 33 01 AM" src="https://github.com/user-attachments/assets/6f292c7a-6c25-4a08-a9dc-991d0c3095af">


- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
