### PR TITLE
enabled copy-all for programmatic fast-registration via FlyteRemote

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -883,7 +883,7 @@ class FlyteRemote(object):
         :param serialization_settings: The serialization settings to be used
         :param default_launch_plan: This should be true if a default launch plan should be created for the workflow
         :param options: Additional execution options that can be configured for the default launchplan
-        :param fast_package_options: Options to customize copy_all behavior
+        :param fast_package_options: Options to customize copying behavior
         :return:
         """
         if not isinstance(entity, PythonFunctionWorkflow):

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -874,6 +874,7 @@ class FlyteRemote(object):
         version: typing.Optional[str] = None,
         default_launch_plan: typing.Optional[bool] = True,
         options: typing.Optional[Options] = None,
+        copy_all: bool = False,
     ) -> FlyteWorkflow:
         """
         Use this method to register a workflow with zip mode.
@@ -912,6 +913,7 @@ class FlyteRemote(object):
             options=options,
             source_path=module_root,
             module_name=mod_name,
+            copy_all=copy_all,
         )
 
     def fast_package(

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -874,7 +874,7 @@ class FlyteRemote(object):
         version: typing.Optional[str] = None,
         default_launch_plan: typing.Optional[bool] = True,
         options: typing.Optional[Options] = None,
-        copy_all: bool = False,
+        fast_package_options: typing.Optional[FastPackageOptions] = None,
     ) -> FlyteWorkflow:
         """
         Use this method to register a workflow with zip mode.
@@ -883,6 +883,7 @@ class FlyteRemote(object):
         :param serialization_settings: The serialization settings to be used
         :param default_launch_plan: This should be true if a default launch plan should be created for the workflow
         :param options: Additional execution options that can be configured for the default launchplan
+        :param fast_package_options: Options to customize copy_all behavior
         :return:
         """
         if not isinstance(entity, PythonFunctionWorkflow):
@@ -913,7 +914,7 @@ class FlyteRemote(object):
             options=options,
             source_path=module_root,
             module_name=mod_name,
-            copy_all=copy_all,
+            fast_package_options=fast_package_options,
         )
 
     def fast_package(

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -679,6 +679,7 @@ def test_register_wf_script_mode(compress_scripts_mock, upload_file_mock, regist
         domain=None,
         version="v1",
         default_launch_plan=True,
+        copy_all=False,
         options=None,
         source_path=str(pathlib.Path(flytekit.__file__).parent.parent),
         module_name="tests.flytekit.unit.remote.resources",

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -679,8 +679,8 @@ def test_register_wf_script_mode(compress_scripts_mock, upload_file_mock, regist
         domain=None,
         version="v1",
         default_launch_plan=True,
-        copy_all=False,
         options=None,
+        fast_package_options=None,
         source_path=str(pathlib.Path(flytekit.__file__).parent.parent),
         module_name="tests.flytekit.unit.remote.resources",
     )


### PR DESCRIPTION
## Why are the changes needed?

One should be able to utilize `--copy-all` via `FlyteRemote.fast_register_workflow`

## What changes were proposed in this pull request?

I expose `--copy-all` to fast-registration.
