### PR TITLE
Revise Pickle Remote Task for Jupyter Notebook Environment

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -828,7 +828,6 @@ class SerializationSettings(DataClassJsonMixin):
             can be fast registered (and thus omit building a Docker image) this object contains additional parameters
             for serialization.
         source_root (Optional[str]): The root directory of the source code.
-        interactive_mode_enabled (bool): Whether or not the task is being serialized in interactive mode.
     """
 
     image_config: ImageConfig
@@ -841,7 +840,6 @@ class SerializationSettings(DataClassJsonMixin):
     flytekit_virtualenv_root: Optional[str] = None
     fast_serialization_settings: Optional[FastSerializationSettings] = None
     source_root: Optional[str] = None
-    interactive_mode_enabled: bool = False
 
     def __post_init__(self):
         if self.flytekit_virtualenv_root is None:
@@ -916,7 +914,6 @@ class SerializationSettings(DataClassJsonMixin):
             python_interpreter=self.python_interpreter,
             fast_serialization_settings=self.fast_serialization_settings,
             source_root=self.source_root,
-            interactive_mode_enabled=self.interactive_mode_enabled,
         )
 
     def should_fast_serialize(self) -> bool:
@@ -968,7 +965,6 @@ class SerializationSettings(DataClassJsonMixin):
         python_interpreter: Optional[str] = None
         fast_serialization_settings: Optional[FastSerializationSettings] = None
         source_root: Optional[str] = None
-        interactive_mode_enabled: bool = False
 
         def with_fast_serialization_settings(self, fss: fast_serialization_settings) -> SerializationSettings.Builder:
             self.fast_serialization_settings = fss
@@ -986,5 +982,4 @@ class SerializationSettings(DataClassJsonMixin):
                 python_interpreter=self.python_interpreter,
                 fast_serialization_settings=self.fast_serialization_settings,
                 source_root=self.source_root,
-                interactive_mode_enabled=self.interactive_mode_enabled,
             )

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -660,14 +660,6 @@ class Promise(object):
 
         return new_promise
 
-    def __getstate__(self) -> Dict[str, Any]:
-        # This func is used to pickle the object.
-        return vars(self)
-
-    def __setstate__(self, state: Dict[str, Any]) -> None:
-        # This func is used to unpickle the object without infinite recursion.
-        vars(self).update(state)
-
 
 def create_native_named_tuple(
     ctx: FlyteContext,

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -292,16 +292,18 @@ class DefaultNotebookTaskResolver(TrackedInstance, TaskResolverMixin):
 
     @timeit("Load task")
     def load_task(self, loader_args: List[str]) -> PythonAutoContainerTask:
+        _, entity_name, *_ = loader_args
         import gzip
 
         import cloudpickle
 
         with gzip.open(PICKLE_FILE_PATH, "r") as f:
-            return cloudpickle.load(f)
+            entity_dict = cloudpickle.load(f)
+        return entity_dict[entity_name]
 
     def loader_args(self, settings: SerializationSettings, task: PythonAutoContainerTask) -> List[str]:  # type:ignore
-        _, m, t, _ = extract_task_module(task)
-        return ["task-module", m, "task-name", t]
+        n, _, _, _ = extract_task_module(task)
+        return ["entity-name", n]
 
     def get_all_tasks(self) -> List[PythonAutoContainerTask]:  # type: ignore
         raise NotImplementedError

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -299,14 +299,15 @@ class _ModuleSanitizer(object):
 
         # Execution in a Jupyter notebook, we cannot resolve the module path
         if not os.path.exists(dirname):
-            logger.debug(
-                f"Directory {dirname} does not exist. It is likely that we are in a Jupyter notebook or a pickle file was received."
-            )
-
             if not is_ipython_or_pickle_exists():
                 raise AssertionError(
                     f"Directory {dirname} does not exist, and we are not in a Jupyter notebook or received a pickle file."
                 )
+            
+            logger.debug(
+                f"Directory {dirname} does not exist. It is likely that we are in a Jupyter notebook or a pickle file was received."
+                f"Returning {basename} as the module name."
+            )
             return basename
 
         # If we have reached a directory with no __init__, ignore

--- a/flytekit/core/tracker.py
+++ b/flytekit/core/tracker.py
@@ -303,7 +303,7 @@ class _ModuleSanitizer(object):
                 raise AssertionError(
                     f"Directory {dirname} does not exist, and we are not in a Jupyter notebook or received a pickle file."
                 )
-            
+
             logger.debug(
                 f"Directory {dirname} does not exist. It is likely that we are in a Jupyter notebook or a pickle file was received."
                 f"Returning {basename} as the module name."

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -10,6 +10,7 @@ import asyncio
 import base64
 import configparser
 import functools
+import gzip
 import hashlib
 import os
 import pathlib
@@ -37,12 +38,18 @@ from flytekit.clients.helpers import iterate_node_executions, iterate_task_execu
 from flytekit.configuration import Config, FastSerializationSettings, ImageConfig, SerializationSettings
 from flytekit.constants import CopyFileDetection
 from flytekit.core import constants, utils
+from flytekit.core.array_node_map_task import ArrayNodeMapTask
 from flytekit.core.artifact import Artifact
 from flytekit.core.base_task import PythonTask
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.data_persistence import FileAccessProvider
 from flytekit.core.launch_plan import LaunchPlan, ReferenceLaunchPlan
-from flytekit.core.python_auto_container import PythonAutoContainerTask
+from flytekit.core.node import Node as CoreNode
+from flytekit.core.python_auto_container import (
+    PICKLE_FILE_PATH,
+    PythonAutoContainerTask,
+    default_notebook_task_resolver,
+)
 from flytekit.core.reference_entity import ReferenceSpec
 from flytekit.core.task import ReferenceTask
 from flytekit.core.tracker import extract_task_module
@@ -769,10 +776,6 @@ class FlyteRemote(object):
             )
         if serialization_settings.version is None:
             serialization_settings.version = version
-        serialization_settings.interactive_mode_enabled = self.interactive_mode_enabled
-
-        options = options or Options()
-        options.file_uploader = options.file_uploader or self.upload_file
 
         _ = get_serializable(m, settings=serialization_settings, entity=entity, options=options)
         # concurrent register
@@ -1834,11 +1837,16 @@ class FlyteRemote(object):
             not_found = True
 
         if not_found:
+            fast_serialization_settings = None
+            if self.interactive_mode_enabled:
+                fast_serialization_settings = self._pickle_entity(entity)
+
             ss = SerializationSettings(
                 image_config=image_config or ImageConfig.auto_default_image(),
                 project=project or self.default_project,
                 domain=domain or self._default_domain,
                 version=version,
+                fast_serialization_settings=fast_serialization_settings,
             )
             flyte_task: FlyteTask = self.register_task(entity, ss)
 
@@ -1901,11 +1909,16 @@ class FlyteRemote(object):
         if not image_config:
             image_config = ImageConfig.auto_default_image()
 
+        fast_serialization_settings = None
+        if self.interactive_mode_enabled:
+            fast_serialization_settings = self._pickle_entity(entity)
+
         ss = SerializationSettings(
             image_config=image_config,
             project=resolved_identifiers.project,
             domain=resolved_identifiers.domain,
             version=resolved_identifiers.version,
+            fast_serialization_settings=fast_serialization_settings,
         )
         try:
             # Just fetch to see if it already exists
@@ -2526,3 +2539,49 @@ class FlyteRemote(object):
                 lm = data
             for var, literal in lm.items():
                 download_literal(self.file_access, var, literal, download_to)
+
+    def _get_pickled_target_dict(self, root_entity: typing.Any) -> typing.Dict[str, typing.Any]:
+        """
+        Get the pickled target dictionary for the entity.
+        :param root_entity: The entity to get the pickled target for.
+        :return: The pickled target dictionary.
+        """
+        queue = [root_entity]
+        pickled_target_dict = {}
+        while queue:
+            entity = queue.pop()
+            if isinstance(entity, PythonTask):
+                if isinstance(entity, (PythonAutoContainerTask, ArrayNodeMapTask)):
+                    if isinstance(entity, ArrayNodeMapTask):
+                        entity._run_task.set_resolver(default_notebook_task_resolver)
+                        pickled_target_dict[entity._run_task.name] = entity._run_task
+                    else:
+                        entity.set_resolver(default_notebook_task_resolver)
+                        pickled_target_dict[entity.name] = entity
+            elif isinstance(entity, WorkflowBase):
+                for task in entity.nodes:
+                    queue.append(task)
+            elif isinstance(entity, CoreNode):
+                queue.append(entity.flyte_entity)
+        return pickled_target_dict
+
+    def _pickle_entity(self, entity: typing.Any):
+        """
+        Pickle the entity to the specified location. This is useful for debugging and for sharing entities across
+        different environments.
+        :param entity: The entity to pickle
+        """
+        # get all entity tasks
+        pickled_dict = self._get_pickled_target_dict(entity)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            dest = pathlib.Path(tmp_dir, PICKLE_FILE_PATH)
+            with gzip.GzipFile(filename=dest, mode="wb", mtime=0) as gzipped:
+                cloudpickle.dump(pickled_dict, gzipped)
+            if os.path.getsize(dest) > 150 * 1024 * 1024:
+                raise ValueError(
+                    "The size of the task to pickled exceeds the limit of 150MB. Please reduce the size of the task."
+                )
+            logger.debug(f"Uploading Pickled representation of Workflow `{entity.name}` to remote storage...")
+            _, native_url = self.upload_file(dest)
+
+        return FastSerializationSettings(enabled=True, distribution_location=native_url, destination_dir=".")

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -1,7 +1,4 @@
-import os
-import pathlib
 import sys
-import tempfile
 import typing
 from collections import OrderedDict
 from typing import Callable, Dict, List, Optional, Tuple, Union
@@ -23,15 +20,12 @@ from flytekit.core.legacy_map_task import MapPythonTask
 from flytekit.core.node import Node
 from flytekit.core.options import Options
 from flytekit.core.python_auto_container import (
-    PICKLE_FILE_PATH,
     PythonAutoContainerTask,
-    default_notebook_task_resolver,
 )
 from flytekit.core.reference_entity import ReferenceEntity, ReferenceSpec, ReferenceTemplate
 from flytekit.core.task import ReferenceTask
 from flytekit.core.utils import ClassDecorator, _dnsify
 from flytekit.core.workflow import ReferenceWorkflow, WorkflowBase
-from flytekit.loggers import logger
 from flytekit.models import common as _common_models
 from flytekit.models import interface as interface_models
 from flytekit.models import launch_plan as _launch_plan_models
@@ -126,52 +120,6 @@ def _fast_serialize_command_fn(
     return fn
 
 
-def _update_serialization_settings_for_ipython(
-    entity: FlyteLocalEntity,
-    serialization_settings: SerializationSettings,
-    options: Optional[Options] = None,
-):
-    # We are in an interactive environment. We will serialize the task as a pickled object and upload it to remote
-    # storage.
-    # if isinstance(entity, PythonFunctionTask):
-    #     if entity.execution_mode == PythonFunctionTask.ExecutionBehavior.DYNAMIC:
-    #         raise FlyteAssertion(
-    #             f"Dynamic tasks are not supported in interactive mode. {entity.name} is a dynamic task."
-    #         )
-
-    # if options is None or options.file_uploader is None:
-    #     raise FlyteAssertion("To work interactively with Flyte, a code transporter/uploader should be configured.")
-
-    # For map tasks, we need to serialize the actual task, not the map task itself
-    if isinstance(entity, ArrayNodeMapTask):
-        entity._run_task.set_resolver(default_notebook_task_resolver)
-        actual_task = entity._run_task
-    else:
-        entity.set_resolver(default_notebook_task_resolver)
-        actual_task = entity
-
-    import gzip
-
-    import cloudpickle
-
-    from flytekit.configuration import FastSerializationSettings
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        dest = pathlib.Path(tmp_dir, PICKLE_FILE_PATH)
-        with gzip.GzipFile(filename=dest, mode="wb", mtime=0) as gzipped:
-            cloudpickle.dump(actual_task, gzipped)
-        if os.path.getsize(dest) > 150 * 1024 * 1024:
-            raise ValueError(
-                "The size of the task to pickled exceeds the limit of 150MB. Please reduce the size of the task."
-            )
-        logger.debug(f"Uploading Pickled representation of Task `{actual_task.name}` to remote storage...")
-        _, native_url = options.file_uploader(dest)
-
-        serialization_settings.fast_serialization_settings = FastSerializationSettings(
-            enabled=True, distribution_location=native_url, destination_dir="."
-        )
-
-
 def get_serializable_task(
     entity_mapping: OrderedDict,
     settings: SerializationSettings,
@@ -185,14 +133,6 @@ def get_serializable_task(
         entity.name,
         settings.version,
     )
-
-    # # Try to update the serialization settings for ipython / jupyter notebook / interactive mode if we are in an
-    # # interactive environment like Jupyter notebook
-    # if settings.interactive_mode_enabled is True:
-    #     # If the entity is not a PythonAutoContainerTask, we don't need to do anything, as only Tasks with container |
-    #     # user code in container needs to be serialized as pickled objects.
-    #     if isinstance(entity, (PythonAutoContainerTask, ArrayNodeMapTask)):
-    #         _update_serialization_settings_for_ipython(entity, settings, options)
 
     if isinstance(entity, PythonFunctionTask) and entity.execution_mode == PythonFunctionTask.ExecutionBehavior.DYNAMIC:
         for e in context_manager.FlyteEntities.entities:

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -31,7 +31,6 @@ from flytekit.core.reference_entity import ReferenceEntity, ReferenceSpec, Refer
 from flytekit.core.task import ReferenceTask
 from flytekit.core.utils import ClassDecorator, _dnsify
 from flytekit.core.workflow import ReferenceWorkflow, WorkflowBase
-from flytekit.exceptions.user import FlyteAssertion
 from flytekit.loggers import logger
 from flytekit.models import common as _common_models
 from flytekit.models import interface as interface_models
@@ -134,14 +133,14 @@ def _update_serialization_settings_for_ipython(
 ):
     # We are in an interactive environment. We will serialize the task as a pickled object and upload it to remote
     # storage.
-    if isinstance(entity, PythonFunctionTask):
-        if entity.execution_mode == PythonFunctionTask.ExecutionBehavior.DYNAMIC:
-            raise FlyteAssertion(
-                f"Dynamic tasks are not supported in interactive mode. {entity.name} is a dynamic task."
-            )
+    # if isinstance(entity, PythonFunctionTask):
+    #     if entity.execution_mode == PythonFunctionTask.ExecutionBehavior.DYNAMIC:
+    #         raise FlyteAssertion(
+    #             f"Dynamic tasks are not supported in interactive mode. {entity.name} is a dynamic task."
+    #         )
 
-    if options is None or options.file_uploader is None:
-        raise FlyteAssertion("To work interactively with Flyte, a code transporter/uploader should be configured.")
+    # if options is None or options.file_uploader is None:
+    #     raise FlyteAssertion("To work interactively with Flyte, a code transporter/uploader should be configured.")
 
     # For map tasks, we need to serialize the actual task, not the map task itself
     if isinstance(entity, ArrayNodeMapTask):
@@ -187,13 +186,13 @@ def get_serializable_task(
         settings.version,
     )
 
-    # Try to update the serialization settings for ipython / jupyter notebook / interactive mode if we are in an
-    # interactive environment like Jupyter notebook
-    if settings.interactive_mode_enabled is True:
-        # If the entity is not a PythonAutoContainerTask, we don't need to do anything, as only Tasks with container |
-        # user code in container needs to be serialized as pickled objects.
-        if isinstance(entity, (PythonAutoContainerTask, ArrayNodeMapTask)):
-            _update_serialization_settings_for_ipython(entity, settings, options)
+    # # Try to update the serialization settings for ipython / jupyter notebook / interactive mode if we are in an
+    # # interactive environment like Jupyter notebook
+    # if settings.interactive_mode_enabled is True:
+    #     # If the entity is not a PythonAutoContainerTask, we don't need to do anything, as only Tasks with container |
+    #     # user code in container needs to be serialized as pickled objects.
+    #     if isinstance(entity, (PythonAutoContainerTask, ArrayNodeMapTask)):
+    #         _update_serialization_settings_for_ipython(entity, settings, options)
 
     if isinstance(entity, PythonFunctionTask) and entity.execution_mode == PythonFunctionTask.ExecutionBehavior.DYNAMIC:
         for e in context_manager.FlyteEntities.entities:
@@ -800,7 +799,7 @@ def get_serializable(
         cp_entity = get_reference_spec(entity_mapping, settings, entity)
 
     elif isinstance(entity, PythonTask):
-        cp_entity = get_serializable_task(entity_mapping, settings, entity, options)
+        cp_entity = get_serializable_task(entity_mapping, settings, entity)
 
     elif isinstance(entity, WorkflowBase):
         cp_entity = get_serializable_workflow(entity_mapping, settings, entity, options)

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -154,55 +154,6 @@ def test_serialization(serialization_settings):
     ]
 
 
-def test_interactive_serialization(interactive_serialization_settings):
-    @task
-    def t1(a: int) -> int:
-        return a + 1
-
-    def mock_file_uploader(dest: pathlib.Path):
-        return (0, dest.name)
-
-    arraynode_maptask = map_task(t1, metadata=TaskMetadata(retries=2))
-    option = Options()
-    option.file_uploader = mock_file_uploader
-    task_spec = get_serializable(OrderedDict(), interactive_serialization_settings, arraynode_maptask, options=option)
-
-    assert task_spec.template.metadata.retries.retries == 2
-    assert task_spec.template.custom["minSuccessRatio"] == 1.0
-    assert task_spec.template.type == "python-task"
-    assert task_spec.template.task_type_version == 1
-    assert task_spec.template.container.args == [
-        "pyflyte-fast-execute",
-        "--additional-distribution",
-        PICKLE_FILE_PATH,
-        "--dest-dir",
-        ".",
-        "--",
-        "pyflyte-map-execute",
-        "--inputs",
-        "{{.input}}",
-        "--output-prefix",
-        "{{.outputPrefix}}",
-        "--raw-output-data-prefix",
-        "{{.rawOutputDataPrefix}}",
-        "--checkpoint-path",
-        "{{.checkpointOutputPrefix}}",
-        "--prev-checkpoint",
-        "{{.prevCheckpointPrefix}}",
-        "--resolver",
-        "flytekit.core.array_node_map_task.ArrayNodeMapTaskResolver",
-        "--",
-        "vars",
-        "",
-        "resolver",
-        "flytekit.core.python_auto_container.default_notebook_task_resolver",
-        "task-module",
-        "tests.flytekit.unit.core.test_array_node_map_task",
-        "task-name",
-        "t1",
-    ]
-
-
 def test_fast_serialization(serialization_settings):
     serialization_settings.fast_serialization_settings = FastSerializationSettings(enabled=True)
 

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -267,7 +267,7 @@ def test_serialization_settings_transport():
     ss = SerializationSettings.from_transport(tp)
     assert ss is not None
     assert ss == serialization_settings
-    assert len(tp) == 432
+    assert len(tp) == 408
 
 
 def test_exec_params():

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -263,21 +263,3 @@ def test_prom_with_union_literals():
     assert bd.scalar.union.stored_type.structure.tag == "int"
     bd = binding_data_from_python_std(ctx, lt, "hello", pt, [])
     assert bd.scalar.union.stored_type.structure.tag == "str"
-
-def test_pickling_promise_object():
-    @task
-    def t1(a: int) -> int:
-        return a
-
-    ctx = context_manager.FlyteContext.current_context().with_compilation_state(CompilationState(prefix=""))
-    p = create_and_link_node(ctx, t1, a=3)
-    assert p.ref.node_id == "n0"
-    assert p.ref.var == "o0"
-    assert len(p.ref.node.bindings) == 1
-
-    import cloudpickle
-
-    p2 = cloudpickle.loads(cloudpickle.dumps(p))
-    assert p2.ref.node_id == "n0"
-    assert p2.ref.var == "o0"
-    assert len(p2.ref.node.bindings) == 1

--- a/tests/flytekit/unit/core/test_resolver.py
+++ b/tests/flytekit/unit/core/test_resolver.py
@@ -1,13 +1,15 @@
 import typing
 from collections import OrderedDict
 
+import cloudpickle
+import mock
 import pytest
 
 import flytekit.configuration
 from flytekit.configuration import Image, ImageConfig
 from flytekit.core.base_task import TaskResolverMixin
 from flytekit.core.class_based_resolver import ClassStorageTaskResolver
-from flytekit.core.python_auto_container import default_task_resolver
+from flytekit.core.python_auto_container import default_task_resolver, default_notebook_task_resolver, PICKLE_FILE_PATH
 from flytekit.core.task import task
 from flytekit.core.workflow import workflow
 from flytekit.tools.translator import get_serializable
@@ -104,3 +106,27 @@ def test_mixin():
 def test_error():
     with pytest.raises(Exception):
         default_task_resolver.get_all_tasks()
+
+
+@mock.patch("cloudpickle.load")  # Mock cloudpickle.load and pass it as the first parameter
+@mock.patch("gzip.open", new_callable=mock.mock_open)
+def test_notebook_resolver(mock_gzip_open, mock_cloudpickle):
+    c = default_notebook_task_resolver
+    assert c.name() != ""
+
+    with pytest.raises(ValueError):
+        c.load_task([])
+
+    @task
+    def t1(a: str, b: str) -> str:
+        return b + a
+
+    assert c.loader_args(None, t1) == ["entity-name", "tests.flytekit.unit.core.test_resolver.t1"]
+
+    pickled_dict = {"tests.flytekit.unit.core.test_resolver.t1": t1}
+    custom_pickled_object = cloudpickle.dumps(pickled_dict)
+    mock_gzip_open.return_value.read.return_value = custom_pickled_object
+    mock_cloudpickle.return_value = pickled_dict
+
+    t = c.load_task(["entity-name", "tests.flytekit.unit.core.test_resolver.t1"])
+    assert t == t1

--- a/tests/flytekit/unit/test_translator.py
+++ b/tests/flytekit/unit/test_translator.py
@@ -84,23 +84,6 @@ def test_basics():
     assert lp_model.id.name == "testlp"
 
 
-def test_interactive():
-    @task
-    def t1(a: int) -> typing.NamedTuple("OutputsBC", t1_int_output=int, c=str):
-        return a + 2, "world"
-
-    b = serialization_settings.new_builder()
-    b.interactive_mode_enabled = True
-    ssettings = b.build()
-
-    fake_file_uploader = lambda dest: (0, dest)
-    options = Options(file_uploader=fake_file_uploader)
-
-    task_spec = get_serializable(OrderedDict(), ssettings, t1, options)
-    assert "--dest-dir" in task_spec.template.container.args
-    assert task_spec.template.container.args[task_spec.template.container.args.index("--dest-dir") + 1] == "."
-
-
 def test_fast():
     @task
     def t1(a: int) -> typing.NamedTuple("OutputsBC", t1_int_output=int, c=str):


### PR DESCRIPTION
## Tracking PR
https://github.com/flyteorg/flytekit/pull/2733

## Why are the changes needed?
As discussed in the comments of flyteorg/flytekit#2733, the current design of the Jupyter Notebook is not well considered.
![image](https://github.com/user-attachments/assets/237989a0-12b2-4513-8001-0d5ec6f54159)

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
- [x] Add `basename` in `logger.debug`
- [x] Remove `__setstate__` and `__getstate__` as pickling `Promise` object is not necessary as expected
- [x] Redesign the interactive mode logic
  - [x] Pickling in the workflow level, so that we don't need extra kwargs in `Options`.
  - [x] Following with the previous point, the `interactive_mode_enabled` field in `SerailizationSettings` is not required either.
  - [x] Make SerializationSettings non-mutating by initializing the fast_registration_setting during construction in `remote.py`.
  - [x] Update `DefaultNotebookTaskResolver` to enable extracting the task entity from the pickled object. 
      - I updated the pickled object from entity to a dictionary of entity, where the key of the dictionary is the name of the task entity. 
  - [x] Automatic versioning for the interactive mode if the version is not provided in `remote.execute(...)` command.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
Testing code is exactly the same as flyteorg/flytekit#2733

### Screenshots
| version 1 | version 2-1 | version 2-2 (run again without modification)|
| - | - | - |
| <img width="816" alt="image" src="https://github.com/user-attachments/assets/b9c35991-ce8d-4354-9a48-046eec6b93c6"> | <img width="818" alt="image" src="https://github.com/user-attachments/assets/28d3b7e1-699a-4221-8926-766ebc7b5046"> | <img width="814" alt="image" src="https://github.com/user-attachments/assets/9ab43db0-c272-4c2c-ac2c-a6c5b3a4ed2c"> |
| <img width="1387" alt="image" src="https://github.com/user-attachments/assets/97247ef8-4348-4fdf-a4cd-2663e2dae218"> | <img width="1376" alt="image" src="https://github.com/user-attachments/assets/0ce5ab78-8d0b-4892-8e36-6e7b32ba5534"> | <img width="1386" alt="image" src="https://github.com/user-attachments/assets/2788d53f-efad-4fd2-bd28-47e6b237423d"> |

Rerunning the code without modification and explicitly specify the `version` value will use the latest version in interactive mode. Note that `wf` workflow will register `hello` task, so the version of `hello` in second round is equal to the version of `wf` in the first round.

<!--
- Jupyter Notebook
    <img width="686" alt="image" src="https://github.com/user-attachments/assets/6b72e68c-2509-404f-9907-140f6606e2d3">
- Task Execution
    <img width="1471" alt="image" src="https://github.com/user-attachments/assets/26149193-28a5-4be7-b987-b316eb051e6b">
- Workflow Execution
    <img width="1471" alt="image" src="https://github.com/user-attachments/assets/960d14f0-aaf9-47e5-aeed-04d734b0cee1">
- Map Task Execution
    <img width="1471" alt="image" src="https://github.com/user-attachments/assets/626ecbdd-d985-4d74-bfd0-4889cfb91430">
-->


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flytekit/pull/2733
<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
