### PR TITLE
fix: cover 500 errors for new Harbor repos

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -145,6 +145,7 @@ class ImageSpec:
                 return False
 
             if re.match(f"unknown: repository .*{self.name} not found", e.explanation):
+                click.secho(f"Received 500 error with explanation: {e.explanation}", fg="yellow")
                 return False
 
             click.secho(f"Failed to check if the image exists with error:\n {e}", fg="red")

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -3,6 +3,7 @@ import copy
 import hashlib
 import os
 import pathlib
+import re
 import typing
 from abc import abstractmethod
 from dataclasses import asdict, dataclass
@@ -141,6 +142,9 @@ class ImageSpec:
             return True
         except APIError as e:
             if e.response.status_code == 404:
+                return False
+
+            if re.match(f"unknown: repository .*{self.name} not found", e.explanation):
                 return False
 
             click.secho(f"Failed to check if the image exists with error:\n {e}", fg="red")


### PR DESCRIPTION
## Why are the changes needed?

ImageSpec builders currently do not support pushing images to repositories on Harbor. For new repositories (i.e. ones that do not exist yet on the registry), the `APIError` except block in `ImageSpec.exist` only checks for 404 errors before returning `False`. However, unlike other registries such as GitLab's, Harbor raises a 500 error not a 404. Therefore, the existence check fails and returns `None` which leads `ImageSpec` to conclude that the image should not be built.

## What changes were proposed in this pull request?

In `ImageSpec.exist` I added an additional check after the 404 status code check that compares the error's explanation against a simple regex pattern aligned with what Harbor produces in this case. If there is a match, then the method returns `False`. 

## How was this patch tested?

Utilizing an on-prem Harbor instance, I first attempted to run `pyflyte package` without the patch and got this (sanitized) output:

```
Failed to check if the image exists with error:
 500 Server Error for http+docker://localhost/v1.46/distribution/<image-name>/json: Internal Server Error ("unknown: repository <image-name-without-fqdn-or-tag> not found")
Flytekit assumes the image <image-name> already exists.
```

After introducing the patch, I ran the exact same command and got the following output:

```
Image <image-name> not found. building...
<docker-build-and-push-logs>
```

I then let it finish pushing the image and ran the exact same command again (`ImageSpec` has `tag_format` set to a fixed value) which produced this output:

```
Image <image-name> found. Skip building.
```