### PR TITLE
[Remote] check subworkflows for launch plan nodes

### DIFF
--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -1,5 +1,6 @@
 import datetime
 import typing
+from functools import lru_cache
 
 from flyteidl.admin import common_pb2 as _common_pb2
 from flyteidl.admin import execution_pb2 as _execution_pb2
@@ -337,6 +338,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
             )
         )
 
+    @lru_cache
     def get_launch_plan(self, id):
         """
         Retrieves a launch plan entity.

--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -165,6 +165,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
             str(task_list.token),
         )
 
+    @lru_cache
     def get_task(self, id):
         """
         This returns a single task for a given identifier.
@@ -294,6 +295,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
             str(wf_list.token),
         )
 
+    @lru_cache
     def get_workflow(self, id):
         """
         This returns a single workflow for a given ID.

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2073,7 +2073,6 @@ class FlyteRemote(object):
         encapsulated in this function.
         """
         # For single task execution - the metadata spec node id is missing. In these cases, revert to regular node id
-        print(f"Syncing {execution.id.node_id=} {execution.metadata.spec_node_id=}", flush=True)
         node_id = execution.metadata.spec_node_id
         # This case supports single-task execution compiled workflows.
         if node_id and node_id not in node_mapping and execution.id.node_id in node_mapping:
@@ -2150,15 +2149,10 @@ class FlyteRemote(object):
                             ).spec
 
                 dynamic_flyte_wf = FlyteWorkflow.promote_from_closure(compiled_wf, node_launch_plans)
-                # execution._underlying_node_executions = [
-                #     self.sync_node_execution(FlyteNodeExecution.promote_from_model(cne), dynamic_flyte_wf._node_map)
-                #     for cne in child_node_executions
-                # ]
-                execution._underlying_node_executions = []
-                for cne in child_node_executions:
-                    print(f"Syncing {cne.id}", flush=True)
-                    nodex = self.sync_node_execution(FlyteNodeExecution.promote_from_model(cne), dynamic_flyte_wf._node_map)
-                    execution._underlying_node_executions.append(nodex)
+                execution._underlying_node_executions = [
+                    self.sync_node_execution(FlyteNodeExecution.promote_from_model(cne), dynamic_flyte_wf._node_map)
+                    for cne in child_node_executions
+                ]
                 execution._task_executions = [
                     node_exes.task_executions for node_exes in execution.subworkflow_node_executions.values()
                 ]

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2139,11 +2139,10 @@ class FlyteRemote(object):
                 for template in [compiled_wf.primary.template] + [swf.template for swf in compiled_wf.sub_workflows]:
                     for node in FlyteWorkflow.get_non_system_nodes(template.nodes):
                         if (
-                                node.workflow_node is not None
-                                and node.workflow_node.launchplan_ref is not None
-                                and node.workflow_node.launchplan_ref not in node_launch_plans
+                            node.workflow_node is not None
+                            and node.workflow_node.launchplan_ref is not None
+                            and node.workflow_node.launchplan_ref not in node_launch_plans
                         ):
-                            logger.warning(f"Fetching launch plan {node.workflow_node.launchplan_ref.name}")
                             node_launch_plans[node.workflow_node.launchplan_ref] = self.client.get_launch_plan(
                                 node.workflow_node.launchplan_ref
                             ).spec


### PR DESCRIPTION
## Why are the changes needed?
Launch plans are not included in closures fetched from Admin because they always refer to and are defined by the ones in Admin.  When FlyteRemote scans for launch plan definitions, it should scan for both the primary as well as any subworkflows.

## What changes were proposed in this pull request?
In addition to the primary workflow template, also check subworkflow templates.

* Also add an lru cache to the get launch plan/wf/task call in the friendly clients, ideally we go through all the friendly client functions and cache all the ones that make sense to, but this determination should be done in a separate pr.
  * Note that the lru cache does not cache exceptions, so if the underlying entity is missing, it will not be cached.

## How was this patch tested?
Tested against a live control plane.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
