### PR TITLE
Allow empty lists and dicts in LaunchPlan creation

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -167,22 +167,22 @@ class TypeTransformer(typing.Generic[T]):
 
         # Optionally check the type of elements if it's a collection like list or dict
         if origin in {list, tuple, set}:
-            if len(obj) == 0:
-                return
-            for item in obj:
-                self.assert_type(args[0], item)
-                return
-            raise TypeTransformerFailedError(f"Not all items in '{obj}' are of type {args[0]}")
+            try:
+                for item in obj:
+                    self.assert_type(args[0], item)
+            except TypeTransformerFailedError:
+                # nicer error than a single value failing
+                raise TypeTransformerFailedError(f"Not all items in '{obj}' are of type {args[0]}")
 
         if origin is dict:
-            if len(obj.items()) == 0:
-                return
             key_type, value_type = args
-            for k, v in obj.items():
-                self.assert_type(key_type, k)
-                self.assert_type(value_type, v)
-                return
-            raise TypeTransformerFailedError(f"Not all values in '{obj}' are of type {value_type}")
+            try:
+                for k, v in obj.items():
+                    self.assert_type(key_type, k)
+                    self.assert_type(value_type, v)
+            except TypeTransformerFailedError:
+                # nicer error than a single key or value failing
+                raise TypeTransformerFailedError(f"Not all values in '{obj}' are of type {value_type}")
 
         return
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -167,12 +167,16 @@ class TypeTransformer(typing.Generic[T]):
 
         # Optionally check the type of elements if it's a collection like list or dict
         if origin in {list, tuple, set}:
+            if len(obj) == 0:
+                return
             for item in obj:
                 self.assert_type(args[0], item)
                 return
             raise TypeTransformerFailedError(f"Not all items in '{obj}' are of type {args[0]}")
 
         if origin is dict:
+            if len(obj.items()) == 0:
+                return
             key_type, value_type = args
             for k, v in obj.items():
                 self.assert_type(key_type, k)


### PR DESCRIPTION
## Why are the changes needed?

When building a `flytekit.LaunchPlan` my default inputs may contain an empty list, but the code in `isinstance_generic` may only pass if at least one element of a list is present. Changes since flytekit 1.13.5 cause a regression in allowing this empty list.


## What changes were proposed in this pull request?

Modify `isinstance_generic` to short-circuit loops/exceptions for lists, tuples, sets, and dicts if these collections are empty.

## How was this patch tested?

The changes are very small and verified by inspection. There are no existing tests for `isinstance_generic` to wire into.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

