### PR TITLE
Related to flyteorg/flyte#5805 [Flyte Deck] Extras has been added

### DIFF
--- a/plugins/flytekit-deck-standard/setup.py
+++ b/plugins/flytekit-deck-standard/setup.py
@@ -13,6 +13,7 @@ extras = {
     'markdown': ['markdown'],
     'plotly': ['plotly'],
     'pygments': ['pygments'],
+    'all':['pandas', 'pillow', 'ydata-profiling', 'markdown', 'plotly', 'pygments']
 }
 
 __version__ = "0.0.0+develop"

--- a/plugins/flytekit-deck-standard/setup.py
+++ b/plugins/flytekit-deck-standard/setup.py
@@ -7,20 +7,13 @@ microlib_name = f"flytekitplugins-{PLUGIN_NAME}-standard"
 plugin_requires = ["flytekit"]
 
 extras = {
-    'pandas': ['pandas'],
-    'pillow': ['pillow'],
-    'ydata-profiling': ['ydata-profiling'],
-    'markdown': ['markdown'],
-    'plotly': ['plotly'],
-    'pygments': ['pygments'],
-    'all': [
-           'pandas',
-           'pillow',
-           'ydata-profiling',
-           'markdown',
-           'plotly',
-           'pygments'
-]
+    "pandas": ["pandas"],
+    "pillow": ["pillow"],
+    "ydata-profiling": ["ydata-profiling"],
+    "markdown": ["markdown"],
+    "plotly": ["plotly"],
+    "pygments": ["pygments"],
+    "all": ["pandas", "pillow", "ydata-profiling", "markdown", "plotly", "pygments"],
 }
 
 __version__ = "0.0.0+develop"

--- a/plugins/flytekit-deck-standard/setup.py
+++ b/plugins/flytekit-deck-standard/setup.py
@@ -13,7 +13,14 @@ extras = {
     'markdown': ['markdown'],
     'plotly': ['plotly'],
     'pygments': ['pygments'],
-    'all':['pandas', 'pillow', 'ydata-profiling', 'markdown', 'plotly', 'pygments']
+    'all': [
+           'pandas',
+           'pillow',
+           'ydata-profiling',
+           'markdown',
+           'plotly',
+           'pygments'
+]
 }
 
 __version__ = "0.0.0+develop"

--- a/plugins/flytekit-deck-standard/setup.py
+++ b/plugins/flytekit-deck-standard/setup.py
@@ -6,6 +6,15 @@ microlib_name = f"flytekitplugins-{PLUGIN_NAME}-standard"
 
 plugin_requires = ["flytekit"]
 
+extras = {
+    'pandas': ['pandas'],
+    'pillow': ['pillow'],
+    'ydata-profiling': ['ydata-profiling'],
+    'markdown': ['markdown'],
+    'plotly': ['plotly'],
+    'pygments': ['pygments'],
+}
+
 __version__ = "0.0.0+develop"
 
 setup(
@@ -20,6 +29,7 @@ setup(
     namespace_packages=["flytekitplugins"],
     packages=[f"flytekitplugins.{PLUGIN_NAME}"],
     install_requires=plugin_requires,
+    extras_require=extras,
     license="apache2",
     python_requires=">=3.8",
     classifiers=[


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

Related to flyteorg/flyte#5805

## Why are the changes needed?
[flytekit-deck-standard](https://github.com/flyteorg/flytekit/tree/master/plugins/flytekit-deck-standard)'s dependency is only flytekit now, however, there are some renders that require requirements and we want the user experience to be more smoothly.
For example, if you import ImageRenderer, you have to also install pillow in your Python environment.
But usually users will raise an error than know that they should install pillow.
We want the user to install flytekitplugins-deck like pip install "flytekit-deck-standard[pandas, ydata-profiling]".

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
I only changed the setup.py on flytekit/plugins/flytekit-deck-standard. This change enables user to have a smooth user experience for package installation. Like they can now write pip install "flytekit-deck-standard[pandas, ydata-profiling] instead of installing extras separately.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

I first made sure I don't have the extras packages installed. Then I first build this package via wheel then locally installed it on python via pip like-
" pip install "dist/flytekitplugins_deck_standard-0.0.0+develop-py3-none-any.whl[pandas,ydata-profiling,markdown,plotly,pygments]" "

Output:
Processing ./dist/flytekitplugins_deck_standard-0.0.0+develop-py3-none-any.whl
Requirement already satisfied: flytekit in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekitplugins-deck-standard==0.0.0+develop) (1.13.7)
Requirement already satisfied: pygments in /usr/lib/python3/dist-packages (from flytekitplugins-deck-standard==0.0.0+develop) (2.11.2)
Collecting plotly
  Downloading plotly-5.24.1-py3-none-any.whl (19.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 19.1/19.1 MB 26.0 kB/s eta 0:00:00
Collecting markdown
  Downloading Markdown-3.7-py3-none-any.whl (106 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 106.3/106.3 KB 24.0 kB/s eta 0:00:00
Collecting pandas
  Downloading pandas-2.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (13.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 13.1/13.1 MB 26.6 kB/s eta 0:00:00
Collecting ydata-profiling
  Downloading ydata_profiling-4.10.0-py2.py3-none-any.whl (356 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 356.2/356.2 KB 20.7 kB/s eta 0:00:00
Requirement already satisfied: pillow in /usr/lib/python3/dist-packages (from flytekitplugins-deck-standard==0.0.0+develop) (9.0.1)
Requirement already satisfied: statsd>=3.0.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (4.0.1)
Requirement already satisfied: keyring>=18.0.1 in /usr/lib/python3/dist-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (23.5.0)
Requirement already satisfied: googleapis-common-protos>=1.57 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.65.0)
Requirement already satisfied: typing-extensions in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (4.12.2)
Requirement already satisfied: urllib3>=1.22 in /usr/lib/python3/dist-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.26.5)
Requirement already satisfied: adlfs>=2023.3.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2024.7.0)
Requirement already satisfied: gcsfs>=2023.3.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2024.9.0.post1)
Requirement already satisfied: mashumaro>=3.11 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (3.13.1)
Requirement already satisfied: marshmallow-enum in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.5.1)
Requirement already satisfied: s3fs!=2024.3.1,>=2023.3.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2024.9.0)
Requirement already satisfied: click>=6.6 in /usr/lib/python3/dist-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (8.0.3)
Requirement already satisfied: python-json-logger>=2.0.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2.0.7)
Requirement already satisfied: jsonpickle in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (3.3.0)
Requirement already satisfied: rich in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (13.9.1)
Requirement already satisfied: croniter>=0.3.20 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (3.0.3)
Requirement already satisfied: pytimeparse>=1.1.8 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.1.8)
Requirement already satisfied: requests>=2.18.4 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2.32.3)
Requirement already satisfied: docstring-parser>=0.9.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (0.16)
Requirement already satisfied: dataclasses-json<0.5.12,>=0.5.2 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (0.5.9)
Requirement already satisfied: rich-click in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.8.3)
Requirement already satisfied: cloudpickle>=2.0.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (3.0.0)
Requirement already satisfied: pyyaml!=5.4.0,!=5.4.1,!=6.0.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (6.0.2)
Requirement already satisfied: importlib-metadata in /usr/lib/python3/dist-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (4.6.4)
Requirement already satisfied: docker>=4.0.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (7.1.0)
Requirement already satisfied: grpcio-status in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.66.2)
Requirement already satisfied: diskcache>=5.2.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (5.6.3)
Requirement already satisfied: flyteidl>=1.13.4 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.13.4)
Requirement already satisfied: protobuf!=4.25.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (5.28.2)
Requirement already satisfied: joblib in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.4.2)
Requirement already satisfied: markdown-it-py in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (3.0.0)
Requirement already satisfied: jsonlines in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (4.0.0)
Requirement already satisfied: grpcio in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.66.2)
Requirement already satisfied: marshmallow-jsonschema>=0.12.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (0.13.0)
Requirement already satisfied: fsspec>=2023.3.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2024.9.0)
Requirement already satisfied: python-dateutil>=2.8.2 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from pandas->flytekitplugins-deck-standard==0.0.0+develop) (2.9.0.post0)
Requirement already satisfied: tzdata>=2022.7 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from pandas->flytekitplugins-deck-standard==0.0.0+develop) (2024.2)
Requirement already satisfied: pytz>=2020.1 in /usr/lib/python3/dist-packages (from pandas->flytekitplugins-deck-standard==0.0.0+develop) (2022.1)
Requirement already satisfied: numpy>=1.22.4 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from pandas->flytekitplugins-deck-standard==0.0.0+develop) (2.0.2)
Requirement already satisfied: packaging in /home/rakibulhasan/.local/lib/python3.10/site-packages (from plotly->flytekitplugins-deck-standard==0.0.0+develop) (24.1)
Requirement already satisfied: tenacity>=6.2.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from plotly->flytekitplugins-deck-standard==0.0.0+develop) (9.0.0)
Requirement already satisfied: scipy<1.14,>=1.4.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (1.13.1)
Requirement already satisfied: phik<0.13,>=0.11.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (0.12.4)
Requirement already satisfied: numba<1,>=0.56.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (0.60.0)
Requirement already satisfied: pydantic>=2 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (2.9.2)
Requirement already satisfied: typeguard<5,>=3 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (4.3.0)
Requirement already satisfied: dacite>=1.8 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (1.8.1)
Requirement already satisfied: htmlmin==0.1.12 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (0.1.12)
Requirement already satisfied: multimethod<2,>=1.4 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (1.12)
Requirement already satisfied: tqdm<5,>=4.48.2 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (4.66.5)
Requirement already satisfied: matplotlib<3.10,>=3.5 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (3.9.2)
Requirement already satisfied: imagehash==4.3.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (4.3.1)
Requirement already satisfied: visions[type_image_path]<0.7.7,>=0.7.5 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (0.7.6)
Requirement already satisfied: wordcloud>=1.9.3 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (1.9.3)
Requirement already satisfied: statsmodels<1,>=0.13.2 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (0.14.4)
Requirement already satisfied: jinja2<3.2,>=2.11.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (3.1.4)
Requirement already satisfied: seaborn<0.14,>=0.10.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (0.13.2)
Requirement already satisfied: PyWavelets in /home/rakibulhasan/.local/lib/python3.10/site-packages (from imagehash==4.3.1->ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (1.7.0)
Requirement already satisfied: azure-core<2.0.0,>=1.23.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.31.0)
Requirement already satisfied: azure-datalake-store<0.1,>=0.0.46 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (0.0.53)
Requirement already satisfied: azure-identity in /home/rakibulhasan/.local/lib/python3.10/site-packages (from adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.18.0)
Requirement already satisfied: azure-storage-blob>=12.12.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (12.23.1)
Requirement already satisfied: aiohttp>=3.7.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (3.10.8)
Requirement already satisfied: marshmallow<4.0.0,>=3.3.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from dataclasses-json<0.5.12,>=0.5.2->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (3.22.0)
Requirement already satisfied: typing-inspect>=0.4.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from dataclasses-json<0.5.12,>=0.5.2->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (0.9.0)
Requirement already satisfied: protoc-gen-openapiv2 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from flyteidl>=1.13.4->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (0.0.1)
Requirement already satisfied: google-auth-oauthlib in /home/rakibulhasan/.local/lib/python3.10/site-packages (from gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.2.1)
Requirement already satisfied: google-cloud-storage in /home/rakibulhasan/.local/lib/python3.10/site-packages (from gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2.18.2)
Requirement already satisfied: decorator>4.1.2 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (5.1.1)
Requirement already satisfied: google-auth>=1.2 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2.35.0)
Requirement already satisfied: MarkupSafe>=2.0 in /usr/lib/python3/dist-packages (from jinja2<3.2,>=2.11.1->ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (2.0.1)
Requirement already satisfied: pyparsing>=2.3.1 in /usr/lib/python3/dist-packages (from matplotlib<3.10,>=3.5->ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (2.4.7)
Requirement already satisfied: cycler>=0.10 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from matplotlib<3.10,>=3.5->ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (0.12.1)
Requirement already satisfied: contourpy>=1.0.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from matplotlib<3.10,>=3.5->ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (1.3.0)
Requirement already satisfied: kiwisolver>=1.3.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from matplotlib<3.10,>=3.5->ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (1.4.7)
Requirement already satisfied: fonttools>=4.22.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from matplotlib<3.10,>=3.5->ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (4.54.1)
Requirement already satisfied: llvmlite<0.44,>=0.43.0dev0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from numba<1,>=0.56.0->ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (0.43.0)
Requirement already satisfied: annotated-types>=0.6.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from pydantic>=2->ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (0.7.0)
Requirement already satisfied: pydantic-core==2.23.4 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from pydantic>=2->ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (2.23.4)
Requirement already satisfied: six>=1.5 in /usr/lib/python3/dist-packages (from python-dateutil>=2.8.2->pandas->flytekitplugins-deck-standard==0.0.0+develop) (1.16.0)
Requirement already satisfied: idna<4,>=2.5 in /usr/lib/python3/dist-packages (from requests>=2.18.4->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (3.3)
Requirement already satisfied: charset-normalizer<4,>=2 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from requests>=2.18.4->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (3.3.2)
Requirement already satisfied: certifi>=2017.4.17 in /usr/lib/python3/dist-packages (from requests>=2.18.4->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2020.6.20)
Requirement already satisfied: aiobotocore<3.0.0,>=2.5.4 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from s3fs!=2024.3.1,>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2.15.1)
Requirement already satisfied: patsy>=0.5.6 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from statsmodels<1,>=0.13.2->ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (0.5.6)
Requirement already satisfied: attrs>=19.3.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from visions[type_image_path]<0.7.7,>=0.7.5->ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (24.2.0)
Requirement already satisfied: networkx>=2.4 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from visions[type_image_path]<0.7.7,>=0.7.5->ydata-profiling->flytekitplugins-deck-standard==0.0.0+develop) (3.3)
Requirement already satisfied: mdurl~=0.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from markdown-it-py->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (0.1.2)
Collecting pygments
  Downloading pygments-2.18.0-py3-none-any.whl (1.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 35.0 kB/s eta 0:00:00
Requirement already satisfied: botocore<1.35.24,>=1.35.16 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from aiobotocore<3.0.0,>=2.5.4->s3fs!=2024.3.1,>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.35.23)
Requirement already satisfied: aioitertools<1.0.0,>=0.5.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from aiobotocore<3.0.0,>=2.5.4->s3fs!=2024.3.1,>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (0.12.0)
Requirement already satisfied: wrapt<2.0.0,>=1.10.10 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from aiobotocore<3.0.0,>=2.5.4->s3fs!=2024.3.1,>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.16.0)
Requirement already satisfied: aiosignal>=1.1.2 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from aiohttp>=3.7.0->adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.3.1)
Requirement already satisfied: frozenlist>=1.1.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from aiohttp>=3.7.0->adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.4.1)
Requirement already satisfied: multidict<7.0,>=4.5 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from aiohttp>=3.7.0->adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (6.1.0)
Requirement already satisfied: async-timeout<5.0,>=4.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from aiohttp>=3.7.0->adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (4.0.3)
Requirement already satisfied: aiohappyeyeballs>=2.3.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from aiohttp>=3.7.0->adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2.4.3)
Requirement already satisfied: yarl<2.0,>=1.12.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from aiohttp>=3.7.0->adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.13.1)
Requirement already satisfied: cffi in /home/rakibulhasan/.local/lib/python3.10/site-packages (from azure-datalake-store<0.1,>=0.0.46->adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.17.1)
Requirement already satisfied: msal<2,>=1.16.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from azure-datalake-store<0.1,>=0.0.46->adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.31.0)
Requirement already satisfied: isodate>=0.6.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from azure-storage-blob>=12.12.0->adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (0.6.1)
Requirement already satisfied: cryptography>=2.1.4 in /usr/lib/python3/dist-packages (from azure-storage-blob>=12.12.0->adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (3.4.8)
Requirement already satisfied: pyasn1-modules>=0.2.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from google-auth>=1.2->gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (0.4.1)
Requirement already satisfied: rsa<5,>=3.1.4 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from google-auth>=1.2->gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (4.9)
Requirement already satisfied: cachetools<6.0,>=2.0.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from google-auth>=1.2->gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (5.5.0)
Requirement already satisfied: mypy-extensions>=0.3.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from typing-inspect>=0.4.0->dataclasses-json<0.5.12,>=0.5.2->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.0.0)
Requirement already satisfied: msal-extensions>=1.2.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from azure-identity->adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.2.0)
Requirement already satisfied: requests-oauthlib>=0.7.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from google-auth-oauthlib->gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2.0.0)
Requirement already satisfied: google-api-core<3.0.0dev,>=2.15.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from google-cloud-storage->gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2.20.0)
Requirement already satisfied: google-cloud-core<3.0dev,>=2.3.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from google-cloud-storage->gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2.4.1)
Requirement already satisfied: google-crc32c<2.0dev,>=1.0 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from google-cloud-storage->gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.6.0)
Requirement already satisfied: google-resumable-media>=2.7.2 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from google-cloud-storage->gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2.7.2)
Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from botocore<1.35.24,>=1.35.16->aiobotocore<3.0.0,>=2.5.4->s3fs!=2024.3.1,>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.0.1)
Requirement already satisfied: proto-plus<2.0.0dev,>=1.22.3 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from google-api-core<3.0.0dev,>=2.15.0->google-cloud-storage->gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (1.24.0)
Requirement already satisfied: PyJWT[crypto]<3,>=1.0.0 in /usr/lib/python3/dist-packages (from msal<2,>=1.16.0->azure-datalake-store<0.1,>=0.0.46->adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2.3.0)
Requirement already satisfied: portalocker<3,>=1.4 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from msal-extensions>=1.2.0->azure-identity->adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2.10.1)
Requirement already satisfied: pyasn1<0.7.0,>=0.4.6 in /home/rakibulhasan/.local/lib/python3.10/site-packages (from pyasn1-modules>=0.2.1->google-auth>=1.2->gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (0.6.1)
Requirement already satisfied: oauthlib>=3.0.0 in /usr/lib/python3/dist-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib->gcsfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (3.2.0)
Requirement already satisfied: pycparser in /home/rakibulhasan/.local/lib/python3.10/site-packages (from cffi->azure-datalake-store<0.1,>=0.0.46->adlfs>=2023.3.0->flytekit->flytekitplugins-deck-standard==0.0.0+develop) (2.22)
flytekitplugins-deck-standard is already installed with the same version as the provided wheel. Use --force-reinstall to force an installation of the wheel.
Installing collected packages: pygments, plotly, markdown, pandas, ydata-profiling
Successfully installed markdown-3.7 pandas-2.2.3 plotly-5.24.1 pygments-2.18.0 ydata-profiling-4.10.0

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
