### PR TITLE
Mock addPyFile in spark test

### DIFF
--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -126,8 +126,8 @@ def test_to_html():
     assert pd.DataFrame(df.schema, columns=["StructField"]).to_html() == output
 
 
-@mock.patch('shutil.make_archive')
-def test_spark_addPyFile(mock_make_archive):
+@mock.patch('pyspark.context.SparkContext.addPyFile')
+def test_spark_addPyFile(mock_add_pyfile):
     @task(
         task_config=Spark(
             spark_conf={"spark": "1"},
@@ -158,5 +158,5 @@ def test_spark_addPyFile(mock_make_archive):
         with zipfile.ZipFile("flyte_wf.zip", 'w') as zipf:
             zipf.writestr("dummy_file.txt", b'This is some dummy content.')
         my_spark.pre_execute(new_ctx.user_space_params)
-        mock_make_archive.assert_called_once()
+        mock_add_pyfile.assert_called_once()
         os.remove(os.path.join(os.getcwd(), "flyte_wf.zip"))

--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -155,8 +155,6 @@ def test_spark_addPyFile(mock_add_pyfile):
             ctx.with_execution_state(
                 ctx.new_execution_state().with_params(mode=ExecutionState.Mode.TASK_EXECUTION)).with_serialization_settings(serialization_settings)
     ) as new_ctx:
-        with zipfile.ZipFile("flyte_wf.zip", 'w') as zipf:
-            zipf.writestr("dummy_file.txt", b'This is some dummy content.')
         my_spark.pre_execute(new_ctx.user_space_params)
         mock_add_pyfile.assert_called_once()
         os.remove(os.path.join(os.getcwd(), "flyte_wf.zip"))

--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -1,5 +1,4 @@
 import os.path
-import zipfile
 from unittest import mock
 
 import pandas as pd


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
To fix the spark unit test

## What changes were proposed in this pull request?
Mock addPyFile since the CI machine doesn't seem to have enough disk space
related issue: https://stackoverflow.com/a/25707870/9574775

## How was this patch tested?
unit test

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
