### PR TITLE
Fix integration tests

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -38,7 +38,6 @@ RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLYTEKIT=$PSEUDO_VERSION \
         uv pip install --system --no-cache-dir -U \
             "git+https://github.com/flyteorg/flyte.git@master#subdirectory=flyteidl" \
             -e /flytekit \
-            -e /flytekit/plugins/flytekit-k8s-pod \
             -e /flytekit/plugins/flytekit-deck-standard \
             -e /flytekit/plugins/flytekit-flyteinteractive \
             scikit-learn \
@@ -49,6 +48,8 @@ RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLYTEKIT=$PSEUDO_VERSION \
     && chown flytekit: /root \
     && chown flytekit: /home \
     && :
+
+ENV PYTHONPATH="/flytekit:"
 
 # Switch to the 'flytekit' user for better security.
 USER flytekit


### PR DESCRIPTION
## Why are the changes needed?
We stopped setting PYTHONPATH in the dev image in https://github.com/flyteorg/flytekit/pull/2673, but that broke integration tests because `flytekit` and can no longer be found (consequently the integration tests modules shipped alongside flytekit can't be found).

## What changes were proposed in this pull request?
Add `/flytekit` back to PYTHONPATH in dev image.

I also took the time and removed the deprecated pod plugin from the image.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
