### PR TITLE
eager workflow: use event loop instead of asyncio.run

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -107,8 +107,7 @@ def _dispatch_execute(
         if inspect.iscoroutine(outputs):
             # Handle eager-mode (async) tasks
             logger.info("Output is a coroutine")
-            with asyncio.Runner() as runner:
-                outputs = runner.run(outputs)
+            outputs = asyncio.get_event_loop().run_until_complete(outputs)
 
         # Step3a
         if isinstance(outputs, VoidPromise):

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -107,7 +107,8 @@ def _dispatch_execute(
         if inspect.iscoroutine(outputs):
             # Handle eager-mode (async) tasks
             logger.info("Output is a coroutine")
-            outputs = asyncio.get_event_loop().run_until_complete(outputs)
+            with asyncio.Runner() as runner:
+                outputs = runner.run(outputs)
 
         # Step3a
         if isinstance(outputs, VoidPromise):

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -107,7 +107,7 @@ def _dispatch_execute(
         if inspect.iscoroutine(outputs):
             # Handle eager-mode (async) tasks
             logger.info("Output is a coroutine")
-            outputs = asyncio.get_event_loop().run_until_complete(outputs)
+            outputs = asyncio.get_running_loop().run_until_complete(outputs)
 
         # Step3a
         if isinstance(outputs, VoidPromise):

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -107,7 +107,7 @@ def _dispatch_execute(
         if inspect.iscoroutine(outputs):
             # Handle eager-mode (async) tasks
             logger.info("Output is a coroutine")
-            outputs = asyncio.run(outputs)
+            outputs = asyncio.get_event_loop().run_until_complete(outputs)
 
         # Step3a
         if isinstance(outputs, VoidPromise):

--- a/tests/flytekit/unit/experimental/test_eager_workflows.py
+++ b/tests/flytekit/unit/experimental/test_eager_workflows.py
@@ -1,4 +1,5 @@
 import asyncio
+import mock
 import os
 import sys
 import typing
@@ -9,8 +10,13 @@ import pytest
 from hypothesis import given
 
 from flytekit import dynamic, task, workflow
+
+from flytekit.bin.entrypoint import _dispatch_execute
+from flytekit.core import context_manager
+from flytekit.core.promise import VoidPromise
 from flytekit.exceptions.user import FlyteValidationException
 from flytekit.experimental import EagerException, eager
+from flytekit.models import literals as _literal_models
 from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import FlyteFile
 from flytekit.types.structured import StructuredDataset
@@ -275,3 +281,28 @@ def test_eager_workflow_with_offloaded_types():
 
     result = asyncio.run(eager_wf_flyte_directory())
     assert result == "some data"
+
+
+@mock.patch("flytekit.core.utils.load_proto_from_file")
+@mock.patch("flytekit.core.data_persistence.FileAccessProvider.get_data")
+@mock.patch("flytekit.core.data_persistence.FileAccessProvider.put_data")
+def test_eager_workflow_dispatch_preserves_event_loop(*args):
+    """Test that event loop is preserved when dispatching eager workflows."""
+
+    @eager
+    async def eager_wf():
+        return await asyncio.sleep(1)
+
+    async def async_func():
+        return 1
+
+    ctx = context_manager.FlyteContext.current_context()
+    with context_manager.FlyteContextManager.with_context(
+        ctx.with_execution_state(
+            ctx.execution_state.with_params(mode=context_manager.ExecutionState.Mode.TASK_EXECUTION)
+        )
+    ) as ctx:
+        _dispatch_execute(ctx, lambda: eager_wf, "inputs path", "outputs prefix")
+        loop = asyncio.get_event_loop()
+        result = loop.run_until_complete(async_func())
+        assert result == 1

--- a/tests/flytekit/unit/experimental/test_eager_workflows.py
+++ b/tests/flytekit/unit/experimental/test_eager_workflows.py
@@ -287,7 +287,7 @@ def test_eager_workflow_with_offloaded_types():
 @mock.patch("flytekit.core.data_persistence.FileAccessProvider.get_data")
 @mock.patch("flytekit.core.data_persistence.FileAccessProvider.put_data")
 @mock.patch("flytekit.core.utils.write_proto_to_file")
-def test_eager_workflow_dispatch(*args):
+def test_eager_workflow_dispatch(mock_write_to_file, mock_put_data, mock_get_data, mock_load_proto, event_loop):
     """Test that event loop is preserved after executing eager workflow via dispatch."""
 
     @eager
@@ -301,9 +301,6 @@ def test_eager_workflow_dispatch(*args):
             ctx.execution_state.with_params(mode=context_manager.ExecutionState.Mode.TASK_EXECUTION)
         )
     ) as ctx:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        asyncio.events.set_event_loop(loop)
         _dispatch_execute(ctx, lambda: eager_wf, "inputs path", "outputs prefix")
         loop_after_execute = asyncio.get_event_loop_policy().get_event_loop()
-        assert loop == loop_after_execute
+        assert event_loop == loop_after_execute


### PR DESCRIPTION
## Why are the changes needed?

The `entrypoint._dispatch_execute` function used `asyncio.run` to run the coroutine. The problem with this is that it closes the event loop, which cause the following error related to task data persistence:

```
[1/1] currentAttempt done. Last Error: USER::
[ajwx7zsjbghhfzhpzhnv-f4usdeia-0] terminated with exit code (1). Reason [Error]. Message: 
micromamba/envs/runtime/bin/pyflyte-execute", line 8, in <module>
    sys.exit(execute_task_cmd())
             ^^^^^^^^^^^^^^^^^^
  File "/opt/micromamba/envs/runtime/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/micromamba/envs/runtime/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/opt/micromamba/envs/runtime/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/micromamba/envs/runtime/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/micromamba/envs/runtime/lib/python3.11/site-packages/flytekit/bin/entrypoint.py", line 528, in execute_task_cmd
    _execute_task(
  File "/opt/micromamba/envs/runtime/lib/python3.11/site-packages/flytekit/bin/entrypoint.py", line 403, in _execute_task
    _dispatch_execute(ctx, load_task, inputs, output_prefix)
  File "/opt/micromamba/envs/runtime/lib/python3.11/site-packages/flytekit/bin/entrypoint.py", line 180, in _dispatch_execute
    ctx.file_access.put_data(ctx.execution_state.engine_dir, output_prefix, is_multipart=True)
  File "/opt/micromamba/envs/runtime/lib/python3.11/site-packages/flytekit/core/data_persistence.py", line 592, in put_data
    raise FlyteAssertion(
flytekit.exceptions.user.FlyteAssertion: USER:AssertionError: error=Failed to put data from /tmp/flytei9z9be0x/local_flytekit/engine_dir to unionmeta://opta-gcp-serverless-1-union-us-central1/cosmicbboy/flytesnacks-development-ajwx7zsjbghhfzhpzhnv/testeagerserverlesssimpleeagerworkflow/data/0 (recursive=True).

Original exception: There is no current event loop in thread 'MainThread'., cause=There is no current event loop in thread 'MainThread'.
Error in sys.excepthook:

Original exception was:
.
```

Execution on [Union serverless](https://serverless.union.ai/org/cosmicbboy/projects/flytesnacks/domains/development/executions/ajwx7zsjbghhfzhpzhnv)

## What changes were proposed in this pull request?

Use `get_event_loop().run_until_complete(<coroutine>)` instead so that the event loop isn't closed.

## How was this patch tested?

Tested on serverless:

```python
import os
from flytekit import task, ImageSpec
from flytekit.experimental import eager
from union.remote import UnionRemote
from union._config import _get_config_obj

flytekit = "git+https://github.com/flyteorg/flytekit@688569c37930be2640a418407ed75e6afb6b9037"

image = ImageSpec(
    name="flytekit-eager",
    packages=["flytekit", flytekit],
    apt_packages=["git"],
)


@task(container_image=image)
def add_one(x: int) -> int:
    return x + 1


@task(container_image=image)
def double(x: int) -> int:
    return x * 2


@eager(
    container_image=image,
    remote=UnionRemote(_get_config_obj(None, default_to_union_semantics=False)),
    client_secret_key="serverless-1-cosmicbboy-niels-functional-testing",  # replace with your own secret
    client_secret_env_var="UNION_SERVERLESS_API_KEY",
)
async def simple_eager_workflow(x: int) -> int:
    out = await add_one(x=x)
    if out < 0:
        return -1
    return await double(x=out)

```

Run with:

```
union run --remote test_eager_serverless.py simple_eager_workflow --x 5
```

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.
