### PR TITLE
[Bug] Set bindings for ArrayNode

### DIFF
--- a/flytekit/core/array_node.py
+++ b/flytekit/core/array_node.py
@@ -193,7 +193,7 @@ class ArrayNode:
 
     def __call__(self, *args, **kwargs):
         ctx = FlyteContext.current_context()
-        if ctx.compilation_state is not None:
+        if ctx.compilation_state:
             # since a new entity with an updated list interface is not created, we have to work around the mismatch
             # between the interface and the inputs
             collection_interface = transform_interface_to_list_interface(self.flyte_entity.python_interface, set())

--- a/flytekit/core/array_node.py
+++ b/flytekit/core/array_node.py
@@ -21,6 +21,8 @@ from flytekit.models import literals as _literal_models
 from flytekit.models.core import workflow as _workflow_model
 from flytekit.models.literals import Literal, LiteralCollection, Scalar
 
+ARRAY_NODE_SUBNODE_NAME = "array_node_sub_node"
+
 
 class ArrayNode:
     def __init__(
@@ -208,6 +210,7 @@ class ArrayNode:
                 entity=self.flyte_entity,
                 add_node_to_compilation_state=False,
                 overridden_interface=collection_interface,
+                node_id=ARRAY_NODE_SUBNODE_NAME,
                 **kwargs,
             )
             self._bindings = bound_subnode.ref.node.bindings

--- a/flytekit/core/array_node.py
+++ b/flytekit/core/array_node.py
@@ -21,7 +21,7 @@ from flytekit.models import literals as _literal_models
 from flytekit.models.core import workflow as _workflow_model
 from flytekit.models.literals import Literal, LiteralCollection, Scalar
 
-ARRAY_NODE_SUBNODE_NAME = "array_node_sub_node"
+ARRAY_NODE_SUBNODE_NAME = "array_node_subnode"
 
 
 class ArrayNode:

--- a/flytekit/core/array_node.py
+++ b/flytekit/core/array_node.py
@@ -192,16 +192,16 @@ class ArrayNode:
         return self._execution_mode
 
     def __call__(self, *args, **kwargs):
-        # interface mismatch between the target and the actual inputs since we don't create a new entity with a
-        # transformed to list interface
-        transformed_kwargs = {
-            key: (val[0] if isinstance(val, list) and val else None) if isinstance(val, list) else val
-            for key, val in kwargs.items()
-        }
-        bound_subnode = create_and_link_node(
-            FlyteContext.current_context(), entity=self.flyte_entity, link_node=False, **transformed_kwargs
-        )
-        self._bindings = bound_subnode.ref.node.bindings
+        ctx = FlyteContext.current_context()
+        if ctx.compilation_state is not None:
+            # interface mismatch between the target and the actual inputs since we don't create a new entity with a
+            # transformed to list interface
+            transformed_kwargs = {
+                key: (val[0] if isinstance(val, list) and val else None) if isinstance(val, list) else val
+                for key, val in kwargs.items()
+            }
+            bound_subnode = create_and_link_node(ctx, entity=self.flyte_entity, link_node=False, **transformed_kwargs)
+            self._bindings = bound_subnode.ref.node.bindings
         return flyte_entity_call_handler(self, *args, **kwargs)
 
 

--- a/flytekit/core/array_node.py
+++ b/flytekit/core/array_node.py
@@ -50,7 +50,7 @@ class ArrayNode:
         self._concurrency = concurrency
         self._execution_mode = execution_mode
         self.id = target.name
-        self._bindings: Optional[List[_literal_models.Binding]] = None
+        self._bindings: List[_literal_models.Binding] = []
 
         if min_successes is not None:
             self._min_successes = min_successes

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1029,6 +1029,7 @@ def extract_obj_name(name: str) -> str:
 def create_and_link_node_from_remote(
     ctx: FlyteContext,
     entity: HasFlyteInterface,
+    link_node: bool = True,
     _inputs_not_allowed: Optional[Set[str]] = None,
     _ignorable_inputs: Optional[Set[str]] = None,
     **kwargs,
@@ -1043,6 +1044,8 @@ def create_and_link_node_from_remote(
 
     :param ctx: FlyteContext
     :param entity: RemoteEntity
+    :param link_node: bool that enables for nodes to be created but not linked to the workflow. This is useful when
+                     creating nodes linked under other nodes such as ArrayNode
     :param _inputs_not_allowed: Set of all variable names that should not be provided when using this entity.
                      Useful for Launchplans with `fixed` inputs
     :param _ignorable_inputs: Set of all variable names that are optional, but if provided will be overridden. Useful
@@ -1114,7 +1117,9 @@ def create_and_link_node_from_remote(
         upstream_nodes=upstream_nodes,
         flyte_entity=entity,
     )
-    ctx.compilation_state.add_node(flytekit_node)
+
+    if link_node:
+        ctx.compilation_state.add_node(flytekit_node)
 
     if len(typed_interface.outputs) == 0:
         return VoidPromise(entity.name, NodeOutput(node=flytekit_node, var="placeholder"))
@@ -1132,6 +1137,7 @@ def create_and_link_node_from_remote(
 def create_and_link_node(
     ctx: FlyteContext,
     entity: SupportsNodeCreation,
+    link_node: bool = True,
     **kwargs,
 ) -> Optional[Union[Tuple[Promise], Promise, VoidPromise]]:
     """
@@ -1140,6 +1146,8 @@ def create_and_link_node(
 
     :param ctx: FlyteContext
     :param entity: RemoteEntity
+    :param link_node: bool that enables for nodes to be created but not linked to the workflow. This is useful when
+                 creating nodes linked under other nodes such as ArrayNode
     :param kwargs: Dict[str, Any] default inputs passed from the user to this entity. Can be promises.
     :return:  Optional[Union[Tuple[Promise], Promise, VoidPromise]]
     """
@@ -1222,7 +1230,9 @@ def create_and_link_node(
         upstream_nodes=upstream_nodes,
         flyte_entity=entity,
     )
-    ctx.compilation_state.add_node(flytekit_node)
+
+    if link_node:
+        ctx.compilation_state.add_node(flytekit_node)
 
     if len(typed_interface.outputs) == 0:
         return VoidPromise(entity.name, NodeOutput(node=flytekit_node, var="placeholder"))

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1137,7 +1137,8 @@ def create_and_link_node_from_remote(
 def create_and_link_node(
     ctx: FlyteContext,
     entity: SupportsNodeCreation,
-    link_node: bool = True,
+    add_node_to_compilation_state: bool = True,
+    overridden_interface: Interface = None,
     **kwargs,
 ) -> Optional[Union[Tuple[Promise], Promise, VoidPromise]]:
     """
@@ -1146,8 +1147,10 @@ def create_and_link_node(
 
     :param ctx: FlyteContext
     :param entity: RemoteEntity
-    :param link_node: bool that enables for nodes to be created but not linked to the workflow. This is useful when
-                 creating nodes nested under other nodes such as ArrayNode
+    :param add_node_to_compilation_state: bool that enables for nodes to be created but not linked to the workflow. This
+                is useful when creating nodes nested under other nodes such as ArrayNode
+    :param overridden_interface: utilize this interface instead of the one provided by the entity. This is useful for
+                ArrayNode as there's a mismatch between the underlying interface and inputs
     :param kwargs: Dict[str, Any] default inputs passed from the user to this entity. Can be promises.
     :return:  Optional[Union[Tuple[Promise], Promise, VoidPromise]]
     """
@@ -1158,7 +1161,7 @@ def create_and_link_node(
     bindings = []
     nodes = []
 
-    interface = entity.python_interface
+    interface = overridden_interface if overridden_interface else entity.python_interface
     typed_interface = flyte_interface.transform_interface_to_typed_interface(
         interface, allow_partial_artifact_id_binding=True
     )
@@ -1231,7 +1234,7 @@ def create_and_link_node(
         flyte_entity=entity,
     )
 
-    if link_node:
+    if add_node_to_compilation_state:
         ctx.compilation_state.add_node(flytekit_node)
 
     if len(typed_interface.outputs) == 0:

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1029,8 +1029,6 @@ def extract_obj_name(name: str) -> str:
 def create_and_link_node_from_remote(
     ctx: FlyteContext,
     entity: HasFlyteInterface,
-    add_node_to_compilation_state: bool = True,
-    overridden_interface: Interface = None,
     _inputs_not_allowed: Optional[Set[str]] = None,
     _ignorable_inputs: Optional[Set[str]] = None,
     **kwargs,
@@ -1120,9 +1118,6 @@ def create_and_link_node_from_remote(
         upstream_nodes=upstream_nodes,
         flyte_entity=entity,
     )
-
-    if add_node_to_compilation_state:
-        ctx.compilation_state.add_node(flytekit_node)
 
     if len(typed_interface.outputs) == 0:
         return VoidPromise(entity.name, NodeOutput(node=flytekit_node, var="placeholder"))

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1045,7 +1045,7 @@ def create_and_link_node_from_remote(
     :param ctx: FlyteContext
     :param entity: RemoteEntity
     :param link_node: bool that enables for nodes to be created but not linked to the workflow. This is useful when
-                     creating nodes linked under other nodes such as ArrayNode
+                     creating nodes nested under other nodes such as ArrayNode
     :param _inputs_not_allowed: Set of all variable names that should not be provided when using this entity.
                      Useful for Launchplans with `fixed` inputs
     :param _ignorable_inputs: Set of all variable names that are optional, but if provided will be overridden. Useful
@@ -1147,7 +1147,7 @@ def create_and_link_node(
     :param ctx: FlyteContext
     :param entity: RemoteEntity
     :param link_node: bool that enables for nodes to be created but not linked to the workflow. This is useful when
-                 creating nodes linked under other nodes such as ArrayNode
+                 creating nodes nested under other nodes such as ArrayNode
     :param kwargs: Dict[str, Any] default inputs passed from the user to this entity. Can be promises.
     :return:  Optional[Union[Tuple[Promise], Promise, VoidPromise]]
     """

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1043,10 +1043,6 @@ def create_and_link_node_from_remote(
 
     :param ctx: FlyteContext
     :param entity: RemoteEntity
-    :param add_node_to_compilation_state: bool that enables for nodes to be created but not linked to the workflow. This
-                is useful when creating nodes nested under other nodes such as ArrayNode
-    :param overridden_interface: utilize this interface instead of the one provided by the entity. This is useful for
-                ArrayNode as there's a mismatch between the underlying interface and inputs
     :param _inputs_not_allowed: Set of all variable names that should not be provided when using this entity.
                      Useful for Launchplans with `fixed` inputs
     :param _ignorable_inputs: Set of all variable names that are optional, but if provided will be overridden. Useful
@@ -1118,6 +1114,7 @@ def create_and_link_node_from_remote(
         upstream_nodes=upstream_nodes,
         flyte_entity=entity,
     )
+    ctx.compilation_state.add_node(flytekit_node)
 
     if len(typed_interface.outputs) == 0:
         return VoidPromise(entity.name, NodeOutput(node=flytekit_node, var="placeholder"))

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1134,6 +1134,7 @@ def create_and_link_node(
     entity: SupportsNodeCreation,
     overridden_interface: Optional[Interface] = None,
     add_node_to_compilation_state: bool = True,
+    node_id: str = "",
     **kwargs,
 ) -> Optional[Union[Tuple[Promise], Promise, VoidPromise]]:
     """
@@ -1146,6 +1147,7 @@ def create_and_link_node(
                 is useful when creating nodes nested under other nodes such as ArrayNode
     :param overridden_interface: utilize this interface instead of the one provided by the entity. This is useful for
                 ArrayNode as there's a mismatch between the underlying interface and inputs
+    :param node_id: str if provided, this will be used as the node id.
     :param kwargs: Dict[str, Any] default inputs passed from the user to this entity. Can be promises.
     :return:  Optional[Union[Tuple[Promise], Promise, VoidPromise]]
     """
@@ -1222,10 +1224,10 @@ def create_and_link_node(
 
     # TODO: Better naming, probably a derivative of the function name.
     # if not adding to compilation state, we don't need to generate a unique node id
-    node_id = (
+    node_id = node_id or (
         f"{ctx.compilation_state.prefix}n{len(ctx.compilation_state.nodes)}"
         if add_node_to_compilation_state and ctx.compilation_state
-        else ""
+        else node_id
     )
 
     flytekit_node = Node(

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1158,7 +1158,7 @@ def create_and_link_node(
     bindings = []
     nodes = []
 
-    interface = overridden_interface if overridden_interface else entity.python_interface
+    interface = overridden_interface or entity.python_interface
     typed_interface = flyte_interface.transform_interface_to_typed_interface(
         interface, allow_partial_artifact_id_binding=True
     )

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1132,8 +1132,8 @@ def create_and_link_node_from_remote(
 def create_and_link_node(
     ctx: FlyteContext,
     entity: SupportsNodeCreation,
+    overridden_interface: Optional[Interface] = None,
     add_node_to_compilation_state: bool = True,
-    overridden_interface: Interface = None,
     **kwargs,
 ) -> Optional[Union[Tuple[Promise], Promise, VoidPromise]]:
     """
@@ -1223,7 +1223,9 @@ def create_and_link_node(
     # TODO: Better naming, probably a derivative of the function name.
     # if not adding to compilation state, we don't need to generate a unique node id
     node_id = (
-        f"{ctx.compilation_state.prefix}n{len(ctx.compilation_state.nodes)}" if add_node_to_compilation_state else ""
+        f"{ctx.compilation_state.prefix}n{len(ctx.compilation_state.nodes)}"
+        if add_node_to_compilation_state and ctx.compilation_state
+        else ""
     )
 
     flytekit_node = Node(
@@ -1234,7 +1236,7 @@ def create_and_link_node(
         flyte_entity=entity,
     )
 
-    if add_node_to_compilation_state:
+    if add_node_to_compilation_state and ctx.compilation_state:
         ctx.compilation_state.add_node(flytekit_node)
 
     if len(typed_interface.outputs) == 0:

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1149,7 +1149,7 @@ def create_and_link_node(
     :param kwargs: Dict[str, Any] default inputs passed from the user to this entity. Can be promises.
     :return:  Optional[Union[Tuple[Promise], Promise, VoidPromise]]
     """
-    if ctx.compilation_state is None:
+    if ctx.compilation_state is None and add_node_to_compilation_state:
         raise _user_exceptions.FlyteAssertion("Cannot create node when not compiling...")
 
     used_inputs = set()
@@ -1220,9 +1220,14 @@ def create_and_link_node(
     # These will be our core Nodes until we can amend the Promise to use NodeOutputs that reference our Nodes
     upstream_nodes = list(set([n for n in nodes if n.id != _common_constants.GLOBAL_INPUT_NODE_ID]))
 
+    # TODO: Better naming, probably a derivative of the function name.
+    # if not adding to compilation state, we don't need to generate a unique node id
+    node_id = (
+        f"{ctx.compilation_state.prefix}n{len(ctx.compilation_state.nodes)}" if add_node_to_compilation_state else ""
+    )
+
     flytekit_node = Node(
-        # TODO: Better naming, probably a derivative of the function name.
-        id=f"{ctx.compilation_state.prefix}n{len(ctx.compilation_state.nodes)}",
+        id=node_id,
         metadata=entity.construct_node_metadata(),
         bindings=sorted(bindings, key=lambda b: b.var),
         upstream_nodes=upstream_nodes,

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1121,7 +1121,7 @@ def create_and_link_node_from_remote(
         flyte_entity=entity,
     )
 
-    if link_node:
+    if add_node_to_compilation_state:
         ctx.compilation_state.add_node(flytekit_node)
 
     if len(typed_interface.outputs) == 0:

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1029,7 +1029,8 @@ def extract_obj_name(name: str) -> str:
 def create_and_link_node_from_remote(
     ctx: FlyteContext,
     entity: HasFlyteInterface,
-    link_node: bool = True,
+    add_node_to_compilation_state: bool = True,
+    overridden_interface: Interface = None,
     _inputs_not_allowed: Optional[Set[str]] = None,
     _ignorable_inputs: Optional[Set[str]] = None,
     **kwargs,
@@ -1044,8 +1045,10 @@ def create_and_link_node_from_remote(
 
     :param ctx: FlyteContext
     :param entity: RemoteEntity
-    :param link_node: bool that enables for nodes to be created but not linked to the workflow. This is useful when
-                     creating nodes nested under other nodes such as ArrayNode
+    :param add_node_to_compilation_state: bool that enables for nodes to be created but not linked to the workflow. This
+                is useful when creating nodes nested under other nodes such as ArrayNode
+    :param overridden_interface: utilize this interface instead of the one provided by the entity. This is useful for
+                ArrayNode as there's a mismatch between the underlying interface and inputs
     :param _inputs_not_allowed: Set of all variable names that should not be provided when using this entity.
                      Useful for Launchplans with `fixed` inputs
     :param _ignorable_inputs: Set of all variable names that are optional, but if provided will be overridden. Useful

--- a/tests/flytekit/unit/core/test_array_node.py
+++ b/tests/flytekit/unit/core/test_array_node.py
@@ -27,7 +27,7 @@ def serialization_settings():
 def multiply(val: int, val1: typing.Union[int, str], val2: int) -> int:
     if type(val1) is str:
         return val * val2
-    return val * val1 * val2
+    return val * int(val1) * val2
 
 
 @workflow

--- a/tests/flytekit/unit/core/test_array_node.py
+++ b/tests/flytekit/unit/core/test_array_node.py
@@ -45,16 +45,22 @@ def test_lp_serialization(serialization_settings):
 
     wf_spec = get_serializable(OrderedDict(), serialization_settings, grandparent_wf)
     assert len(wf_spec.template.nodes) == 1
-    assert wf_spec.template.nodes[0].array_node is not None
-    assert wf_spec.template.nodes[0].array_node.node is not None
-    assert wf_spec.template.nodes[0].array_node.node.workflow_node is not None
+    serialized_array_node = wf_spec.template.nodes[0].array_node
+    assert serialized_array_node is not None
+    assert serialized_array_node.node is not None
+    assert serialized_array_node.node.workflow_node is not None
     assert (
-        wf_spec.template.nodes[0].array_node.node.workflow_node.launchplan_ref.resource_type
+        serialized_array_node.node.workflow_node.launchplan_ref.resource_type
         == identifier_models.ResourceType.LAUNCH_PLAN
     )
-    assert wf_spec.template.nodes[0].array_node.node.workflow_node.launchplan_ref.name == "tests.flytekit.unit.core.test_array_node.parent_wf"
-    assert wf_spec.template.nodes[0].array_node._min_success_ratio == 0.9
-    assert wf_spec.template.nodes[0].array_node._parallelism == 10
+    assert serialized_array_node.node.workflow_node.launchplan_ref.name == "tests.flytekit.unit.core.test_array_node.parent_wf"
+    assert serialized_array_node._min_success_ratio == 0.9
+    assert serialized_array_node._parallelism == 10
+    assert len(serialized_array_node.node.inputs) == 2
+    assert serialized_array_node.node.inputs[0].var == "a"
+    assert serialized_array_node.node.inputs[0].binding.value.primitive.integer is not None
+    assert serialized_array_node.node.inputs[1].var == "b"
+    assert serialized_array_node.node.inputs[0].binding.value.primitive.integer is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/flytekit/unit/core/test_array_node.py
+++ b/tests/flytekit/unit/core/test_array_node.py
@@ -24,13 +24,15 @@ def serialization_settings():
 
 
 @task
-def multiply(val: int, val1: int) -> int:
-    return val * val1
+def multiply(val: int, val1: typing.Union[int, str], val2: int) -> int:
+    if type(val1) is str:
+        return val * val2
+    return val * val1 * val2
 
 
 @workflow
-def parent_wf(a: int, b: int = 2) -> int:
-    return multiply(val=a, val1=b)
+def parent_wf(a: int, b: typing.Union[int, str], c: int = 2) -> int:
+    return multiply(val=a, val1=b, val2=c)
 
 
 lp = LaunchPlan.get_default_launch_plan(current_context(), parent_wf)
@@ -38,29 +40,41 @@ lp = LaunchPlan.get_default_launch_plan(current_context(), parent_wf)
 
 @workflow
 def grandparent_wf() -> typing.List[int]:
-    return array_node(lp, concurrency=10, min_success_ratio=0.9)(a=[1, 3, 5], b=[2, 4, 6])
+    return array_node(lp, concurrency=10, min_success_ratio=0.9)(a=[1, 3, 5], b=["two", 4, "six"], c=[7, 8, 9])
 
 
 def test_lp_serialization(serialization_settings):
-
     wf_spec = get_serializable(OrderedDict(), serialization_settings, grandparent_wf)
     assert len(wf_spec.template.nodes) == 1
-    serialized_array_node = wf_spec.template.nodes[0].array_node
-    assert serialized_array_node is not None
-    assert serialized_array_node.node is not None
-    assert serialized_array_node.node.workflow_node is not None
+
+    top_level = wf_spec.template.nodes[0]
+    assert top_level.inputs[0].var == "a"
+    assert len(top_level.inputs[0].binding.collection.bindings) == 3
+    for binding in top_level.inputs[0].binding.collection.bindings:
+        assert binding.scalar.primitive.integer is not None
+    assert top_level.inputs[1].var == "b"
+    for binding in top_level.inputs[1].binding.collection.bindings:
+        assert binding.scalar.union is not None
+    assert len(top_level.inputs[1].binding.collection.bindings) == 3
+    assert top_level.inputs[2].var == "c"
+    assert len(top_level.inputs[2].binding.collection.bindings) == 3
+    for binding in top_level.inputs[2].binding.collection.bindings:
+        assert binding.scalar.primitive.integer is not None
+
+    serialized_array_node = top_level.array_node
     assert (
-        serialized_array_node.node.workflow_node.launchplan_ref.resource_type
-        == identifier_models.ResourceType.LAUNCH_PLAN
+            serialized_array_node.node.workflow_node.launchplan_ref.resource_type
+            == identifier_models.ResourceType.LAUNCH_PLAN
     )
-    assert serialized_array_node.node.workflow_node.launchplan_ref.name == "tests.flytekit.unit.core.test_array_node.parent_wf"
+    assert (
+            serialized_array_node.node.workflow_node.launchplan_ref.name
+            == "tests.flytekit.unit.core.test_array_node.parent_wf"
+    )
     assert serialized_array_node._min_success_ratio == 0.9
     assert serialized_array_node._parallelism == 10
-    assert len(serialized_array_node.node.inputs) == 2
-    assert serialized_array_node.node.inputs[0].var == "a"
-    assert serialized_array_node.node.inputs[0].binding.value.primitive.integer is not None
-    assert serialized_array_node.node.inputs[1].var == "b"
-    assert serialized_array_node.node.inputs[0].binding.value.primitive.integer is not None
+
+    subnode = serialized_array_node.node
+    assert subnode.inputs == top_level.inputs
 
 
 @pytest.mark.parametrize(
@@ -103,8 +117,8 @@ def test_local_exec_lp_min_successes(min_successes, min_success_ratio, should_ra
 
 
 def test_map_task_wrapper():
-    mapped_task = map_task(multiply)(val=[1, 3, 5], val1=[2, 4, 6])
-    assert mapped_task == [2, 12, 30]
+    mapped_task = map_task(multiply)(val=[1, 3, 5], val1=[2, 4, 6], val2=[7, 8, 9])
+    assert mapped_task == [14, 96, 270]
 
-    mapped_lp = map_task(lp)(a=[1, 3, 5], b=[2, 4, 6])
-    assert mapped_lp == [2, 12, 30]
+    mapped_lp = map_task(lp)(a=[1, 3, 5], b=[2, 4, 6], c=[7, 8, 9])
+    assert mapped_lp == [14, 96, 270]

--- a/tests/flytekit/unit/core/test_array_node.py
+++ b/tests/flytekit/unit/core/test_array_node.py
@@ -29,7 +29,7 @@ def multiply(val: int, val1: int) -> int:
 
 
 @workflow
-def parent_wf(a: int, b: int) -> int:
+def parent_wf(a: int, b: int = 2) -> int:
     return multiply(val=a, val1=b)
 
 

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -39,14 +39,23 @@ def test_create_and_link_node():
     assert p.ref.node_id == "n0"
     assert p.ref.var == "o0"
     assert len(p.ref.node.bindings) == 1
+    assert len(ctx.compilation_state.nodes) == 1
 
     @task
     def t2(a: typing.Optional[int] = None) -> typing.Optional[int]:
         return a
 
+    ctx = context_manager.FlyteContext.current_context().with_compilation_state(CompilationState(prefix=""))
     p = create_and_link_node(ctx, t2)
     assert p.ref.var == "o0"
     assert len(p.ref.node.bindings) == 1
+    assert len(ctx.compilation_state.nodes) == 1
+
+    ctx = context_manager.FlyteContext.current_context().with_compilation_state(CompilationState(prefix=""))
+    p = create_and_link_node(ctx, t2, link_node=False)
+    assert p.ref.var == "o0"
+    assert len(p.ref.node.bindings) == 1
+    assert len(ctx.compilation_state.nodes) == 0
 
 
 def test_create_and_link_node_from_remote():
@@ -63,14 +72,23 @@ def test_create_and_link_node_from_remote():
     assert p.ref.node_id == "n0"
     assert p.ref.var == "placeholder"
     assert len(p.ref.node.bindings) == 0
+    assert len(ctx.compilation_state.nodes) == 1
 
     @task
     def t2(a: int) -> int:
         return a
 
+    ctx = context_manager.FlyteContext.current_context().with_compilation_state(CompilationState(prefix=""))
     p = create_and_link_node_from_remote(ctx, t2, a=3)
     assert p.ref.var == "o0"
     assert len(p.ref.node.bindings) == 1
+    assert len(ctx.compilation_state.nodes) == 1
+
+    ctx = context_manager.FlyteContext.current_context().with_compilation_state(CompilationState(prefix=""))
+    p = create_and_link_node_from_remote(ctx, t2, link_node=False, a=3)
+    assert p.ref.var == "o0"
+    assert len(p.ref.node.bindings) == 1
+    assert len(ctx.compilation_state.nodes) == 0
 
 
 def test_create_and_link_node_from_remote_ignore():

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -52,7 +52,7 @@ def test_create_and_link_node():
     assert len(ctx.compilation_state.nodes) == 1
 
     ctx = context_manager.FlyteContext.current_context().with_compilation_state(CompilationState(prefix=""))
-    p = create_and_link_node(ctx, t2, link_node=False)
+    p = create_and_link_node(ctx, t2, add_node_to_compilation_state=False)
     assert p.ref.var == "o0"
     assert len(p.ref.node.bindings) == 1
     assert len(ctx.compilation_state.nodes) == 0
@@ -72,23 +72,14 @@ def test_create_and_link_node_from_remote():
     assert p.ref.node_id == "n0"
     assert p.ref.var == "placeholder"
     assert len(p.ref.node.bindings) == 0
-    assert len(ctx.compilation_state.nodes) == 1
 
     @task
     def t2(a: int) -> int:
         return a
 
-    ctx = context_manager.FlyteContext.current_context().with_compilation_state(CompilationState(prefix=""))
     p = create_and_link_node_from_remote(ctx, t2, a=3)
     assert p.ref.var == "o0"
     assert len(p.ref.node.bindings) == 1
-    assert len(ctx.compilation_state.nodes) == 1
-
-    ctx = context_manager.FlyteContext.current_context().with_compilation_state(CompilationState(prefix=""))
-    p = create_and_link_node_from_remote(ctx, t2, link_node=False, a=3)
-    assert p.ref.var == "o0"
-    assert len(p.ref.node.bindings) == 1
-    assert len(ctx.compilation_state.nodes) == 0
 
 
 def test_create_and_link_node_from_remote_ignore():


### PR DESCRIPTION
## Tracking issue
fixes: https://linear.app/unionai/issue/COR-1822/mapping-over-launch-plans-w-default-inputs-doesnt-compile

## Why are the changes needed?

Compiling a workflow fails when evaluating an ArrayNode that maps over a LaunchPlan contains a default input. This occurs since we don't set the input bindings for the node.

https://github.com/unionai/flyte/blob/926cadac9a8cf406b85c8e7443668a13a3f60dfe/flytepropeller/pkg/compiler/validators/interface.go#L76-L86

Get errors such as:

```
pyflyte run --remote tests/flytekit/integration/map_ref_lp.py map_regression_line_wf
Running Execution on Remote.
Request rejected by the API, due to Invalid input.
RPC Failed, with Status: StatusCode.INVALID_ARGUMENT
        details: failed to compile workflow for [resource_type:WORKFLOW project:"flytesnacks" domain:"development" name:"tests.flytekit.integration.map_ref_lp.map_regression_line_wf" version:"m6vMatWi-HCjUFD5scx4rQ"] with err failed to compile workflow with err Collected Errors: 3
        Error 0: Code: VariableNameNotFound, Node Id: n0, Description: Variable [val] not found on node [n0].
        Error 1: Code: VariableNameNotFound, Node Id: n0, Description: Variable [x] not found on node [n0].
        Error 2: Code: VariableNameNotFound, Node Id: n0, Description: Variable [y] not found on node [n0].

```

## What changes were proposed in this pull request?
- Update create_and_link_node and create_and_link_node_remote functions to create a node and optionally link it to the workflow context

- clean up some of the setting of bound_inputs for array node since that isn't supported atm

## How was this patch tested?
- added unit test to confirm the serialized array node contains the bindings
- ran E2E
```
@task
def slope(x: list[int], y: list[int]) -> float:
    sum_xy = sum([x[i] * y[i] for i in range(len(x))])
    sum_x_squared = sum([x[i] ** 2 for i in range(len(x))])
    n = len(x)
    return (n * sum_xy - sum(x) * sum(y)) / (n * sum_x_squared - sum(x) ** 2)


@task
def intercept(x: list[int], y: list[int], slope: float) -> float:
    mean_x = sum(x) / len(x)
    mean_y = sum(y) / len(y)
    intercept = mean_y - slope * mean_x
    return intercept


@workflow
def slope_intercept_wf(x: list[int], y: list[int]) -> (float, float):
    slope_value = slope(x=x, y=y)
    intercept_value = intercept(x=x, y=y, slope=slope_value)
    return (slope_value, intercept_value)


@task
def regression_line(val: int, slope_value: float, intercept_value: float) -> float:
    return (slope_value * val) + intercept_value  # y = mx + c


@workflow
def regression_line_wf(val: int = 5, x: list[int] = [-3, 0, 3], y: list[int] = [7, 4, -2]) -> float:
    slope_value, intercept_value = slope_intercept_wf(x=x, y=y)
    return regression_line(val=val, slope_value=slope_value, intercept_value=intercept_value)
```

```
@reference_launch_plan(
    project="flytesnacks",
    domain="development",
    name="advanced_composition.subworkflow.regression_line_wf",
    version="1jtCscLI-_FBiNcmL8Nr4Q",
)
def ref_regression_line_wf(
    val: int, x: list[int], y: list[int]
) -> float:
    return 1.0


@workflow
def map_regression_line_wf() -> list[float]:
    a = [1, 2, 3]
    b = [[-3, 0, 3], [-8, 2, 4], [7, 3, 1]]
    c = [[7, 4, -2], [-2, 4, 7], [3, 6, 4]]
    return map_task(ref_regression_line_wf)(val=a, x=b, y=c)
```

### Setup process
- need to run w/ union's flyte fork

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
