### PR TITLE
Fix backfill command

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -781,9 +781,13 @@ class FlyteRemote(object):
         # serial register
         cp_other_entities = OrderedDict(filter(lambda x: not isinstance(x[1], task_models.TaskSpec), m.items()))
         for entity, cp_entity in cp_other_entities.items():
-            identifiers_or_exceptions.append(
-                self.raw_register(cp_entity, serialization_settings, version, og_entity=entity)
-            )
+            try:
+                identifiers_or_exceptions.append(
+                    self.raw_register(cp_entity, serialization_settings, version, og_entity=entity)
+                )
+            except RegistrationSkipped as e:
+                logger.info(f"Skipping registration... {e}")
+                continue
         return identifiers_or_exceptions[-1]
 
     def register_task(


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Failed to run backfill command

```bash
│    785 │   │   │   │   identifiers_or_exceptions.append(                                         │
│ ❱  786 │   │   │   │   │   self.raw_register(cp_entity, serialization_settings, version, og_ent  │
│    787 │   │   │   │   )                                                                         │
│    788 │   │   │   except RegistrationSkipped as e:                                              │
│    789 │   │   │   │   logger.info(f"Skipping registration... {e}")                              │
│                                                                                                  │
│ /Users/kevin/git/flytekit/flytekit/remote/remote.py:661 in raw_register                          │
│                                                                                                  │
│    658 │   │   │   │   │   raise RegistrationSkipped(f"Remote task/Workflow {cp_entity.name} is  │
│    659 │   │   │   else:                                                                         │
│    660 │   │   │   │   logger.debug(f"Skipping registration of remote entity: {cp_entity.name}"  │
│ ❱  661 │   │   │   │   raise RegistrationSkipped(f"Remote entity {cp_entity.name} is not regist  │
│    662 │   │                                                                                     │
│    663 │   │   if isinstance(                                                                    │
│    664 │   │   │   cp_entity,                                                                    │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
RegistrationSkipped: Remote entity pyl510_lp is not registrable.

```

## What changes were proposed in this pull request?
Ignore RegistrationSkipped error during registration

## How was this patch tested?
```
pyflyte -v backfill --from-date "2023-10-27 15:30:00" --to-date "2023-10-29 16:40:00"  pyl510_lp
```

### Setup process

### Screenshots
![Screenshot 2024-09-04 at 2 38 05 PM](https://github.com/user-attachments/assets/7a398dce-fa93-407a-bb65-fcfc86948cd8)


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
