### PR TITLE
add motherduck support for duckdb plugin

### DIFF
--- a/plugins/flytekit-duckdb/flytekitplugins/duckdb/__init__.py
+++ b/plugins/flytekit-duckdb/flytekitplugins/duckdb/__init__.py
@@ -8,4 +8,4 @@
    DuckDBQuery
 """
 
-from .task import DuckDBQuery
+from .task import DuckDBProvider, DuckDBQuery

--- a/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
+++ b/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
@@ -12,6 +12,10 @@ pd = lazy_module("pandas")
 pa = lazy_module("pyarrow")
 
 
+class MissingSecretError(ValueError):
+    pass
+
+
 def connect_local(token: Optional[str]):
     """Connect to local DuckDB."""
     return duckdb.connect(":memory:")
@@ -89,6 +93,8 @@ class DuckDBQuery(PythonInstanceTask):
                 group_version=self._connect_secret.group_version,
             )
         if isinstance(self._provider, DuckDBProvider):
+            if not connect_token and self._provider != DuckDBProvider.LOCAL:
+                raise MissingSecretError(f"A secret_requests must be provided for the {self._provider.name} provider.")
             return self._provider.value(connect_token)
         else:  # callable
             return self._provider(connect_token)

--- a/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
+++ b/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
@@ -16,7 +16,7 @@ class MissingSecretError(ValueError):
     pass
 
 
-def connect_local(token: Optional[str]):
+def connect_local():
     """Connect to local DuckDB."""
     return duckdb.connect(":memory:")
 
@@ -114,9 +114,9 @@ class DuckDBQuery(PythonInstanceTask):
                 group_version=self._connect_secret.group_version,
             )
         if isinstance(self._provider, DuckDBProvider):
-            return self._provider.value(connect_token)
+            return self._provider.value(connect_token) if connect_token else self._provider.value()
         else:  # callable
-            return self._provider(connect_token)
+            return self._provider(connect_token) if connect_token else self._provider()
 
     def _execute_query(
         self, con: duckdb.DuckDBPyConnection, params: list, query: str, counter: int, multiple_params: bool

--- a/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
+++ b/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
@@ -1,7 +1,7 @@
 import json
 from typing import Dict, List, NamedTuple, Optional, Union
 
-from flytekit import PythonInstanceTask, lazy_module, current_context
+from flytekit import PythonInstanceTask, lazy_module, current_context, Secret
 from flytekit.extend import Interface
 from flytekit.types.structured.structured_dataset import StructuredDataset
 
@@ -23,7 +23,7 @@ class DuckDBQuery(PythonInstanceTask):
         name: str,
         query: Union[str, List[str]],
         inputs: Optional[Dict[str, Union[StructuredDataset, list]]] = None,
-        md_token_name: Optional[str] = None,
+        md_secret: Optional[Secret] = None,
         **kwargs,
     ):
         """
@@ -33,14 +33,18 @@ class DuckDBQuery(PythonInstanceTask):
             name: Name of the task
             query: DuckDB query to execute
             inputs: The query parameters to be used while executing the query
-            md_token_name: Name of the secret containing a MotherDuck authentication token
+            md_secret: Secret containing a MotherDuck authentication token
         """
-        if md_token_name is None:
+        if md_secret is None:
             # create an in-memory database that's non-persistent
             self._con = duckdb.connect(":memory:")
         else:
             # connect to motherduck
-            md_token = current_context().secrets.get(md_token_name)
+            md_token = current_context().secrets.get(
+                group=md_secret.group,
+                key=md_secret.key,
+                group_version=md_secret.group_version,
+            )
             self._con = duckdb.connect("md:", config={'motherduck_token': md_token})
 
         self._query = query

--- a/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
+++ b/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
@@ -45,6 +45,7 @@ class DuckDBQuery(PythonInstanceTask):
         query: Optional[Union[str, List[str]]] = None,
         inputs: Optional[Dict[str, Union[StructuredDataset, list]]] = None,
         provider: Union[DuckDBProvider, Callable] = DuckDBProvider.LOCAL,
+        secret: Optional[Secret] = None,
         **kwargs,
     ):
         """
@@ -65,8 +66,7 @@ class DuckDBQuery(PythonInstanceTask):
         """
         self._query = query
         self._provider = provider
-        secret_requests: Optional[list[Secret]] = kwargs.get("secret_requests", None)
-        self._connect_secret = secret_requests[0] if secret_requests else None
+        self._secret = secret
 
         outputs = {"result": StructuredDataset}
 
@@ -86,11 +86,11 @@ class DuckDBQuery(PythonInstanceTask):
             A DuckDB connection object.
         """
         connect_token = None
-        if self._connect_secret:
+        if self._secret:
             connect_token = current_context().secrets.get(
-                group=self._connect_secret.group,
-                key=self._connect_secret.key,
-                group_version=self._connect_secret.group_version,
+                group=self._secret.group,
+                key=self._secret.key,
+                group_version=self._secret.group_version,
             )
         if isinstance(self._provider, DuckDBProvider):
             if not connect_token and self._provider != DuckDBProvider.LOCAL:

--- a/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
+++ b/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
@@ -40,12 +40,12 @@ class DuckDBQuery(PythonInstanceTask):
             self._con = duckdb.connect(":memory:")
         else:
             # connect to motherduck
-            md_token = current_context().secrets.get(
+            motherduck_token = current_context().secrets.get(
                 group=motherduck_secret.group,
                 key=motherduck_secret.key,
                 group_version=motherduck_secret.group_version,
             )
-            self._con = duckdb.connect("md:", config={"motherduck_token": md_token})
+            self._con = duckdb.connect("md:", config={"motherduck_token": motherduck_token})
 
         self._query = query
 

--- a/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
+++ b/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
@@ -128,7 +128,7 @@ class DuckDBQuery(PythonInstanceTask):
             if key == "query" and val is not None:
                 # Execution query takes priority
                 self._query = val
-            if isinstance(val, StructuredDataset):
+            elif isinstance(val, StructuredDataset):
                 # register structured dataset
                 con.register(key, val.open(pa.Table).all())
             elif isinstance(val, (pd.DataFrame, pa.Table)):

--- a/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
+++ b/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
@@ -1,7 +1,7 @@
 import json
 from typing import Dict, List, NamedTuple, Optional, Union
 
-from flytekit import PythonInstanceTask, lazy_module, current_context, Secret
+from flytekit import PythonInstanceTask, Secret, current_context, lazy_module
 from flytekit.extend import Interface
 from flytekit.types.structured.structured_dataset import StructuredDataset
 
@@ -23,7 +23,7 @@ class DuckDBQuery(PythonInstanceTask):
         name: str,
         query: Union[str, List[str]],
         inputs: Optional[Dict[str, Union[StructuredDataset, list]]] = None,
-        md_secret: Optional[Secret] = None,
+        motherduck_secret: Optional[Secret] = None,
         **kwargs,
     ):
         """
@@ -33,19 +33,19 @@ class DuckDBQuery(PythonInstanceTask):
             name: Name of the task
             query: DuckDB query to execute
             inputs: The query parameters to be used while executing the query
-            md_secret: Secret containing a MotherDuck authentication token
+            motherduck_secret: Secret containing a MotherDuck authentication token
         """
-        if md_secret is None:
+        if motherduck_secret is None:
             # create an in-memory database that's non-persistent
             self._con = duckdb.connect(":memory:")
         else:
             # connect to motherduck
             md_token = current_context().secrets.get(
-                group=md_secret.group,
-                key=md_secret.key,
-                group_version=md_secret.group_version,
+                group=motherduck_secret.group,
+                key=motherduck_secret.key,
+                group_version=motherduck_secret.group_version,
             )
-            self._con = duckdb.connect("md:", config={'motherduck_token': md_token})
+            self._con = duckdb.connect("md:", config={"motherduck_token": md_token})
 
         self._query = query
 

--- a/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
+++ b/plugins/flytekit-duckdb/flytekitplugins/duckdb/task.py
@@ -43,7 +43,7 @@ class DuckDBQuery(PythonInstanceTask):
     def __init__(
         self,
         name: str,
-        query: Union[str, List[str]],
+        query: Optional[Union[str, List[str]]] = None,
         inputs: Optional[Dict[str, Union[StructuredDataset, list]]] = None,
         provider: DuckDBProvider = DuckDBProvider.LOCAL,
         **kwargs,
@@ -118,7 +118,7 @@ class DuckDBQuery(PythonInstanceTask):
         else:
             yield QueryOutput(output=con.execute(query), counter=counter)
 
-    def execute(self, **kwargs) -> StructuredDataset:
+    def execute(self, query: Optional[Union[str, List[str]]] = None, **kwargs) -> StructuredDataset:
         # TODO: Enable iterative download after adding the functionality to structured dataset code.
         con = self._connect_to_duckdb()
 
@@ -139,6 +139,13 @@ class DuckDBQuery(PythonInstanceTask):
                 params = json.loads(val)
             else:
                 raise ValueError(f"Expected inputs of type StructuredDataset, str or list, received {type(val)}")
+
+        if self._query is None and query is None:
+            raise ValueError("A query must be specified when defining or executing a DuckDBQuery.")
+
+        # Execution query takes priority
+        if query is not None:
+            self._query = query
 
         final_query = self._query
         query_output = QueryOutput()

--- a/plugins/flytekit-duckdb/tests/test_task.py
+++ b/plugins/flytekit-duckdb/tests/test_task.py
@@ -1,12 +1,13 @@
 import json
 from typing import List
-
+import pytest
 import pandas as pd
 import pyarrow as pa
-from flytekitplugins.duckdb import DuckDBQuery
+from flytekitplugins.duckdb import DuckDBQuery, DuckDBProvider
+from flytekitplugins.duckdb.task import MissingSecretError
 from typing_extensions import Annotated
 
-from flytekit import kwtypes, task, workflow
+from flytekit import kwtypes, task, workflow, Secret
 from flytekit.types.structured.structured_dataset import StructuredDataset
 
 
@@ -146,3 +147,33 @@ def test_insert_query_with_single_params():
         return duckdb_params_query(params=params)
 
     assert isinstance(params_wf(params=json.dumps([[[500], [300], [2]]])), pa.Table)
+
+
+def test_motherduck_no_token():
+    duckdb_params_query = DuckDBQuery(
+        name="motherduck_query",
+        query="SELECT SUM(a) FROM sometable",
+        provider=DuckDBProvider.MOTHERDUCK,
+    )
+
+    @workflow
+    def motherduck_wf() -> pd.DataFrame:
+        return duckdb_params_query()
+
+    with pytest.raises(MissingSecretError, match="A secret_requests must be provided for the MOTHERDUCK provider."):
+        motherduck_wf()
+
+
+def test_runtime_query():
+    runtime_duckdb_query = DuckDBQuery(
+        name="runtime_query", inputs=kwtypes(mydf=pd.DataFrame, query=str)
+    )
+
+    @workflow
+    def pandas_wf(mydf: pd.DataFrame, query: str) -> pd.DataFrame:
+        return runtime_duckdb_query(mydf=df, query=query)
+
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    query = "SELECT SUM(a) FROM mydf"
+    assert isinstance(pandas_wf(mydf=df, query=query), pd.DataFrame)
+    assert pandas_wf(mydf=df, query=query).iloc[0, 0] == 6

--- a/plugins/flytekit-duckdb/tests/test_task.py
+++ b/plugins/flytekit-duckdb/tests/test_task.py
@@ -150,18 +150,12 @@ def test_insert_query_with_single_params():
 
 
 def test_motherduck_no_token():
-    duckdb_params_query = DuckDBQuery(
-        name="motherduck_query",
-        query="SELECT SUM(a) FROM sometable",
-        provider=DuckDBProvider.MOTHERDUCK,
-    )
-
-    @workflow
-    def motherduck_wf() -> pd.DataFrame:
-        return duckdb_params_query()
-
     with pytest.raises(MissingSecretError, match="A secret_requests must be provided for the MOTHERDUCK provider."):
-        motherduck_wf()
+        duckdb_params_query = DuckDBQuery(
+            name="motherduck_query",
+            query="SELECT SUM(a) FROM sometable",
+            provider=DuckDBProvider.MOTHERDUCK,
+        )
 
 
 def test_runtime_query():


### PR DESCRIPTION
## Why are the changes needed?

We would like to integrate motherduck support with the current duckdb plugin such that a `DuckDBQuery` can query the motherduck data warehouse and/or in memory files at the same time.

## What changes were proposed in this pull request?

Simply add a connection to motherduck and authenticate via a secret. `duckdb` handles the rest.

## How was this patch tested?

Tested on a motherduck free trial with a combinarion query like:
```
"""
WITH db1 AS (
    SELECT
        SUM(a) AS sum_a,
    FROM mydf
),
db2 AS (
    SELECT
        MEAN(trip_time) AS mean_tt
    FROM sample_data.nyc.rideshare
)
SELECT
    db1.sum_a + db2.mean_tt AS total_sum,
FROM db1, db2;
"""
```

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
