### PR TITLE
Fix: Make  flyte-iap catch when trying to generate token for service account from user credentials

### DIFF
--- a/plugins/flytekit-identity-aware-proxy/flytekitplugins/identity_aware_proxy/cli.py
+++ b/plugins/flytekit-identity-aware-proxy/flytekitplugins/identity_aware_proxy/cli.py
@@ -240,8 +240,16 @@ def generate_service_account_id_token(webapp_client_id: str, service_account_key
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = service_account_key
 
     application_default_credentials, _ = default()
-    token = get_service_account_id_token(webapp_client_id, application_default_credentials.service_account_email)
-    click.echo(token)
+
+    try:
+        service_account_email = application_default_credentials.service_account_email
+        token = get_service_account_id_token(webapp_client_id, service_account_email)
+        click.echo(token)
+    except AttributeError:
+        raise click.ClickException(
+            "You appear to be authenticated with user credentials. Revert to service account credentials "
+            "with `gcloud auth application-default revoke` or instead use `flyte-iap generate-user-id-token`."
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The cli `flyte-iap` provided by [`flytekitplugins-identity-aware-proxy`](https://pypi.org/project/flytekitplugins-identity-aware-proxy/) can be used by `flytekit` and `flytectl` as a so-called `proxyCommand` to generate a token sent as `proxy-authorization` header to a flyteadmin protected by [GCP Identity Aware Proxy](https://cloud.google.com/security/products/iap). See original [issue](https://github.com/flyteorg/flyte/issues/3965).

We currently don't catch when users try to generate a token for a service account when logged in with their user account.
This PR catches this and raises an actionable error.

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
