### PR TITLE
[Flytekit] Envd builder with extra copy commands

### DIFF
--- a/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
+++ b/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
@@ -176,6 +176,46 @@ def build():
         else:
             envd_config += '    io.copy(source="./", target="/root")\n'
 
+    if image_spec.copy:
+
+        def add_envd_copy_command(src_path: pathlib.Path, envd_config: str) -> str:
+            envd_version = metadata.version("envd")
+            if Version(envd_version) <= Version("0.3.37"):
+                if src_path.is_dir():
+                    envd_config += (
+                        f'    io.copy(host_path="{src_path.as_posix()}", envd_path="/root/{src_path.as_posix()}/")\n'
+                    )
+                else:
+                    envd_config += (
+                        f'    io.copy(source="{src_path.as_posix()}", target="/root/{src_path.parent.as_posix()}/")\n'
+                    )
+            else:
+                if src_path.is_dir():
+                    envd_config += (
+                        f'    io.copy(host_path="{src_path.as_posix()}", envd_path="/root/{src_path.as_posix()}/")\n'
+                    )
+                else:
+                    envd_config += (
+                        f'    io.copy(source="{src_path.as_posix()}", target="/root/{src_path.parent.as_posix()}/")\n'
+                    )
+            return envd_config
+
+        for src in image_spec.copy:
+            src_path = pathlib.Path(src)
+
+            if src_path.is_absolute() or ".." in src_path.parts:
+                raise ValueError("Absolute paths or paths with '..' are not allowed in COPY command.")
+
+            dst_path = pathlib.Path(cfg_path).parent / src_path
+            dst_path.parent.mkdir(parents=True, exist_ok=True)
+
+            if src_path.is_dir():
+                shutil.copytree(src_path, dst_path, dirs_exist_ok=True)
+            else:
+                shutil.copy(src_path, dst_path)
+
+            envd_config = add_envd_copy_command(src_path, envd_config)
+
     with open(cfg_path, "w+") as f:
         f.write(envd_config)
 

--- a/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
+++ b/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
@@ -186,13 +186,11 @@ def build():
                         f'    io.copy(host_path="{src_path.as_posix()}", envd_path="/root/{src_path.as_posix()}/")\n'
                     )
                 else:
-                    envd_config += (
-                        f'    io.copy(source="{src_path.as_posix()}", target="/root/{src_path.parent.as_posix()}/")\n'
-                    )
+                    envd_config += f'    io.copy(host_path="{src_path.as_posix()}", envd_path="/root/{src_path.parent.as_posix()}/")\n'
             else:
                 if src_path.is_dir():
                     envd_config += (
-                        f'    io.copy(host_path="{src_path.as_posix()}", envd_path="/root/{src_path.as_posix()}/")\n'
+                        f'    io.copy(source="{src_path.as_posix()}", target="/root/{src_path.as_posix()}/")\n'
                     )
                 else:
                     envd_config += (


### PR DESCRIPTION
## Tracking issue
Related to #2715, after adding support for extra copy commands in the default builder, we also want to extend this support to the envd builder.

## Why are the changes needed?
When creating images with ImageSpec on a remote cluster, we may need to copy additional files or directories required during the container build process. To address this, we aim to support extra copy commands in ImageSpec for copying files and directories into the container’s `/root` directory.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
1. Now we support ImageSpec with `copy` commands to be built by the envd builder.

Example Usage:
`input.txt`
```
test for document example
```
`build_image.py`
```py
from flytekit.image_spec import ImageSpec
from flytekit import task, workflow

image_spec = ImageSpec(
    name="envd-copy-cmds",
    registry="localhost:30000",
   # envd is the default builder for imageSpec
    apt_packages=["git", "gh"],
    copy=["local_test/input.txt"],
    env={"GH_TOKEN": "<YOUR_GITHUB_TOKEN>"},
    commands=[
        "git clone https://github.com/flyteorg/flytekit.git", 
        "cd flytekit", 
        "gh pr checkout 2774", 
        "pip install -e ."
    ]
)

@task(container_image=image_spec)
def my_task() -> str:
    with open("/root/local_test/input.txt", "r") as f:
        return f.read()


@workflow
def my_wf() -> str:
    return my_task()
```
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
3. If there is design documentation, please add the link.
-->

## How was this patch tested?
1. Run the example above with remote execution.
2. Added tests in `plugins/flytekit-envd/tests/test_image_spec.py` to verify the correctness of the envd configuration and its ability to be built.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
```
git clone https://github.com/flyteorg/flytekit.git
gh pr checkout 2774
make setup && pip install -e .
```
### Screenshots

Screenshots of running `pyflyte run --remote build_image.py my_wf`.

- Remote Execution

![image](https://github.com/user-attachments/assets/6ff3fe73-7e38-4bd4-a50c-7dd6111f0a18)

- Terminal
The entire building process is too lengthy; therefore, only the start and the end of the build process are displayed here.

![image](https://github.com/user-attachments/assets/13637530-7082-48d8-b56c-ce54aba586f8)

![image](https://github.com/user-attachments/assets/7412e28e-ac7d-47d4-aedc-ad74bde51330)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
#2715 
<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
