### PR TITLE
GH-5732: Make `TypeEngine.lazy_import_transformers()` thread safe

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -9,8 +9,8 @@ import inspect
 import json
 import mimetypes
 import sys
-import threading
 import textwrap
+import threading
 import typing
 from abc import ABC, abstractmethod
 from collections import OrderedDict

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -9,6 +9,7 @@ import inspect
 import json
 import mimetypes
 import sys
+import threading
 import textwrap
 import typing
 from abc import ABC, abstractmethod
@@ -842,6 +843,7 @@ class TypeEngine(typing.Generic[T]):
     _DATACLASS_TRANSFORMER: TypeTransformer = DataclassTransformer()  # type: ignore
     _ENUM_TRANSFORMER: TypeTransformer = EnumTransformer()  # type: ignore
     has_lazy_import = False
+    lazy_import_lock = threading.Lock()
 
     @classmethod
     def register(
@@ -995,51 +997,55 @@ class TypeEngine(typing.Generic[T]):
         """
         Only load the transformers if needed.
         """
-        if cls.has_lazy_import:
-            return
-        from flytekit.types.structured import (
-            register_arrow_handlers,
-            register_bigquery_handlers,
-            register_pandas_handlers,
-            register_snowflake_handlers,
-        )
-        from flytekit.types.structured.structured_dataset import DuplicateHandlerError
+        with cls.lazy_import_lock:
+            # Avoid a race condition where concurrent threads may exit lazy_import_transformers before the transformers
+            # have been imported. This could be implemented without a lock if you assume python assignments are atomic
+            # and re-registering transformers is acceptable, but I decided to play it safe.
+            if cls.has_lazy_import:
+                return
+            cls.has_lazy_import = True
+            from flytekit.types.structured import (
+                register_arrow_handlers,
+                register_bigquery_handlers,
+                register_pandas_handlers,
+                register_snowflake_handlers,
+            )
+            from flytekit.types.structured.structured_dataset import DuplicateHandlerError
 
-        if is_imported("tensorflow"):
-            from flytekit.extras import tensorflow  # noqa: F401
-        if is_imported("torch"):
-            from flytekit.extras import pytorch  # noqa: F401
-        if is_imported("sklearn"):
-            from flytekit.extras import sklearn  # noqa: F401
-        if is_imported("pandas"):
-            try:
-                from flytekit.types.schema.types_pandas import PandasSchemaReader, PandasSchemaWriter  # noqa: F401
-            except ValueError:
-                logger.debug("Transformer for pandas is already registered.")
-            try:
-                register_pandas_handlers()
-            except DuplicateHandlerError:
-                logger.debug("Transformer for pandas is already registered.")
-        if is_imported("pyarrow"):
-            try:
-                register_arrow_handlers()
-            except DuplicateHandlerError:
-                logger.debug("Transformer for arrow is already registered.")
-        if is_imported("google.cloud.bigquery"):
-            try:
-                register_bigquery_handlers()
-            except DuplicateHandlerError:
-                logger.debug("Transformer for bigquery is already registered.")
-        if is_imported("numpy"):
-            from flytekit.types import numpy  # noqa: F401
-        if is_imported("PIL"):
-            from flytekit.types.file import image  # noqa: F401
-        if is_imported("snowflake.connector"):
-            try:
-                register_snowflake_handlers()
-            except DuplicateHandlerError:
-                logger.debug("Transformer for snowflake is already registered.")
-        cls.has_lazy_import = True
+            if is_imported("tensorflow"):
+                from flytekit.extras import tensorflow  # noqa: F401
+            if is_imported("torch"):
+                from flytekit.extras import pytorch  # noqa: F401
+            if is_imported("sklearn"):
+                from flytekit.extras import sklearn  # noqa: F401
+            if is_imported("pandas"):
+                try:
+                    from flytekit.types.schema.types_pandas import PandasSchemaReader, PandasSchemaWriter  # noqa: F401
+                except ValueError:
+                    logger.debug("Transformer for pandas is already registered.")
+                try:
+                    register_pandas_handlers()
+                except DuplicateHandlerError:
+                    logger.debug("Transformer for pandas is already registered.")
+            if is_imported("pyarrow"):
+                try:
+                    register_arrow_handlers()
+                except DuplicateHandlerError:
+                    logger.debug("Transformer for arrow is already registered.")
+            if is_imported("google.cloud.bigquery"):
+                try:
+                    register_bigquery_handlers()
+                except DuplicateHandlerError:
+                    logger.debug("Transformer for bigquery is already registered.")
+            if is_imported("numpy"):
+                from flytekit.types import numpy  # noqa: F401
+            if is_imported("PIL"):
+                from flytekit.types.file import image  # noqa: F401
+            if is_imported("snowflake.connector"):
+                try:
+                    register_snowflake_handlers()
+                except DuplicateHandlerError:
+                    logger.debug("Transformer for snowflake is already registered.")
 
     @classmethod
     def to_literal_type(cls, python_type: Type) -> LiteralType:

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -997,7 +997,6 @@ class TypeEngine(typing.Generic[T]):
         """
         if cls.has_lazy_import:
             return
-        cls.has_lazy_import = True
         from flytekit.types.structured import (
             register_arrow_handlers,
             register_bigquery_handlers,
@@ -1040,6 +1039,7 @@ class TypeEngine(typing.Generic[T]):
                 register_snowflake_handlers()
             except DuplicateHandlerError:
                 logger.debug("Transformer for snowflake is already registered.")
+        cls.has_lazy_import = True
 
     @classmethod
     def to_literal_type(cls, python_type: Type) -> LiteralType:

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -3251,7 +3251,7 @@ def test_dataclass_none_output_input_deserialization():
 
 @pytest.mark.serial
 def test_lazy_import_transformers_concurrently():
-    # Ensure that next call to TypeEngine.lazy_import_transformers doesn't skip the import. Mark as serial to ensure 
+    # Ensure that next call to TypeEngine.lazy_import_transformers doesn't skip the import. Mark as serial to ensure
     # this achieves what we expect.
     TypeEngine.has_lazy_import = False
 

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -3274,6 +3274,4 @@ def test_lazy_import_transformers_concurrently():
         # Assert that all the register calls come before anything else.
         assert mock_wrapper.mock_calls[-N:] == [mock.call.after_import_mock()]*N
         expected_number_of_register_calls = len(mock_wrapper.mock_calls) - N
-        assert mock_wrapper.mock_calls[:expected_number_of_register_calls] == [
-            mock.call.mock_register(mock.ANY, default_format_for_type=mock.ANY)
-        ] * expected_number_of_register_calls
+        assert all([mock_call[0] == "mock_register" for mock_call in mock_wrapper.mock_calls[:expected_number_of_register_calls]])

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -3248,9 +3248,12 @@ def test_dataclass_none_output_input_deserialization():
     none_value_output = outer_workflow(OuterWorkflowInput(input=0)).nullable_output
     assert none_value_output is None, f"None value was {none_value_output}, not None as expected"
 
+
+@pytest.mark.serial
 def test_lazy_import_transformers_concurrently():
-    TypeEngine.has_lazy_import = False  # Ensure that next call to TypeEngine.lazy_import_transformers doesn't
-    # skip the import
+    # Ensure that next call to TypeEngine.lazy_import_transformers doesn't skip the import. Mark as serial to ensure 
+    # this achieves what we expect.
+    TypeEngine.has_lazy_import = False
 
     # Configure the mocks similar to https://stackoverflow.com/questions/29749193/python-unit-testing-with-two-mock-objects-how-to-verify-call-order
     after_import_mock, mock_register = mock.Mock(), mock.Mock()
@@ -3271,4 +3274,6 @@ def test_lazy_import_transformers_concurrently():
         # Assert that all the register calls come before anything else.
         assert mock_wrapper.mock_calls[-N:] == [mock.call.after_import_mock()]*N
         expected_number_of_register_calls = len(mock_wrapper.mock_calls) - N
-        assert mock_wrapper.mock_calls[:expected_number_of_register_calls] == [mock.call.mock_register(mock.ANY, default_format_for_type=mock.ANY)]*expected_number_of_register_calls
+        assert mock_wrapper.mock_calls[:expected_number_of_register_calls] == [
+            mock.call.mock_register(mock.ANY, default_format_for_type=mock.ANY)
+        ] * expected_number_of_register_calls

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -74,7 +74,7 @@ from flytekit.types.file.file import FlyteFile, FlyteFilePathTransformer, noop
 from flytekit.types.pickle import FlytePickle
 from flytekit.types.pickle.pickle import BatchSize, FlytePickleTransformer
 from flytekit.types.schema import FlyteSchema
-from flytekit.types.structured.structured_dataset import StructuredDataset
+from flytekit.types.structured.structured_dataset import StructuredDataset, StructuredDatasetTransformerEngine
 
 T = typing.TypeVar("T")
 
@@ -3269,5 +3269,6 @@ def test_lazy_import_transformers_concurrently():
             [f.result() for f in futures]
 
         # Assert that all the register calls come before anything else.
-        for i in range(N):
-            assert mock_wrapper.mock_calls[-(i+1)] == mock.call.after_import_mock()
+        assert mock_wrapper.mock_calls[-N:] == [mock.call.after_import_mock()]*N
+        expected_number_of_register_calls = len(mock_wrapper.mock_calls) - N
+        assert mock_wrapper.mock_calls[:expected_number_of_register_calls] == [mock.call.mock_register(mock.ANY, default_format_for_type=mock.ANY)]*expected_number_of_register_calls


### PR DESCRIPTION
## Tracking issue
Closes: https://github.com/flyteorg/flyte/issues/5732

## Why are the changes needed?
Lack of thread safety in `TypeEngine.lazy_import_transformers()` can cause errors when triggering Flyte executions simultaneously from concurrent threads. 

## What changes were proposed in this pull request?
- Add a lock to make it threadsafe. 
  - I considered just moving `cls.has_lazy_import = True` to the end of the function but I decided against it for 2 reasons:
    - Its possible that importing transformers twice could cause issues - though currently I don't think it does. 
    - Apparently python variable assignments are not always atomic https://github.com/google/styleguide/blob/91d6e367e384b0d8aaaf7ce95029514fcdf38651/pyguide.md#218-threading - though in practice I doubt this will be a problem. 
- Write a test
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Wrote a test
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly. - not applicable 
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
