### PR TITLE
Remove false error inside dynamic task in local executions

### DIFF
--- a/flytekit/core/node_creation.py
+++ b/flytekit/core/node_creation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Union
 
 from flytekit.core.base_task import PythonTask
-from flytekit.core.context_manager import BranchEvalMode, FlyteContext
+from flytekit.core.context_manager import BranchEvalMode, ExecutionState, FlyteContext
 from flytekit.core.launch_plan import LaunchPlan
 from flytekit.core.node import Node
 from flytekit.core.promise import VoidPromise
@@ -129,9 +129,12 @@ def create_node(
         return node
 
     # Handling local execution
-    # Note: execution state is set to TASK_EXECUTION when running dynamic task locally
+    # Note: execution state is set to DYNAMIC_TASK_EXECUTION when running a dynamic task locally
     # https://github.com/flyteorg/flytekit/blob/0815345faf0fae5dc26746a43d4bda4cc2cdf830/flytekit/core/python_function_task.py#L262
-    elif ctx.execution_state and ctx.execution_state.is_local_execution():
+    elif ctx.execution_state and (
+        ctx.execution_state.is_local_execution()
+        or ctx.execution_state.mode == ExecutionState.Mode.DYNAMIC_TASK_EXECUTION
+    ):
         if isinstance(entity, RemoteEntity):
             raise AssertionError(f"Remote entities are not yet runnable locally {entity.name}")
 

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1270,7 +1270,7 @@ def flyte_entity_call_handler(
         if inspect.iscoroutine(result):
             return result
 
-        if ctx.execution_state.mode == ExecutionState.Mode.DYNAMIC_TASK_EXECUTION:
+        if ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.DYNAMIC_TASK_EXECUTION:
             return result
 
         if (1 < expected_outputs == len(cast(Tuple[Promise], result))) or (

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1270,6 +1270,9 @@ def flyte_entity_call_handler(
         if inspect.iscoroutine(result):
             return result
 
+        if ctx.execution_state.mode == ExecutionState.Mode.DYNAMIC_TASK_EXECUTION:
+            return result
+
         if (1 < expected_outputs == len(cast(Tuple[Promise], result))) or (
             result is not None and expected_outputs == 1
         ):

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -308,7 +308,12 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):  # type: ignore
             # local_execute directly though since that converts inputs into Promises.
             logger.debug(f"Executing Dynamic workflow, using raw inputs {kwargs}")
             self._create_and_cache_dynamic_workflow()
-            function_outputs = cast(PythonFunctionWorkflow, self._wf).execute(**kwargs)
+            if self.execution_mode == self.ExecutionBehavior.DYNAMIC:
+                es = ctx.new_execution_state().with_params(mode=ExecutionState.Mode.DYNAMIC_TASK_EXECUTION)
+            else:
+                es = cast(ExecutionState, ctx.execution_state)
+            with FlyteContextManager.with_context(ctx.with_execution_state(es)):
+                function_outputs = cast(PythonFunctionWorkflow, self._wf).execute(**kwargs)
 
             if isinstance(function_outputs, VoidPromise) or function_outputs is None:
                 return VoidPromise(self.name)


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Got below error when running the dynamic task

```python
{"asctime": "2024-06-24 17:21:38,715", "name": "flytekit", "levelname": "ERROR", "message": "You are not supposed to nest @Task/@Workflow inside a @Task!", "taskName": null}
{"asctime": "2024-06-24 17:21:38,716", "name": "flytekit", "levelname": "ERROR", "message": "You are not supposed to nest @Task/@Workflow inside a @Task!", "taskName": null}
{"asctime": "2024-06-24 17:21:38,716", "name": "flytekit", "levelname": "ERROR", "message": "You are not supposed to nest @Task/@Workflow inside a @Task!", "taskName": null}
{"asctime": "2024-06-24 17:21:38,716", "name": "flytekit", "levelname": "ERROR", "message": "You are not supposed to nest @Task/@Workflow inside a @Task!", "taskName": null}
{"asctime": "2024-06-24 17:21:38,717", "name": "flytekit", "levelname": "ERROR", "message": "You are not supposed to nest @Task/@Workflow inside a @Task!", "taskName": null}
```

## What changes were proposed in this pull request?
update the execution mode to `DYNAMIC_TASK_EXECUTION` when running a dynamic task

## How was this patch tested?
```bash
pyflyte -vv run flyte-example/improve_error/task_inside_dynamic.py d2
```

```python
from click.testing import CliRunner

from flytekit import task, workflow, ImageSpec, dynamic
from flytekit.clis.sdk_in_container import pyflyte

image_spec = ImageSpec(registry="pingsutw", packages=["pandas", "mypy"], env={"FLYTE_SDK_LOGGING_LEVEL": "10"})


@task(container_image=image_spec)
def t1() -> int:
    return 3 + 2


@task(container_image=image_spec)
def t2(a: int) -> int:
    return a + 3


@dynamic(container_image=image_spec)
def d1() -> int:
    t1()
    return t2(a=1)


@dynamic(container_image=image_spec)
def d2() -> int:
    d1()
    return t2(a=1)


@workflow()
def wf() -> int:
    d2()
    return 1


if __name__ == '__main__':
    runner = CliRunner()
    result = runner.invoke(
        pyflyte.main,
        [
            "-vv",
            "run",
            "/Users/kevin/git/flytekit/flyte-example/improve_error/task_inside_dynamic.py",
            "d1"
        ]
    )
    print(result.stdout)
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
