### PR TITLE
Fix array node map task for offloaded literal

### DIFF
--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -251,14 +251,14 @@ class ArrayNodeMapTask(PythonTask):
             inputs_interface = self._run_task.python_interface.inputs
             for k in self.interface.inputs.keys():
                 v = literal_map.literals[k]
+                # If the input is offloaded, we need to unwrap it
+                if v.offloaded_metadata:
+                    v = TypeEngine.unwrap_offloaded_literal(ctx, v)
                 if k not in self.bound_inputs:
                     # assert that v.collection is not None
-                    if not v.offloaded_metadata and (not v.collection or not isinstance(v.collection.literals, list)):
-                        raise ValueError(f"Expected a list of literals for {k} or an offloaded metadata")
-                    if v.offloaded_metadata:
-                        map_task_inputs[k] = v
-                    else:
-                        map_task_inputs[k] = v.collection.literals[task_index]
+                    if not v.collection or not isinstance(v.collection.literals, list):
+                        raise ValueError(f"Expected a list of literals for {k}")
+                    map_task_inputs[k] = v.collection.literals[task_index]
                 else:
                     map_task_inputs[k] = v
             inputs_map = _literal_models.LiteralMap(literals=map_task_inputs)

--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -251,12 +251,14 @@ class ArrayNodeMapTask(PythonTask):
             inputs_interface = self._run_task.python_interface.inputs
             for k in self.interface.inputs.keys():
                 v = literal_map.literals[k]
-
                 if k not in self.bound_inputs:
                     # assert that v.collection is not None
-                    if not v.collection or not isinstance(v.collection.literals, list):
-                        raise ValueError(f"Expected a list of literals for {k}")
-                    map_task_inputs[k] = v.collection.literals[task_index]
+                    if not v.offloaded_metadata and (not v.collection or not isinstance(v.collection.literals, list)):
+                        raise ValueError(f"Expected a list of literals for {k} or an offloaded metadata")
+                    if v.offloaded_metadata:
+                        map_task_inputs[k] = v
+                    else:
+                        map_task_inputs[k] = v.collection.literals[task_index]
                 else:
                     map_task_inputs[k] = v
             inputs_map = _literal_models.LiteralMap(literals=map_task_inputs)

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1151,18 +1151,24 @@ class TypeEngine(typing.Generic[T]):
         return lv
 
     @classmethod
+    def unwrap_offloaded_literal(cls, ctx: FlyteContext, lv: Literal) -> Literal:
+        if not lv.offloaded_metadata:
+            return lv
+
+        literal_local_file = ctx.file_access.get_random_local_path()
+        assert lv.offloaded_metadata.uri, "missing offloaded uri"
+        ctx.file_access.download(lv.offloaded_metadata.uri, literal_local_file)
+        input_proto = load_proto_from_file(literals_pb2.Literal, literal_local_file)
+        return Literal.from_flyte_idl(input_proto)
+
+    @classmethod
     def to_python_value(cls, ctx: FlyteContext, lv: Literal, expected_python_type: Type) -> typing.Any:
         """
         Converts a Literal value with an expected python type into a python value.
         """
         # Initiate the process of loading the offloaded literal if offloaded_metadata is set
         if lv.offloaded_metadata:
-            literal_local_file = ctx.file_access.get_random_local_path()
-            assert lv.offloaded_metadata.uri, "missing offloaded uri"
-            ctx.file_access.download(lv.offloaded_metadata.uri, literal_local_file)
-            input_proto = load_proto_from_file(literals_pb2.Literal, literal_local_file)
-            lv = Literal.from_flyte_idl(input_proto)
-
+            lv = cls.unwrap_offloaded_literal(ctx, lv)
         transformer = cls.get_transformer(expected_python_type)
         return transformer.to_python_value(ctx, lv, expected_python_type)
 

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -260,8 +260,8 @@ def test_inputs_outputs_length():
     m = map_task(p3)
     assert m.python_interface.inputs == {"a": int, "b": str, "c": float}
     assert (
-         m.name
-         == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_5d2500dc176052a030efda3b8c283f96-arraynode"
+        m.name
+        == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_5d2500dc176052a030efda3b8c283f96-arraynode"
     )
     r_m = ArrayNodeMapTask(many_inputs, bound_inputs={"a", "c", "b"})
     assert str(r_m.python_interface) == str(m.python_interface)
@@ -482,9 +482,9 @@ def test_load_offloaded_literal(tmp_path, monkeypatch):
                 ctx.execution_state.with_params(mode=context_manager.ExecutionState.Mode.TASK_EXECUTION)
             )
     ) as ctx:
-        list_ints = ["a", "b", "c"]
+        list_strs = ["a", "b", "c"]
         lt = TypeEngine.to_literal_type(typing.List[str])
-        to_be_offloaded = TypeEngine.to_literal(ctx, list_ints, typing.List[str], lt)
+        to_be_offloaded = TypeEngine.to_literal(ctx, list_strs, typing.List[str], lt)
         with open(f"{tmp_path}/literal.pb", "wb") as f:
             f.write(to_be_offloaded.to_flyte_idl().SerializeToString())
 
@@ -499,9 +499,11 @@ def test_load_offloaded_literal(tmp_path, monkeypatch):
             "name": literal
         })
 
-        monkeypatch.setenv("BATCH_JOB_ARRAY_INDEX_VAR_NAME", "name")
-        monkeypatch.setenv("name", "0")
-        t = map_task(say_hello)
-        res = t.dispatch_execute(ctx, lm)
-        assert len(res.literals) == 1
-        assert res.literals["o0"].scalar.primitive.string_value == "hello a!"
+        for index, map_input_str in enumerate(list_strs):
+            monkeypatch.setenv("BATCH_JOB_ARRAY_INDEX_VAR_NAME", "name")
+            monkeypatch.setenv("name", str(index))
+            t = map_task(say_hello)
+            res = t.dispatch_execute(ctx, lm)
+            assert len(res.literals) == 1
+            assert res.literals[f"o{0}"].scalar.primitive.string_value == f"hello {map_input_str}!"
+            monkeypatch.undo()

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -197,17 +197,17 @@ def test_fast_serialization(serialization_settings):
         ({"min_success_ratio": 0.42}, {"min_success_ratio": 0.42}, True),
         ({"min_success_ratio": 0.42}, {"min_success_ratio": 0.42}, True),
         (
-                {
-                    "concurrency": 1,
-                    "min_successes": 2,
-                    "min_success_ratio": 0.42,
-                },
-                {
-                    "concurrency": 1,
-                    "min_successes": 2,
-                    "min_success_ratio": 0.99,
-                },
-                False,
+            {
+                "concurrency": 1,
+                "min_successes": 2,
+                "min_success_ratio": 0.42,
+            },
+            {
+                "concurrency": 1,
+                "min_successes": 2,
+                "min_success_ratio": 0.99,
+            },
+            False,
         ),
     ],
 )
@@ -230,8 +230,8 @@ def test_inputs_outputs_length():
     m = map_task(many_inputs)
     assert m.python_interface.inputs == {"a": List[int], "b": List[str], "c": List[float]}
     assert (
-            m.name
-            == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_6b3bd0353da5de6e84d7982921ead2b3-arraynode"
+        m.name
+        == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_6b3bd0353da5de6e84d7982921ead2b3-arraynode"
     )
     r_m = ArrayNodeMapTask(many_inputs)
     assert str(r_m.python_interface) == str(m.python_interface)
@@ -240,8 +240,8 @@ def test_inputs_outputs_length():
     m = map_task(p1)
     assert m.python_interface.inputs == {"a": List[int], "b": List[str], "c": float}
     assert (
-            m.name
-            == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_7df6892fe8ce5343c76197a0b6127e80-arraynode"
+        m.name
+        == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_7df6892fe8ce5343c76197a0b6127e80-arraynode"
     )
     r_m = ArrayNodeMapTask(many_inputs, bound_inputs=set("c"))
     assert str(r_m.python_interface) == str(m.python_interface)
@@ -250,8 +250,8 @@ def test_inputs_outputs_length():
     m = map_task(p2)
     assert m.python_interface.inputs == {"a": List[int], "b": str, "c": float}
     assert (
-            m.name
-            == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_80fd21f14571026755b99d6b1c045089-arraynode"
+        m.name
+        == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_80fd21f14571026755b99d6b1c045089-arraynode"
     )
     r_m = ArrayNodeMapTask(many_inputs, bound_inputs={"c", "b"})
     assert str(r_m.python_interface) == str(m.python_interface)
@@ -260,8 +260,8 @@ def test_inputs_outputs_length():
     m = map_task(p3)
     assert m.python_interface.inputs == {"a": int, "b": str, "c": float}
     assert (
-            m.name
-            == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_5d2500dc176052a030efda3b8c283f96-arraynode"
+         m.name
+         == "tests.flytekit.unit.core.test_array_node_map_task.map_many_inputs_5d2500dc176052a030efda3b8c283f96-arraynode"
     )
     r_m = ArrayNodeMapTask(many_inputs, bound_inputs={"a", "c", "b"})
     assert str(r_m.python_interface) == str(m.python_interface)


### PR DESCRIPTION
## Why are the changes needed?

When the input to a map task array node is offloaded literal then the current condition breaks out and fails the task.
Adds support to check for offloaded literal in array node and download the literal before the condition checks are done 


## How was this patch tested?

Tested this on sandbox by passing an offloaded literal to map task and using the fix from here https://github.com/flyteorg/flyte/pull/5771 and removing the input overwriting and saw flytekit correctly downloaded offloaded metadata for the passed in literal
example used here for integration test:

```
import typing
from dataclasses import dataclass
from flytekit import task, workflow, map_task
from flytekit.types.file import FlyteFile
from mashumaro.mixins.json import DataClassJSONMixin

@dataclass
# class InnerDC(DataClassJSONMixin):
class InnerDC:
    a: bool
    b: int
    c: float
    d: list[int]
    e: dict[str, int]
    f: FlyteFile

@dataclass
# class DC(DataClassJSONMixin):
class DC:
    name: str
    other: str
    f: FlyteFile
    inner: InnerDC


@task(cache=True, cache_version="1.1")
def f(n: int) -> DC:
    with open("/tmp/abc", "w") as f:
        f.write("wow")
    name = "a" * 500_000
    return DC(
        name=name,
        other=name,
        f=FlyteFile("/tmp/abc"),
        inner=InnerDC(
            a=True,
            b=42,
            c=3.1415,
            d=[1,2,3],
            e={"a": 1, "b": 2},
            f=FlyteFile("/tmp/abc"),
        )
    )

@task(cache=True, cache_version="1.1")
def get_list(n: int) -> list[int]:
    return list(range(n))

@task(cache=True, cache_version="1.1")
def id_dataclass(dc: DC) -> DC:
    with open(dc.f, "r") as f:
        print(f.read())
    return dc


@task(cache=True, cache_version="1.1")
def consume_list_of_objects(xs: list[DC]) -> list[DC]:
    with open(xs[0].f, "r") as f:
        print(f.read())
    return xs[0:2]


@workflow
def working_wf(n: int = 15) -> list[DC]:
    xs=map_task(f)(n=get_list(n=n))
    return consume_list_of_objects(xs=xs)


@workflow
def passing_map_output_wf(n: int = 15) -> list[DC]:
    xs=map_task(f)(n=get_list(n=n))
    # Notice how we pass the offloaded literal to map_task
    return map_task(id_dataclass)(dc=xs) 

@task(cache=True, cache_version="1.1")
def consume_single_element(y: DC) -> DC:
    with open(y.f, "r") as f:
        print(f.read())
    return y

@workflow
def indexing_map_output_wf(n: int = 15):
    a=passing_map_output_wf(n=n)
    consume_single_element(y=a[0])
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
