### PR TITLE
[FlyteClient][FlyteDeck] Get Downloaded Artifact Signed URL via Data Proxy

### DIFF
--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -1054,7 +1054,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         node_id: str,
         project: str,
         domain: str,
-        execution_id: str,
+        name: str,
         org: str = "",
         expires_in: datetime.timedelta = None,
     ) -> _data_proxy_pb2.CreateDownloadLinkResponse:
@@ -1073,7 +1073,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
                     execution_id=_identifier_pb2.WorkflowExecutionIdentifier(
                         project=project,
                         domain=domain,
-                        name=execution_id,
+                        name=name,
                         org=org,
                     ),
                 ),

--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -1049,7 +1049,6 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         resp = self._dataproxy_stub.GetData(req, metadata=self._metadata)
         return resp
 
-
     def get_download_deck_signed_url(
         self,
         node_id: str,

--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -1060,7 +1060,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         expires_in: datetime.timedelta = None,
     ) -> _data_proxy_pb2.CreateDownloadLinkResponse:
         """
-        This is new API for flyte and union cluster to get the signed url for the deck artifact.
+        This is a new API for flyte and union cluster to get the signed url for the deck artifact.
         """
         expires_in_pb = None
         if expires_in:

--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -1049,16 +1049,25 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         resp = self._dataproxy_stub.GetData(req, metadata=self._metadata)
         return resp
 
-    def get_download_deck_signed_url(
+    def get_download_artifact_signed_url(
         self,
         node_id: str,
         project: str,
         domain: str,
         name: str,
+        artifact_type: _data_proxy_pb2.ArtifactType = ARTIFACT_TYPE_DECK,
         expires_in: datetime.timedelta = None,
     ) -> _data_proxy_pb2.CreateDownloadLinkResponse:
         """
-        This is a new API for flyte and union cluster to get the signed url for the deck artifact.
+        Get a signed url for an artifact.
+
+        :param node_id: Node id associated with artifact
+        :param project: Name of the project the resource belongs to
+        :param domain: Name of the domain the resource belongs to
+        :param name: User or system provided value for the resource
+        :param artifact_type: ArtifactType of the artifact requested
+        :param expires_in: If provided this defines a requested expiration duration for the generated url
+        :rtype: flyteidl.service.dataproxy_pb2.CreateDownloadLinkResponse
         """
         expires_in_pb = None
         if expires_in:
@@ -1066,7 +1075,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
             expires_in_pb.FromTimedelta(expires_in)
         return super(SynchronousFlyteClient, self).create_download_link(
             _data_proxy_pb2.CreateDownloadLinkRequest(
-                artifact_type=ARTIFACT_TYPE_DECK,
+                artifact_type=artifact_type,
                 node_execution_id=_identifier_pb2.NodeExecutionIdentifier(
                     node_id=node_id,
                     execution_id=_identifier_pb2.WorkflowExecutionIdentifier(

--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -1055,7 +1055,6 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         project: str,
         domain: str,
         name: str,
-        org: str = "",
         expires_in: datetime.timedelta = None,
     ) -> _data_proxy_pb2.CreateDownloadLinkResponse:
         """
@@ -1074,7 +1073,6 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
                         project=project,
                         domain=domain,
                         name=name,
-                        org=org,
                     ),
                 ),
                 expires_in=expires_in_pb,

--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -1049,9 +1049,6 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         resp = self._dataproxy_stub.GetData(req, metadata=self._metadata)
         return resp
 
-    """
-    This is for Union's Cluster.
-    """
 
     def get_download_deck_signed_url(
         self,
@@ -1062,6 +1059,9 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         org: str = "",
         expires_in: datetime.timedelta = None,
     ) -> _data_proxy_pb2.CreateDownloadLinkResponse:
+        """
+        This is new API for flyte and union cluster to get the signed url for the deck artifact.
+        """
         expires_in_pb = None
         if expires_in:
             expires_in_pb = Duration()

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -103,14 +103,8 @@ def test_fetch_execute_launch_plan(register):
 
 def test_get_download_deck_signed_url(register):
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
-
-    # Fetch the launch plan for the workflow
     flyte_launch_plan = remote.fetch_launch_plan(name="basic.basic_workflow.my_wf", version=VERSION)
-
-    # Execute the workflow with required inputs
     execution = remote.execute(flyte_launch_plan, inputs={"a": 10, "b": "foobar"}, wait=True)
-
-    # Fetch the execution details
     project, domain, name = execution.id.project, execution.id.domain, execution.id.name
 
     # Fetch the download deck signed URL for the execution

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -118,7 +118,7 @@ def test_get_download_deck_signed_url(register):
 
     # Check if the signed URL is valid and starts with the expected prefix
     signed_url = download_link_response.signed_url[0]
-    assert signed_url.startswith("http://localhost:30002/")
+    assert signed_url.startswith(f"http://localhost:30002/my-s3-bucket/metadata/propeller/{project}-{domain}-{name}/n0/data/0/deck.html")
 
 def test_fetch_execute_launch_plan_with_args(register):
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -23,6 +23,7 @@ from flytekit.core.workflow import reference_workflow
 from flytekit.exceptions.user import FlyteAssertion, FlyteEntityNotExistException
 from flytekit.extras.sqlite3.task import SQLite3Config, SQLite3Task
 from flytekit.remote.remote import FlyteRemote
+from flyteidl.service import dataproxy_pb2 as _data_proxy_pb2
 from flytekit.types.schema import FlyteSchema
 from flytekit.clients.friendly import SynchronousFlyteClient as _SynchronousFlyteClient
 from flytekit.configuration import PlatformConfig
@@ -101,7 +102,7 @@ def test_fetch_execute_launch_plan(register):
     assert execution.outputs["o0"] == "hello world"
 
 
-def test_get_download_deck_signed_url(register):
+def test_get_download_artifact_signed_url(register):
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
     flyte_launch_plan = remote.fetch_launch_plan(name="basic.basic_workflow.my_wf", version=VERSION)
     execution = remote.execute(flyte_launch_plan, inputs={"a": 10, "b": "foobar"}, wait=True)
@@ -109,11 +110,12 @@ def test_get_download_deck_signed_url(register):
 
     # Fetch the download deck signed URL for the execution
     client = _SynchronousFlyteClient(PlatformConfig.for_endpoint("localhost:30080", True))
-    download_link_response = client.get_download_deck_signed_url(
+    download_link_response = client.get_download_artifact_signed_url(
         node_id="n0",  # Assuming node_id is "n0"
         project=project,
         domain=domain,
         name=name,
+        artifact_type=_data_proxy_pb2.ARTIFACT_TYPE_DECK,
     )
 
     # Check if the signed URL is valid and starts with the expected prefix

--- a/tests/flytekit/integration/remote/workflows/basic/basic_workflow.py
+++ b/tests/flytekit/integration/remote/workflows/basic/basic_workflow.py
@@ -26,7 +26,7 @@ def t1(a: int) -> typing.NamedTuple("OutputsBC", t1_int_output=int, c=str):
     return a + 2, "world"
 
 
-@task(enable_deck=True)
+@task
 def t2(a: str, b: str) -> str:
     return b + a
 

--- a/tests/flytekit/integration/remote/workflows/basic/basic_workflow.py
+++ b/tests/flytekit/integration/remote/workflows/basic/basic_workflow.py
@@ -21,12 +21,12 @@ import typing
 from flytekit import task, workflow
 
 
-@task
+@task(enable_deck=True)
 def t1(a: int) -> typing.NamedTuple("OutputsBC", t1_int_output=int, c=str):
     return a + 2, "world"
 
 
-@task
+@task(enable_deck=True)
 def t2(a: str, b: str) -> str:
     return b + a
 


### PR DESCRIPTION
## Why are the changes needed?
This is a new API for Flyte to get the signed URL for the deck artifact.

## What changes were proposed in this pull request?
add a method called `get_download_deck_signed_url` using the IDL `CreateDownloadLinkRequest` and `CreateDownloadLinkResponse`.

## How was this patch tested?
1. flyte sandbox


```python
from flytekit.clients.friendly import SynchronousFlyteClient as _SynchronousFlyteClient
from flytekit.configuration import PlatformConfig, AuthType


client = _SynchronousFlyteClient(PlatformConfig.for_endpoint("localhost:30080", True))
signed_url = client.get_download_deck_signed_url(
    node_id="n1",
    project="flytesnacks",
    domain="development",
    execution_id="awzmsq9jbjfz8p6jksdg",
)
print(signed_url.signed_url)
```

### Screenshots
- sandbox
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/5275253e-9162-4426-8dbc-e5e80a95f1da">
<img width="1270" alt="image" src="https://github.com/user-attachments/assets/b27e65ba-104f-4da3-88a5-df7cfd4d15d7">



## Check all the applicable boxes  

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs


## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
