### PR TITLE
Update uv and remove pip workaround

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 import shutil
 import subprocess
@@ -28,13 +27,6 @@ RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
     --requirement requirements_uv.txt
 """)
 
-PIP_PYTHON_INSTALL_COMMAND_TEMPLATE = Template("""\
-RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/pip,id=pip \
-    --mount=type=bind,target=requirements_pip.txt,src=requirements_pip.txt \
-    /opt/micromamba/envs/runtime/bin/python -m pip install $PIP_EXTRA \
-    --requirement requirements_pip.txt
-""")
-
 APT_INSTALL_COMMAND_TEMPLATE = Template(
     """\
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/var/cache/apt,id=apt \
@@ -46,7 +38,7 @@ RUN --mount=type=cache,sharing=locked,mode=0777,target=/var/cache/apt,id=apt \
 DOCKER_FILE_TEMPLATE = Template(
     """\
 #syntax=docker/dockerfile:1.5
-FROM ghcr.io/astral-sh/uv:0.2.13 as uv
+FROM ghcr.io/astral-sh/uv:0.2.35 as uv
 FROM mambaorg/micromamba:1.5.8-bookworm-slim as micromamba
 
 FROM $BASE_IMAGE
@@ -66,7 +58,6 @@ id=micromamba \
     python=$PYTHON_VERSION $CONDA_PACKAGES
 
 $UV_PYTHON_INSTALL_COMMAND
-$PIP_PYTHON_INSTALL_COMMAND
 
 # Configure user space
 ENV PATH="/opt/micromamba/envs/runtime/bin:$$PATH" \
@@ -149,19 +140,8 @@ def create_docker_context(image_spec: ImageSpec, tmp_dir: Path):
     if not any(_is_flytekit(package) for package in requirements):
         requirements.append(get_flytekit_for_pypi())
 
-    uv_requirements = []
-
-    # uv does not support git + subdirectory, so we use pip to install them instead
-    pip_requirements = []
-
-    for requirement in requirements:
-        if "git" in requirement and "subdirectory" in requirement:
-            pip_requirements.append(requirement)
-        else:
-            uv_requirements.append(requirement)
-
     requirements_uv_path = tmp_dir / "requirements_uv.txt"
-    requirements_uv_path.write_text("\n".join(uv_requirements))
+    requirements_uv_path.write_text("\n".join(requirements))
 
     pip_extra_args = ""
 
@@ -172,14 +152,6 @@ def create_docker_context(image_spec: ImageSpec, tmp_dir: Path):
         pip_extra_args += " ".join(extra_urls)
 
     uv_python_install_command = UV_PYTHON_INSTALL_COMMAND_TEMPLATE.substitute(PIP_EXTRA=pip_extra_args)
-
-    if pip_requirements:
-        requirements_uv_path = tmp_dir / "requirements_pip.txt"
-        requirements_uv_path.write_text(os.linesep.join(pip_requirements))
-
-        pip_python_install_command = PIP_PYTHON_INSTALL_COMMAND_TEMPLATE.substitute(PIP_EXTRA=pip_extra_args)
-    else:
-        pip_python_install_command = ""
 
     env_dict = {"PYTHONPATH": "/root", _F_IMG_ID: image_spec.image_name()}
 
@@ -239,7 +211,6 @@ def create_docker_context(image_spec: ImageSpec, tmp_dir: Path):
     docker_content = DOCKER_FILE_TEMPLATE.substitute(
         PYTHON_VERSION=python_version,
         UV_PYTHON_INSTALL_COMMAND=uv_python_install_command,
-        PIP_PYTHON_INSTALL_COMMAND=pip_python_install_command,
         CONDA_PACKAGES=conda_packages_concat,
         CONDA_CHANNELS=conda_channels_concat,
         APT_INSTALL_COMMAND=apt_install_command,

--- a/tests/flytekit/unit/core/image_spec/test_default_builder.py
+++ b/tests/flytekit/unit/core/image_spec/test_default_builder.py
@@ -80,8 +80,8 @@ def test_create_docker_context_with_git_subfolder(tmp_path):
     assert dockerfile_path.exists()
     dockerfile_content = dockerfile_path.read_text()
 
-    assert "--requirement requirements_pip.txt" in dockerfile_content
-    requirements_path = docker_context_path / "requirements_pip.txt"
+    assert "--requirement requirements_uv.txt" in dockerfile_content
+    requirements_path = docker_context_path / "requirements_uv.txt"
     assert requirements_path.exists()
 
 


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
With https://github.com/astral-sh/uv/pull/5944 the latest version of uv now works with git & subdirectories.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR removed the work around with using pip.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I ran this image spec:

```python
from flytekit import ImageSpec, task, workflow

interactive = "git+https://github.com/flyteorg/flytekit.git@master#subdirectory=plugins/flytekit-flyteinteractive"

image = ImageSpec(
    name="interactive",
    builder="default",
    apt_packages=["git"],
    packages=["numpy==1.26.4", interactive],
    registry="localhost:30000",
)


@task(container_image=image)
def fn() -> int:
    import numpy as np

    x = np.array([1, 2, 3])

    return int(x.sum())


@workflow
def main() -> int:
    return fn()
```

