### PR TITLE
Fix getting started link, remove extra parenthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ def my_workflow(x: int, y: int) -> int:
 ```
 
 ## 📦 Resources
-- [Learn Flytekit by example](https://docs.flyte.org/en/latest/quickstart_guide.html#getting-started-quickstart-guide))
+- [Learn Flytekit by example](https://docs.flyte.org/en/latest/user_guide/quickstart_guide.html)
 - [Flytekit API documentation](https://docs.flyte.org/en/latest/api/flytekit/docs_index.html)
 
 


### PR DESCRIPTION
## Why are the changes needed?

The quickstart guide link is broken.

## What changes were proposed in this pull request?

Fix the link.

## How was this patch tested?

Click the link.

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
Pending
