### PR TITLE
Better error message for FailureNodeInputMismatch error

### DIFF
--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -693,7 +693,11 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
         ) as inner_comp_ctx:
             # Now lets compile the failure-node if it exists
             if self.on_failure:
-                if self.on_failure.python_interface.inputs != self.python_interface.inputs:
+                if (
+                    self.on_failure.python_interface
+                    and self.python_interface
+                    and self.on_failure.python_interface.inputs != self.python_interface.inputs
+                ):
                     raise FlyteFailureNodeInputMismatchException(self.on_failure, self)
                 c = wf_args.copy()
                 exception_scopes.user_entry_point(self.on_failure)(**c)

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -8,6 +8,8 @@ from enum import Enum
 from functools import update_wrapper
 from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple, Type, Union, cast, overload
 
+from typing_inspect import is_optional_type
+
 try:
     from typing import ParamSpec
 except ImportError:
@@ -693,12 +695,19 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
         ) as inner_comp_ctx:
             # Now lets compile the failure-node if it exists
             if self.on_failure:
-                if (
-                    self.on_failure.python_interface
-                    and self.python_interface
-                    and self.on_failure.python_interface.inputs != self.python_interface.inputs
-                ):
-                    raise FlyteFailureNodeInputMismatchException(self.on_failure, self)
+                if self.on_failure.python_interface and self.python_interface:
+                    workflow_inputs = self.python_interface.inputs
+                    failure_node_inputs = self.on_failure.python_interface.inputs
+
+                    # Workflow inputs should be a subset of failure node inputs.
+                    if (failure_node_inputs | workflow_inputs) != failure_node_inputs:
+                        raise FlyteFailureNodeInputMismatchException(self.on_failure, self)
+                    additional_keys = failure_node_inputs.keys() - workflow_inputs.keys()
+                    # Raising an error if the additional inputs in the failure node are not optional.
+                    for k in additional_keys:
+                        if not is_optional_type(failure_node_inputs[k]):
+                            raise FlyteFailureNodeInputMismatchException(self.on_failure, self)
+
                 c = wf_args.copy()
                 exception_scopes.user_entry_point(self.on_failure)(**c)
                 inner_nodes = None

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -47,7 +47,11 @@ from flytekit.core.reference_entity import ReferenceEntity, WorkflowReference
 from flytekit.core.tracker import extract_task_module
 from flytekit.core.type_engine import TypeEngine
 from flytekit.exceptions import scopes as exception_scopes
-from flytekit.exceptions.user import FlyteValidationException, FlyteValueException
+from flytekit.exceptions.user import (
+    FlyteFailureNodeInputMismatchException,
+    FlyteValidationException,
+    FlyteValueException,
+)
 from flytekit.loggers import logger
 from flytekit.models import interface as _interface_models
 from flytekit.models import literals as _literal_models
@@ -689,6 +693,8 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
         ) as inner_comp_ctx:
             # Now lets compile the failure-node if it exists
             if self.on_failure:
+                if self.on_failure.python_interface.inputs != self.python_interface.inputs:
+                    raise FlyteFailureNodeInputMismatchException(self.on_failure, self)
                 c = wf_args.copy()
                 exception_scopes.user_entry_point(self.on_failure)(**c)
                 inner_nodes = None

--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -3,6 +3,10 @@ import typing
 from flytekit.exceptions.base import FlyteException as _FlyteException
 from flytekit.exceptions.base import FlyteRecoverableException as _Recoverable
 
+if typing.TYPE_CHECKING:
+    from flytekit.core.base_task import Task
+    from flytekit.core.workflow import WorkflowBase
+
 
 class FlyteUserException(_FlyteException):
     _ERROR_CODE = "USER:Unknown"
@@ -66,6 +70,24 @@ class FlyteAssertion(FlyteUserException, AssertionError):
 
 class FlyteValidationException(FlyteAssertion):
     _ERROR_CODE = "USER:ValidationError"
+
+
+class FlyteFailureNodeInputMismatchException(FlyteAssertion):
+    _ERROR_CODE = "USER:FailureNodeInputMismatch"
+
+    def __init__(self, failure_node_node: typing.Union["WorkflowBase", "Task"], workflow: "WorkflowBase"):
+        self.failure_node_node = failure_node_node
+        self.workflow = workflow
+
+    def __str__(self):
+        return (
+            f"Mismatched Inputs Detected\n"
+            f"The failure node `{self.failure_node_node.name}` has inputs that do not align with those expected by the workflow `{self.workflow.name}`.\n"
+            f"Failure Node's Inputs: {self.failure_node_node.python_interface.inputs}\n"
+            f"Workflow's Inputs: {self.workflow.python_interface.inputs}\n"
+            "Action Required:\n"
+            "Please ensure that all input arguments in the failure node are provided and match the expected arguments specified in the workflow."
+        )
 
 
 class FlyteDisapprovalException(FlyteAssertion):

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1689,22 +1689,21 @@ def test_failure_node():
 
 def test_failure_node_mismatch_inputs():
     @task()
-    def t1() -> int:
-        return 3 + 2
-
-    @task()
     def t2(a: int) -> int:
         return a + 3
 
     @workflow(on_failure=t2)
     def wf(a: int = 3, b: str = "hello"):
-        t1()
         t2(a=a)
+
+    # pytest-xdist uses `__channelexec__` as the top-level module
+    running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
+    prefix = "__channelexec__." if running_xdist else ""
 
     with pytest.raises(
         FlyteFailureNodeInputMismatchException,
         match="Mismatched Inputs Detected\n"
-              "The failure node `tests.flytekit.unit.core.test_type_hints.t2` has "
+              f"The failure node `{prefix}tests.flytekit.unit.core.test_type_hints.t2` has "
               "inputs that do not align with those expected by the workflow `tests.flytekit.unit.core.test_type_hints.wf`.\n"
               "Failure Node's Inputs: {'a': <class 'int'>}\n"
               "Workflow's Inputs: {'a': <class 'int'>, 'b': <class 'str'>}\n"

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1689,12 +1689,12 @@ def test_failure_node():
 
 def test_failure_node_mismatch_inputs():
     @task()
-    def t2(a: int) -> int:
+    def t1(a: int) -> int:
         return a + 3
 
-    @workflow(on_failure=t2)
-    def wf(a: int = 3, b: str = "hello"):
-        t2(a=a)
+    @workflow(on_failure=t1)
+    def wf1(a: int = 3, b: str = "hello"):
+        t1(a=a)
 
     # pytest-xdist uses `__channelexec__` as the top-level module
     running_xdist = os.environ.get("PYTEST_XDIST_WORKER") is not None
@@ -1703,14 +1703,24 @@ def test_failure_node_mismatch_inputs():
     with pytest.raises(
         FlyteFailureNodeInputMismatchException,
         match="Mismatched Inputs Detected\n"
-              f"The failure node `{prefix}tests.flytekit.unit.core.test_type_hints.t2` has "
-              "inputs that do not align with those expected by the workflow `tests.flytekit.unit.core.test_type_hints.wf`.\n"
+              f"The failure node `{prefix}tests.flytekit.unit.core.test_type_hints.t1` has "
+              "inputs that do not align with those expected by the workflow `tests.flytekit.unit.core.test_type_hints.wf1`.\n"
               "Failure Node's Inputs: {'a': <class 'int'>}\n"
               "Workflow's Inputs: {'a': <class 'int'>, 'b': <class 'str'>}\n"
               "Action Required:\n"
               "Please ensure that all input arguments in the failure node are provided and match the expected arguments specified in the workflow.",
     ):
-        wf()
+        wf1()
+
+    @task()
+    def t2(a: int, b: typing.Optional[int] = None) -> int:
+        return a + 3
+
+    @workflow(on_failure=t2)
+    def wf2(a: int = 3):
+        t2(a=a)
+
+    wf2()
 
 
 @pytest.mark.skipif("pandas" not in sys.modules, reason="Pandas is not installed.")


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
The error message is not clear enough.

```
 /Users/kevin/git/flytekit/flytekit/core/promise.py:1213 in flyte_entity_call_handler             │
│                                                                                                  │
│   1210 │   # Make sure arguments are part of interface                                           │
│   1211 │   for k, v in kwargs.items():                                                           │
│   1212 │   │   if k not in entity.python_interface.inputs:                                       │
│ ❱ 1213 │   │   │   raise AssertionError(f"Received unexpected keyword argument '{k}' in functio  │
│   1214 │                                                                                         │
│   1215 │   # Check if we have more arguments than expected                                       │
│   1216 │   if len(args) > len(entity.python_interface.inputs):                                   │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AssertionError: Error encountered while executing 't2':
  Received unexpected keyword argument 'b' in function 'failure_node_mismatch_interface.t2'
```

## What changes were proposed in this pull request?
Add a new exception (`FlyteFailureNodeInputMismatchException`) with a clear error message for this exception.
Use it when the failure node's interface doesn't match the workflow interface.

## How was this patch tested?
```bash
pyflyte -vv run --remote flyte-example/improve_error/failure_node_mismatch_interface.py
```

### Setup process
```python
from click.testing import CliRunner

from flytekit import task, workflow, ImageSpec
from flytekit.clis.sdk_in_container import pyflyte

default = ["pandas", "mypy"]

image = ImageSpec(registry="pingsutw", packages=[*default])


@task(container_image=image)
def t1() -> int:
    return 3 + 2


@task(container_image=image)
def t2(a: int) -> int:
    return a + 3


@workflow(on_failure=t2)
def wf(a: int = 3, b: str = "hello"):
    t1()
    t2(a=a)
```

### Screenshots
Before:
<img width="1234" alt="Screenshot 2024-08-19 at 4 33 40 PM" src="https://github.com/user-attachments/assets/ff0a942d-b711-437e-aeae-765c7fe4de12">

After:
<img width="1234" alt="Screenshot 2024-08-19 at 4 28 31 PM" src="https://github.com/user-attachments/assets/84745057-9078-4113-a164-6ec241dab27e">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
