### PR TITLE
wip Flyte loop in FlyteContext & multi-threaded loops

### DIFF
--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -81,7 +81,7 @@ from flytekit.models.core import workflow as _workflow_model
 from flytekit.models.documentation import Description, Documentation
 from flytekit.models.interface import Variable
 from flytekit.models.security import SecurityContext
-from flytekit.utils.async_utils import ensure_no_loop
+from flytekit.utils.async_utils import run_sync_new_thread
 
 DYNAMIC_PARTITIONS = "_uap"
 MODEL_CARD = "_ucm"
@@ -781,8 +781,8 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
             ):
                 return native_outputs
 
-            ensure_no_loop("Cannot run PythonTask.dispatch_execute from within a loop")
-            literals_map, native_outputs_as_map = asyncio.run(self._output_to_literal_map(native_outputs, exec_ctx))
+            synced = run_sync_new_thread(self._output_to_literal_map)
+            literals_map, native_outputs_as_map = synced(native_outputs, exec_ctx)
             self._write_decks(native_inputs, native_outputs_as_map, ctx, new_user_params)
 
             # After the execute has been successfully completed

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -604,6 +604,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
     ) -> Dict[str, Any]:
         return TypeEngine.literal_map_to_kwargs(ctx, literal_map, self.python_interface.inputs)
 
+    @timeit("base_task._output_to_literal_map")
     async def _output_to_literal_map(self, native_outputs: Dict[int, Any], ctx: FlyteContext):
         expected_output_names = list(self._outputs_interface.keys())
         if len(expected_output_names) == 1:

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -13,10 +13,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging as _logging
 import os
-import sys
-import asyncio
 import pathlib
 import tempfile
 import traceback
@@ -650,21 +649,9 @@ class FlyteContext(object):
     @property
     def loop(self) -> asyncio.AbstractEventLoop:
         """
-        Can remove this property in the future, just prints a warning for now if the current
-        loop is not the same as the FlyteContext loop.
+        Can remove this property in the future
         """
-        running_loop = None
-        try:
-            running_loop = asyncio.get_running_loop()
-        except RuntimeError as e:
-            if "no running event loop" not in str(e):
-                user_space_logger.error(f"Unknown RuntimeError when getting loop {str(e)}")
-                raise
-        if self._loop and running_loop:
-            if running_loop is not self._loop:
-                user_space_logger.warning(
-                    "Returning FlyteContext loop, but is not running loop."
-                )
+        assert self._loop is not None
         return self._loop
 
     @property
@@ -983,9 +970,13 @@ class FlyteContextManager(object):
             decks=[],
         )
 
-        default_context = default_context.with_execution_state(
-            default_context.new_execution_state().with_params(user_space_params=default_user_space_params)
-        ).with_ensure_loop().build()
+        default_context = (
+            default_context.with_execution_state(
+                default_context.new_execution_state().with_params(user_space_params=default_user_space_params)
+            )
+            .with_ensure_loop()
+            .build()
+        )
         default_context.set_stackframe(s=FlyteContextManager.get_origin_stackframe())
         flyte_context_Var.set([default_context])
 

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -45,7 +45,7 @@ from flytekit.models.core import workflow as _workflow_model
 from flytekit.models.literals import Primitive
 from flytekit.models.task import Resources
 from flytekit.models.types import SimpleType
-from flytekit.utils.async_utils import top_level_sync_wrapper
+from flytekit.utils.async_utils import run_sync_new_thread
 
 
 async def _translate_inputs_to_literals(
@@ -105,7 +105,7 @@ async def _translate_inputs_to_literals(
     return result
 
 
-translate_inputs_to_literals = top_level_sync_wrapper(_translate_inputs_to_literals)
+translate_inputs_to_literals = run_sync_new_thread(_translate_inputs_to_literals)
 
 
 async def resolve_attr_path_in_promise(p: Promise) -> Promise:

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1312,6 +1312,7 @@ class TypeEngine(typing.Generic[T]):
         return _interface_models.VariableMap(variables=variables)
 
     @classmethod
+    @timeit("Translate literal to python value")
     def literal_map_to_kwargs(
         cls,
         ctx: FlyteContext,
@@ -1323,7 +1324,7 @@ class TypeEngine(typing.Generic[T]):
         return synced(ctx, lm, python_types, literal_types)
 
     @classmethod
-    @timeit("Translate literal to python value")
+    @timeit("AsyncTranslate literal to python value")
     async def _literal_map_to_kwargs(
         cls,
         ctx: FlyteContext,

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1311,7 +1311,6 @@ class TypeEngine(typing.Generic[T]):
             variables[var_name] = _interface_models.Variable(type=literal_type, description=f"{idx}")
         return _interface_models.VariableMap(variables=variables)
 
-    # Declare empty function to get linting to work. Monkeypatched below.
     @classmethod
     def literal_map_to_kwargs(
         cls,
@@ -1320,7 +1319,8 @@ class TypeEngine(typing.Generic[T]):
         python_types: typing.Optional[typing.Dict[str, type]] = None,
         literal_types: typing.Optional[typing.Dict[str, _interface_models.Variable]] = None,
     ) -> typing.Dict[str, typing.Any]:
-        raise NotImplementedError
+        synced = run_sync_new_thread(cls._literal_map_to_kwargs)
+        return synced(ctx, lm, python_types, literal_types)
 
     @classmethod
     @timeit("Translate literal to python value")
@@ -1358,7 +1358,6 @@ class TypeEngine(typing.Generic[T]):
                 raise
         return kwargs
 
-    # Declare empty function to get linting to work. Monkeypatched below.
     @classmethod
     def dict_to_literal_map(
         cls,
@@ -1366,7 +1365,8 @@ class TypeEngine(typing.Generic[T]):
         d: typing.Dict[str, typing.Any],
         type_hints: Optional[typing.Dict[str, type]] = None,
     ) -> LiteralMap:
-        raise NotImplementedError
+        synced = run_sync_new_thread(cls._dict_to_literal_map)
+        return synced(ctx, d, type_hints)
 
     @classmethod
     async def _dict_to_literal_map(
@@ -1444,10 +1444,6 @@ class TypeEngine(typing.Generic[T]):
         except ValueError:
             logger.debug(f"Skipping transformer {cls._DATACLASS_TRANSFORMER.name} for {flyte_type}")
         raise ValueError(f"No transformers could reverse Flyte literal type {flyte_type}")
-
-
-TypeEngine.literal_map_to_kwargs = run_sync_new_thread(TypeEngine._literal_map_to_kwargs)  # type: ignore[method-assign]
-TypeEngine.dict_to_literal_map = run_sync_new_thread(TypeEngine._dict_to_literal_map)  # type: ignore[method-assign]
 
 
 class ListTransformer(AsyncTypeTransformer[T]):

--- a/flytekit/utils/async_utils.py
+++ b/flytekit/utils/async_utils.py
@@ -128,14 +128,6 @@ def run_sync_new_thread(coro_function: Callable[..., Awaitable[T]]) -> Callable[
     return wrapped
 
 
-# def run_async_correctly(loop: asyncio.AbstractEventLoop, coro_function: Callable[..., Awaitable[T]]) -> T:
-#     if loop.is_running():
-#         return run_sync_new_thread(coro_function)
-#     else:
-#         coro = coro_function(ctx, lv, expected_python_type)
-#         return ctx.loop.run_until_complete(coro)
-
-
 class ContextExecutor(ThreadPoolExecutor):
     def __init__(self):
         self.context = copy_context()

--- a/flytekit/utils/async_utils.py
+++ b/flytekit/utils/async_utils.py
@@ -1,29 +1,34 @@
 import asyncio
-import contextvars
-import functools
-from concurrent.futures import ThreadPoolExecutor
-from types import CoroutineType
+import atexit
 import sys
-
-from typing_extensions import Any, Callable
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar, copy_context
+from types import CoroutineType
+from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar
 
 from flytekit.loggers import logger
 
 AsyncFuncType = Callable[[Any], CoroutineType]
 Synced = Callable[[Any], Any]
+T = TypeVar("T")
 
 
-def ensure_no_loop(error_msg: str):
+def get_running_loop_if_exists() -> Optional[asyncio.AbstractEventLoop]:
     try:
-        asyncio.get_running_loop()
-        raise AssertionError(error_msg)
+        loop = asyncio.get_running_loop()
+        return loop
     except RuntimeError as e:
         if "no running event loop" not in str(e):
             logger.error(f"Unknown RuntimeError {str(e)}")
             raise
+    return None
 
 
 def get_or_create_loop(use_windows: bool = False) -> asyncio.AbstractEventLoop:
+    # todo: what happens if we remove this? never rely on the running loop
+    #   something to test. import flytekit, inside an async function, what happens?
+    #   import flytekit, inside a jupyter notebook (which sets its own loop)
     try:
         running_loop = asyncio.get_running_loop()
         return running_loop
@@ -37,36 +42,103 @@ def get_or_create_loop(use_windows: bool = False) -> asyncio.AbstractEventLoop:
     else:
         loop = asyncio.new_event_loop()
     # Intentionally not calling asyncio.set_event_loop(loop)
-    # maybe add signal handlers
+    #   Unclear what the downside of this is. But should be better in the Jupyter case where it seems to
+    #   co-opt set_event_loop somehow
+
+    # maybe add signal handlers in the future
+
     return loop
 
 
-def top_level_sync(func: AsyncFuncType, *args, **kwargs):
+class _CoroRunner:
     """
-    Make sure there is no current loop. Then run the func in a new loop
-    """
-    ensure_no_loop(f"Calling {func.__name__} when event loop active not allowed")
-    coro = func(*args, **kwargs)
-    return asyncio.run(coro)
-
-
-def top_level_sync_wrapper(func: AsyncFuncType) -> Synced:
-    """Given a function, make so can be called in async or blocking contexts
-
-    Leave obj=None if defining within a class. Pass the instance if attaching
-    as an attribute of the instance.
+    Runs a coroutine and a loop for it on a background thread, in a blocking manner
     """
 
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        return top_level_sync(func, *args, **kwargs)
+    def __init__(self) -> None:
+        self.__io_loop: asyncio.AbstractEventLoop | None = None
+        self.__runner_thread: threading.Thread | None = None
+        self.__lock = threading.Lock()
+        atexit.register(self._close)
 
-    return wrapper
+    def _close(self) -> None:
+        if self.__io_loop:
+            self.__io_loop.stop()
+
+    def _runner(self) -> None:
+        loop = self.__io_loop
+        assert loop is not None
+        try:
+            loop.run_forever()
+        finally:
+            loop.close()
+
+    def run(self, coro: Any) -> Any:
+        """
+        This is a blocking function.
+        Synchronously runs the coroutine on a background thread.
+        """
+        name = f"{threading.current_thread().name} - runner"
+        with self.__lock:
+            # remove before merging
+            if f"{threading.current_thread().name} - runner" != name:
+                raise AssertionError
+            if self.__io_loop is None:
+                self.__io_loop = asyncio.new_event_loop()
+                self.__runner_thread = threading.Thread(target=self._runner, daemon=True, name=name)
+                self.__runner_thread.start()
+        logger.debug(f"Runner thread started {name}")
+        fut = asyncio.run_coroutine_threadsafe(coro, self.__io_loop)
+        res = fut.result(None)
+
+        return res
+
+
+_runner_map: dict[str, _CoroRunner] = {}
+
+
+class MyContext(object):
+    def __init__(self, vals: Optional[Dict[str, int]] = None):
+        self.vals = vals
+
+
+dummy_context: ContextVar[List[MyContext]] = ContextVar("dummy_context", default=[])
+dummy_context.set([MyContext(vals={"depth": 0})])
+
+
+def run_sync_new_thread(coro_function: Callable[..., Awaitable[T]]) -> Callable[..., T]:
+    """
+    Decorator to run a coroutine function with a loop that runs in a different thread.
+    Always run in a new thread, even if no current thread is running.
+
+    :param coro_function: A coroutine function
+    """
+    # if not inspect.iscoroutinefunction(coro_function):
+    #     raise AssertionError
+
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        name = threading.current_thread().name
+        logger.debug(f"Invoking coro_f synchronously in thread: {threading.current_thread().name}")
+        inner = coro_function(*args, **kwargs)
+        if name not in _runner_map:
+            _runner_map[name] = _CoroRunner()
+        return _runner_map[name].run(inner)
+
+    wrapped.__doc__ = coro_function.__doc__
+    return wrapped
+
+
+# def run_async_correctly(loop: asyncio.AbstractEventLoop, coro_function: Callable[..., Awaitable[T]]) -> T:
+#     if loop.is_running():
+#         return run_sync_new_thread(coro_function)
+#     else:
+#         coro = coro_function(ctx, lv, expected_python_type)
+#         return ctx.loop.run_until_complete(coro)
 
 
 class ContextExecutor(ThreadPoolExecutor):
     def __init__(self):
-        self.context = contextvars.copy_context()
+        self.context = copy_context()
         super().__init__(initializer=self._set_child_context)
 
     def _set_child_context(self):

--- a/flytekit/utils/async_utils.py
+++ b/flytekit/utils/async_utils.py
@@ -3,9 +3,9 @@ import atexit
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
-from contextvars import ContextVar, copy_context
+from contextvars import copy_context
 from types import CoroutineType
-from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Awaitable, Callable, Optional, TypeVar
 
 from flytekit.loggers import logger
 
@@ -97,15 +97,6 @@ class _CoroRunner:
 _runner_map: dict[str, _CoroRunner] = {}
 
 
-class MyContext(object):
-    def __init__(self, vals: Optional[Dict[str, int]] = None):
-        self.vals = vals
-
-
-dummy_context: ContextVar[List[MyContext]] = ContextVar("dummy_context", default=[])
-dummy_context.set([MyContext(vals={"depth": 0})])
-
-
 def run_sync_new_thread(coro_function: Callable[..., Awaitable[T]]) -> Callable[..., T]:
     """
     Decorator to run a coroutine function with a loop that runs in a different thread.
@@ -113,6 +104,7 @@ def run_sync_new_thread(coro_function: Callable[..., Awaitable[T]]) -> Callable[
 
     :param coro_function: A coroutine function
     """
+
     # if not inspect.iscoroutinefunction(coro_function):
     #     raise AssertionError
 

--- a/plugins/flytekit-flyteinteractive/tests/test_flyteinteractive_vscode.py
+++ b/plugins/flytekit-flyteinteractive/tests/test_flyteinteractive_vscode.py
@@ -202,7 +202,7 @@ def test_vscode_run_task_first_fail(vscode_patches, mock_remote_execution):
     mock_process.assert_called_once()
     mock_exit_handler.assert_called_once()
     mock_prepare_interactive_python.assert_called_once()
-    mock_signal.assert_called_once()
+    assert mock_signal.call_count >= 1
     mock_prepare_resume_task_python.assert_called_once()
     mock_prepare_launch_json.assert_called_once()
 

--- a/tests/flytekit/unit/core/test_data.py
+++ b/tests/flytekit/unit/core/test_data.py
@@ -458,7 +458,6 @@ async def dummy_output_to_literal_map(ctx: FlyteContext, ff: typing.List[FlyteFi
 
 @pytest.mark.sandbox_test
 def test_walk_local_copy_to_s3():
-    import typing
     import time
     import datetime
 

--- a/tests/flytekit/unit/core/test_data.py
+++ b/tests/flytekit/unit/core/test_data.py
@@ -457,7 +457,7 @@ async def dummy_output_to_literal_map(ctx: FlyteContext, ff: typing.List[FlyteFi
 
 
 @pytest.mark.sandbox_test
-def test_walk_local_copy_to_s3():
+def test_async_local_copy_to_s3():
     import time
     import datetime
 

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -225,7 +225,7 @@ async def test_resolve_attr_path_in_promise():
 
     src = {"a": [Foo(b="foo")]}
 
-    src_lit = await TypeEngine.to_literal(
+    src_lit = TypeEngine.to_literal(
         FlyteContextManager.current_context(),
         src,
         Dict[str, List[Foo]],
@@ -235,7 +235,7 @@ async def test_resolve_attr_path_in_promise():
 
     # happy path
     tgt_promise = await resolve_attr_path_in_promise(src_promise["a"][0]["b"])
-    assert "foo" == await TypeEngine.to_python_value(FlyteContextManager.current_context(), tgt_promise.val, str)
+    assert "foo" == TypeEngine.to_python_value(FlyteContextManager.current_context(), tgt_promise.val, str)
 
     # exception
     with pytest.raises(FlytePromiseAttributeResolveException):

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -736,8 +736,9 @@ def test_comparison_refs():
 
 
 def test_comparison_lits():
-    px = Promise("x", TypeEngine.to_literal(None, 5, int, None))
-    py = Promise("y", TypeEngine.to_literal(None, 8, int, None))
+    ctx = context_manager.FlyteContextManager.current_context()
+    px = Promise("x", TypeEngine.to_literal(ctx, 5, int, None))
+    py = Promise("y", TypeEngine.to_literal(ctx, 8, int, None))
 
     def eval_expr(expr, expected: bool):
         print(f"{expr} evals to {expr.eval()}")

--- a/tests/flytekit/unit/interactive/test_flyteinteractive_vscode.py
+++ b/tests/flytekit/unit/interactive/test_flyteinteractive_vscode.py
@@ -122,7 +122,7 @@ def test_vscode_remote_execution_but_disable(vscode_patches, mock_remote_executi
     mock_process.assert_not_called()
     mock_exit_handler.assert_not_called()
     mock_prepare_interactive_python.assert_not_called()
-    assert mock_signal.call_count >= 1
+    assert mock_signal.call_count == 0
     mock_prepare_resume_task_python.assert_not_called()
     mock_prepare_launch_json.assert_not_called()
 


### PR DESCRIPTION
This is a PR into https://github.com/flyteorg/flytekit/pull/2752

Changes in this PR (move notes if merging)

* Create a new loop at module load time that is stored in the FlyteContext but is
  * not started
  * `asyncio.set_event_loop` is intentionally not called.
  The idea here is that the loop is protected because it's stored in a contextvar and is not associated directly with the asyncio library.  However I've seen already one error associated with not calling `set_event_loop` and others may crop up.  Not sure what Jupyter is doing, but if you try to create a new loop in Jupyter, and call asyncio.set_event_loop, it doesn't actually overwrite the event loop.  If you call get_running_loop before and after set, it remains the same.  Been looking through their code but not sure how they achieved this, they don't seem to be doing anything special.

* Introduce a threaded coroutine runner, along with helper functions.  Basically if already in an async context, and another async function needs to be called from within a synchronous function, then a new thread will be used to run that coroutine and corresponding loop.

