### PR TITLE
Fix: Catch unsupported node types in map node array task

### DIFF
--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -63,8 +63,16 @@ class ArrayNodeMapTask(PythonTask):
             actual_task = python_function_task
 
         # TODO: add support for other Flyte entities
-        if not (isinstance(actual_task, PythonFunctionTask) or isinstance(actual_task, PythonInstanceTask)):
-            raise ValueError("Only PythonFunctionTask and PythonInstanceTask are supported in map tasks.")
+        if not (
+            (
+                isinstance(actual_task, PythonFunctionTask)
+                and actual_task.execution_mode == PythonFunctionTask.ExecutionBehavior.DEFAULT
+            )
+            or isinstance(actual_task, PythonInstanceTask)
+        ):
+            raise ValueError(
+                "Only PythonFunctionTask with default execution mode (not @dynamic or @eager) and PythonInstanceTask are supported in map tasks."
+            )
 
         for k, v in actual_task.python_interface.inputs.items():
             if bound_inputs and k in bound_inputs:

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -6,13 +6,14 @@ from typing_extensions import Annotated
 
 import pytest
 
-from flytekit import map_task, task, workflow
+from flytekit import dynamic, map_task, task, workflow
 from flytekit.configuration import FastSerializationSettings, Image, ImageConfig, SerializationSettings
 from flytekit.core import context_manager
 from flytekit.core.array_node_map_task import ArrayNodeMapTask, ArrayNodeMapTaskResolver
 from flytekit.core.task import TaskMetadata
 from flytekit.core.type_engine import TypeEngine
 from flytekit.extras.accelerators import GPUAccelerator
+from flytekit.experimental.eager_function import eager
 from flytekit.tools.translator import get_serializable
 from flytekit.types.pickle import BatchSize
 
@@ -403,3 +404,34 @@ def test_serialization_extended_resources(serialization_settings):
     task_spec = od[arraynode_maptask]
 
     assert task_spec.template.extended_resources.gpu_accelerator.device == "test_gpu"
+
+
+def test_supported_node_type():
+    @task
+    def test_task():
+        ...
+
+    map_task(test_task)
+
+
+def test_unsupported_node_types():
+    @dynamic
+    def test_dynamic():
+        ...
+
+    with pytest.raises(ValueError):
+        map_task(test_dynamic)
+
+    @eager
+    def test_eager():
+        ...
+
+    with pytest.raises(ValueError):
+        map_task(test_eager)
+
+    @workflow
+    def test_wf():
+        ...
+
+    with pytest.raises(ValueError):
+        map_task(test_wf)


### PR DESCRIPTION
## Why are the changes needed?

Map node array tasks allow mapping a `@task` over a list of inputs. They do not support `@dynamic` or `@eager` tasks though.

However, using unsupported task types is not being caught during registration.


## What changes were proposed in this pull request?

* Detect when a user tries to map an `@eager` or `@dynamic` task

## How was this patch tested?

* Add a unit test that would have caught this bug


- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

