### PR TITLE
feat(image_spec): validate container registry names

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -419,7 +419,7 @@ class ImageBuildEngine:
 def validate_container_registry_name(name: str) -> bool:
     """Validate Docker container registry name."""
     # Define the regular expression for the registry name
-    registry_pattern = r"^(localhost:\d{1,5}|([a-z0-9._-]+)(:[0-9]{1,5})?)(/[a-zA-Z0-9._-]+)*$"
+    registry_pattern = r"^(localhost:\d{1,5}|([a-z\d\._-]+)(:\d{1,5})?)(/[\w\.-]+)*$"
 
     # Use regex to validate the given name
     return bool(re.match(registry_pattern, name))

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -90,6 +90,13 @@ class ImageSpec:
         self._is_force_push = os.environ.get(FLYTE_FORCE_PUSH_IMAGE_SPEC, False)  # False by default
         if self.registry:
             self.registry = self.registry.lower()
+            if not validate_docker_registry_name(self.registry):
+                raise ValueError(
+                    f"Invalid container registry name: '{self.registry}'.\n Expected formats:\n"
+                    f"- 'localhost:30000' (for local registries)\n"
+                    f"- 'ghcr.io/username' (for GitHub Container Registry)\n"
+                    f"- 'docker.io/username' (for docker hub)\n"
+                )
 
         # If not set, help the user set this option as well, to support the older default behavior where existence
         # of the source root implied that copying of files was needed.
@@ -407,3 +414,12 @@ class ImageBuildEngine:
                     f" Please upgrade envd to v0.3.39+."
                 )
         return cls._REGISTRY[builder][0]
+
+
+def validate_docker_registry_name(name: str) -> bool:
+    """Validate Docker container registry name."""
+    # Define the regular expression for the registry name
+    registry_pattern = r"^(localhost:\d{1,5}|([a-z0-9._-]+)(:[0-9]{1,5})?)(/[a-zA-Z0-9._-]+)*$"
+
+    # Use regex to validate the given name
+    return bool(re.match(registry_pattern, name))

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -90,7 +90,7 @@ class ImageSpec:
         self._is_force_push = os.environ.get(FLYTE_FORCE_PUSH_IMAGE_SPEC, False)  # False by default
         if self.registry:
             self.registry = self.registry.lower()
-            if not validate_docker_registry_name(self.registry):
+            if not validate_container_registry_name(self.registry):
                 raise ValueError(
                     f"Invalid container registry name: '{self.registry}'.\n Expected formats:\n"
                     f"- 'localhost:30000' (for local registries)\n"
@@ -416,7 +416,7 @@ class ImageBuildEngine:
         return cls._REGISTRY[builder][0]
 
 
-def validate_docker_registry_name(name: str) -> bool:
+def validate_container_registry_name(name: str) -> bool:
     """Validate Docker container registry name."""
     # Define the regular expression for the registry name
     registry_pattern = r"^(localhost:\d{1,5}|([a-z0-9._-]+)(:[0-9]{1,5})?)(/[a-zA-Z0-9._-]+)*$"

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -215,3 +215,28 @@ def test_update_image_spec_copy_handling():
     update_image_spec_copy_handling(image_spec, ss)
     assert image_spec.source_copy_mode is None
     assert image_spec.source_root is None
+
+
+def test_registry_name():
+    invalid_registry_names = [
+        "invalid:port:50000",
+        "ghcr.io/flyteorg:latest",
+        "flyteorg:latest"
+    ]
+    for invalid_registry_name in invalid_registry_names:
+        with pytest.raises(ValueError, match="Invalid container registry name"):
+            ImageSpec(registry=invalid_registry_name)
+
+    valid_registry_names = [
+        "localhost:30000",
+        "localhost:30000/flyte",
+        "192.168.1.1:30000",
+        "192.168.1.1:30000/myimage",
+        "ghcr.io/flyteorg",
+        "my.registry.com/myimage",
+        "myregistry:5000/myimage",
+        "us-west1-docker.pkg.dev/example.com/my-project/my-repo"
+        "flyteorg",
+    ]
+    for valid_registry_name in valid_registry_names:
+        ImageSpec(registry=valid_registry_name)

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -234,6 +234,7 @@ def test_registry_name():
         "192.168.1.1:30000/myimage",
         "ghcr.io/flyteorg",
         "my.registry.com/myimage",
+        "my.registry.com:5000/myimage",
         "myregistry:5000/myimage",
         "us-west1-docker.pkg.dev/example.com/my-project/my-repo"
         "flyteorg",


### PR DESCRIPTION
## Tracking issue
closes https://github.com/flyteorg/flyte/issues/5689

## Why are the changes needed?
It's better to check if the registry name is valid or not before building and pushing it.

## What changes were proposed in this pull request?
validate the name in `__post__init__`

## How was this patch tested?
unit test

### Setup process
```
from flytekit import task, workflow, ImageSpec

image_spec = ImageSpec(
    registry="localhost:30000/UNIONAI",
    packages=["pandas"],
    builder="default"
)


@task(enable_deck=True, container_image=image_spec)
def t1(a: int) -> int:
    return a + 1


@workflow()
def wf() -> int:
    return t1(a=3)
```
### Screenshots

Before:
![Screenshot 2024-09-11 at 3 16 29 PM](https://github.com/user-attachments/assets/334d1c73-2f1e-4060-a354-bb554274b823)

After:
![Screenshot 2024-09-11 at 2 40 29 PM](https://github.com/user-attachments/assets/543f9a25-4d71-4c5c-95bb-ae1afcb680d8)


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
