### PR TITLE
Fix: Prevent UnionTransformer type ambiguity in combination with PyTorchTypeTransformer

### DIFF
--- a/flytekit/extras/pytorch/native.py
+++ b/flytekit/extras/pytorch/native.py
@@ -28,6 +28,9 @@ class PyTorchTypeTransformer(TypeTransformer[T]):
         python_type: Type[T],
         expected: LiteralType,
     ) -> Literal:
+        if not isinstance(python_val, torch.Tensor) and not isinstance(python_val, torch.nn.Module):
+            raise TypeTransformerFailedError("Expected a torch.Tensor or nn.Module")
+
         meta = BlobMetadata(
             type=_core_types.BlobType(
                 format=self.PYTORCH_FORMAT,

--- a/tests/flytekit/unit/extras/pytorch/test_transformations.py
+++ b/tests/flytekit/unit/extras/pytorch/test_transformations.py
@@ -7,6 +7,7 @@ import flytekit
 from flytekit import task
 from flytekit.configuration import Image, ImageConfig
 from flytekit.core import context_manager
+from flytekit.core.type_engine import TypeTransformerFailedError
 from flytekit.extras.pytorch import (
     PyTorchCheckpoint,
     PyTorchCheckpointTransformer,
@@ -17,6 +18,7 @@ from flytekit.models.core.types import BlobType
 from flytekit.models.literals import BlobMetadata
 from flytekit.models.types import LiteralType
 from flytekit.tools.translator import get_serializable
+
 
 default_img = Image(name="default", fqn="test", tag="tag")
 serialization_settings = flytekit.configuration.SerializationSettings(
@@ -130,3 +132,25 @@ def test_example_checkpoint():
         task_spec.template.interface.outputs["o0"].type.blob.format
         is PyTorchCheckpointTransformer.PYTORCH_CHECKPOINT_FORMAT
     )
+
+
+def test_to_literal_unambiguity():
+    """Test that the pytorch type transformers raise an error when the input is a list of tensors or modules.
+
+    The PyTorchTypeTransformer uses `torch.save` for serialization which is able to serialize a list of tensors
+    or modules but this causes ambiguity in the Union type transformer as it cannot distinguish whether the
+    ListTransformer should invoke the PyTorchTypeTransformer for every element in the list or the
+    PyTorchTypeTransformer for the entire list.
+    """
+    ctx = context_manager.FlyteContext.current_context()
+
+    with pytest.raises(TypeTransformerFailedError):
+        test_inp = torch.tensor([1, 2, 3])
+        trans = PyTorchTensorTransformer()
+        trans.to_literal(ctx, [test_inp], torch.Tensor, trans.get_literal_type(torch.Tensor))
+
+
+    with pytest.raises(TypeTransformerFailedError):
+        model = torch.nn.Linear(2, 2)
+        trans = PyTorchModuleTransformer()
+        trans.to_literal(ctx, [model], torch.nn.Module, trans.get_literal_type(torch.nn.Module))

--- a/tests/flytekit/unit/extras/pytorch/test_transformations.py
+++ b/tests/flytekit/unit/extras/pytorch/test_transformations.py
@@ -1,10 +1,11 @@
 from collections import OrderedDict
+from typing import Union
 
 import pytest
 import torch
 
 import flytekit
-from flytekit import task
+from flytekit import task, workflow
 from flytekit.configuration import Image, ImageConfig
 from flytekit.core import context_manager
 from flytekit.core.type_engine import TypeTransformerFailedError
@@ -154,3 +155,20 @@ def test_to_literal_unambiguity():
         model = torch.nn.Linear(2, 2)
         trans = PyTorchModuleTransformer()
         trans.to_literal(ctx, [model], torch.nn.Module, trans.get_literal_type(torch.nn.Module))
+
+
+def test_torch_tensor_list_union():
+    """Test that a task can return a union of list of tensor and tensor.
+
+    See test_to_literal_unambiguity for more details why this failed.
+    """
+
+    @task
+    def foo() -> Union[list[torch.Tensor], torch.Tensor]:
+        return [torch.tensor([1, 2, 3])]
+
+    @workflow
+    def wf():
+        foo()
+
+    wf()


### PR DESCRIPTION
## Why are the changes needed?

```py
@task
def foo() -> Union[list[torch.Tensor], torch.Tensor]:
    return [torch.tensor([1, 2, 3])]


@workflow
def wf():
    foo()
```

This example fails with:

```console
TypeError: Failed to convert outputs of task 'wf.foo' at position 0.
Failed to convert type <class 'list'> to type typing.Union[list[torch.Tensor], torch.Tensor].
Error Message: Ambiguous choice of variant for union type.
```

The type transformer choice should, however, not be ambiguous. 

The problem arises as follows:

[Here](https://github.com/flyteorg/flytekit/blob/839f555f497c29bac6f12897697a5a93a182fc8d/flytekit/core/type_engine.py#L1526) in the `UnionTransformer` we test all union variants and raise the observed error if more than one of the union variants work.

In this case, the two union working variants are:

* Call the `ListTransformer` for a list of tensors and then the `PyTorchTensorTransformer` for each element in the list. This is the expected behaviour and does work.
* Call the `PyTorchTensorTransformer` for the list of tensors. This, however, works as well as `torch.save([some_tensor], ...)` works. This is not intended and hence causes the ambiguity.

## What changes were proposed in this pull request?

We need to prevent the pytorch type transformers from serializing lists of tensors or modules since the type engine (i.e. the `UnionTransformer` expects these cases to be handled by the `ListTransformer`).

## How was this patch tested?

Tested with the snippet above and added a unit test that would have caught this.

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
