### PR TITLE
Fix docker warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-ARG PYTHON_VERSION
+ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION}-slim-bookworm
 
-MAINTAINER Flyte Team <users@flyte.org>
+LABEL org.opencontainers.image.authors="Flyte Team <users@flyte.org>"
 LABEL org.opencontainers.image.source=https://github.com/flyteorg/flytekit
 
 WORKDIR /root
-ENV PYTHONPATH /root
-ENV FLYTE_SDK_RICH_TRACEBACKS 0
+ENV PYTHONPATH=/root
+ENV FLYTE_SDK_RICH_TRACEBACKS=0
 
 ARG VERSION
 ARG DOCKER_IMAGE
@@ -35,4 +35,4 @@ RUN apt-get update && apt-get install build-essential -y \
 
 USER flytekit
 
-ENV FLYTE_INTERNAL_IMAGE "$DOCKER_IMAGE"
+ENV FLYTE_INTERNAL_IMAGE="$DOCKER_IMAGE"

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,6 +1,6 @@
-FROM python:3.10-slim-bookworm as agent-slim
+FROM python:3.10-slim-bookworm AS agent-slim
 
-MAINTAINER Flyte Team <users@flyte.org>
+LABEL org.opencontainers.image.authors="Flyte Team <users@flyte.org>"
 LABEL org.opencontainers.image.source=https://github.com/flyteorg/flytekit
 
 ARG VERSION
@@ -19,9 +19,9 @@ RUN pip install --no-cache-dir -U flytekit==$VERSION \
   && rm -rf /var/lib/{apt,dpkg,cache,log}/ \
   && :
 
-CMD pyflyte serve agent --port 8000
+CMD ["pyflyte", "serve", "agent", "--port", "8000"]
 
-FROM agent-slim as agent-all
+FROM agent-slim AS agent-all
 ARG VERSION
 
 RUN pip install --no-cache-dir -U \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,7 +15,7 @@ WORKDIR /root
 ENV FLYTE_SDK_RICH_TRACEBACKS=0
 
 # Flytekit version of flytekit to be installed in the image
-ARG PSEUDO_VERSION=latest
+ARG PSEUDO_VERSION=1.13.3
 
 
 # Note: Pod tasks should be exposed in the default image

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,17 +5,17 @@
 # From your test user code
 # $ pyflyte run --image localhost:30000/flytekittest:someversion
 
-ARG PYTHON_VERSION
+ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION}-slim-bookworm
 
-MAINTAINER Flyte Team <users@flyte.org>
+LABEL org.opencontainers.image.authors="Flyte Team <users@flyte.org>"
 LABEL org.opencontainers.image.source=https://github.com/flyteorg/flytekit
 
 WORKDIR /root
-ENV FLYTE_SDK_RICH_TRACEBACKS 0
+ENV FLYTE_SDK_RICH_TRACEBACKS=0
 
 # Flytekit version of flytekit to be installed in the image
-ARG PSEUDO_VERSION
+ARG PSEUDO_VERSION=latest
 
 
 # Note: Pod tasks should be exposed in the default image
@@ -51,7 +51,7 @@ RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLYTEKIT=$PSEUDO_VERSION \
     && :
 
 
-ENV PYTHONPATH "/flytekit:/flytekit/plugins/flytekit-k8s-pod:/flytekit/plugins/flytekit-deck-standard:"
+ENV PYTHONPATH="/flytekit:/flytekit/plugins/flytekit-k8s-pod:/flytekit/plugins/flytekit-deck-standard:"
 
 # Switch to the 'flytekit' user for better security.
 USER flytekit


### PR DESCRIPTION
## Why are the changes needed?
Warning are annoying and eventually lead to errors. Better to nip them in the bud.

Here's how they manifest in the agent dockerfile:
```
❯ docker --debug build -f Dockerfile.agent . --build-arg VERSION=1.13.2
...
 4 warnings found:
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
The 'as' keyword should match the case of the 'from' keyword
More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
Dockerfile.agent:1
--------------------
   1 | >>> FROM python:3.10-slim-bookworm as agent-slim
   2 |
   3 |     MAINTAINER Flyte Team <users@flyte.org>
--------------------

 - MaintainerDeprecated: Maintainer instruction is deprecated in favor of using label (line 3)
The MAINTAINER instruction is deprecated, use a label instead to define an image author
More info: https://docs.docker.com/go/dockerfile/rule/maintainer-deprecated/
Dockerfile.agent:3
--------------------
   1 |     FROM python:3.10-slim-bookworm as agent-slim
   2 |
   3 | >>> MAINTAINER Flyte Team <users@flyte.org>
   4 |     LABEL org.opencontainers.image.source=https://github.com/flyteorg/flytekit
   5 |
--------------------

 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 24)
The 'as' keyword should match the case of the 'from' keyword
More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
Dockerfile.agent:24
--------------------
  22 |     CMD pyflyte serve agent --port 8000
  23 |
  24 | >>> FROM agent-slim as agent-all
  25 |     ARG VERSION
  26 |
--------------------

 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 22)
JSON arguments recommended for ENTRYPOINT/CMD to prevent unintended behavior related to OS signals
More info: https://docs.docker.com/go/dockerfile/rule/json-args-recommended/
Dockerfile.agent:22
--------------------
  20 |       && :
  21 |
  22 | >>> CMD pyflyte serve agent --port 8000
  23 |
  24 |     FROM agent-slim as agent-all
--------------------
...
```

In the default image dockerfile:
```
❯ docker build -f Dockerfile . --build-arg VERSION=1.13.3 --build-arg PYTHON_VERSION=3.12
...
 5 warnings found (use docker --debug to expand):
 - InvalidDefaultArgInFrom: Default value for ARG python:${PYTHON_VERSION}-slim-bookworm results in empty or invalid base image name (line 2)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 8)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 9)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 38)
 - MaintainerDeprecated: Maintainer instruction is deprecated in favor of using label (line 4)
...

```

And in the dev dockerfile:
```
❯ docker build -f Dockerfile.dev . --build-arg VERSION=1.13.3 --build-arg PYTHON_VERSION=3.12
...

 4 warnings found (use docker --debug to expand):
 - InvalidDefaultArgInFrom: Default value for ARG python:${PYTHON_VERSION}-slim-bookworm results in empty or invalid base image name (line 9)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 15)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 54)
 - MaintainerDeprecated: Maintainer instruction is deprecated in favor of using label (line 11)
...
```

## What changes were proposed in this pull request?
I just followed the recommendations in https://docs.docker.com/reference/build-checks/invalid-default-arg-in-from/, https://docs.docker.com/reference/build-checks/json-args-recommended/, and https://docs.docker.com/reference/build-checks/maintainer-deprecated/ in the three dockerfiles.


## How was this patch tested?
Built images locally and confirmed that warnings were gone.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
