### PR TITLE
Support default label/annotation for the default launch plan creating from workflow definition

### DIFF
--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -93,22 +93,20 @@ class LaunchPlan(object):
 
         parameter_map = transform_inputs_to_parameters(ctx, workflow.python_interface)
 
+        default_labels = None
+        default_annotations = None
         if workflow.default_options is not None:
-            lp = LaunchPlan(
-                name=workflow.name,
-                workflow=workflow,
-                parameters=parameter_map,
-                fixed_inputs=_literal_models.LiteralMap(literals={}),
-                labels=workflow.default_options.labels,
-                annotations=workflow.default_options.annotations,
-            )
-        else:
-            lp = LaunchPlan(
-                name=workflow.name,
-                workflow=workflow,
-                parameters=parameter_map,
-                fixed_inputs=_literal_models.LiteralMap(literals={}),
-            )
+            default_labels = workflow.default_options.labels
+            default_annotations = workflow.default_options.annotations
+
+        lp = LaunchPlan(
+            name=workflow.name,
+            workflow=workflow,
+            parameters=parameter_map,
+            fixed_inputs=_literal_models.LiteralMap(literals={}),
+            labels=default_labels,
+            annotations=default_annotations,
+        )
 
         # Ensure default parameters are available when using lp.__call__()
         default_inputs = {

--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -93,12 +93,22 @@ class LaunchPlan(object):
 
         parameter_map = transform_inputs_to_parameters(ctx, workflow.python_interface)
 
-        lp = LaunchPlan(
-            name=workflow.name,
-            workflow=workflow,
-            parameters=parameter_map,
-            fixed_inputs=_literal_models.LiteralMap(literals={}),
-        )
+        if workflow.default_options is not None:
+            lp = LaunchPlan(
+                name=workflow.name,
+                workflow=workflow,
+                parameters=parameter_map,
+                fixed_inputs=_literal_models.LiteralMap(literals={}),
+                labels=workflow.default_options.labels,
+                annotations=workflow.default_options.annotations,
+            )
+        else:
+            lp = LaunchPlan(
+                name=workflow.name,
+                workflow=workflow,
+                parameters=parameter_map,
+                fixed_inputs=_literal_models.LiteralMap(literals={}),
+            )
 
         # Ensure default parameters are available when using lp.__call__()
         default_inputs = {

--- a/flytekit/core/options.py
+++ b/flytekit/core/options.py
@@ -1,0 +1,53 @@
+import typing
+from dataclasses import dataclass
+
+from flytekit.models import common as common_models
+from flytekit.models import security
+
+
+@dataclass
+class Options(object):
+    """
+    These are options that can be configured for a launchplan during registration or overridden during an execution.
+    For instance two people may want to run the same workflow but have the offloaded data stored in two different
+    buckets. Or you may want labels or annotations to be different. This object is used when launching an execution
+    in a Flyte backend, and also when registering launch plans.
+
+    Args:
+        labels: Custom labels to be applied to the execution resource
+        annotations: Custom annotations to be applied to the execution resource
+        security_context: Indicates security context for permissions triggered with this launch plan
+        raw_output_data_config: Optional location of offloaded data for things like S3, etc.
+            remote prefix for storage location of the form ``s3://<bucket>/key...`` or
+            ``gcs://...`` or ``file://...``. If not specified will use the platform configured default. This is where
+            the data for offloaded types is stored.
+        max_parallelism: Controls the maximum number of tasknodes that can be run in parallel for the entire workflow.
+        notifications: List of notifications for this execution.
+        disable_notifications: This should be set to true if all notifications are intended to be disabled for this execution.
+    """
+
+    labels: typing.Optional[common_models.Labels] = None
+    annotations: typing.Optional[common_models.Annotations] = None
+    raw_output_data_config: typing.Optional[common_models.RawOutputDataConfig] = None
+    security_context: typing.Optional[security.SecurityContext] = None
+    max_parallelism: typing.Optional[int] = None
+    notifications: typing.Optional[typing.List[common_models.Notification]] = None
+    disable_notifications: typing.Optional[bool] = None
+    overwrite_cache: typing.Optional[bool] = None
+
+    @classmethod
+    def default_from(
+        cls,
+        k8s_service_account: typing.Optional[str] = None,
+        raw_data_prefix: typing.Optional[str] = None,
+    ) -> "Options":
+        return cls(
+            security_context=(
+                security.SecurityContext(run_as=security.Identity(k8s_service_account=k8s_service_account))
+                if k8s_service_account
+                else None
+            ),
+            raw_output_data_config=(
+                common_models.RawOutputDataConfig(output_location_prefix=raw_data_prefix) if raw_data_prefix else None
+            ),
+        )

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -6,7 +6,7 @@ import typing
 from dataclasses import dataclass
 from enum import Enum
 from functools import update_wrapper
-from typing import TYPE_CHECKING, Any, Callable, Coroutine, Dict, List, Optional, Tuple, Type, Union, cast, overload
+from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple, Type, Union, cast, overload
 
 from typing_inspect import is_optional_type
 
@@ -34,6 +34,7 @@ from flytekit.core.interface import (
     transform_interface_to_typed_interface,
 )
 from flytekit.core.node import Node
+from flytekit.core.options import Options
 from flytekit.core.promise import (
     NodeOutput,
     Promise,
@@ -59,9 +60,6 @@ from flytekit.models import literals as _literal_models
 from flytekit.models.core import workflow as _workflow_model
 from flytekit.models.documentation import Description, Documentation
 from flytekit.types.error import FlyteError
-
-if TYPE_CHECKING:
-    from flytekit.tools.translator import Options
 
 GLOBAL_START_NODE = Node(
     id=_common_constants.GLOBAL_INPUT_NODE_ID,

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -1,7 +1,6 @@
 import sys
 import typing
 from collections import OrderedDict
-from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 from flyteidl.admin import schedule_pb2
@@ -19,16 +18,15 @@ from flytekit.core.gate import Gate
 from flytekit.core.launch_plan import LaunchPlan, ReferenceLaunchPlan
 from flytekit.core.legacy_map_task import MapPythonTask
 from flytekit.core.node import Node
+from flytekit.core.options import Options
 from flytekit.core.python_auto_container import PythonAutoContainerTask
 from flytekit.core.reference_entity import ReferenceEntity, ReferenceSpec, ReferenceTemplate
 from flytekit.core.task import ReferenceTask
 from flytekit.core.utils import ClassDecorator, _dnsify
 from flytekit.core.workflow import ReferenceWorkflow, WorkflowBase
 from flytekit.models import common as _common_models
-from flytekit.models import common as common_models
 from flytekit.models import interface as interface_models
 from flytekit.models import launch_plan as _launch_plan_models
-from flytekit.models import security
 from flytekit.models.admin import workflow as admin_workflow_models
 from flytekit.models.admin.workflow import WorkflowSpec
 from flytekit.models.core import identifier as _identifier_model
@@ -59,50 +57,6 @@ FlyteControlPlaneEntity = Union[
     BranchNodeModel,
     ArrayNodeModel,
 ]
-
-
-@dataclass
-class Options(object):
-    """
-    These are options that can be configured for a launchplan during registration or overridden during an execution.
-    For instance two people may want to run the same workflow but have the offloaded data stored in two different
-    buckets. Or you may want labels or annotations to be different. This object is used when launching an execution
-    in a Flyte backend, and also when registering launch plans.
-
-    Args:
-        labels: Custom labels to be applied to the execution resource
-        annotations: Custom annotations to be applied to the execution resource
-        security_context: Indicates security context for permissions triggered with this launch plan
-        raw_output_data_config: Optional location of offloaded data for things like S3, etc.
-            remote prefix for storage location of the form ``s3://<bucket>/key...`` or
-            ``gcs://...`` or ``file://...``. If not specified will use the platform configured default. This is where
-            the data for offloaded types is stored.
-        max_parallelism: Controls the maximum number of tasknodes that can be run in parallel for the entire workflow.
-        notifications: List of notifications for this execution.
-        disable_notifications: This should be set to true if all notifications are intended to be disabled for this execution.
-    """
-
-    labels: typing.Optional[common_models.Labels] = None
-    annotations: typing.Optional[common_models.Annotations] = None
-    raw_output_data_config: typing.Optional[common_models.RawOutputDataConfig] = None
-    security_context: typing.Optional[security.SecurityContext] = None
-    max_parallelism: typing.Optional[int] = None
-    notifications: typing.Optional[typing.List[common_models.Notification]] = None
-    disable_notifications: typing.Optional[bool] = None
-    overwrite_cache: typing.Optional[bool] = None
-
-    @classmethod
-    def default_from(
-        cls, k8s_service_account: typing.Optional[str] = None, raw_data_prefix: typing.Optional[str] = None
-    ) -> "Options":
-        return cls(
-            security_context=security.SecurityContext(run_as=security.Identity(k8s_service_account=k8s_service_account))
-            if k8s_service_account
-            else None,
-            raw_output_data_config=common_models.RawOutputDataConfig(output_location_prefix=raw_data_prefix)
-            if raw_data_prefix
-            else None,
-        )
 
 
 def to_serializable_case(

--- a/tests/flytekit/unit/core/test_launch_plan.py
+++ b/tests/flytekit/unit/core/test_launch_plan.py
@@ -7,13 +7,14 @@ from flyteidl.admin import launch_plan_pb2 as _launch_plan_idl
 import flytekit.configuration
 from flytekit.configuration import Image, ImageConfig
 from flytekit.core import launch_plan, notification
+from flytekit.core.options import Options
 from flytekit.core.schedule import CronSchedule
 from flytekit.core.task import task
 from flytekit.core.workflow import workflow
 from flytekit.models.common import Annotations, AuthRole, Labels, RawOutputDataConfig
 from flytekit.models.core import execution as _execution_model
 from flytekit.models.core import identifier as identifier_models
-from flytekit.tools.translator import get_serializable, Options
+from flytekit.tools.translator import get_serializable
 
 default_img = Image(name="default", fqn="test", tag="tag")
 serialization_settings = flytekit.configuration.SerializationSettings(


### PR DESCRIPTION
## Tracking issue
Close flyteorg/flyte#5774
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the problem.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?
As mentioned in the tracking issue, users need to manually adjust launch plans or toggle settings in the Flyte Console, which is prone to accidents. This PR simplifies the process by allowing labels and annotations to be defined directly in the workflow definition, reducing the need for manual interventions.

Right now, fields in the [Options](https://github.com/flyteorg/flytekit/blob/8bcb9d0cd3f2eea179dd35385bbf9ed6eebba840/flytekit/tools/translator.py#L65) class are used to set values for a LaunchPlan during registration or execution overrides. When a workflow is registered, it automatically creates a default LaunchPlan, but there is currently no way to set default values for these fields in the workflow itself. Adding this capability will allow users to customize the default LaunchPlan at the workflow definition level, ensuring consistency and making the configuration process more efficient.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
This PR introduces a new `default_options` argument of type `Options` in the workflow decorator. When a default LaunchPlan is created from a workflow, it will now check if `default_options` is provided and use the specified fields (currently only `labels` and `annotations`, but we can add others in the future) as default values. 
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
```python
from flytekit import task, workflow, Annotations, Labels
from flytekit.tools.translator import Options

img = "localhost:30000/flytekit:wf_annotation"

@task(container_image=img)
def wf_labeling_task() -> int:
    return 42


@workflow(
    default_options=Options(
        annotations=Annotations({"annotation": "annotation_wf5"}),
        labels=Labels({"label": "labeling_wf5"}),
    )
)
def wf_labeling_wf5() -> int:
    return wf_labeling_task()


if __name__ == "__main__":
    from click.testing import CliRunner
    from flytekit.clis.sdk_in_container import pyflyte
    import os

    print(wf_labeling_wf5())

    runner = CliRunner()
    result = runner.invoke(
        pyflyte.main,
        [
            "run",
            "--remote",
            os.path.realpath(__file__),
            "wf_labeling_wf5",
        ],
    )
    print(result.output)
```
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
1. Build the image and replace the `img` variable in the code above.
2. Run the code directly or use `pyflyte run`.

### Screenshots
- Successfully execution from FlyteConsole
    <img width="1476" alt="image" src="https://github.com/user-attachments/assets/0fd25145-ffd7-4449-861f-cafb84b3dd62">
- Default annotation and labels
   <img width="1476" alt="image" src="https://github.com/user-attachments/assets/4d298f6c-cb82-4201-9cbc-088171b40ffa">
- Successfully annotating and labeling
    <img width="1017" alt="image" src="https://github.com/user-attachments/assets/eeef078b-ddfa-4567-9d2d-0594b338670e">

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
