### PR TITLE
Use logger.debug when numpy is not found

### DIFF
--- a/flytekit/types/schema/types.py
+++ b/flytekit/types/schema/types.py
@@ -367,7 +367,7 @@ def _get_numpy_type_mappings() -> typing.Dict[Type, SchemaType.SchemaColumn.Sche
             _np.object_: SchemaType.SchemaColumn.SchemaColumnType.STRING,
         }
     except ImportError as e:
-        logger.warning("Numpy not found, skipping numpy type mappings, error: %s", e)
+        logger.debug("Numpy not found, skipping numpy type mappings, error: %s", e)
         return {}
 
 


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
Given that NumPy is not a dependency for `flytekit`, this warning will always show up with the default `flytekit` install.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR changes the logger to use `debug` instead.