### PR TITLE
Pull secrets from environment when running locally

### DIFF
--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -346,9 +346,14 @@ class SecretsManager(object):
     def __init__(self, secrets_cfg: typing.Optional[SecretsConfig] = None):
         if secrets_cfg is None:
             secrets_cfg = SecretsConfig.auto()
+            is_local_execution = os.getenv("FLYTE_INTERNAL_EXECUTION_ID") is None
+            if is_local_execution:
+                self._env_prefix = ""
+            else:
+                self._env_prefix = secrets_cfg.env_prefix.strip()
+
         self._base_dir = secrets_cfg.default_dir.strip()
         self._file_prefix = secrets_cfg.file_prefix.strip()
-        self._env_prefix = secrets_cfg.env_prefix.strip()
 
     def __getattr__(self, item: str) -> _GroupSecrets:
         """

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -378,7 +378,7 @@ class SecretsManager(object):
 
         # During local execution check for the key without a prefix
         ctx = FlyteContextManager.current_context()
-        if ctx.execution_state.is_local_execution():
+        if ctx.execution_state is None or ctx.execution_state.is_local_execution():
             env_prefixes.append("")
 
         for env_prefix in env_prefixes:

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -377,8 +377,8 @@ class SecretsManager(object):
         env_prefixes = [self._env_prefix]
 
         # During local execution check for the key without a prefix
-        is_local_execution = os.getenv("FLYTE_INTERNAL_EXECUTION_ID") is None
-        if is_local_execution:
+        ctx = FlyteContextManager.current_context()
+        if ctx.execution_state.is_local_execution():
             env_prefixes.append("")
 
         for env_prefix in env_prefixes:

--- a/flytekit/core/task.py
+++ b/flytekit/core/task.py
@@ -302,6 +302,13 @@ def task(
                      Possible options for secret stores are - Vault, Confidant, Kube secrets, AWS KMS etc
                      Refer to :py:class:`Secret` to understand how to specify the request for a secret. It
                      may change based on the backend provider.
+
+                     .. note::
+
+                         During local execution, the secrets will be pulled from the local environment variables
+                         with the format `{GROUP}_{GROUP_VERSION}_{KEY}`, where all the characters are capitalized
+                         and the prefix is not used.
+
     :param execution_mode: This is mainly for internal use. Please ignore. It is filled in automatically.
     :param node_dependency_hints: A list of tasks, launchplans, or workflows that this task depends on. This is only
         for dynamic tasks/workflows, where flyte cannot automatically determine the dependencies prior to runtime.

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -239,6 +239,46 @@ def test_secrets_manager_env():
     assert sec.get(group="group", key="key") == "value"
 
 
+@pytest.mark.parametrize("is_local_execution", [True, False])
+def test_secrets_manager_execution(monkeypatch, is_local_execution):
+    if not is_local_execution:
+        monkeypatch.setenv("FLYTE_INTERNAL_EXECUTION_ID", "my-execution-id")
+
+    sec = SecretsManager()
+    prefix = sec._env_prefix
+
+    if not is_local_execution:
+        assert prefix == "_FSEC_"
+    else:
+        assert prefix == ""
+
+    monkeypatch.setenv(f"{prefix}ABC_XYZ", "my-abc-secret")
+    assert sec.get(group="ABC", key="XYZ") == "my-abc-secret"
+
+
+@pytest.mark.parametrize("is_local_execution", [True, False])
+def test_secrets_manager_execution_no_group_required(monkeypatch, is_local_execution):
+    # Remove group requirements
+    plugin_mock = Mock()
+    plugin_mock.secret_requires_group.return_value = False
+    mock_global_plugin = {"plugin": plugin_mock}
+    monkeypatch.setattr(flytekit.configuration.plugin, "_GLOBAL_CONFIG", mock_global_plugin)
+
+    if not is_local_execution:
+        monkeypatch.setenv("FLYTE_INTERNAL_EXECUTION_ID", "my-execution-id")
+
+    sec = SecretsManager()
+    prefix = sec._env_prefix
+
+    if not is_local_execution:
+        assert prefix == "_FSEC_"
+    else:
+        assert prefix == ""
+
+    monkeypatch.setenv(f"{prefix}XYZ", "my-abc-secret")
+    assert sec.get(key="XYZ") == "my-abc-secret"
+
+
 def test_serialization_settings_transport():
     default_img = Image(name="default", fqn="test", tag="tag")
     serialization_settings = SerializationSettings(

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -239,25 +239,19 @@ def test_secrets_manager_env():
     assert sec.get(group="group", key="key") == "value"
 
 
-@pytest.mark.parametrize("is_local_execution", [True, False])
-def test_secrets_manager_execution(monkeypatch, is_local_execution):
+@pytest.mark.parametrize("is_local_execution, prefix", [(True, ""), (False, "_FSEC_")])
+def test_secrets_manager_execution(monkeypatch, is_local_execution, prefix):
     if not is_local_execution:
         monkeypatch.setenv("FLYTE_INTERNAL_EXECUTION_ID", "my-execution-id")
 
     sec = SecretsManager()
-    prefix = sec._env_prefix
-
-    if not is_local_execution:
-        assert prefix == "_FSEC_"
-    else:
-        assert prefix == ""
 
     monkeypatch.setenv(f"{prefix}ABC_XYZ", "my-abc-secret")
     assert sec.get(group="ABC", key="XYZ") == "my-abc-secret"
 
 
-@pytest.mark.parametrize("is_local_execution", [True, False])
-def test_secrets_manager_execution_no_group_required(monkeypatch, is_local_execution):
+@pytest.mark.parametrize("is_local_execution, prefix", [(True, ""), (False, "_FSEC_")])
+def test_secrets_manager_execution_no_group_required(monkeypatch, is_local_execution, prefix):
     # Remove group requirements
     plugin_mock = Mock()
     plugin_mock.secret_requires_group.return_value = False
@@ -268,12 +262,6 @@ def test_secrets_manager_execution_no_group_required(monkeypatch, is_local_execu
         monkeypatch.setenv("FLYTE_INTERNAL_EXECUTION_ID", "my-execution-id")
 
     sec = SecretsManager()
-    prefix = sec._env_prefix
-
-    if not is_local_execution:
-        assert prefix == "_FSEC_"
-    else:
-        assert prefix == ""
 
     monkeypatch.setenv(f"{prefix}XYZ", "my-abc-secret")
     assert sec.get(key="XYZ") == "my-abc-secret"


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
When running locally, it is not natural to have a `_FSEC_` prefix on your secrets.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
With this PR, the `_FSPEC_` prefix is not used anymore for local execution.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I added unit tests to this PR to check the new behavior and ran this test:

```python
from flytekit import task, Secret
from flytekit import current_context


@task(
    secret_requests=[Secret(key="apikey", group="mygroup")],
    container_image="localhost:30000/flytekit:dev",
)
def check_secret() -> str:
    ctx = current_context()
    secret = ctx.secrets.get(key="apikey", group="mygroup")
    return secret
```

```bash
export MYGROUP_APIKEY=my-secret
pyflyte run --remote main.py check_secret
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.