### PR TITLE
Imgspec/copy auto

### DIFF
--- a/flytekit/clis/sdk_in_container/helpers.py
+++ b/flytekit/clis/sdk_in_container/helpers.py
@@ -4,10 +4,9 @@ from typing import Optional
 import rich_click as click
 
 from flytekit.clis.sdk_in_container.constants import CTX_CONFIG_FILE
-from flytekit.configuration import ImageConfig
+from flytekit.configuration import ImageConfig, CopyFileDetection
 from flytekit.configuration.plugin import get_plugin
 from flytekit.remote.remote import FlyteRemote
-from flytekit.tools.fast_registration import CopyFileDetection
 
 FLYTE_REMOTE_INSTANCE_KEY = "flyte_remote"
 

--- a/flytekit/clis/sdk_in_container/helpers.py
+++ b/flytekit/clis/sdk_in_container/helpers.py
@@ -4,8 +4,9 @@ from typing import Optional
 import rich_click as click
 
 from flytekit.clis.sdk_in_container.constants import CTX_CONFIG_FILE
-from flytekit.configuration import ImageConfig, CopyFileDetection
+from flytekit.configuration import ImageConfig
 from flytekit.configuration.plugin import get_plugin
+from flytekit.constants import CopyFileDetection
 from flytekit.remote.remote import FlyteRemote
 
 FLYTE_REMOTE_INSTANCE_KEY = "flyte_remote"

--- a/flytekit/clis/sdk_in_container/package.py
+++ b/flytekit/clis/sdk_in_container/package.py
@@ -10,10 +10,10 @@ from flytekit.configuration import (
     DEFAULT_RUNTIME_PYTHON_INTERPRETER,
     FastSerializationSettings,
     ImageConfig,
-    SerializationSettings,
+    SerializationSettings, CopyFileDetection,
 )
 from flytekit.interaction.click_types import key_value_callback
-from flytekit.tools.fast_registration import CopyFileDetection, FastPackageOptions
+from flytekit.tools.fast_registration import FastPackageOptions
 from flytekit.tools.repo import NoSerializableEntitiesError, serialize_and_package
 
 

--- a/flytekit/clis/sdk_in_container/package.py
+++ b/flytekit/clis/sdk_in_container/package.py
@@ -10,8 +10,9 @@ from flytekit.configuration import (
     DEFAULT_RUNTIME_PYTHON_INTERPRETER,
     FastSerializationSettings,
     ImageConfig,
-    SerializationSettings, CopyFileDetection,
+    SerializationSettings,
 )
+from flytekit.constants import CopyFileDetection
 from flytekit.interaction.click_types import key_value_callback
 from flytekit.tools.fast_registration import FastPackageOptions
 from flytekit.tools.repo import NoSerializableEntitiesError, serialize_and_package

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -11,12 +11,11 @@ from flytekit.clis.sdk_in_container.helpers import (
     patch_image_config,
 )
 from flytekit.clis.sdk_in_container.utils import domain_option_dec, project_option_dec
-from flytekit.configuration import ImageConfig
+from flytekit.configuration import ImageConfig, CopyFileDetection
 from flytekit.configuration.default_images import DefaultImages
 from flytekit.interaction.click_types import key_value_callback
 from flytekit.loggers import logger
 from flytekit.tools import repo
-from flytekit.tools.fast_registration import CopyFileDetection
 
 _register_help = """
 This command is similar to ``package`` but instead of producing a zip file, all your Flyte entities are compiled,

--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -11,8 +11,9 @@ from flytekit.clis.sdk_in_container.helpers import (
     patch_image_config,
 )
 from flytekit.clis.sdk_in_container.utils import domain_option_dec, project_option_dec
-from flytekit.configuration import ImageConfig, CopyFileDetection
+from flytekit.configuration import ImageConfig
 from flytekit.configuration.default_images import DefaultImages
+from flytekit.constants import CopyFileDetection
 from flytekit.interaction.click_types import key_value_callback
 from flytekit.loggers import logger
 from flytekit.tools import repo

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -35,9 +35,10 @@ from flytekit.configuration import (
     DefaultImages,
     FastSerializationSettings,
     ImageConfig,
-    SerializationSettings, CopyFileDetection,
+    SerializationSettings,
 )
 from flytekit.configuration.plugin import get_plugin
+from flytekit.constants import CopyFileDetection
 from flytekit.core import context_manager
 from flytekit.core.artifact import ArtifactQuery
 from flytekit.core.base_task import PythonTask

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -35,7 +35,7 @@ from flytekit.configuration import (
     DefaultImages,
     FastSerializationSettings,
     ImageConfig,
-    SerializationSettings,
+    SerializationSettings, CopyFileDetection,
 )
 from flytekit.configuration.plugin import get_plugin
 from flytekit.core import context_manager
@@ -66,7 +66,7 @@ from flytekit.remote import (
 )
 from flytekit.remote.executions import FlyteWorkflowExecution
 from flytekit.tools import module_loader
-from flytekit.tools.fast_registration import CopyFileDetection, FastPackageOptions
+from flytekit.tools.fast_registration import FastPackageOptions
 from flytekit.tools.script_mode import _find_project_root, compress_scripts, get_all_modules
 from flytekit.tools.translator import Options
 

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -139,7 +139,6 @@ import re
 import tempfile
 import typing
 from dataclasses import dataclass, field
-from enum import Enum
 from io import BytesIO
 from typing import Dict, List, Optional
 
@@ -984,14 +983,3 @@ class SerializationSettings(DataClassJsonMixin):
                 fast_serialization_settings=self.fast_serialization_settings,
                 source_root=self.source_root,
             )
-
-
-class CopyFileDetection(Enum):
-    LOADED_MODULES = 1
-    ALL = 2
-    # This option's meaning will change in the future. In the future this will mean that no files should be copied
-    # (i.e. no fast registration is used). For now, both this value and setting this Enum to Python None are both
-    # valid to distinguish between users explicitly setting --copy none and not setting the flag.
-    # Currently, this is only used for register, not for package or run because run doesn't have a no-fast-register
-    # option and package is by default non-fast.
-    NO_COPY = 3

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -139,6 +139,7 @@ import re
 import tempfile
 import typing
 from dataclasses import dataclass, field
+from enum import Enum
 from io import BytesIO
 from typing import Dict, List, Optional
 
@@ -983,3 +984,14 @@ class SerializationSettings(DataClassJsonMixin):
                 fast_serialization_settings=self.fast_serialization_settings,
                 source_root=self.source_root,
             )
+
+
+class CopyFileDetection(Enum):
+    LOADED_MODULES = 1
+    ALL = 2
+    # This option's meaning will change in the future. In the future this will mean that no files should be copied
+    # (i.e. no fast registration is used). For now, both this value and setting this Enum to Python None are both
+    # valid to distinguish between users explicitly setting --copy none and not setting the flag.
+    # Currently, this is only used for register, not for package or run because run doesn't have a no-fast-register
+    # option and package is by default non-fast.
+    NO_COPY = 3

--- a/flytekit/constants/__init__.py
+++ b/flytekit/constants/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from enum import Enum
+
+
+class CopyFileDetection(Enum):
+    LOADED_MODULES = 1
+    ALL = 2
+    # This option's meaning will change in the future. In the future this will mean that no files should be copied
+    # (i.e. no fast registration is used). For now, both this value and setting this Enum to Python None are both
+    # valid to distinguish between users explicitly setting --copy none and not setting the flag.
+    # Currently, this is only used for register, not for package or run because run doesn't have a no-fast-register
+    # option and package is by default non-fast.
+    NO_COPY = 3

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -3,6 +3,7 @@ import typing
 from enum import Enum
 from typing import Any, Dict, List, Optional, OrderedDict, Tuple, Type
 
+import flytekit.configuration
 from flytekit.configuration import SerializationSettings
 from flytekit.core.base_task import PythonTask, TaskMetadata
 from flytekit.core.context_manager import FlyteContext
@@ -16,6 +17,8 @@ from flytekit.loggers import logger
 from flytekit.models import task as _task_model
 from flytekit.models.literals import LiteralMap
 from flytekit.models.security import Secret, SecurityContext
+
+flytekit.configuration.CopyFileDetection
 
 _PRIMARY_CONTAINER_NAME_FIELD = "primary_container_name"
 DOCKER_IMPORT_ERROR_MESSAGE = "Docker is not installed. Please install Docker by running `pip install docker`."
@@ -279,6 +282,9 @@ class ContainerTask(PythonTask):
         )
 
     def _get_image(self, settings: SerializationSettings) -> str:
+        # This is where the relationship between fast register and imagespec is set
+        # If fast register is not enabled, then source root is used.
+        # and then files are copied.
         if settings.fast_serialization_settings is None or not settings.fast_serialization_settings.enabled:
             if isinstance(self._image, ImageSpec):
                 # Set the source root for the image spec if it's non-fast registration

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -168,6 +168,11 @@ def create_docker_context(image_spec: ImageSpec, tmp_dir: Path):
     if image_spec.source_root:
         source_path = tmp_dir / "src"
 
+        """
+        Basically if slow register is specified, then files are copied.
+        Currently files are copied from the source root in their entirety. Need to be able to use auto by default
+        as well as somehow specify all. 
+        """
         ignore = IgnoreGroup(image_spec.source_root, [GitIgnore, DockerIgnore, StandardIgnore])
         shutil.copytree(
             image_spec.source_root,

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -56,7 +56,7 @@ class ImageSpec:
     name: str = "flytekit"
     python_version: str = None  # Use default python in the base image if None.
     builder: Optional[str] = None
-    source_root: Optional[str] = None
+    source_root: Optional[str] = None  # a.txt:auto
     env: Optional[typing.Dict[str, str]] = None
     registry: Optional[str] = None
     packages: Optional[List[str]] = None

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -11,13 +11,13 @@ import tarfile
 import tempfile
 import typing
 from dataclasses import dataclass
-from enum import Enum
 from typing import Optional
 
 import click
 from rich import print as rich_print
 from rich.tree import Tree
 
+from flytekit.configuration import CopyFileDetection
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.utils import timeit
 from flytekit.exceptions.user import FlyteDataNotFoundException
@@ -27,17 +27,6 @@ from flytekit.tools.script_mode import _filehash_update, _pathhash_update, ls_fi
 
 FAST_PREFIX = "fast"
 FAST_FILEENDING = ".tar.gz"
-
-
-class CopyFileDetection(Enum):
-    LOADED_MODULES = 1
-    ALL = 2
-    # This option's meaning will change in the future. In the future this will mean that no files should be copied
-    # (i.e. no fast registration is used). For now, both this value and setting this Enum to Python None are both
-    # valid to distinguish between users explicitly setting --copy none and not setting the flag.
-    # Currently, this is only used for register, not for package or run because run doesn't have a no-fast-register
-    # option and package is by default non-fast.
-    NO_COPY = 3
 
 
 @dataclass(frozen=True)
@@ -106,7 +95,7 @@ def fast_package(
     # This function is temporarily split into two, to support the creation of the tar file in both the old way,
     # copying the underlying items in the source dir by doing a listdir, and the new way, relying on a list of files.
     if options and (
-        options.copy_style == CopyFileDetection.LOADED_MODULES or options.copy_style == CopyFileDetection.ALL
+            options.copy_style == CopyFileDetection.LOADED_MODULES or options.copy_style == CopyFileDetection.ALL
     ):
         if options.copy_style == CopyFileDetection.LOADED_MODULES:
             # This is the 'auto' semantic by default used for pyflyte run, it only copies loaded .py files.

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -17,7 +17,7 @@ import click
 from rich import print as rich_print
 from rich.tree import Tree
 
-from flytekit.configuration import CopyFileDetection
+from flytekit.constants import CopyFileDetection
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.utils import timeit
 from flytekit.exceptions.user import FlyteDataNotFoundException
@@ -95,7 +95,7 @@ def fast_package(
     # This function is temporarily split into two, to support the creation of the tar file in both the old way,
     # copying the underlying items in the source dir by doing a listdir, and the new way, relying on a list of files.
     if options and (
-            options.copy_style == CopyFileDetection.LOADED_MODULES or options.copy_style == CopyFileDetection.ALL
+        options.copy_style == CopyFileDetection.LOADED_MODULES or options.copy_style == CopyFileDetection.ALL
     ):
         if options.copy_style == CopyFileDetection.LOADED_MODULES:
             # This is the 'auto' semantic by default used for pyflyte run, it only copies loaded .py files.

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import click
 
+import flytekit.configuration
 from flytekit.configuration import FastSerializationSettings, ImageConfig, SerializationSettings
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.loggers import logger
@@ -235,7 +236,7 @@ def register(
     fast: bool,
     package_or_module: typing.Tuple[str],
     remote: FlyteRemote,
-    copy_style: typing.Optional[fast_registration.CopyFileDetection],
+    copy_style: typing.Optional[flytekit.configuration.CopyFileDetection],
     env: typing.Optional[typing.Dict[str, str]],
     dry_run: bool = False,
     activate_launchplans: bool = False,

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import click
 
 import flytekit.configuration
+import flytekit.constants
 from flytekit.configuration import FastSerializationSettings, ImageConfig, SerializationSettings
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.loggers import logger
@@ -236,7 +237,7 @@ def register(
     fast: bool,
     package_or_module: typing.Tuple[str],
     remote: FlyteRemote,
-    copy_style: typing.Optional[flytekit.configuration.CopyFileDetection],
+    copy_style: typing.Optional[flytekit.constants.CopyFileDetection],
     env: typing.Optional[typing.Dict[str, str]],
     dry_run: bool = False,
     activate_launchplans: bool = False,

--- a/tests/flytekit/unit/cli/test_cli_helpers.py
+++ b/tests/flytekit/unit/cli/test_cli_helpers.py
@@ -10,7 +10,7 @@ from flyteidl.core.identifier_pb2 import LAUNCH_PLAN
 from flytekit.clis import helpers
 from flytekit.clis.helpers import _hydrate_identifier, _hydrate_workflow_template_nodes, hydrate_registration_parameters
 from flytekit.clis.sdk_in_container.helpers import parse_copy
-from flytekit.configuration import CopyFileDetection
+from flytekit.constants import CopyFileDetection
 
 
 def test_parse_args_into_dict():

--- a/tests/flytekit/unit/cli/test_cli_helpers.py
+++ b/tests/flytekit/unit/cli/test_cli_helpers.py
@@ -10,7 +10,7 @@ from flyteidl.core.identifier_pb2 import LAUNCH_PLAN
 from flytekit.clis import helpers
 from flytekit.clis.helpers import _hydrate_identifier, _hydrate_workflow_template_nodes, hydrate_registration_parameters
 from flytekit.clis.sdk_in_container.helpers import parse_copy
-from flytekit.tools.fast_registration import CopyFileDetection
+from flytekit.configuration import CopyFileDetection
 
 
 def test_parse_args_into_dict():

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -14,8 +14,6 @@ REGISTRY_CONFIG_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 
 
 def test_uilkj():
-
-
     image_spec = ImageSpec(
         name="FLYTEKIT",
         builder="dummy",

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -13,6 +13,80 @@ REQUIREMENT_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "re
 REGISTRY_CONFIG_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "registry_config.json")
 
 
+def test_uilkj():
+
+
+    image_spec = ImageSpec(
+        name="FLYTEKIT",
+        builder="dummy",
+        packages=["pandas"],
+        apt_packages=["git"],
+        python_version="3.8",
+        registry="localhost:30001",
+        # base_image=base_image,
+        cuda="11.2.2",
+        cudnn="8",
+        requirements=REQUIREMENT_FILE,
+        registry_config=REGISTRY_CONFIG_FILE,
+        entrypoint=["/bin/bash"],
+    )
+    print(f"{image_spec.id=}")
+    print(f"{image_spec.tag=}")
+
+    @task(image_spec)
+    def t1(): ...
+
+    # cat > requirements.txt: add pandas
+    #
+
+    """
+    when you do non-fast register, package, serialize, with ImageSpec
+        * by default, the entire source root is copied into the image
+        * source root of IS, is set to SS.local source root
+
+    (add copy auto functionality)
+    non-fast register but copy auto for image spec
+    
+    (make sure this is still true)
+    when you do --copy none register, package, serialize, with ImageSpec
+        * by default, the entire source root is copied into the image
+
+    
+    when you do fast register, package, serialize, run
+        * no files copied into the image
+    
+    
+    """
+
+    image_spec2 = ImageSpec(
+        name="FLYTEKIT",
+        builder="dummy",
+        packages=["pandas"],
+        apt_packages=["git"],
+        python_version="3.8",
+        registry="localhost:30001",
+        # base_image=base_image,
+        cuda="11.2.2",
+        cudnn="8",
+        requirements=REQUIREMENT_FILE,
+        registry_config=REGISTRY_CONFIG_FILE,
+        source_root=".",
+        entrypoint=["/bin/bash"],
+    )
+    print(f"{image_spec2.id=}")
+    print(f"{image_spec2.tag=}")
+
+    @task(image_spec2)
+    def t2(): ...
+
+    # {image_specs.id: image_specs.tag}
+
+    # remote.register t1
+
+    # remote.register t2
+
+
+
 def test_image_spec(mock_image_spec_builder, monkeypatch):
     base_image = ImageSpec(name="base", builder="dummy", base_image="base_image")
 

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -13,7 +13,7 @@ REQUIREMENT_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "re
 REGISTRY_CONFIG_FILE = os.path.join(os.path.dirname(os.path.realpath(__file__)), "registry_config.json")
 
 
-def test_uilkj():
+def test_pr_notes():
     image_spec = ImageSpec(
         name="FLYTEKIT",
         builder="dummy",
@@ -37,23 +37,7 @@ def test_uilkj():
     # cat > requirements.txt: add pandas
     #
 
-    """
-    when you do non-fast register, package, serialize, with ImageSpec
-        * by default, the entire source root is copied into the image
-        * source root of IS, is set to SS.local source root
-
-    (add copy auto functionality)
-    non-fast register but copy auto for image spec
-    
-    (make sure this is still true)
-    when you do --copy none register, package, serialize, with ImageSpec
-        * by default, the entire source root is copied into the image
-
-    
-    when you do fast register, package, serialize, run
-        * no files copied into the image
-    
-    
+    """    
     """
 
     image_spec2 = ImageSpec(
@@ -224,3 +208,6 @@ def test_image_spec_validation_string_list(parameter_name, value):
 
     with pytest.raises(ValueError, match=msg):
         ImageSpec(**input_params)
+
+
+# test update_image_spec_copy_handling


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
    ImageSpec, added a copy option. Note that this is the first time ImageSpec has a non-primitive option. Think it's
    okay but wanted to be aware of it.
    
    NB the tag property changed based on when the new update function is called in relation to it. Also true for the
      id property. Is there a way around this?  We can make update_image_spec_copy_handling not mutate, but that also
      doesn't work since tag/id need correct source_root/copy in order to correctly compute the tag.
      Basically the question is how to make sure serialization settings has been taken into account before these
      two properties are called. 
    
    guidelines for how to raise errors while developing flytekit
    
    moved the logic that modifies ImageSpec common to ContainerTask and PythonAutoContainerTask to a helper function
    
    deref symlink behavior
    
    when you do non-fast register, package, serialize, with ImageSpec
        * by default, the entire source root is copied into the image
        * source root of IS, is set to SS.local source root

    (add copy auto functionality)
    non-fast register but copy auto for image spec
    
    (make sure this is still true)
    when you do --copy none register, package, serialize, with ImageSpec
        * by default, the entire source root is copied into the image

    
    when you do fast register, package, serialize, run
        * no files copied into the image
    

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
