### PR TITLE
Fix local test `test_saving_remote` fail

### DIFF
--- a/tests/flytekit/unit/cli/pyflyte/test_register.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_register.py
@@ -57,8 +57,10 @@ def test_get_remote(mock_remote, reset_flytectl_config_env_var):
     )
 
 
+@mock.patch("flytekit.configuration.plugin.get_config_file")
 @mock.patch("flytekit.configuration.plugin.FlyteRemote")
-def test_saving_remote(mock_remote):
+def test_saving_remote(mock_remote, mock_config_file):
+    mock_config_file.return_value = None
     mock_context = mock.MagicMock
     mock_context.obj = {}
     get_and_save_remote_with_click_context(mock_context, "p", "d")


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5687
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?
`get_and_save_remote_with_click_context(...)` will call `get_remote(cfg_file_location, ...)`, which will call `get_config_file` if the first argument is `None`.
As described in https://github.com/flyteorg/flytekit/pull/2705, `get_config_file` will not always return `None` in developers' local environments.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Add a mock function that forces the return value of `get_config_file` to `None`.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
```
make unit_test
```
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
Run it locally

### Screenshots
I'll open other PRs to fix the other 2 unit tests.
<img width="1495" alt="image" src="https://github.com/user-attachments/assets/20cbb0cf-0991-45f1-a02f-43ae7c5a94b4">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flytekit/pull/2705
https://github.com/flyteorg/flytekit/pull/2706
<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
