### PR TITLE
fix: Calculate the tag based on the name of the base image

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -130,7 +130,7 @@ class ImageSpec:
         # copy the image spec to avoid modifying the original image spec. otherwise, the hash will be different.
         spec = copy.deepcopy(self)
         if isinstance(spec.base_image, ImageSpec):
-            spec = dataclasses.replace(spec, base_image=spec.base_image)
+            spec = dataclasses.replace(spec, base_image=spec.base_image.image_name())
 
         if self.source_root:
             from flytekit.tools.fast_registration import compute_digest

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -56,7 +56,7 @@ def test_image_spec(mock_image_spec_builder, monkeypatch):
     assert image_spec._is_force_push is True
     assert image_spec.entrypoint == ["/bin/bash"]
 
-    assert image_spec.image_name() == f"localhost:30001/flytekit:lh20ze1E7qsZn5_kBQifRw"
+    assert image_spec.image_name() == f"localhost:30001/flytekit:nDg0IzEKso7jtbBnpLWTnw"
     ctx = context_manager.FlyteContext.current_context()
     with context_manager.FlyteContextManager.with_context(
         ctx.with_execution_state(ctx.execution_state.with_params(mode=ExecutionState.Mode.TASK_EXECUTION))


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
If the base image is an ImageSpec, the flytekit image builder pushes the image to an unexpected place because the tag is not calculated based on the image spec's name.

## What changes were proposed in this pull request?
use the name of base ImageSpec to calculate the tag.

## How was this patch tested?
### Setup process
```python
from flytekit import task, workflow, ImageSpec

image_sklearn = ImageSpec(
    packages=["scikit-learn"],
    apt_packages=["git"],
    registry="ghcr.io/unionai",
    name="flyte-conformance",
)
image_tensorflow = ImageSpec(
    base_image=image_sklearn,
    packages=["tensorflow"],
    registry="ghcr.io/unionai",
    name="flyte-conformance",
)


@task(container_image=image_sklearn)
def t1(a: int) -> int:
    return a + 2


@task(container_image=image_tensorflow)
def t2(a: int) -> int:
    return a + 2


@workflow
def composition_image_wf(a: int = 3):
    t1(a=a)
    t2(a=a)


if __name__ == "__main__":
    print(f"Running my_wf: {composition_image_wf(a=50)}")
```

### Screenshots
<img width="1904" alt="Screenshot 2024-09-09 at 10 07 25 PM" src="https://github.com/user-attachments/assets/6e048e78-b766-4812-857f-c787d50831b5">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
