### PR TITLE
pin duckdb version in plugin

### DIFF
--- a/plugins/flytekit-duckdb/setup.py
+++ b/plugins/flytekit-duckdb/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "duckdb"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.3.0b2,<2.0.0", "duckdb", "pandas"]
+plugin_requires = ["flytekit>=1.3.0b2,<2.0.0", "duckdb==1.0.0", "pandas"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-duckdb/setup.py
+++ b/plugins/flytekit-duckdb/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "duckdb"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.3.0b2,<2.0.0", "duckdb==1.0.0", "pandas"]
+plugin_requires = ["flytekit>=1.3.0b2,<2.0.0", "duckdb<=1.0.0", "pandas"]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
## Why are the changes needed?

Motherduck required duckdb v1.0.0 to work. Without pinning it we can install duckdb 1.1.0 which is incompatible. 

## What changes were proposed in this pull request?

pin duckdb version in plugin

## How was this patch tested?

tested using the plugin after duckdb released 1.1.0

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flytekit/pull/2680