### PR TITLE
Polars lazyframe

### DIFF
--- a/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
+++ b/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
@@ -15,8 +15,9 @@ from flytekit.types.structured.structured_dataset import (
 )
 
 if typing.TYPE_CHECKING:
-    import polars as pl
     import fsspec.utils as fsspec_utils
+
+    import polars as pl
 else:
     pl = lazy_module("polars")
     fsspec_utils = lazy_module("fsspec.utils")
@@ -25,6 +26,7 @@ else:
 ############################
 # Polars DataFrame classes #
 ############################
+
 
 class PolarsDataFrameRenderer:
     """
@@ -99,6 +101,7 @@ class ParquetToPolarsDataFrameDecodingHandler(StructuredDatasetDecoder):
 ############################
 # Polars LazyFrame classes #
 ############################
+
 
 class PolarsLazyFrameToParquetEncodingHandler(StructuredDatasetEncoder):
     def __init__(self):

--- a/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
+++ b/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
@@ -162,6 +162,7 @@ class ParquetToPolarsLazyFrameDecodingHandler(StructuredDatasetDecoder):
                 data_config=ctx.file_access.data_config,
             )
 
+        print("uri", uri)
         print("kwargs", kwargs)
 
         if current_task_metadata.structured_dataset_type and current_task_metadata.structured_dataset_type.columns:

--- a/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
+++ b/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
@@ -41,8 +41,11 @@ class PolarsDataFrameRenderer:
             # LazyFrames in polars <= 0.19 does not support `describe`
             describe_df = df.collect().describe()
 
-        columns = describe_df["describe"]
-        html_repr = describe_df.drop("describe").transpose(column_names=columns)._repr_html_()
+        # the value is "statistic" or "describe" depending on polars version
+        stat_colname = describe_df.columns[0]
+
+        columns = describe_df[stat_colname]
+        html_repr = describe_df.drop(stat_colname).transpose(column_names=columns)._repr_html_()
         return html_repr
 
 
@@ -173,4 +176,3 @@ StructuredDatasetTransformerEngine.register_renderer(pl.DataFrame, PolarsDataFra
 # Register the Polars LazyFrame handlers
 StructuredDatasetTransformerEngine.register(PolarsLazyFrameToParquetEncodingHandler())
 StructuredDatasetTransformerEngine.register(ParquetToPolarsLazyFrameDecodingHandler())
-StructuredDatasetTransformerEngine.register_renderer(pl.LazyFrame, PolarsDataFrameRenderer())

--- a/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
+++ b/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
@@ -161,8 +161,8 @@ class ParquetToPolarsLazyFrameDecodingHandler(StructuredDatasetDecoder):
         # https://github.com/pola-rs/polars/issues/16737
         if current_task_metadata.structured_dataset_type and current_task_metadata.structured_dataset_type.columns:
             columns = [c.name for c in current_task_metadata.structured_dataset_type.columns]
-            return pl.read_parquet(uri, columns=columns, use_pyarrow=True, storage_options=kwargs)
-        return pl.read_parquet(uri, use_pyarrow=True, storage_options=kwargs)
+            return pl.read_parquet(uri, columns=columns, use_pyarrow=True, storage_options=kwargs).lazy()
+        return pl.read_parquet(uri, use_pyarrow=True, storage_options=kwargs).lazy()
 
 
 # Register the Polars DataFrame handlers

--- a/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
+++ b/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
@@ -158,12 +158,9 @@ class ParquetToPolarsLazyFrameDecodingHandler(StructuredDatasetDecoder):
             kwargs = None
         else:
             kwargs = get_fsspec_storage_options(
-                protocol=fsspec_utils.get_protocol(uri),
+                protocol=protocol,
                 data_config=ctx.file_access.data_config,
             )
-
-        print("uri", uri)
-        print("kwargs", kwargs)
 
         if current_task_metadata.structured_dataset_type and current_task_metadata.structured_dataset_type.columns:
             columns = [c.name for c in current_task_metadata.structured_dataset_type.columns]

--- a/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
+++ b/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
@@ -157,7 +157,7 @@ class ParquetToPolarsLazyFrameDecodingHandler(StructuredDatasetDecoder):
             protocol=fsspec_utils.get_protocol(uri),
             data_config=ctx.file_access.data_config,
         )
-        # use read_parquet instead of scan_parquet for now because scan_parquet currently does't work with fsspec:
+        # use read_parquet instead of scan_parquet for now because scan_parquet currently doesn't work with fsspec:
         # https://github.com/pola-rs/polars/issues/16737
         if current_task_metadata.structured_dataset_type and current_task_metadata.structured_dataset_type.columns:
             columns = [c.name for c in current_task_metadata.structured_dataset_type.columns]

--- a/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
+++ b/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
@@ -162,6 +162,8 @@ class ParquetToPolarsLazyFrameDecodingHandler(StructuredDatasetDecoder):
                 data_config=ctx.file_access.data_config,
             )
 
+        print("kwargs", kwargs)
+
         if current_task_metadata.structured_dataset_type and current_task_metadata.structured_dataset_type.columns:
             columns = [c.name for c in current_task_metadata.structured_dataset_type.columns]
             return pl.scan_parquet(uri, storage_options=kwargs).select(columns)

--- a/plugins/flytekit-polars/tests/test_polars_plugin_sd.py
+++ b/plugins/flytekit-polars/tests/test_polars_plugin_sd.py
@@ -87,7 +87,8 @@ def test_polars_renderer(df_cls):
     else:
         df_desc = df.describe()
 
-    expected = df_desc.drop("describe").transpose(column_names=df_desc["describe"])._repr_html_()
+    stat_colname = df_desc.columns[0]
+    expected = df_desc.drop(stat_colname).transpose(column_names=df_desc[stat_colname])._repr_html_()
     assert PolarsDataFrameRenderer().to_html(df) == expected
 
 
@@ -105,7 +106,7 @@ def test_parquet_to_polars_dataframe(df_cls):
     if isinstance(polars_df, pl.LazyFrame):
         polars_df = polars_df.collect()
 
-    assert pl.DataFrame(data).frame_equal(polars_df)
+    assert_frame_equal(pl.DataFrame(data), polars_df)
 
     tmp = tempfile.mktemp()
     pl.DataFrame(data).write_parquet(tmp)
@@ -120,7 +121,7 @@ def test_parquet_to_polars_dataframe(df_cls):
     if df_cls is pl.LazyFrame:
         df_out = df_out.collect()
 
-    assert df_out.frame_equal(polars_df)
+    assert_frame_equal(df_out, polars_df)
 
     @task
     def consume_sd_return_sd(sd: StructuredDataset) -> StructuredDataset:
@@ -132,4 +133,4 @@ def test_parquet_to_polars_dataframe(df_cls):
     if df_cls is pl.LazyFrame:
         opened_sd = opened_sd.collect()
 
-    assert opened_sd.frame_equal(polars_df)
+    assert_frame_equal(opened_sd, polars_df)


### PR DESCRIPTION
## Tracking issue

Fixes https://github.com/flyteorg/flyte/issues/5678

## Why are the changes needed?

The flytekit plugin for polars only supports `polars.DataFrame`. Many polars users rely on the `LazyFrame` API to make data handling more memory efficient.

## What changes were proposed in this pull request?

This PR:
- Adds and registers a `LazyFrame` encoder/decoder to the `StructuredDataset` type.

## How was this patch tested?

Unit tests run on CI.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.
