### PR TITLE
[flyteagent] All agents return dict instead of literal map

### DIFF
--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_agent.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_agent.py
@@ -122,22 +122,20 @@ class BotoAgent(SyncAgentBase):
                 )
             )
             with context_manager.FlyteContextManager.with_context(builder) as new_ctx:
-                outputs = LiteralMap(
-                    literals={
-                        "result": TypeEngine.to_literal(
-                            new_ctx,
-                            truncated_result if truncated_result else result,
-                            Annotated[dict, kwtypes(allow_pickle=True)],
-                            TypeEngine.to_literal_type(dict),
-                        ),
-                        "idempotence_token": TypeEngine.to_literal(
-                            new_ctx,
-                            idempotence_token,
-                            str,
-                            TypeEngine.to_literal_type(str),
-                        ),
-                    }
-                )
+                outputs = {
+                    "result": TypeEngine.to_literal(
+                        new_ctx,
+                        truncated_result if truncated_result else result,
+                        Annotated[dict, kwtypes(allow_pickle=True)],
+                        TypeEngine.to_literal_type(dict),
+                    ),
+                    "idempotence_token": TypeEngine.to_literal(
+                        new_ctx,
+                        idempotence_token,
+                        str,
+                        TypeEngine.to_literal_type(str),
+                    ),
+                }
 
         return Resource(phase=TaskExecution.SUCCEEDED, outputs=outputs)
 

--- a/plugins/flytekit-bigquery/flytekitplugins/bigquery/agent.py
+++ b/plugins/flytekit-bigquery/flytekitplugins/bigquery/agent.py
@@ -84,9 +84,8 @@ class BigQueryAgent(AsyncAgentBase):
         if cur_phase == TaskExecution.SUCCEEDED:
             dst = job.destination
             if dst:
-                ctx = FlyteContextManager.current_context()
                 output_location = f"bq://{dst.project}:{dst.dataset_id}.{dst.table_id}"
-                res = TypeEngine.dict_to_literal_map(ctx, {"results": StructuredDataset(uri=output_location)})
+                res = {"results": StructuredDataset(uri=output_location)}
 
         return Resource(phase=cur_phase, message=str(job.state), log_links=[log_link], outputs=res)
 

--- a/plugins/flytekit-bigquery/tests/test_agent.py
+++ b/plugins/flytekit-bigquery/tests/test_agent.py
@@ -90,7 +90,7 @@ def test_bigquery_agent(mock_client, mock_query_job):
     resource = agent.get(metadata)
     assert resource.phase == TaskExecution.SUCCEEDED
     assert (
-        resource.outputs.literals["results"].scalar.structured_dataset.uri
+        resource.outputs["results"].uri
         == "bq://dummy_project:dummy_dataset.dummy_table"
     )
     assert resource.log_links[0].name == "BigQuery Console"

--- a/plugins/flytekit-openai/flytekitplugins/openai/batch/agent.py
+++ b/plugins/flytekit-openai/flytekitplugins/openai/batch/agent.py
@@ -105,9 +105,7 @@ class BatchEndpointAgent(AsyncAgentBase):
         result = retrieved_result.to_dict()
 
         ctx = FlyteContextManager.current_context()
-        outputs = LiteralMap(
-            literals={"result": TypeEngine.to_literal(ctx, result, Dict, TypeEngine.to_literal_type(Dict))}
-        )
+        outputs = {"result": TypeEngine.to_literal(ctx, result, Dict, TypeEngine.to_literal_type(Dict))}
 
         return Resource(phase=flyte_phase, outputs=outputs, message=message)
 

--- a/plugins/flytekit-snowflake/flytekitplugins/snowflake/agent.py
+++ b/plugins/flytekit-snowflake/flytekitplugins/snowflake/agent.py
@@ -7,7 +7,6 @@ from flytekit import FlyteContextManager, StructuredDataset, logger
 from flytekit.core.type_engine import TypeEngine
 from flytekit.extend.backend.base_agent import AgentRegistry, AsyncAgentBase, Resource, ResourceMeta
 from flytekit.extend.backend.utils import convert_to_flyte_phase, get_agent_secret
-from flytekit.models import literals
 from flytekit.models.literals import LiteralMap
 from flytekit.models.task import TaskTemplate
 from flytekit.models.types import LiteralType, StructuredDatasetType
@@ -114,16 +113,14 @@ class SnowflakeAgent(AsyncAgentBase):
         if cur_phase == TaskExecution.SUCCEEDED and resource_meta.has_output:
             ctx = FlyteContextManager.current_context()
             uri = f"snowflake://{resource_meta.user}:{resource_meta.account}/{resource_meta.warehouse}/{resource_meta.database}/{resource_meta.schema}/{resource_meta.query_id}"
-            res = literals.LiteralMap(
-                {
-                    "results": TypeEngine.to_literal(
-                        ctx,
-                        StructuredDataset(uri=uri),
-                        StructuredDataset,
-                        LiteralType(structured_dataset_type=StructuredDatasetType(format="")),
-                    )
-                }
-            )
+            res = {
+                "results": TypeEngine.to_literal(
+                    ctx,
+                    StructuredDataset(uri=uri),
+                    StructuredDataset,
+                    LiteralType(structured_dataset_type=StructuredDatasetType(format="")),
+                )
+            }
 
         return Resource(phase=cur_phase, outputs=res, log_links=[log_link])
 


### PR DESCRIPTION
## Tracking issue
[https://github.com/flyteorg/flyte/issues/3936](https://github.com/flyteorg/flyte/issues/3936)

## Why are the changes needed?
When users trace the code, they tend to follow patterns we use in Flytekit's agent. By allowing them to use `dict` instead of `LiteralMap`, we can improve their development experience. This way, they don't need to understand the details of how `LiteralMap` works or what a literal is.

## What changes were proposed in this pull request?
In the agent's `get` request:

**Before:**
- Returns a `LiteralMap`.

**After:**
- Returns a `dict`.

Note: We will automatically handle the conversion from `dict` to `LiteralMap` for the user.
- In local execution: 
  [flytekit base_agent.py](https://github.com/flyteorg/flytekit/blob/9bce7c37e950d33688820849b127d1b8ee8af7aa/flytekit/extend/backend/base_agent.py#L315-L316)
- In remote execution: 
  [flytekit agent_service.py](https://github.com/flyteorg/flytekit/blob/9bce7c37e950d33688820849b127d1b8ee8af7aa/flytekit/extend/backend/agent_service.py#L141-L145)

## How was this patch tested?
Through unit tests.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
