### PR TITLE
Update eager: make sure client secret can be specified as env var

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -177,13 +177,6 @@ def _dispatch_execute(
     for k, v in output_file_dict.items():
         utils.write_proto_to_file(v.to_flyte_idl(), os.path.join(ctx.execution_state.engine_dir, k))
 
-    # make sure an event loop exists for data persistence step
-    try:
-        asyncio.get_event_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
     ctx.file_access.put_data(ctx.execution_state.engine_dir, output_prefix, is_multipart=True)
     logger.info(f"Engine folder written successfully to the output prefix {output_prefix}")
 

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -108,6 +108,9 @@ def _dispatch_execute(
             # Handle eager-mode (async) tasks
             logger.info("Output is a coroutine")
             outputs = asyncio.run(outputs)
+            # make sure an event loop exists for data persistence step
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
 
         # Step3a
         if isinstance(outputs, VoidPromise):

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -180,7 +180,7 @@ def _dispatch_execute(
     # make sure an event loop exists for data persistence step
     try:
         asyncio.get_event_loop()
-    except Exception:
+    except RuntimeError:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -109,8 +109,11 @@ def _dispatch_execute(
             logger.info("Output is a coroutine")
             outputs = asyncio.run(outputs)
             # make sure an event loop exists for data persistence step
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
+            try:
+                asyncio.get_event_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
 
         # Step3a
         if isinstance(outputs, VoidPromise):

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -108,12 +108,6 @@ def _dispatch_execute(
             # Handle eager-mode (async) tasks
             logger.info("Output is a coroutine")
             outputs = asyncio.run(outputs)
-            # make sure an event loop exists for data persistence step
-            try:
-                asyncio.get_event_loop()
-            except RuntimeError:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
 
         # Step3a
         if isinstance(outputs, VoidPromise):
@@ -182,6 +176,13 @@ def _dispatch_execute(
 
     for k, v in output_file_dict.items():
         utils.write_proto_to_file(v.to_flyte_idl(), os.path.join(ctx.execution_state.engine_dir, k))
+
+    # make sure an event loop exists for data persistence step
+    try:
+        asyncio.get_event_loop()
+    except Exception:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
     ctx.file_access.put_data(ctx.execution_state.engine_dir, output_prefix, is_multipart=True)
     logger.info(f"Engine folder written successfully to the output prefix {output_prefix}")

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -68,15 +68,6 @@ def _compute_array_job_index():
     return offset
 
 
-def _reset_event_loop_if_needed():
-    """Create new event loop if it doesn't exist."""
-    try:
-        asyncio.get_event_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-
 def _dispatch_execute(
     ctx: FlyteContext,
     load_task: Callable[[], PythonTask],
@@ -116,14 +107,13 @@ def _dispatch_execute(
         if inspect.iscoroutine(outputs):
             # Handle eager-mode (async) tasks
             logger.info("Output is a coroutine")
-
-            # make sure event loop exists before running the coroutine
-            _reset_event_loop_if_needed()
-
             outputs = asyncio.run(outputs)
-
             # make sure an event loop exists for data persistence step
-            _reset_event_loop_if_needed()
+            try:
+                asyncio.get_event_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
 
         # Step3a
         if isinstance(outputs, VoidPromise):

--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -528,6 +528,13 @@ def eager(
         signal.signal(signal.SIGTERM, partial(node_cleanup, loop=loop, async_stack=async_stack))
 
         async with eager_context(_fn, _remote, ctx, async_stack, timeout, poll_interval, local_entrypoint):
+            # make sure an event loop exists
+            try:
+                asyncio.get_event_loop()
+            except RuntimeError:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+
             try:
                 if _remote is not None:
                     with _remote.remote_context():

--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -623,6 +623,11 @@ def _internal_remote(
 ) -> FlyteRemote:
     """Derives a FlyteRemote object from a yaml configuration file, modifying parts to make it work internally."""
     secrets_manager = current_context().secrets
+
+    assert (
+        client_secret_group is not None or client_secret_key is not None
+    ), "One of client_secret_group or client_secret_key must be defined when using a remote cluster"
+
     client_secret = secrets_manager.get(client_secret_group, client_secret_key)
     # get the raw output prefix from the context that's set from the pyflyte-execute entrypoint
     # (see flytekit/bin/entrypoint.py)

--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -528,13 +528,6 @@ def eager(
         signal.signal(signal.SIGTERM, partial(node_cleanup, loop=loop, async_stack=async_stack))
 
         async with eager_context(_fn, _remote, ctx, async_stack, timeout, poll_interval, local_entrypoint):
-            # make sure an event loop exists
-            try:
-                asyncio.get_event_loop()
-            except RuntimeError:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-
             try:
                 if _remote is not None:
                     with _remote.remote_context():

--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -622,8 +622,13 @@ def _internal_remote(
     # (see flytekit/bin/entrypoint.py)
 
     if bind_secret_to_env_var is not None:
+        # this creates a remote client where the env var client secret is sufficient for authentication
         os.environ[bind_secret_to_env_var] = client_secret
-        return type(remote)()
+        try:
+            remote_cls = type(remote)
+            return remote_cls()
+        except Exception as exc:
+            raise TypeError(f"Unable to authenticate remote class {remote_cls} with client secret") from exc
 
     ctx = FlyteContextManager.current_context()
     return FlyteRemote(

--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -495,8 +495,7 @@ def eager(
             timeout=timeout,
             poll_interval=poll_interval,
             local_entrypoint=local_entrypoint,
-            client_secret_env_var=client_secret_env_var
-            **kwargs,
+            client_secret_env_var=client_secret_env_var**kwargs,
         )
 
     if local_entrypoint and remote is None:

--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -542,7 +542,10 @@ def eager(
                 await cleanup_fn()
 
     secret_requests = kwargs.pop("secret_requests", None) or []
-    secret_requests.append(Secret(group=client_secret_group, key=client_secret_key))
+    try:
+        secret_requests.append(Secret(group=client_secret_group, key=client_secret_key))
+    except ValueError:
+        pass
 
     return task(
         wrapper,

--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -495,7 +495,7 @@ def eager(
             timeout=timeout,
             poll_interval=poll_interval,
             local_entrypoint=local_entrypoint,
-            client_secret_env_var=client_secret_env_var**kwargs,
+            client_secret_env_var=client_secret_env_var,
         )
 
     if local_entrypoint and remote is None:

--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -632,7 +632,10 @@ def _internal_remote(
         os.environ[client_secret_env_var] = client_secret
         try:
             remote_cls = type(remote)
-            return remote_cls()
+            return remote_cls(
+                default_domain=remote.default_domain,
+                default_project=remote.default_project,
+            )
         except Exception as exc:
             raise TypeError(f"Unable to authenticate remote class {remote_cls} with client secret") from exc
 

--- a/flytekit/experimental/eager_function.py
+++ b/flytekit/experimental/eager_function.py
@@ -496,6 +496,7 @@ def eager(
             poll_interval=poll_interval,
             local_entrypoint=local_entrypoint,
             client_secret_env_var=client_secret_env_var,
+            **kwargs,
         )
 
     if local_entrypoint and remote is None:


### PR DESCRIPTION
## Why are the changes needed?

Currently, the `@eager` workflows are too strict with its handling of the client secret values. Both secret group and key need to be specified for the secret request to be passed down to the underlying task. There is also an issue with the async event loop not being available for the downstream data persistence step in the task execution.

## What changes were proposed in this pull request?

This PR loosens this requirement to be compatible with Flyte backends that do not require secret groups. This PR also:

- Allows the user to bind the client secret to an environment variable in cases where the `FlyteRemote` object can authenticate with just the client secret
- Makes sure that an async loop is available for downstream data persistence step in the task execution

## How was this patch tested?

The following workflow was tested on flyte sandbox
```python
from flytekit import task, ImageSpec
from flytekit.configuration import Config
from flytekit.experimental import eager
from flytekit.remote import FlyteRemote

flytekit = "git+https://github.com/flyteorg/flytekit@54c4471a56311ff8201ba76d9bda726bc5b4689b"

image = ImageSpec(
    name="polars",
    packages=["flytekit", flytekit],
    registry="localhost:30000",
    apt_packages=["git"],
)


@task
def add_one(x: int) -> int:
    return x + 1


@task
def double(x: int) -> int:
    return x * 2


@eager(
    container_image=image,
    remote=FlyteRemote(
        config=Config.for_sandbox(),
        default_project="flytesnacks",
        default_domain="development",
    ),
)
async def simple_eager_workflow(x: int) -> int:
    out = await add_one(x=x)
    if out < 0:
        return -1
    return await double(x=out)

```

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.
