### PR TITLE
GH-5768: Better pyflyte boolean parsing

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -449,10 +449,14 @@ def to_click_option(
     # If a query has been specified, the input is never strictly required at this layer
     required = False if default_val and isinstance(default_val, ArtifactQuery) else required
 
+    if literal_converter.is_bool():
+        click_cli_paramater_name = f"--{input_name}/--no_{input_name}"
+    else:
+        click_cli_paramater_name = f"--{input_name}"
+
     return click.Option(
-        param_decls=[f"--{input_name}"],
+        param_decls=[click_cli_paramater_name],
         type=literal_converter.click_type,
-        is_flag=literal_converter.is_bool(),
         default=default_val,
         show_default=True,
         required=required,

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -450,7 +450,10 @@ def to_click_option(
     required = False if default_val and isinstance(default_val, ArtifactQuery) else required
 
     if literal_converter.is_bool():
-        click_cli_parameter_names = [f"--{input_name}/--no_{input_name}", f"--{input_name}/--no-{input_name.replace('_', '-')}"]
+        click_cli_parameter_names = [
+            f"--{input_name}/--no_{input_name}",
+            f"--{input_name}/--no-{input_name.replace('_', '-')}",
+        ]
     else:
         click_cli_parameter_names = [f"--{input_name}"]
 

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -450,12 +450,12 @@ def to_click_option(
     required = False if default_val and isinstance(default_val, ArtifactQuery) else required
 
     if literal_converter.is_bool():
-        click_cli_paramater_name = f"--{input_name}/--no_{input_name}"
+        click_cli_parameter_names = [f"--{input_name}/--no_{input_name}", f"--{input_name}/--no-{input_name.replace('_', '-')}"]
     else:
-        click_cli_paramater_name = f"--{input_name}"
+        click_cli_parameter_names = [f"--{input_name}"]
 
     return click.Option(
-        param_decls=[click_cli_paramater_name],
+        param_decls=click_cli_parameter_names,
         type=literal_converter.click_type,
         default=default_val,
         show_default=True,

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -243,7 +243,7 @@ def test_union_type1(input):
     [
         (("--a",), "test_task_boolean", True),
         (("--no_a",), "test_task_boolean", False),
-        
+
         (tuple(), "test_task_boolean_default_true", True),
         (("--a",), "test_task_boolean_default_true", True),
         (("--no_a",), "test_task_boolean_default_true", False),

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -241,16 +241,19 @@ def test_union_type1(input):
 @pytest.mark.parametrize(
     "extra_cli_args, task_name, expected_output",
     [
-        (("--a",), "test_boolean", True),
-        (("--no_a",), "test_boolean", False),
+        (("--a_b",), "test_boolean", True),
+        (("--no_a_b",), "test_boolean", False),
+        (("--no-a-b",), "test_boolean", False),
 
         (tuple(), "test_boolean_default_true", True),
-        (("--a",), "test_boolean_default_true", True),
-        (("--no_a",), "test_boolean_default_true", False),
+        (("--a_b",), "test_boolean_default_true", True),
+        (("--no_a_b",), "test_boolean_default_true", False),
+        (("--no-a-b",), "test_boolean_default_true", False),
 
         (tuple(), "test_boolean_default_false", False),
-        (("--a",), "test_boolean_default_false", True),
-        (("--no_a",), "test_boolean_default_false", False),
+        (("--a_b",), "test_boolean_default_false", True),
+        (("--no_a_b",), "test_boolean_default_false", False),
+        (("--no-a-b",), "test_boolean_default_false", False),
     ],
 )
 def test_boolean_type(extra_cli_args, task_name, expected_output):

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -238,6 +238,37 @@ def test_union_type1(input):
     assert result.exit_code == 0
 
 
+@pytest.mark.parametrize(
+    "extra_cli_args, task_name, expected_output",
+    [
+        (("--a",), "test_task_boolean", True),
+        (("--no_a",), "test_task_boolean", False),
+        
+        (tuple(), "test_task_boolean_default_true", True),
+        (("--a",), "test_task_boolean_default_true", True),
+        (("--no_a",), "test_task_boolean_default_true", False),
+
+        (tuple(), "test_task_boolean_default_false", False),
+        (("--a",), "test_task_boolean_default_false", True),
+        (("--no_a",), "test_task_boolean_default_false", False),
+    ],
+)
+def test_boolean_type(extra_cli_args, task_name, expected_output):
+    runner = CliRunner()
+    result = runner.invoke(
+        pyflyte.main,
+        [
+            "run",
+            os.path.join(DIR_NAME, "workflow.py"),
+            task_name,
+            *extra_cli_args,
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert str(expected_output) in result.stdout
+
+
 def test_all_types_with_json_input():
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -241,16 +241,16 @@ def test_union_type1(input):
 @pytest.mark.parametrize(
     "extra_cli_args, task_name, expected_output",
     [
-        (("--a",), "test_task_boolean", True),
-        (("--no_a",), "test_task_boolean", False),
+        (("--a",), "test_boolean", True),
+        (("--no_a",), "test_boolean", False),
 
-        (tuple(), "test_task_boolean_default_true", True),
-        (("--a",), "test_task_boolean_default_true", True),
-        (("--no_a",), "test_task_boolean_default_true", False),
+        (tuple(), "test_boolean_default_true", True),
+        (("--a",), "test_boolean_default_true", True),
+        (("--no_a",), "test_boolean_default_true", False),
 
-        (tuple(), "test_task_boolean_default_false", False),
-        (("--a",), "test_task_boolean_default_false", True),
-        (("--no_a",), "test_task_boolean_default_false", False),
+        (tuple(), "test_boolean_default_false", False),
+        (("--a",), "test_boolean_default_false", True),
+        (("--no_a",), "test_boolean_default_false", False),
     ],
 )
 def test_boolean_type(extra_cli_args, task_name, expected_output):
@@ -422,6 +422,9 @@ def test_get_entities_in_file(workflow_file):
         "task_with_env_vars",
         "task_with_list",
         "task_with_optional",
+        "test_boolean",
+        "test_boolean_default_false",
+        "test_boolean_default_true",
         "test_union1",
         "test_union2",
     ]
@@ -436,6 +439,9 @@ def test_get_entities_in_file(workflow_file):
         "task_with_env_vars",
         "task_with_list",
         "task_with_optional",
+        "test_boolean",
+        "test_boolean_default_false",
+        "test_boolean_default_true",
         "test_union1",
         "test_union2",
     ]

--- a/tests/flytekit/unit/cli/pyflyte/workflow.py
+++ b/tests/flytekit/unit/cli/pyflyte/workflow.py
@@ -81,16 +81,16 @@ def test_union2(a: typing.Union[float, typing.List[int], MyDataclass]):
     print(a)
 
 @task
-def test_boolean(a: bool):
-    print(a)
+def test_boolean(a_b: bool):
+    print(a_b)
 
 @task
-def test_boolean_default_true(a: bool = True):
-    print(a)
+def test_boolean_default_true(a_b: bool = True):
+    print(a_b)
 
 @task
-def test_boolean_default_false(a: bool = False):
-    print(a)
+def test_boolean_default_false(a_b: bool = False):
+    print(a_b)
 
 
 @workflow

--- a/tests/flytekit/unit/cli/pyflyte/workflow.py
+++ b/tests/flytekit/unit/cli/pyflyte/workflow.py
@@ -81,15 +81,15 @@ def test_union2(a: typing.Union[float, typing.List[int], MyDataclass]):
     print(a)
 
 @task
-def test_task_boolean(a: bool):
+def test_boolean(a: bool):
     print(a)
 
 @task
-def test_task_boolean_default_true(a: bool = True):
+def test_boolean_default_true(a: bool = True):
     print(a)
 
 @task
-def test_task_boolean_default_false(a: bool = False):
+def test_boolean_default_false(a: bool = False):
     print(a)
 
 

--- a/tests/flytekit/unit/cli/pyflyte/workflow.py
+++ b/tests/flytekit/unit/cli/pyflyte/workflow.py
@@ -80,6 +80,18 @@ def test_union1(a: typing.Union[int, FlyteFile, typing.Dict[str, float], datetim
 def test_union2(a: typing.Union[float, typing.List[int], MyDataclass]):
     print(a)
 
+@task
+def test_task_boolean(a: bool):
+    print(a)
+
+@task
+def test_task_boolean_default_true(a: bool = True):
+    print(a)
+
+@task
+def test_task_boolean_default_false(a: bool = False):
+    print(a)
+
 
 @workflow
 def my_wf(


### PR DESCRIPTION
## Tracking issue
Closes [flyteorg/flyte#999](https://github.com/flyteorg/flyte/issues/5768)

## Why are the changes needed?
The current boolean parsing behaviour is confusing for default True arguments. 


## What changes were proposed in this pull request?
Add `--no_...` and `--no-...` variants for boolean flags as per the recommendation at https://click.palletsprojects.com/en/8.1.x/options/#boolean-flags

## How was this patch tested?
Wrote new unit tests to cover it. 
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly - I'm not aware of any docs that need updating. pyflyte's `--help` should be automatically taken care of by the `click` library. 
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
