### PR TITLE
Adds new pyflyte capability to run arbitrary scripts on remote server.

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -13,7 +13,7 @@ from typing import Iterator, get_args
 
 import rich_click as click
 import yaml
-from click import Context
+from click import Context, Command
 from mashumaro.codecs.json import JSONEncoder
 from rich.progress import Progress
 from typing_extensions import get_origin
@@ -63,7 +63,7 @@ from flytekit.remote import (
     FlyteRemote,
     FlyteTask,
     FlyteWorkflow,
-    remote_fs,
+    remote_fs, raw_script,
 )
 from flytekit.remote.executions import FlyteWorkflowExecution
 from flytekit.tools import module_loader
@@ -678,6 +678,74 @@ def run_command(ctx: click.Context, entity: typing.Union[PythonFunctionWorkflow,
     return _run
 
 
+def file_lister() -> typing.List[str]:
+    """
+    Lists all python files in the current path
+    """
+    files = [str(p) for p in pathlib.Path(".").glob("*.py") if str(p) != "__init__.py"]
+    return sorted(files)
+
+
+def yaml_json_load(stream, param_hint) -> typing.Any:
+    try:
+        inputs = yaml.safe_load(stream)
+    except yaml.YAMLError as e:
+        yaml_e = e
+        try:
+            inputs = json.loads(stream)
+        except json.JSONDecodeError as e:
+            raise click.BadParameter(
+                message=f"Could not load the {param_hint}. Please make sure it is a valid JSON or YAML file."
+                        f"\n json error: {e},"
+                        f"\n yaml error: {yaml_e}",
+                param_hint=f"--{param_hint}",
+            )
+    return inputs
+
+class RawScriptRunCommand(click.RichCommand):
+    _help = """
+    This command can be used to execute a raw script onto a Flyte cluster. This is akin to having a simple
+    Remote Job runner. These can be arbitrary python scripts, without the need to even import flytekit.
+    TODO: support more than single node execution, e.g. distributed training, spark jobs, ray jobs etc
+    """
+    __doc__ = _help
+    SCRIPT_COMMAND = "script"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, name="script", help=self._help, **kwargs)
+
+    def get_params(self, ctx: Context) -> typing.List[click.Parameter]:
+        ctx.obj.remote = True
+        if not self.params:
+            self.params = [
+                click.Option(
+                    ["--cfg", "--config-file"],
+                    help="Config file to use to launch the command, you can generate a template config file ... TODO",
+                    required=False,
+                    type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True, resolve_path=True),
+                ),
+                click.Argument(
+                    ["script_file"],
+                    type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True, resolve_path=True),
+                ),
+            ]
+        return super().get_params(ctx)
+
+    def invoke(self, ctx: click.Context) -> typing.Any:
+        run_level_params: RunLevelParams = ctx.obj
+        r = run_level_params.remote_instance()
+        print(ctx.params)
+        script = ctx.params["script_file"]
+        cfg_file = ctx.params["cfg"]
+        cfg = None
+        if cfg_file:
+            with open(cfg_file, "r") as f:
+                cfg = yaml_json_load(f.read(), "cfg")
+                cfg = raw_script.TaskLaunchConfig.from_dict(cfg)
+        raw_script.run(script=script, cfg=cfg, remote=r, local=not run_level_params.is_remote)
+        return None
+
+
 class DynamicEntityLaunchCommand(click.RichCommand):
     """
     This is a dynamic command that is created for each launch plan. This is used to execute a launch plan.
@@ -840,6 +908,10 @@ class RemoteEntityGroup(click.RichGroup):
 
 
 class YamlFileReadingCommand(click.RichCommand):
+    """
+    A Wrapper command for reading inputs from a YAML file and passing them to the task, workflow or launchplan
+    execution.
+    """
     def __init__(
         self,
         name: str,
@@ -859,20 +931,7 @@ class YamlFileReadingCommand(click.RichCommand):
 
     def parse_args(self, ctx: Context, args: t.List[str]) -> t.List[str]:
         def load_inputs(f: str) -> t.Dict[str, str]:
-            try:
-                inputs = yaml.safe_load(f)
-            except yaml.YAMLError as e:
-                yaml_e = e
-                try:
-                    inputs = json.loads(f)
-                except json.JSONDecodeError as e:
-                    raise click.BadParameter(
-                        message=f"Could not load the inputs file. Please make sure it is a valid JSON or YAML file."
-                        f"\n json error: {e},"
-                        f"\n yaml error: {yaml_e}",
-                        param_hint="--inputs-file",
-                    )
-
+            yaml_json_load(f, "inputs-file")
             return inputs
 
         inputs = {}
@@ -1021,13 +1080,13 @@ class RunCommand(click.RichGroup):
     def list_commands(self, ctx, add_remote: bool = True):
         if self._files:
             return self._files
-        self._files = [str(p) for p in pathlib.Path(".").glob("*.py") if str(p) != "__init__.py"]
-        self._files = sorted(self._files)
+        self._files = file_lister()
         if add_remote:
             self._files = self._files + [
                 RemoteEntityGroup.LAUNCHPLAN_COMMAND,
                 RemoteEntityGroup.WORKFLOW_COMMAND,
                 RemoteEntityGroup.TASK_COMMAND,
+                RawScriptRunCommand.SCRIPT_COMMAND,
             ]
         return self._files
 
@@ -1045,6 +1104,8 @@ class RunCommand(click.RichGroup):
             return RemoteEntityGroup(RemoteEntityGroup.WORKFLOW_COMMAND)
         elif filename == RemoteEntityGroup.TASK_COMMAND:
             return RemoteEntityGroup(RemoteEntityGroup.TASK_COMMAND)
+        elif filename == RawScriptRunCommand.SCRIPT_COMMAND:
+            return RawScriptRunCommand()
         return WorkflowCommand(filename, name=filename, help=f"Run a [workflow|task] from {filename}")
 
 

--- a/flytekit/remote/raw_script.py
+++ b/flytekit/remote/raw_script.py
@@ -1,0 +1,113 @@
+import subprocess
+from dataclasses import dataclass
+from typing import Optional, Union, List
+
+from mashumaro.mixins.json import DataClassJSONMixin
+from mashumaro.mixins.yaml import DataClassYAMLMixin
+
+from flytekit import ImageSpec, Resources, PythonFunctionTask, Secret, FlyteContextManager
+from flytekit.configuration import SerializationSettings
+from flytekit.core.base_task import TaskResolverMixin, Task
+from flytekit.extras.tasks.shell import subproc_execute
+from flytekit.remote import FlyteRemote
+from flytekit.tools.fast_registration import FastPackageOptions
+
+
+class ImageSpecConfig(DataClassYAMLMixin, DataClassJSONMixin, ImageSpec):
+    def __hash__(self):
+        return hash(self.to_dict().__str__())
+
+
+class ResourceConfig(DataClassYAMLMixin, Resources):
+    pass
+
+
+class SecretsConfig(DataClassYAMLMixin, DataClassJSONMixin, Secret):
+    pass
+
+
+@dataclass
+class TaskLaunchConfig(DataClassYAMLMixin, DataClassJSONMixin):
+    name: Optional[str] = None
+    project: Optional[str] = None
+    domain: Optional[str] = None
+    run_command: Optional[str] = None
+    container_image: Optional[Union[ImageSpecConfig, str]] = None
+    resources: Optional[ResourceConfig] = None
+    secrets: Optional[List[Secret]] = None
+    copy_all: bool = False
+
+
+def runner(script_file: str, run_command: str):
+    if not run_command:
+        run_command = ["python", script_file]
+    print(f"Running {run_command}")
+    shell = False if run_command and isinstance(run_command, list) else True
+    subprocess.check_call(run_command, shell=shell)
+
+
+class RawTaskLaunchResolver(TaskResolverMixin):
+    @property
+    def location(self) -> str:
+        return "flytekit.remote.raw_script.resolver"
+
+    @property
+    def name(self) -> str:
+        return "flytekit.remote.raw_script"
+
+    def get_task_for_script(
+            self,
+            config: TaskLaunchConfig,
+    ) -> PythonFunctionTask:
+        return PythonFunctionTask(
+            task_config=None,
+            task_function=runner,
+            task_type="raw_script",
+            task_resolver=self,
+            requests=config.resources,
+            container_image=config.container_image,
+            secret_requests=config.secrets,
+        )
+
+    def load_task(self, loader_args: List[str]) -> PythonFunctionTask:
+        return PythonFunctionTask(
+            task_config=None,
+            task_function=runner,
+            task_type="workspace",
+            task_resolver=self,
+        )
+
+    def loader_args(self, settings: SerializationSettings, task: PythonFunctionTask) -> List[str]:
+        return ["workspace"]
+
+    def get_all_tasks(self) -> List[Task]:
+        raise NotImplementedError
+
+
+resolver = RawTaskLaunchResolver()
+
+
+def run(script: str, cfg: Optional[TaskLaunchConfig] = None, envvars=None,
+        overwrite_cache=False, local=True, remote: Optional[FlyteRemote] = None):
+    """
+    Entrypoint to run scripts locally or remote.
+    """
+    if not cfg:
+        cfg = TaskLaunchConfig()
+    tk = resolver.get_task_for_script(cfg)
+
+    if local:
+        # TODO this has to be rationalized with run.pys local execution. Many arguments have to passed
+        # We should make a common local run setup method
+        import os
+        if envvars:
+            for env_var, value in envvars.items():
+                os.environ[env_var] = value
+        if overwrite_cache:
+            os.environ["FLYTE_LOCAL_CACHE_OVERWRITE"] = "true"
+        output = tk(script_file=script, run_command=cfg.run_command or "")
+        return
+
+    remote_task = remote.register_script(tk, source_path=script) #, copy_all=cfg.copy_all)
+    remote.execute_remote_task_lp(remote_task, inputs={"script_file": script, "run_command": cfg.run_command},
+                                  overwrite_cache=overwrite_cache)


### PR DESCRIPTION
## Why are the changes needed? 
A lot of repos in the world have simply scripts or torchrun scripts to run. Also some users where flyte is already deployed may want to run a script on remote. This command makes it possible, with a future extension to support arbitrary job type.

No need to import flytekit, just have local flytekit environment and run any python scripts on remote. Example training scripts etc. You can request specific resources too

Example Code:
hello.py
```python
print("Hello world")
```

Can be run
```bash
pyflyte run --remote script hello.py
```

To run on a bigger box `cfg.yaml`
```bash
run_command: |
  python test.py
resources:
  gpu: 1
  mem: 2Gi
  accelerator: nvidia-a10g
secrets:
  - key: openai
```
## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
