### PR TITLE
Do not copy flytekit itself during fast registration

### DIFF
--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import List, Optional, Tuple, Union
 
+import flytekit
 from flytekit.constants import CopyFileDetection
 from flytekit.loggers import logger
 from flytekit.tools.ignore import IgnoreGroup
@@ -192,6 +193,7 @@ def list_imported_modules_as_files(source_path: str, modules: List[ModuleType]) 
     site_packages_set = set(site_packages)
     bin_directory = os.path.dirname(sys.executable)
     files = []
+    flytekit_root = os.path.dirname(flytekit.__file__)
 
     for mod in modules:
         try:
@@ -206,6 +208,10 @@ def list_imported_modules_as_files(source_path: str, modules: List[ModuleType]) 
         # installed packages & libraries that are not user files. This happens when
         # there is a virtualenv like `.venv` in the working directory.
         try:
+            # Do not upload code if it is from the flytekit library
+            if os.path.commonpath([flytekit_root, mod_file]) == flytekit_root:
+                continue
+
             if os.path.commonpath(site_packages + [mod_file]) in site_packages_set:
                 # Do not upload files from site-packages
                 continue


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
When writing a workflow from the root `flytekit` directory, the flytekit is automatically picked up and bundled it during fast registration. This upload is incomplete because `flytekit` depends on `flytekit.bin.entrypoints`, which is not imported by the workflow but required by the workflow to work. When this partial copy of `flytekit` is copied into `/root`, then will look for `flytekit.bin.entrypoints` here first, but it does not exist.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
With this PR, any files that share the root with `flytekit` will not be uploaded.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Create a workflow in the root directory and run `pyflyte run --remote`.
