### PR TITLE
Enable Spark Fast Register

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -18,6 +18,7 @@ from flyteidl.core import literals_pb2 as _literals_pb2
 from flytekit.configuration import (
     SERIALIZED_CONTEXT_ENV_VAR,
     FastSerializationSettings,
+    ImageConfig,
     SerializationSettings,
     StatsConfig,
 )
@@ -325,16 +326,20 @@ def setup_execution(
     if compressed_serialization_settings:
         ss = SerializationSettings.from_transport(compressed_serialization_settings)
         ssb = ss.new_builder()
-        ssb.project = ssb.project or exe_project
-        ssb.domain = ssb.domain or exe_domain
-        ssb.version = tk_version
-        if dynamic_addl_distro:
-            ssb.fast_serialization_settings = FastSerializationSettings(
-                enabled=True,
-                destination_dir=dynamic_dest_dir,
-                distribution_location=dynamic_addl_distro,
-            )
-        cb = cb.with_serialization_settings(ssb.build())
+    else:
+        ss = SerializationSettings(ImageConfig.auto())
+        ssb = ss.new_builder()
+
+    ssb.project = ssb.project or exe_project
+    ssb.domain = ssb.domain or exe_domain
+    ssb.version = tk_version
+    if dynamic_addl_distro:
+        ssb.fast_serialization_settings = FastSerializationSettings(
+            enabled=True,
+            destination_dir=dynamic_dest_dir,
+            distribution_location=dynamic_addl_distro,
+        )
+    cb = cb.with_serialization_settings(ssb.build())
 
     with FlyteContextManager.with_context(cb) as ctx:
         yield ctx

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -270,6 +270,8 @@ class _ModuleSanitizer(object):
         # Let us remove any extensions like .py
         basename = os.path.splitext(basename)[0]
 
+        # This is an escape hatch for the zipimporter (used by spark).  As this function is called recursively,
+        # it'll eventually reach the zip file, which is not extracted, so we should return.
         if not Path(dirname).is_dir():
             return basename
 

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -274,6 +274,9 @@ class _ModuleSanitizer(object):
         # Let us remove any extensions like .py
         basename = os.path.splitext(basename)[0]
 
+        if not Path(dirname).is_dir():
+            return basename
+
         if dirname == package_root:
             return basename
 

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -113,6 +113,10 @@ class TrackedInstance(metaclass=InstanceTrackingMeta):
         return n
 
     @property
+    def module_file(self) -> str:
+        return str(self._module_file)
+
+    @property
     def lhs(self):
         if self._lhs is not None:
             return self._lhs

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -113,10 +113,6 @@ class TrackedInstance(metaclass=InstanceTrackingMeta):
         return n
 
     @property
-    def module_file(self) -> str:
-        return str(self._module_file)
-
-    @property
     def lhs(self):
         if self._lhs is not None:
             return self._lhs

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -9,6 +9,7 @@ import sys
 import tarfile
 import tempfile
 import typing
+from datetime import datetime
 from pathlib import Path
 from types import ModuleType
 from typing import List, Optional, Tuple, Union
@@ -68,9 +69,9 @@ def compress_scripts(source_path: str, destination: str, modules: List[ModuleTyp
 # intended to be passed as a filter to tarfile.add
 # https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.add
 def tar_strip_file_attributes(tar_info: tarfile.TarInfo) -> tarfile.TarInfo:
-    # set time to epoch timestamp 0, aka 00:00:00 UTC on 1 January 1970
+    # set time to epoch timestamp 0, aka 00:00:00 UTC on 1 January 1980
     # note that when extracting this tarfile, this time will be shown as the modified date
-    tar_info.mtime = 0
+    tar_info.mtime = datetime("1980", 1, 1)
 
     # user/group info
     tar_info.uid = 0

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -71,7 +71,7 @@ def compress_scripts(source_path: str, destination: str, modules: List[ModuleTyp
 def tar_strip_file_attributes(tar_info: tarfile.TarInfo) -> tarfile.TarInfo:
     # set time to epoch timestamp 0, aka 00:00:00 UTC on 1 January 1980
     # note that when extracting this tarfile, this time will be shown as the modified date
-    tar_info.mtime = datetime("1980", 1, 1)
+    tar_info.mtime = datetime(1980, 1, 1).timestamp()
 
     # user/group info
     tar_info.uid = 0

--- a/plugins/flytekit-spark/Dockerfile
+++ b/plugins/flytekit-spark/Dockerfile
@@ -3,7 +3,11 @@ FROM apache/spark-py:3.3.1
 LABEL org.opencontainers.image.source=https://github.com/flyteorg/flytekit
 
 USER 0
-	@@ -11,10 +11,7 @@ ARG VERSION
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN apt-get update && apt-get install -y wget
+
+ARG VERSION
 RUN pip install --no-cache-dir flytekitplugins-spark==$VERSION flytekit==$VERSION
 
 RUN wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.2/hadoop-aws-3.2.2.jar -P /opt/spark/jars && \

--- a/plugins/flytekit-spark/Dockerfile
+++ b/plugins/flytekit-spark/Dockerfile
@@ -1,17 +1,16 @@
-# https://hub.docker.com/_/spark/tags
-FROM spark:latest
+# https://github.com/apache/spark/blob/master/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
+FROM apache/spark-py:3.3.1
 LABEL org.opencontainers.image.source=https://github.com/flyteorg/flytekit
 
 USER 0
-RUN ln -s /usr/bin/python3 /usr/bin/python
-
-RUN apt-get update && apt-get install -y wget
-
-ARG VERSION
+	@@ -11,10 +11,7 @@ ARG VERSION
 RUN pip install --no-cache-dir flytekitplugins-spark==$VERSION flytekit==$VERSION
 
 RUN wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.2/hadoop-aws-3.2.2.jar -P /opt/spark/jars && \
-    wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar -P /opt/spark/jars && \
-    wget https://github.com/GoogleCloudDataproc/hadoop-connectors/releases/download/v2.2.17/util-hadoop-hadoop3-2.2.17.jar -P /opt/spark/jars
+    wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar -P /opt/spark/jars
 
-USER spark
+RUN wget https://github.com/GoogleCloudDataproc/hadoop-connectors/releases/download/v2.2.17/util-hadoop-hadoop3-2.2.17.jar -P /opt/spark/jars
+
+RUN chown -R ${spark_uid}:${spark_uid} /root
+WORKDIR /root
+USER ${spark_uid}

--- a/plugins/flytekit-spark/Dockerfile
+++ b/plugins/flytekit-spark/Dockerfile
@@ -1,5 +1,5 @@
-# https://github.com/apache/spark/blob/master/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
-FROM apache/spark-py:3.3.1
+# https://hub.docker.com/_/spark/tags
+FROM apache/spark:latest
 LABEL org.opencontainers.image.source=https://github.com/flyteorg/flytekit
 
 USER 0
@@ -11,10 +11,7 @@ ARG VERSION
 RUN pip install --no-cache-dir flytekitplugins-spark==$VERSION flytekit==$VERSION
 
 RUN wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.2/hadoop-aws-3.2.2.jar -P /opt/spark/jars && \
-    wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar -P /opt/spark/jars
+    wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar -P /opt/spark/jars && \
+    wget https://github.com/GoogleCloudDataproc/hadoop-connectors/releases/download/v2.2.17/util-hadoop-hadoop3-2.2.17.jar -P /opt/spark/jars
 
-RUN wget https://github.com/GoogleCloudDataproc/hadoop-connectors/releases/download/v2.2.17/util-hadoop-hadoop3-2.2.17.jar -P /opt/spark/jars
-
-RUN chown -R ${spark_uid}:${spark_uid} /root
-WORKDIR /root
-USER ${spark_uid}
+USER spark

--- a/plugins/flytekit-spark/Dockerfile
+++ b/plugins/flytekit-spark/Dockerfile
@@ -1,5 +1,5 @@
 # https://hub.docker.com/_/spark/tags
-FROM apache/spark:latest
+FROM spark:latest
 LABEL org.opencontainers.image.source=https://github.com/flyteorg/flytekit
 
 USER 0

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -218,8 +218,8 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         self.sess = sess_builder.getOrCreate()
         # self.sess.addArtifacts("fast_spark.py", file=True)
         # self.sess.sparkContext.addPyFile(self.module_file)
-        shutil.make_archive("archive", 'zip', os.getcwd())
-        self.sess.sparkContext.addPyFile("archive.zip")
+        # shutil.make_archive("archive", 'zip', os.getcwd(), ignore=["script_mode.tar.gz"])
+        self.sess.sparkContext.addArchive("script_mode.tar.gz")
 
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -196,7 +196,9 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         self.sess = sess_builder.getOrCreate()
 
         if (
-            ctx.serialization_settings.fast_serialization_settings.enabled
+            ctx.serialization_settings
+            and ctx.serialization_settings.fast_serialization_settings
+            and ctx.serialization_settings.fast_serialization_settings.enabled
             and ctx.execution_state
             and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION
         ):

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -1,17 +1,15 @@
-import glob
 import os
+import shutil
+import time
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Union, cast
 
-import time
 import click
-import shutil
 from google.protobuf.json_format import MessageToDict
 
 from flytekit import FlyteContextManager, PythonFunctionTask, lazy_module, logger
 from flytekit.configuration import DefaultImages, SerializationSettings
 from flytekit.core.context_manager import ExecutionParameters
-from flytekit.core.python_auto_container import get_registerable_container_image
 from flytekit.extend import ExecutionState, TaskPlugins
 from flytekit.extend.backend.base_agent import AsyncAgentExecutorMixin
 from flytekit.image_spec import ImageSpec
@@ -209,7 +207,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
                     file_path = os.path.join(foldername, filename)
                     os.utime(file_path, (current_time, current_time))
 
-            shutil.make_archive("flyte_wf", 'zip', current_dir)
+            shutil.make_archive("flyte_wf", "zip", current_dir)
             self.sess.sparkContext.addPyFile("flyte_wf.zip")
 
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Union, cast
 
 import click
+import shutil
 from google.protobuf.json_format import MessageToDict
 
 from flytekit import FlyteContextManager, PythonFunctionTask, lazy_module, logger

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -216,7 +216,9 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
             print(f)
         self.sess = sess_builder.getOrCreate()
         # self.sess.addArtifacts("fast_spark.py", file=True)
-        self.sess.sparkContext.addPyFile(self.module_file)
+        # self.sess.sparkContext.addPyFile(self.module_file)
+        shutil.make_archive("archive", 'zip', current_directory)
+
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 
     def execute(self, **kwargs) -> Any:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -211,6 +211,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
 
         print("fast_files", fast_files)
         print("script_mode_files", script_mode_files)
+        os.remove("/root/script_mode.tar.gz")
 
         files = [f for f in os.listdir('.') if os.path.isfile(f)]
         for f in files:
@@ -218,7 +219,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         self.sess = sess_builder.getOrCreate()
         # self.sess.addArtifacts("fast_spark.py", file=True)
         # self.sess.sparkContext.addPyFile(self.module_file)
-        os.remove("script_mode.tar.gz")
+
         shutil.make_archive("archive", 'zip', os.getcwd())
         self.sess.sparkContext.addPyFile("archive.zip")
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -218,7 +218,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         self.sess = sess_builder.getOrCreate()
         # self.sess.addArtifacts("fast_spark.py", file=True)
         # self.sess.sparkContext.addPyFile(self.module_file)
-        shutil.make_archive("archive", 'zip', current_directory)
+        shutil.make_archive("archive", 'zip', os.getcwd())
         self.sess.sparkContext.addPyFile("archive.zip")
 
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -220,20 +220,20 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
 
         current_time = time.time()
         current_dir = os.getcwd()
-        # for foldername, subfolders, filenames in os.walk(current_dir):
-        #     for filename in filenames:
-        #         file_path = os.path.join(foldername, filename)
-        #         os.utime(file_path, (current_time, current_time))
-        #
-        # shutil.make_archive("archive", 'zip', current_dir)
-        # self.sess.sparkContext.addPyFile("archive.zip")
-        files = [f for f in os.listdir('.') if os.path.isfile(f)]
-        for f in files:
-            _, ext = os.path.splitext(f)
-            if ext == '.py':
-                self.sess.sparkContext.addPyFile(f)
-            else:
-                self.sess.sparkContext.addFile(f)
+        for foldername, subfolders, filenames in os.walk(current_dir):
+            for filename in filenames:
+                file_path = os.path.join(foldername, filename)
+                os.utime(file_path, (current_time, current_time))
+
+        shutil.make_archive("archive", 'zip', current_dir)
+        self.sess.sparkContext.addPyFile("archive.zip")
+        # files = [f for f in os.listdir('.') if os.path.isfile(f)]
+        # for f in files:
+        #     _, ext = os.path.splitext(f)
+        #     if ext == '.py':
+        #         self.sess.sparkContext.addPyFile(f)
+        #     else:
+        #         self.sess.sparkContext.addFile(f)
 
 
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -207,7 +207,8 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
             print(f)
         self.sess = sess_builder.getOrCreate()
         # self.sess.addArtifacts("fast_spark.py", file=True)
-        self.sess.sparkContext.addFile("fast_spark.py")
+        print("self.instantiated_in", self.instantiated_in)
+        self.sess.sparkContext.addFile(self.instantiated_in)
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 
     def execute(self, **kwargs) -> Any:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -206,7 +206,8 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         for f in files:
             print(f)
         self.sess = sess_builder.getOrCreate()
-        self.sess.addArtifacts("fast_spark.py", file=True)
+        # self.sess.addArtifacts("fast_spark.py", file=True)
+        self.sess.sparkContext.addFile("fast_spark.py")
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 
     def execute(self, **kwargs) -> Any:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -206,6 +206,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         for f in files:
             print(f)
         self.sess = sess_builder.getOrCreate()
+        self.sess.addArtifacts("fast_spark.py", file=True)
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 
     def execute(self, **kwargs) -> Any:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -197,17 +197,17 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         self.sess = sess_builder.getOrCreate()
 
         if ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
-            current_time = time.time()
-            current_dir = os.getcwd()
-            # Set the modification time of all files in the current directory to the current time
-            # since fast register doesn't preserve the modification time of the files and make_archive
-            # does not support timestamps before 1980
-            for foldername, subfolders, filenames in os.walk(current_dir):
-                for filename in filenames:
-                    file_path = os.path.join(foldername, filename)
-                    os.utime(file_path, (current_time, current_time))
+            # current_time = time.time()
+            # current_dir = os.getcwd()
+            # # Set the modification time of all files in the current directory to the current time
+            # # since fast register doesn't preserve the modification time of the files and make_archive
+            # # does not support timestamps before 1980
+            # for foldername, subfolders, filenames in os.walk(current_dir):
+            #     for filename in filenames:
+            #         file_path = os.path.join(foldername, filename)
+            #         os.utime(file_path, (current_time, current_time))
 
-            shutil.make_archive("flyte_wf", "zip", current_dir)
+            shutil.make_archive("flyte_wf", "zip", os.getcwd())
             self.sess.sparkContext.addPyFile("flyte_wf.zip")
 
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -229,8 +229,12 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         # self.sess.sparkContext.addPyFile("archive.zip")
         files = [f for f in os.listdir('.') if os.path.isfile(f)]
         for f in files:
-            print(f)
-            self.sess.sparkContext.addPyFile(f)
+            _, ext = os.path.splitext(f)
+            if ext == '.py':
+                self.sess.sparkContext.addPyFile(f)
+            else:
+                self.sess.sparkContext.addFile(f)
+
 
 
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -207,7 +207,6 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
             print(f)
         self.sess = sess_builder.getOrCreate()
         # self.sess.addArtifacts("fast_spark.py", file=True)
-        breakpoint()
         print("self.module_file", self.module_file)
         self.sess.sparkContext.addFile(self.module_file)
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -209,8 +209,8 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
                     file_path = os.path.join(foldername, filename)
                     os.utime(file_path, (current_time, current_time))
 
-            shutil.make_archive("archive", 'zip', current_dir)
-            self.sess.sparkContext.addPyFile("archive.zip")
+            shutil.make_archive("flyte_wf", 'zip', current_dir)
+            self.sess.sparkContext.addPyFile("flyte_wf.zip")
 
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -1,3 +1,4 @@
+import glob
 import os
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Union, cast
@@ -201,6 +202,14 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
             sess_builder = sess_builder.config(conf=spark_conf)
 
         print("os.getcwd()", os.getcwd())
+        fast_pattern = os.path.join(os.getcwd(), 'fast*.tar.gz')
+        script_mode_pattern = os.path.join(os.getcwd(), 'script_mode.tar.gz')
+
+        fast_files = glob.glob(fast_pattern)
+        script_mode_files = glob.glob(script_mode_pattern)
+
+        print("fast_files", fast_files)
+        print("script_mode_files", script_mode_files)
 
         files = [f for f in os.listdir('.') if os.path.isfile(f)]
         for f in files:
@@ -208,7 +217,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         self.sess = sess_builder.getOrCreate()
         # self.sess.addArtifacts("fast_spark.py", file=True)
         print("self.module_file", self.module_file)
-        self.sess.sparkContext.addFile(os.getcwd(), recursive=True)
+        self.sess.sparkContext.addArchive("script_mode.tar.gz")
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 
     def execute(self, **kwargs) -> Any:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import time
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Union, cast
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -216,8 +216,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
             print(f)
         self.sess = sess_builder.getOrCreate()
         # self.sess.addArtifacts("fast_spark.py", file=True)
-        print("self.module_file", self.module_file)
-        self.sess.sparkContext.addArchive("script_mode.tar.gz")
+        self.sess.sparkContext.addPyFile(self.module_file)
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 
     def execute(self, **kwargs) -> Any:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -218,8 +218,9 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         self.sess = sess_builder.getOrCreate()
         # self.sess.addArtifacts("fast_spark.py", file=True)
         # self.sess.sparkContext.addPyFile(self.module_file)
-        # shutil.make_archive("archive", 'zip', os.getcwd(), ignore=["script_mode.tar.gz"])
-        self.sess.sparkContext.addArchive("script_mode.tar.gz")
+        os.remove("script_mode.tar.gz")
+        shutil.make_archive("archive", 'zip', os.getcwd())
+        self.sess.sparkContext.addPyFile("archive.zip")
 
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -205,7 +205,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         files = [f for f in os.listdir('.') if os.path.isfile(f)]
         for f in files:
             print(f)
-        # self.sess = sess_builder.getOrCreate().addArtifacts()
+        self.sess = sess_builder.getOrCreate()
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 
     def execute(self, **kwargs) -> Any:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -208,7 +208,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         self.sess = sess_builder.getOrCreate()
         # self.sess.addArtifacts("fast_spark.py", file=True)
         print("self.module_file", self.module_file)
-        self.sess.sparkContext.addFile(self.module_file)
+        self.sess.sparkContext.addFile(os.getcwd(), recursive=True)
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 
     def execute(self, **kwargs) -> Any:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -197,18 +197,10 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         self.sess = sess_builder.getOrCreate()
 
         if ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
-            # current_time = time.time()
-            # current_dir = os.getcwd()
-            # # Set the modification time of all files in the current directory to the current time
-            # # since fast register doesn't preserve the modification time of the files and make_archive
-            # # does not support timestamps before 1980
-            # for foldername, subfolders, filenames in os.walk(current_dir):
-            #     for filename in filenames:
-            #         file_path = os.path.join(foldername, filename)
-            #         os.utime(file_path, (current_time, current_time))
-
-            shutil.make_archive("flyte_wf", "zip", os.getcwd())
-            self.sess.sparkContext.addPyFile("flyte_wf.zip")
+            file_name = "flyte_wf"
+            file_format = "zip"
+            shutil.make_archive(file_name, file_format, os.getcwd())
+            self.sess.sparkContext.addPyFile(f"{file_name}.{file_format}")
 
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -207,8 +207,9 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
             print(f)
         self.sess = sess_builder.getOrCreate()
         # self.sess.addArtifacts("fast_spark.py", file=True)
-        print("self.instantiated_in", self.instantiated_in)
-        self.sess.sparkContext.addFile(self.instantiated_in)
+        breakpoint()
+        print("self.module_file", self.module_file)
+        self.sess.sparkContext.addFile(self.module_file)
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 
     def execute(self, **kwargs) -> Any:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -159,10 +159,10 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         )
 
     def get_image(self, settings: SerializationSettings) -> str:
-        if isinstance(self.container_image, ImageSpec):
-            # Ensure that the code is always copied into the image, even during fast-registration.
-            self.container_image.source_root = settings.source_root
-
+        # if isinstance(self.container_image, ImageSpec):
+        #     # Ensure that the code is always copied into the image, even during fast-registration.
+        #     self.container_image.source_root = settings.source_root
+        #
         return get_registerable_container_image(self.container_image, settings.image_config)
 
     def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
@@ -200,7 +200,12 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
                 spark_conf.setExecutorEnv("PYTHONPATH", os.environ["PYTHONPATH"])
             sess_builder = sess_builder.config(conf=spark_conf)
 
-        self.sess = sess_builder.getOrCreate()
+        print("os.getcwd()", os.getcwd())
+
+        files = [f for f in os.listdir('.') if os.path.isfile(f)]
+        for f in files:
+            print(f)
+        # self.sess = sess_builder.getOrCreate().addArtifacts()
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 
     def execute(self, **kwargs) -> Any:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -220,7 +220,14 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         # self.sess.addArtifacts("fast_spark.py", file=True)
         # self.sess.sparkContext.addPyFile(self.module_file)
 
-        shutil.make_archive("archive", 'zip', os.getcwd())
+        current_time = time.time()
+        current_dir = os.getcwd()
+        for foldername, subfolders, filenames in os.walk(current_dir):
+            for filename in filenames:
+                file_path = os.path.join(foldername, filename)
+                os.utime(file_path, (current_time, current_time))
+
+        shutil.make_archive("archive", 'zip', current_dir)
         self.sess.sparkContext.addPyFile("archive.zip")
 
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -3,6 +3,7 @@ import os
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Union, cast
 
+import time
 import click
 import shutil
 from google.protobuf.json_format import MessageToDict

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -195,7 +195,11 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
 
         self.sess = sess_builder.getOrCreate()
 
-        if ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION:
+        if (
+            ctx.serialization_settings.fast_serialization_settings.enabled
+            and ctx.execution_state
+            and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION
+        ):
             file_name = "flyte_wf"
             file_format = "zip"
             shutil.make_archive(file_name, file_format, os.getcwd())

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -214,22 +214,24 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         print("script_mode_files", script_mode_files)
         os.remove("/root/script_mode.tar.gz")
 
-        files = [f for f in os.listdir('.') if os.path.isfile(f)]
-        for f in files:
-            print(f)
         self.sess = sess_builder.getOrCreate()
         # self.sess.addArtifacts("fast_spark.py", file=True)
         # self.sess.sparkContext.addPyFile(self.module_file)
 
         current_time = time.time()
         current_dir = os.getcwd()
-        for foldername, subfolders, filenames in os.walk(current_dir):
-            for filename in filenames:
-                file_path = os.path.join(foldername, filename)
-                os.utime(file_path, (current_time, current_time))
+        # for foldername, subfolders, filenames in os.walk(current_dir):
+        #     for filename in filenames:
+        #         file_path = os.path.join(foldername, filename)
+        #         os.utime(file_path, (current_time, current_time))
+        #
+        # shutil.make_archive("archive", 'zip', current_dir)
+        # self.sess.sparkContext.addPyFile("archive.zip")
+        files = [f for f in os.listdir('.') if os.path.isfile(f)]
+        for f in files:
+            print(f)
+            self.sess.sparkContext.addPyFile(f)
 
-        shutil.make_archive("archive", 'zip', current_dir)
-        self.sess.sparkContext.addPyFile("archive.zip")
 
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -218,6 +218,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         # self.sess.addArtifacts("fast_spark.py", file=True)
         # self.sess.sparkContext.addPyFile(self.module_file)
         shutil.make_archive("archive", 'zip', current_directory)
+        self.sess.sparkContext.addPyFile("archive.zip")
 
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 

--- a/plugins/flytekit-spark/setup.py
+++ b/plugins/flytekit-spark/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "spark"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>1.10.7", "pyspark>=3.0.0", "aiohttp", "flyteidl>=1.11.0b1", "pandas"]
+plugin_requires = ["flytekit>1.13.5", "pyspark>=3.0.0", "aiohttp", "flyteidl>=1.11.0b1", "pandas"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -1,5 +1,3 @@
-import os
-
 import pandas as pd
 import pyspark
 import pytest

--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -1,3 +1,5 @@
+import os
+
 import pandas as pd
 import pyspark
 import pytest
@@ -118,3 +120,7 @@ def test_to_html():
     tf = StructuredDatasetTransformerEngine()
     output = tf.to_html(FlyteContextManager.current_context(), sd, pyspark.sql.DataFrame)
     assert pd.DataFrame(df.schema, columns=["StructField"]).to_html() == output
+
+
+def test_archive_cwd():
+    print(os.getcwd())

--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -120,7 +120,3 @@ def test_to_html():
     tf = StructuredDatasetTransformerEngine()
     output = tf.to_html(FlyteContextManager.current_context(), sd, pyspark.sql.DataFrame)
     assert pd.DataFrame(df.schema, columns=["StructField"]).to_html() == output
-
-
-def test_archive_cwd():
-    print(os.getcwd())

--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -151,6 +151,6 @@ def test_spark_addPyFile():
     with context_manager.FlyteContextManager.with_context(
             ctx.with_execution_state(
                 ctx.new_execution_state().with_params(mode=ExecutionState.Mode.TASK_EXECUTION)).with_serialization_settings(serialization_settings)
-    ) as ctx:
-        my_spark.pre_execute(ctx.user_space_params)
+    ) as new_ctx:
+        my_spark.pre_execute(new_ctx.user_space_params)
         os.remove(os.path.join(os.getcwd(), "flyte_wf.zip"))

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -349,6 +349,15 @@ def test_setup_disk_prefix():
         }
 
 
+def test_setup_for_fast_register():
+    dynamic_addl_distro = "distro"
+    dynamic_dest_dir = "/root"
+    with setup_execution(raw_output_data_prefix="qwerty", dynamic_addl_distro=dynamic_addl_distro, dynamic_dest_dir=dynamic_dest_dir) as ctx:
+        assert ctx.serialization_settings.fast_serialization_settings.enabled is True
+        assert ctx.serialization_settings.fast_serialization_settings.distribution_location == dynamic_addl_distro
+        assert ctx.serialization_settings.fast_serialization_settings.destination_dir == dynamic_dest_dir
+
+
 @mock.patch("google.auth.compute_engine._metadata")
 def test_setup_cloud_prefix(mock_gcs):
     with setup_execution("s3://", checkpoint_path=None, prev_checkpoint=None) as ctx:


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
When we fast-register a Spark task, we will always get a `module not found` error in the Spark executors.

## What changes were proposed in this pull request?
Archive the current directory into a zip file and send it to the spark executor. Exectors will load the module from that zip file.

## How was this patch tested?
```
pyflyte run --remote fast_spark.py my_spark
```

### Setup process
```python
import datetime
import random
from operator import add

import flytekit
from flytekit import ImageSpec, Resources, task, workflow
from flytekitplugins.spark import Spark
from long_description import hello  # local module 
from misc.ignore_pattens import hello123  # local module

flytekit_hash = "be5d8eac263fc8e5d57de110f9648b696d48f20d"
new_flytekit = f"git+https://github.com/flyteorg/flytekit@{flytekit_hash}"
spark_plugins = f"git+https://github.com/flyteorg/flytekit.git@{flytekit_hash}#subdirectory=plugins/flytekit-spark"
custom_image = ImageSpec(
    # python_version="3.9",
    # base_image="pingsutw/spark:v1",
    registry="ghcr.io/flyteorg",
    # packages=[spark_plugins],
    packages=[spark_plugins, new_flytekit],
    apt_packages=["git"]
)


@task(
    task_config=Spark(
        # This configuration is applied to the Spark cluster
        spark_conf={
            "spark.driver.memory": "1000M",
            "spark.executor.memory": "1000M",
            "spark.executor.cores": "1",
            "spark.executor.instances": "2",
            "spark.driver.cores": "1",
            "spark.jars": "https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop3-latest.jar",
        },
        executor_path="/usr/bin/python3",
        applications_path="local:///usr/local/bin/entrypoint.py",
    ),
    limits=Resources(mem="2000M"),
    container_image=custom_image,
)
def hello_spark(partitions: int) -> float:
    print("Starting Spark with Partitionsssss: {}".format(partitions))
    hello()
    hello123()

    n = 1 * partitions
    sess = flytekit.current_context().spark_session
    count = sess.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)

    pi_val = 4.0 * count / n
    return pi_val


def f(_):
    x = random.random() * 2 - 1
    y = random.random() * 2 - 1
    return 1 if x**2 + y**2 <= 1 else 0


@task(
    container_image=custom_image,
)
def print_every_time(value_to_print: float, date_triggered: datetime.datetime) -> int:
    print("My printed value: {} @ {}".format(value_to_print, date_triggered))
    hello()
    hello123()

    return 1


@workflow
def my_spark(triggered_date: datetime.datetime = datetime.datetime(2020, 9, 11)) -> float:
    """
    Using the workflow is still as any other workflow. As image is a property of the task, the workflow does not care
    about how the image is configured.
    """
    pi = hello_spark(partitions=1)
    print_every_time(value_to_print=pi, date_triggered=triggered_date)
    return pi
```

### Screenshots
![Screenshot 2024-09-23 at 2 03 50 PM](https://github.com/user-attachments/assets/86622e5f-afdd-4d89-b0f9-dab04fc63517)


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
