### PR TITLE
Fix assertion in test_type_engine_binary_idl

### DIFF
--- a/tests/flytekit/unit/core/test_type_engine_binary_idl.py
+++ b/tests/flytekit/unit/core/test_type_engine_binary_idl.py
@@ -605,24 +605,24 @@ def test_all_types_in_dataclass_wf(local_dummy_file, local_dummy_directory):
 
     @task
     def t_inner(inner_dc: InnerDC):
-        assert (type(inner_dc), InnerDC) # type: ignore
+        assert type(inner_dc) is InnerDC
 
         # f: List[FlyteFile]
         for ff in inner_dc.f:
-            assert (type(ff), FlyteFile) # type: ignore
+            assert type(ff) is FlyteFile
             with open(ff, "r") as f:
                 assert f.read() == "Hello FlyteFile"
         # j: Dict[int, FlyteFile]
         for _, ff in inner_dc.j.items():
-            assert (type(ff), FlyteFile) # type: ignore
+            assert type(ff) is FlyteFile
             with open(ff, "r") as f:
                 assert f.read() == "Hello FlyteFile"
         # n: FlyteFile
-        assert (type(inner_dc.n), FlyteFile) # type: ignore
+        assert type(inner_dc.n) is FlyteFile
         with open(inner_dc.n, "r") as f:
             assert f.read() == "Hello FlyteFile"
         # o: FlyteDirectory
-        assert (type(inner_dc.o), FlyteDirectory) # type: ignore
+        assert type(inner_dc.o) is FlyteDirectory
         assert not inner_dc.o.downloaded
         with open(os.path.join(inner_dc.o, "file"), "r") as fh:
             assert fh.read() == "Hello FlyteDirectory"
@@ -755,24 +755,24 @@ def test_backward_compatible_with_dataclass_in_protobuf_struct(local_dummy_file,
         enum_status: Status = field(default=Status.PENDING)
 
     def t_inner(inner_dc: InnerDC):
-        assert (type(inner_dc), InnerDC) # type: ignore
+        assert type(inner_dc) is InnerDC
 
         # f: List[FlyteFile]
         for ff in inner_dc.f:
-            assert (type(ff), FlyteFile) # type: ignore
+            assert type(ff) is FlyteFile
             with open(ff, "r") as f:
                 assert f.read() == "Hello FlyteFile"
         # j: Dict[int, FlyteFile]
         for _, ff in inner_dc.j.items():
-            assert (type(ff), FlyteFile) # type: ignore
+            assert type(ff) is FlyteFile
             with open(ff, "r") as f:
                 assert f.read() == "Hello FlyteFile"
         # n: FlyteFile
-        assert (type(inner_dc.n), FlyteFile) # type: ignore
+        assert type(inner_dc.n) is FlyteFile
         with open(inner_dc.n, "r") as f:
             assert f.read() == "Hello FlyteFile"
         # o: FlyteDirectory
-        assert (type(inner_dc.o), FlyteDirectory) # type: ignore
+        assert type(inner_dc.o) is FlyteDirectory
         assert not inner_dc.o.downloaded
         with open(os.path.join(inner_dc.o, "file"), "r") as fh:
             assert fh.read() == "Hello FlyteDirectory"


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
The assertion on main is not always true, and pytest raises this warning:

```
/home/runner/work/flytekit/flytekit/tests/flytekit/unit/core/test_type_engine_binary_idl.py:608: SyntaxWarning: assertion is always true, perhaps remove parentheses?
  assert (type(inner_dc), InnerDC) # type: ignore
```


## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR fixes the assertion to actual check the types.