### PR TITLE
Use uv in agent image

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -5,10 +5,11 @@ LABEL org.opencontainers.image.source=https://github.com/flyteorg/flytekit
 
 ARG VERSION
 
-RUN apt-get update && apt-get install build-essential -y
+RUN apt-get update && apt-get install build-essential -y \
+    && pip install uv
 
-RUN pip install prometheus-client grpcio-health-checking
-RUN pip install --no-cache-dir -U flytekit==$VERSION \
+RUN uv pip install --system prometheus-client grpcio-health-checking
+RUN uv pip install --system --no-cache-dir -U flytekit==$VERSION \
   flytekitplugins-airflow==$VERSION \
   flytekitplugins-bigquery==$VERSION \
   flytekitplugins-openai==$VERSION \
@@ -24,6 +25,6 @@ CMD ["pyflyte", "serve", "agent", "--port", "8000"]
 FROM agent-slim AS agent-all
 ARG VERSION
 
-RUN pip install --no-cache-dir -U \
+RUN uv pip install --system --no-cache-dir -U \
   flytekitplugins-mmcloud==$VERSION \
   flytekitplugins-spark==$VERSION


### PR DESCRIPTION
## Why are the changes needed?
Agent image builds are broken since [flytekit 1.13.5](https://github.com/flyteorg/flytekit/actions/workflows/pythonpublish.yml): 
<img width="656" alt="image" src="https://github.com/user-attachments/assets/eb64df92-ac23-40fa-a626-b2f7a56490e5">

All failures related to the agent image failing to build.

## What changes were proposed in this pull request?
Use uv to build the image, which is able to satisfy all version requirements (and it's also blazing fast).

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
