### PR TITLE
Make task loading a part of dispatch execute

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 import traceback
 from sys import exit
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import click
 from flyteidl.core import literals_pb2 as _literals_pb2
@@ -72,7 +72,7 @@ def _compute_array_job_index():
 
 def _dispatch_execute(
     ctx: FlyteContext,
-    task_def: PythonTask,
+    load_task: Callable[[], PythonTask],
     inputs_path: str,
     output_prefix: str,
 ):
@@ -86,8 +86,17 @@ def _dispatch_execute(
             c: OR if an unhandled exception is retrieved - record it as an errors.pb
     """
     output_file_dict = {}
-    logger.debug(f"Starting _dispatch_execute for {task_def.name}")
+
+    task_def = None
     try:
+        try:
+            task_def = load_task()
+        except Exception as e:
+            # If the task can not be loaded, then it's most likely a user error. For example,
+            # a dependency is not installed during execution.
+            raise _scoped_exceptions.FlyteScopedUserException(*sys.exc_info()) from e
+
+        logger.debug(f"Starting _dispatch_execute for {task_def.name}")
         # Step1
         local_inputs_file = os.path.join(ctx.execution_state.working_dir, "inputs.pb")
         ctx.file_access.get_data(inputs_path, local_inputs_file)
@@ -163,7 +172,11 @@ def _dispatch_execute(
                 _execution_models.ExecutionError.ErrorKind.SYSTEM,
             )
         )
-        logger.error(f"Exception when executing task {task_def.name or task_def.id.name}, reason {str(e)}")
+        if task_def is not None:
+            logger.error(f"Exception when executing task {task_def.name or task_def.id.name}, reason {str(e)}")
+        else:
+            logger.error(f"Exception when loading_task, reason {str(e)}")
+
         logger.error("!! Begin Unknown System Error Captured by Flyte !!")
         logger.error(exc_str)
         logger.error("!! End Error Captured by Flyte !!")
@@ -174,7 +187,7 @@ def _dispatch_execute(
     ctx.file_access.put_data(ctx.execution_state.engine_dir, output_prefix, is_multipart=True)
     logger.info(f"Engine folder written successfully to the output prefix {output_prefix}")
 
-    if not getattr(task_def, "disable_deck", True):
+    if task_def is not None and not getattr(task_def, "disable_deck", True):
         _output_deck(task_def.name.split(".")[-1], ctx.user_space_params)
 
     logger.debug("Finished _dispatch_execute")
@@ -318,18 +331,6 @@ def setup_execution(
         yield ctx
 
 
-def _handle_annotated_task(
-    ctx: FlyteContext,
-    task_def: PythonTask,
-    inputs: str,
-    output_prefix: str,
-):
-    """
-    Entrypoint for all PythonTask extensions
-    """
-    _dispatch_execute(ctx, task_def, inputs, output_prefix)
-
-
 @_scopes.system_entry_point
 def _execute_task(
     inputs: str,
@@ -381,14 +382,17 @@ def _execute_task(
         if all(os.path.realpath(path) != working_dir for path in sys.path):
             sys.path.append(working_dir)
         resolver_obj = load_object_from_module(resolver)
-        # Use the resolver to load the actual task object
-        _task_def = resolver_obj.load_task(loader_args=resolver_args)
+
+        def load_task():
+            # Use the resolver to load the actual task object
+            return resolver_obj.load_task(loader_args=resolver_args)
+
         if test:
             logger.info(
                 f"Test detected, returning. Args were {inputs} {output_prefix} {raw_output_data_prefix} {resolver} {resolver_args}"
             )
             return
-        _handle_annotated_task(ctx, _task_def, inputs, output_prefix)
+        _dispatch_execute(ctx, load_task, inputs, output_prefix)
 
 
 @_scopes.system_entry_point
@@ -433,7 +437,9 @@ def _execute_map_task(
             sys.path.append(working_dir)
         task_index = _compute_array_job_index()
         mtr = load_object_from_module(resolver)()
-        map_task = mtr.load_task(loader_args=resolver_args, max_concurrency=max_concurrency)
+
+        def load_task():
+            return mtr.load_task(loader_args=resolver_args, max_concurrency=max_concurrency)
 
         # Special case for the map task resolver, we need to append the task index to the output prefix.
         # TODO: (https://github.com/flyteorg/flyte/issues/5011) Remove legacy map task
@@ -448,7 +454,7 @@ def _execute_map_task(
             )
             return
 
-        _handle_annotated_task(ctx, map_task, inputs, output_prefix)
+        _dispatch_execute(ctx, load_task, inputs, output_prefix)
 
 
 def normalize_inputs(


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, if `load_task` raises an error, it is not captured by `_dispatch_execute`. For example, `load_task` can raise import errors if the container environment is not consistent with the registration environment.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
With this PR, the error will be captured by flytekit and written to `error.pb`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I added a unit test to check this change. The other unit tests were updated because `_dispatch_execute`'s signature changed.