### PR TITLE
[WIP] Remove `dataclasses json` dependency from flytekit V2

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -319,3 +319,9 @@ load_implicit_plugins()
 # Pretty-print exception messages
 if os.environ.get(LOGGING_RICH_FMT_ENV_VAR) != "0":
     traceback.install(width=None, extra_lines=0)
+
+try:
+    from dataclasses_json import DataClassJsonMixin
+    DataClassBaseClass = DataClassJsonMixin
+except ImportError:
+    DataClassBaseClass = object

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -143,7 +143,6 @@ from io import BytesIO
 from typing import Dict, List, Optional
 
 import yaml
-from dataclasses_json import DataClassJsonMixin
 
 from flytekit.configuration import internal as _internal
 from flytekit.configuration.default_images import DefaultImages
@@ -162,9 +161,14 @@ DEFAULT_IN_CONTAINER_SRC_PATH = "/root"
 _IMAGE_FQN_TAG_REGEX = re.compile(r"([^:]+)(?=:.+)?")
 SERIALIZED_CONTEXT_ENV_VAR = "_F_SS_C"
 
+try:
+    from dataclasses_json import DataClassJsonMixin
+    DataClassBaseClass = DataClassJsonMixin
+except ImportError:
+    DataClassBaseClass = object
 
 @dataclass(init=True, repr=True, eq=True, frozen=True)
-class Image(DataClassJsonMixin):
+class Image(DataClassBaseClass):
     """
     Image is a structured wrapper for task container images used in object serialization.
 

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -144,6 +144,7 @@ from typing import Dict, List, Optional
 
 import yaml
 
+from flytekit import DataClassBaseClass
 from flytekit.configuration import internal as _internal
 from flytekit.configuration.default_images import DefaultImages
 from flytekit.configuration.file import ConfigEntry, ConfigFile, get_config_file, read_file_if_exists, set_if_exists
@@ -161,11 +162,6 @@ DEFAULT_IN_CONTAINER_SRC_PATH = "/root"
 _IMAGE_FQN_TAG_REGEX = re.compile(r"([^:]+)(?=:.+)?")
 SERIALIZED_CONTEXT_ENV_VAR = "_F_SS_C"
 
-try:
-    from dataclasses_json import DataClassJsonMixin
-    DataClassBaseClass = DataClassJsonMixin
-except ImportError:
-    DataClassBaseClass = object
 
 @dataclass(init=True, repr=True, eq=True, frozen=True)
 class Image(DataClassBaseClass):

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -960,8 +960,15 @@ class FlyteRemote(object):
 
         additional_context = additional_context or []
 
+        if hasattr(serialization_settings, "to_json"):
+            json_str = serialization_settings.to_json()
+        else:
+            from mashumaro.codecs.json import JSONEncoder
+            encoder = JSONEncoder(SerializationSettings)
+            json_str = encoder.encode(serialization_settings)
+
         h = hashlib.md5(md5_bytes)
-        h.update(bytes(serialization_settings.to_json(), "utf-8"))
+        h.update(bytes(json_str, "utf-8"))
         h.update(bytes(__version__, "utf-8"))
 
         for s in additional_context:


### PR DESCRIPTION
I am going to collaborate with @guyarad, an engineer from `Nimble Way` to finish this.


## Tracking issue
https://github.com/flyteorg/flyte/issues/4418

## Why are the changes needed?
Reduce container's size.

## What changes were proposed in this pull request?


The philosophy of removing dataclasses-json from flytekit but keep ensuring backward compatibility is to try `import dataclasses_json` except `ImportError` for all cases.
When we can't use api from `dataclasses-json`, we can use `mashumaro`.

1. inheritance

example: https://github.com/flyteorg/flytekit/pull/2709/files#diff-542ea91d83fb95892fd56588f09967f76665eed2f6cb40afd1fddde776800875R164-R171

(1) get a new class called `BaseClass`
(2) change every dataclasses with "DataClassJsonMixin" parent class to `BaseClass`

Before
```python
class ImageConfig(DataClassJsonMixin):
```

After
```python
try:
    from dataclasses_json import DataClassJsonMixin
    DataClassBaseClass = DataClassJsonMixin
except ImportError:
    DataClassBaseClass = object

class ImageConfig(BaseClass):
```

2. command line input (click_types)
example: https://github.com/flyteorg/flytekit/pull/2709/commits/fcb49c861ba537f182eaf8f5378d6572de2eabef#diff-cc3172a3cdf60bb2ffb23b81cb5b92d6c4a89063d691e86932b312e1df09f292R317-R328

3. `from_json` and `to_json` functions

example: https://github.com/flyteorg/flytekit/pull/2709/commits/fcb49c861ba537f182eaf8f5378d6572de2eabef#diff-c56afc489e5060224889036253b85ae7c7f1df9f0f7b1130916d9c614293cbb9R963-R968

the `from_json` and `to_json` functions are from `DataClassJsonMixin`
we can should use `decoder.decode(json_str)` when 

```python
if has_attr(from_json):
    return cls.from_json(json_str)
else:
    decoder = JSONDecoder(SerializationSettings)
    return decoder.decode(json_str)
```
```python
if has_attr(to_json):
    json_str = self.to_json()
else:
    encoder = JSONEncoder(SerializationSettings)
    json_str = encoder.encode(self)
```

4. `get_literal_type`

example: https://github.com/flyteorg/flytekit/pull/2709/files#diff-68624e201f644896b015de1a5716eabef9b8b5a106caba1d9f21c51c0708684bR442-R443

from marshmallow_jsonschema import JSONSchema
from mashumaro.jsonschema import build_json_schema

5. `dataclass_json()`
example: https://github.com/flyteorg/flytekit/pull/2709/files#diff-68624e201f644896b015de1a5716eabef9b8b5a106caba1d9f21c51c0708684bR1849-R1853

6. for unit tests, we should use `pytest skip if dataclasses_json` is not in the dependency

7. add CI to test cases when we remove dataclass-json

8. add warning logs when `dataclasses-json` is needed



## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flytekit/pull/2557

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
