### PR TITLE
DOC-648 Add pages for Neptune and W&B plugins

### DIFF
--- a/docs/source/plugins/index.rst
+++ b/docs/source/plugins/index.rst
@@ -38,7 +38,7 @@ Plugin API reference
 
 .. toctree::
    :maxdepth: 2
-   :caption: API reference
+   :hidden:
 
    AWS Athena <athena>
    AWS Batch <awsbatch>

--- a/docs/source/plugins/index.rst
+++ b/docs/source/plugins/index.rst
@@ -33,6 +33,8 @@ Plugin API reference
 * :ref:`SageMaker Inference <awssagemaker_inference>` - SageMaker Inference API reference
 * :ref:`OpenAI <openai>` - OpenAI API reference
 * :ref:`Inference <inference>` - Inference API reference
+* :ref:`Neptune <neptune>` - Neptune API reference
+* :ref:`Weights & Biases <wandb>` - Weights & Biases API reference
 
 .. toctree::
    :maxdepth: 2
@@ -67,3 +69,5 @@ Plugin API reference
    SageMaker Inference <awssagemaker_inference>
    OpenAI <openai>
    Inference <inference>
+   Neptune <neptune>
+   Weights & Biases <wandb>

--- a/docs/source/plugins/neptune.rst
+++ b/docs/source/plugins/neptune.rst
@@ -1,0 +1,12 @@
+.. _neptune:
+
+###################################################
+Neptune API reference
+###################################################
+
+.. tags:: Integration
+
+.. automodule:: flytekitplugins.neptune
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/docs/source/plugins/wandb.rst
+++ b/docs/source/plugins/wandb.rst
@@ -1,0 +1,12 @@
+.. _wandb:
+
+###################################################
+Weights & Biases API reference
+###################################################
+
+.. tags:: Integration
+
+.. automodule:: flytekitplugins.wandb
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/plugins/flytekit-neptune/flytekitplugins/neptune/__init__.py
+++ b/plugins/flytekit-neptune/flytekitplugins/neptune/__init__.py
@@ -1,3 +1,15 @@
+"""
+.. currentmodule:: flytekitplugins.neptune
+
+This package contains things that are useful when extending Flytekit.
+
+.. autosummary::
+   :template: custom.rst
+   :toctree: generated/
+
+   neptune_init_run
+"""
+
 from .tracking import neptune_init_run
 
 __all__ = ["neptune_init_run"]

--- a/plugins/flytekit-wandb/flytekitplugins/wandb/__init__.py
+++ b/plugins/flytekit-wandb/flytekitplugins/wandb/__init__.py
@@ -1,3 +1,15 @@
+"""
+.. currentmodule:: flytekitplugins.wandb
+
+This package contains things that are useful when extending Flytekit.
+
+.. autosummary::
+   :template: custom.rst
+   :toctree: generated/
+
+   wandb_init
+"""
+
 from .tracking import wandb_init
 
 __all__ = ["wandb_init"]


### PR DESCRIPTION
## Why are the changes needed?

Adds docs pages for Neptune and W&B plugins.

This is one of three PRs we need to merge in the following order to get the neptune and wandb flytekit plugin docs onto the docs site:
1. [flytesnacks PR](https://github.com/flyteorg/flytesnacks/pull/1748) to fix refs in neptune and wandb plugin docs
1. [flyte PR](https://github.com/flyteorg/flyte/pull/5842) to update monodocs dependencies
1. flytekit PR (this one) to add new flytekit plugin docs for neptune and wandb plugins (after re-running monodocs build)

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.
