### PR TITLE
Update task.py

### DIFF
--- a/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
+++ b/plugins/flytekit-papermill/flytekitplugins/papermill/task.py
@@ -78,6 +78,7 @@ class NotebookTask(PythonInstanceTask[T]):
                                                # idea to use the modulename
             notebook_path="../path/to/my_notebook",
             render_deck=True,
+            enable_deck=True,
             inputs=kwtypes(v=int),
             outputs=kwtypes(x=int, y=str),
             metadata=TaskMetadata(retries=3, cache=True, cache_version="1.0"),


### PR DESCRIPTION

## Why are the changes needed?

Issue description: 
[the papermill example](https://docs.flyte.org/projects/cookbook/en/latest/auto_examples/papermill_plugin/simple.html) in the flyte docs lacks info on rendering the notebook in a deck. 

slack thread for reference: https://discuss.flyte.org/t/15484282/hi-all-flyte-rookie-here-maybe-you-can-help-me-out-i-m-tryin#33b0b813-6822-4451-8977-eaec3387a4ff
<!--

-->

## What changes were proposed in this pull request?

to achieve this, added render_deck=True and enable_deck=True to the notebooktask.

### Screenshots

