### PR TITLE
Deprecation notice for pod plugin

### DIFF
--- a/plugins/flytekit-k8s-pod/README.md
+++ b/plugins/flytekit-k8s-pod/README.md
@@ -1,6 +1,6 @@
 # Flytekit Kubernetes Pod Plugin
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > This plugin is no longer needed and is here only for backwards compatibility. No new versions will be published after v1.13.x
 > Please use the `pod_template` and `pod_template_name` args to `@task` instead.
 

--- a/plugins/flytekit-k8s-pod/README.md
+++ b/plugins/flytekit-k8s-pod/README.md
@@ -2,7 +2,8 @@
 
 > [!IMPORTANT]
 > This plugin is no longer needed and is here only for backwards compatibility. No new versions will be published after v1.13.x
-> Please use the `pod_template` and `pod_template_name` args to `@task` instead.
+> Please use the `pod_template` and `pod_template_name` args to `@task` as described in https://docs.flyte.org/en/latest/deployment/configuration/general.html#configuring-task-pods-with-k8s-podtemplates
+> instead.
 
 
 By default, Flyte tasks decorated with `@task` are essentially single functions that are loaded in one container. But often, there is a need to run a job with more than one container.

--- a/plugins/flytekit-k8s-pod/README.md
+++ b/plugins/flytekit-k8s-pod/README.md
@@ -1,5 +1,10 @@
 # Flytekit Kubernetes Pod Plugin
 
+> [!IMPORTANT]  
+> This plugin is no longer needed and is here only for backwards compatibility. No new versions will be published after v1.13.x
+> Please use the `pod_template` and `pod_template_name` args to `@task` instead.
+
+
 By default, Flyte tasks decorated with `@task` are essentially single functions that are loaded in one container. But often, there is a need to run a job with more than one container.
 
 In this case, a regular task is not enough. Hence, Flyte provides a Kubernetes pod abstraction to execute multiple containers, which can be accomplished using Pod's `task_config`. The `task_config` can be leveraged to fully customize the pod spec used to run the task.

--- a/plugins/flytekit-k8s-pod/flytekitplugins/pod/__init__.py
+++ b/plugins/flytekit-k8s-pod/flytekitplugins/pod/__init__.py
@@ -1,3 +1,7 @@
+import warnings
+
+from .task import Pod
+
 """
 .. currentmodule:: flytekitplugins.pod
 
@@ -10,11 +14,7 @@ This package contains things that are useful when extending Flytekit.
    Pod
 """
 
-import warnings
-
 warnings.warn(
     "This pod plugin is no longer necessary, please use the pod_template and pod_template_name options to @task instead.",
     DeprecationWarning,
 )
-
-from .task import Pod

--- a/plugins/flytekit-k8s-pod/flytekitplugins/pod/__init__.py
+++ b/plugins/flytekit-k8s-pod/flytekitplugins/pod/__init__.py
@@ -10,4 +10,11 @@ This package contains things that are useful when extending Flytekit.
    Pod
 """
 
+import warnings
+
+warnings.warn(
+    "This pod plugin is no longer necessary, please use the pod_template and pod_template_name options to @task instead.",
+    DeprecationWarning,
+)
+
 from .task import Pod

--- a/plugins/flytekit-k8s-pod/flytekitplugins/pod/__init__.py
+++ b/plugins/flytekit-k8s-pod/flytekitplugins/pod/__init__.py
@@ -17,5 +17,5 @@ This package contains things that are useful when extending Flytekit.
 warnings.warn(
     "This pod plugin is no longer necessary, please use the pod_template and pod_template_name options to @task as described "
     "in https://docs.flyte.org/en/latest/deployment/configuration/general.html#configuring-task-pods-with-k8s-podtemplates",
-    DeprecationWarning,
+    FutureWarning,
 )

--- a/plugins/flytekit-k8s-pod/flytekitplugins/pod/__init__.py
+++ b/plugins/flytekit-k8s-pod/flytekitplugins/pod/__init__.py
@@ -15,6 +15,7 @@ This package contains things that are useful when extending Flytekit.
 """
 
 warnings.warn(
-    "This pod plugin is no longer necessary, please use the pod_template and pod_template_name options to @task instead.",
+    "This pod plugin is no longer necessary, please use the pod_template and pod_template_name options to @task as described "
+    "in https://docs.flyte.org/en/latest/deployment/configuration/general.html#configuring-task-pods-with-k8s-podtemplates",
     DeprecationWarning,
 )


### PR DESCRIPTION
## Why are the changes needed?
The pod plugin functionality has been in the core task code for a while now.  Users no longer need this plugin.

## What changes were proposed in this pull request?
Add a deprecation notice to the init file and readme.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
