### PR TITLE
Make sure user errors contain the entire chain of the stack trace

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -245,18 +245,6 @@ def get_traceback_str(e: Exception) -> str:
     format_str = "Trace:\n\n{exception_str}\nMessage:\n\n{message_str}"
     return format_str.format(exception_str=exception_str, message_str=message_str)
 
-    if isinstance(e, FlyteUserRuntimeException):
-        tb = e.__cause__.__traceback__ if e.__cause__ else e.__traceback__
-    else:
-        tb = e.__traceback__
-    lines = traceback.format_tb(tb)
-    lines = [line.rstrip() for line in lines]
-    tb_str = "\n    ".join(lines)
-    format_str = "Traceback (most recent call last):\n" "\n    {traceback}\n" "\n" "Message:\n" "\n" "    {message}"
-
-    value = e.value if isinstance(e, FlyteUserRuntimeException) else e
-    return format_str.format(traceback=tb_str, message=f"{type(value).__name__}: {value}")
-
 
 def get_one_of(*args) -> str:
     """

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -8,10 +8,10 @@ import signal
 import subprocess
 import sys
 import tempfile
+import textwrap
 import traceback
 import warnings
 from sys import exit
-import textwrap
 from typing import Callable, List, Optional
 
 import click
@@ -236,22 +236,15 @@ def get_traceback_str(e: Exception) -> str:
         # user code, not the Flyte internals.
         root_exception = e.__cause__ if e.__cause__ else e
     indentation = "    "
-    exception_str = textwrap.indent(
-        text="".join(traceback.format_exception(root_exception)),
-        prefix=indentation
-    )
+    exception_str = textwrap.indent(text="".join(traceback.format_exception(root_exception)), prefix=indentation)
     # Second, format a summary exception message
     value = e.value if isinstance(e, FlyteUserRuntimeException) else e
     message = f"{type(value).__name__}: {value}"
-    message_str = textwrap.indent(
-        text=message,
-        prefix=indentation
-    )
+    message_str = textwrap.indent(text=message, prefix=indentation)
     # Last, create the overall traceback string
     format_str = "Trace:\n\n{exception_str}\nMessage:\n\n{message_str}"
     return format_str.format(exception_str=exception_str, message_str=message_str)
 
-    
     if isinstance(e, FlyteUserRuntimeException):
         tb = e.__cause__.__traceback__ if e.__cause__ else e.__traceback__
     else:

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -236,7 +236,10 @@ def get_traceback_str(e: Exception) -> str:
         # user code, not the Flyte internals.
         root_exception = e.__cause__ if e.__cause__ else e
     indentation = "    "
-    exception_str = textwrap.indent(text="".join(traceback.format_exception(root_exception)), prefix=indentation)
+    exception_str = textwrap.indent(
+        text="".join(traceback.format_exception(type(root_exception), root_exception, root_exception.__traceback__)),
+        prefix=indentation,
+    )
     # Second, format a summary exception message
     value = e.value if isinstance(e, FlyteUserRuntimeException) else e
     message = f"{type(value).__name__}: {value}"

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -1,4 +1,6 @@
 import os
+import re
+import textwrap
 import typing
 from collections import OrderedDict
 
@@ -7,7 +9,7 @@ import mock
 import pytest
 from flyteidl.core.errors_pb2 import ErrorDocument
 
-from flytekit.bin.entrypoint import _dispatch_execute, normalize_inputs, setup_execution
+from flytekit.bin.entrypoint import _dispatch_execute, normalize_inputs, setup_execution, get_traceback_str
 from flytekit.configuration import Image, ImageConfig, SerializationSettings
 from flytekit.core import context_manager
 from flytekit.core.base_task import IgnoreOutputs
@@ -17,7 +19,7 @@ from flytekit.core.task import task
 from flytekit.core.type_engine import TypeEngine
 from flytekit.exceptions import user as user_exceptions
 from flytekit.exceptions.scopes import system_entry_point
-from flytekit.exceptions.user import FlyteUserRuntimeException
+from flytekit.exceptions.user import FlyteRecoverableException, FlyteUserRuntimeException
 from flytekit.models import literals as _literal_models
 from flytekit.models.core import errors as error_models
 from flytekit.models.core import execution as execution_models
@@ -412,3 +414,45 @@ def test_env_reading(mock_os):
         assert ctx.execution_state.user_space_params.task_id.name == "task_name"
         assert ctx.execution_state.user_space_params.task_id.version == "task_ver"
         assert ctx.execution_state.user_space_params.execution_id.name == "exec_name"
+
+
+def test_get_traceback_str():
+    try:
+        try:
+            try:
+                raise RuntimeError("a")
+            except Exception as e:
+                raise FlyteRecoverableException("b") from e
+        except Exception as e:
+            # This is how Flyte wraps user exceptions
+            raise FlyteUserRuntimeException(e) from e
+    except Exception as e:
+        traceback_str = get_traceback_str(e)
+
+    expected_error_pattern = textwrap.dedent(r"""
+        Trace:
+
+            Traceback \(most recent call last\):
+              File ".*flytekit/tests/flytekit/unit/bin/test_python_entrypoint.py", line \d+, in test_get_traceback_str
+                raise RuntimeError\("a"\)
+            RuntimeError: a
+
+            The above exception was the direct cause of the following exception:
+
+            Traceback \(most recent call last\):
+              File ".*flytekit/tests/flytekit/unit/bin/test_python_entrypoint.py", line \d+, in test_get_traceback_str
+                raise FlyteRecoverableException\("b"\) from e
+            flytekit.exceptions.user.FlyteRecoverableException: USER:Recoverable: error=b, cause=a
+
+        Message:
+
+            FlyteRecoverableException: USER:Recoverable: error=b, cause=a""")
+    # remove the initial newline
+    expected_error_pattern = expected_error_pattern[1:]
+
+    expected_error_re = re.compile(expected_error_pattern)
+
+    print(expected_error_pattern)
+    print(traceback_str)
+    assert expected_error_re.match(traceback_str) is not None
+    

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -455,4 +455,3 @@ def test_get_traceback_str():
     print(expected_error_pattern)
     print(traceback_str)
     assert expected_error_re.match(traceback_str) is not None
-    

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -433,14 +433,14 @@ def test_get_traceback_str():
         Trace:
 
             Traceback \(most recent call last\):
-              File ".*flytekit/tests/flytekit/unit/bin/test_python_entrypoint.py", line \d+, in test_get_traceback_str
+              File ".*test_python_entrypoint.py", line \d+, in test_get_traceback_str
                 raise RuntimeError\("a"\)
             RuntimeError: a
 
             The above exception was the direct cause of the following exception:
 
             Traceback \(most recent call last\):
-              File ".*flytekit/tests/flytekit/unit/bin/test_python_entrypoint.py", line \d+, in test_get_traceback_str
+              File ".*test_python_entrypoint.py", line \d+, in test_get_traceback_str
                 raise FlyteRecoverableException\("b"\) from e
             flytekit.exceptions.user.FlyteRecoverableException: USER:Recoverable: error=b, cause=a
 
@@ -451,5 +451,5 @@ def test_get_traceback_str():
     expected_error_pattern = expected_error_pattern[1:]
 
     expected_error_re = re.compile(expected_error_pattern)
-    print(traceback_str)
+    print(traceback_str)  # helpful for debugging
     assert expected_error_re.match(traceback_str) is not None

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -452,6 +452,4 @@ def test_get_traceback_str():
 
     expected_error_re = re.compile(expected_error_pattern)
 
-    print(expected_error_pattern)
-    print(traceback_str)
     assert expected_error_re.match(traceback_str) is not None

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -451,5 +451,5 @@ def test_get_traceback_str():
     expected_error_pattern = expected_error_pattern[1:]
 
     expected_error_re = re.compile(expected_error_pattern)
-
+    print(traceback_str)
     assert expected_error_re.match(traceback_str) is not None


### PR DESCRIPTION
## Tracking issue

See https://flyte-org.slack.com/archives/CP2HDHKE1/p1728515674311849

## Why are the changes needed?

User errors that have exception chains are not reported with the full stack trace, including the causes

## What changes were proposed in this pull request?

Fix to the stack trace exporting function.

## How was this patch tested?

Unit tests.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.
