### PR TITLE
Deduce cache version iff `cache_version` is not set

### DIFF
--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -143,8 +143,6 @@ class TaskMetadata(object):
                 self.timeout = datetime.timedelta(seconds=self.timeout)
             elif not isinstance(self.timeout, datetime.timedelta):
                 raise ValueError("timeout should be duration represented as either a datetime.timedelta or int seconds")
-        if self.cache and not self.cache_version:
-            raise ValueError("Caching is enabled ``cache=True`` but ``cache_version`` is not set.")
         if self.cache_serialize and not self.cache:
             raise ValueError("Cache serialize is enabled ``cache_serialize=True`` but ``cache`` is not enabled.")
         if self.cache_ignore_input_vars and not self.cache:


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/770

## Why are the changes needed?
We should decrease the burden to use a cache in the case of python tasks.

## What changes were proposed in this pull request?
This PR calls [inspect.getsource](https://docs.python.org/3/library/inspect.html#inspect.getsource) passing the task function as an argument, which loads the actual source code of the function and use that to use generate a string to represent the cache version.

Notice that any change to the function (including adding/removing a parameter, changing the docstring, rearranging/reindenting some code) is going to produce a new value. In other words, the function can be moved around in a file, but its contents cannot change, otherwise a new value is going to be generated.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Unit tests and local executions.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
