### PR TITLE
Feat: Optionally use pigz to speed up tarball compression

### DIFF
--- a/docs/source/design/clis.rst
+++ b/docs/source/design/clis.rst
@@ -49,6 +49,10 @@ Suppose you execute a script that defines 10 tasks and a workflow that calls onl
 
 It is considered fast registration because when a script is executed using ``pyflyte run``, the script is bundled up and uploaded to FlyteAdmin. When the task is executed in the backend, this zipped file is extracted and used.
 
+.. note ::
+
+   If `pigz <https://zlib.net/pigz/>`_ is installed, it will be leveraged by ``pyflyte`` to accelerate the compression of the code tarball.
+
 .. _pyflyte-register:
 
 What is ``pyflyte register``?

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -152,8 +152,9 @@ def fast_package(
                 end_time = time.time()
                 warning_time = 30
                 if end_time - start_time > warning_time:
-                    logger.info(
-                        f"Code tarball compression took {end_time - start_time:.0f} seconds. Consider installing `pigz` for faster compression."
+                    click.secho(
+                        f"Code tarball compression took {end_time - start_time:.0f} seconds. Consider installing `pigz` for faster compression.",
+                        fg="yellow",
                     )
 
     # Original tar command - This condition to be removed in the future.
@@ -188,8 +189,9 @@ def fast_package(
                 end_time = time.time()
                 warning_time = 30
                 if end_time - start_time > warning_time:
-                    logger.info(
-                        f"Code tarball compression took {end_time - start_time:.0f} seconds. Consider installing `pigz` for faster compression."
+                    click.secho(
+                        f"Code tarball compression took {end_time - start_time:.0f} seconds. Consider installing `pigz` for faster compression.",
+                        fg="yellow",
                     )
 
     return archive_fname

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -77,6 +77,26 @@ def print_ls_tree(source: os.PathLike, ls: typing.List[str]):
     rich_print(tree_root)
 
 
+def compress_tarball(source: os.PathLike, output: os.PathLike) -> None:
+    """Compress code tarball using pigz if available, otherwise gzip"""
+    if pigz := shutil.which("pigz"):
+        with open(output, "wb") as gzipped:
+            subprocess.run([pigz, "-c", source], stdout=gzipped, check=True)
+    else:
+        start_time = time.time()
+        with gzip.GzipFile(filename=output, mode="wb", mtime=0) as gzipped:
+            with open(source, "rb") as source_file:
+                gzipped.write(source_file.read())
+
+        end_time = time.time()
+        warning_time = 10
+        if end_time - start_time > warning_time:
+            click.secho(
+                f"Code tarball compression took {end_time - start_time:.0f} seconds. Consider installing `pigz` for faster compression.",
+                fg="yellow",
+            )
+
+
 def fast_package(
     source: os.PathLike,
     output_dir: os.PathLike,
@@ -141,22 +161,7 @@ def fast_package(
                         filter=lambda x: tar_strip_file_attributes(x),
                     )
 
-            if shutil.which("pigz"):
-                with open(archive_fname, "wb") as gzipped:
-                    subprocess.run(["pigz", "-c", tar_path], stdout=gzipped, check=True)
-            else:
-                start_time = time.time()
-                with gzip.GzipFile(filename=archive_fname, mode="wb", mtime=0) as gzipped:
-                    with open(tar_path, "rb") as tar_file:
-                        gzipped.write(tar_file.read())
-
-                end_time = time.time()
-                warning_time = 30
-                if end_time - start_time > warning_time:
-                    click.secho(
-                        f"Code tarball compression took {end_time - start_time:.0f} seconds. Consider installing `pigz` for faster compression.",
-                        fg="yellow",
-                    )
+            compress_tarball(tar_path, archive_fname)
 
     # Original tar command - This condition to be removed in the future.
     else:
@@ -179,22 +184,7 @@ def fast_package(
                     )
                 # tar.list(verbose=True)
 
-            if shutil.which("pigz"):
-                with open(archive_fname, "wb") as gzipped:
-                    subprocess.run(["pigz", "-c", tar_path], stdout=gzipped, check=True)
-            else:
-                start_time = time.time()
-                with gzip.GzipFile(filename=archive_fname, mode="wb", mtime=0) as gzipped:
-                    with open(tar_path, "rb") as tar_file:
-                        gzipped.write(tar_file.read())
-
-                end_time = time.time()
-                warning_time = 10
-                if end_time - start_time > warning_time:
-                    click.secho(
-                        f"Code tarball compression took {end_time - start_time:.0f} seconds. Consider installing `pigz` for faster compression.",
-                        fg="yellow",
-                    )
+            compress_tarball(tar_path, archive_fname)
 
     return archive_fname
 

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -142,8 +142,7 @@ def fast_package(
                     )
 
             if shutil.which("pigz"):
-                with open(archive_fname, "wb") as gzipped:
-                    subprocess.run(["pigz", "-c", tar_path], stdout=gzipped)
+                subprocess.run([f"pigz -c {tar_path} > {archive_fname}"], shell=True, check=True)
             else:
                 start_time = time.time()
                 with gzip.GzipFile(filename=archive_fname, mode="wb", mtime=0) as gzipped:
@@ -179,8 +178,7 @@ def fast_package(
                 # tar.list(verbose=True)
 
             if shutil.which("pigz"):
-                with open(archive_fname, "wb") as gzipped:
-                    subprocess.run(["pigz", "-c", tar_path], stdout=gzipped)
+                subprocess.run([f"pigz -c {tar_path} > {archive_fname}"], shell=True, check=True)
             else:
                 start_time = time.time()
                 with gzip.GzipFile(filename=archive_fname, mode="wb", mtime=0) as gzipped:

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -142,7 +142,8 @@ def fast_package(
                     )
 
             if shutil.which("pigz"):
-                subprocess.run([f"pigz -c {tar_path} > {archive_fname}"], shell=True, check=True)
+                with open(archive_fname, "wb") as gzipped:
+                    subprocess.run(["pigz", "-c", tar_path], stdout=gzipped)
             else:
                 start_time = time.time()
                 with gzip.GzipFile(filename=archive_fname, mode="wb", mtime=0) as gzipped:
@@ -179,7 +180,8 @@ def fast_package(
                 # tar.list(verbose=True)
 
             if shutil.which("pigz"):
-                subprocess.run([f"pigz -c {tar_path} > {archive_fname}"], shell=True, check=True)
+                with open(archive_fname, "wb") as gzipped:
+                    subprocess.run(["pigz", "-c", tar_path], stdout=gzipped)
             else:
                 start_time = time.time()
                 with gzip.GzipFile(filename=archive_fname, mode="wb", mtime=0) as gzipped:

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -143,7 +143,7 @@ def fast_package(
 
             if shutil.which("pigz"):
                 with open(archive_fname, "wb") as gzipped:
-                    subprocess.run(["pigz", "-c", tar_path], stdout=gzipped)
+                    subprocess.run(["pigz", "-c", tar_path], stdout=gzipped, check=True)
             else:
                 start_time = time.time()
                 with gzip.GzipFile(filename=archive_fname, mode="wb", mtime=0) as gzipped:
@@ -181,7 +181,7 @@ def fast_package(
 
             if shutil.which("pigz"):
                 with open(archive_fname, "wb") as gzipped:
-                    subprocess.run(["pigz", "-c", tar_path], stdout=gzipped)
+                    subprocess.run(["pigz", "-c", tar_path], stdout=gzipped, check=True)
             else:
                 start_time = time.time()
                 with gzip.GzipFile(filename=archive_fname, mode="wb", mtime=0) as gzipped:

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -5,10 +5,12 @@ import hashlib
 import os
 import pathlib
 import posixpath
+import shutil
 import subprocess
 import sys
 import tarfile
 import tempfile
+import time
 import typing
 from dataclasses import dataclass
 from enum import Enum
@@ -139,9 +141,21 @@ def fast_package(
                         filter=lambda x: tar_strip_file_attributes(x),
                     )
 
-            with gzip.GzipFile(filename=archive_fname, mode="wb", mtime=0) as gzipped:
-                with open(tar_path, "rb") as tar_file:
-                    gzipped.write(tar_file.read())
+            if shutil.which("pigz"):
+                with open(archive_fname, "wb") as gzipped:
+                    subprocess.run(["pigz", "-c", tar_path], stdout=gzipped)
+            else:
+                start_time = time.time()
+                with gzip.GzipFile(filename=archive_fname, mode="wb", mtime=0) as gzipped:
+                    with open(tar_path, "rb") as tar_file:
+                        gzipped.write(tar_file.read())
+
+                end_time = time.time()
+                warning_time = 30
+                if end_time - start_time > warning_time:
+                    logger.info(
+                        f"Code tarball compression took {end_time - start_time:.0f} seconds. Consider installing `pigz` for faster compression."
+                    )
 
     # Original tar command - This condition to be removed in the future.
     else:
@@ -164,9 +178,21 @@ def fast_package(
                     )
                 # tar.list(verbose=True)
 
-            with gzip.GzipFile(filename=archive_fname, mode="wb", mtime=0) as gzipped:
-                with open(tar_path, "rb") as tar_file:
-                    gzipped.write(tar_file.read())
+            if shutil.which("pigz"):
+                with open(archive_fname, "wb") as gzipped:
+                    subprocess.run(["pigz", "-c", tar_path], stdout=gzipped)
+            else:
+                start_time = time.time()
+                with gzip.GzipFile(filename=archive_fname, mode="wb", mtime=0) as gzipped:
+                    with open(tar_path, "rb") as tar_file:
+                        gzipped.write(tar_file.read())
+
+                end_time = time.time()
+                warning_time = 30
+                if end_time - start_time > warning_time:
+                    logger.info(
+                        f"Code tarball compression took {end_time - start_time:.0f} seconds. Consider installing `pigz` for faster compression."
+                    )
 
     return archive_fname
 

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -187,7 +187,7 @@ def fast_package(
                         gzipped.write(tar_file.read())
 
                 end_time = time.time()
-                warning_time = 30
+                warning_time = 10
                 if end_time - start_time > warning_time:
                     click.secho(
                         f"Code tarball compression took {end_time - start_time:.0f} seconds. Consider installing `pigz` for faster compression.",


### PR DESCRIPTION
## Why are the changes needed?

In an (admittedly large) repository, fast registration has become quite slow for us. The culprit appears to be the compression of the code tarball which I have observed to take up to a minute. (I'm already ignoring non-relevant parts of the code base using a `.flyteignore`.)

## What changes were proposed in this pull request?

In the fast package helper, where we currently compress the code tarball using cpython's `gzip`, I propose to check whether the user has [`pigz`](https://zlib.net/pigz/) installed and if yes, leverage it to speed up the compression.

In our case, I'm seeing a speedup from ~60s to ~1-2s.

I expect that the majority of users will not run into these performance issues but for those that might, I propose to add a log message with a hint to install `pigz` in case the default compression mechanism takes to long.

I see that you recently refactored the fast registration logic @wild-endeavor, what do you think about this proposal?


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.