### PR TITLE
add links to register

### DIFF
--- a/flytekit/clis/sdk_in_container/register.py
+++ b/flytekit/clis/sdk_in_container/register.py
@@ -229,4 +229,5 @@ def register(
         activate_launchplans=activate_launchplans,
         skip_errors=skip_errors,
         show_files=show_files,
+        verbosity=ctx.obj[constants.CTX_VERBOSE],
     )

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2399,12 +2399,15 @@ class FlyteRemote(object):
 
         if not isinstance(entity, (FlyteWorkflow, FlyteTask, FlyteLaunchPlan)):
             raise ValueError(f"Only remote entities can be looked at in the console, got type {type(entity)}")
+        return self.generate_url_from_id(id=entity.id)
+
+    def generate_url_from_id(self, id: Identifier):
         rt = "workflow"
-        if entity.id.resource_type == ResourceType.TASK:
+        if id.resource_type == ResourceType.TASK:
             rt = "task"
-        elif entity.id.resource_type == ResourceType.LAUNCH_PLAN:
+        elif id.resource_type == ResourceType.LAUNCH_PLAN:
             rt = "launch_plan"
-        return f"{self.generate_console_http_domain()}/console/projects/{entity.id.project}/domains/{entity.id.domain}/{rt}/{entity.name}/version/{entity.id.version}"  # noqa
+        return f"{self.generate_console_http_domain()}/console/projects/{id.project}/domains/{id.domain}/{rt}/{id.name}/version/{id.version}"
 
     def launch_backfill(
         self,

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -210,7 +210,7 @@ def secho(i: Identifier, state: str = "success", reason: str = None, op: str = "
         fg = "green"
         nl = True
         if not reason:
-            reason = f"successful: {console_url}" if console_url else f"version: {i.version}"
+            reason = f"successful: {click.style(console_url, fg="cyan")}" if console_url else f"version: {i.version}"
     elif state == "failed":
         state_ind = "\r[x]"
         fg = "red"

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -210,7 +210,8 @@ def secho(i: Identifier, state: str = "success", reason: str = None, op: str = "
         fg = "green"
         nl = True
         if not reason:
-            reason = f"successful: {click.style(console_url, fg="cyan")}" if console_url else f"version: {i.version}"
+            url_string = click.style(console_url, fg="cyan")
+            reason = f"successful: {url_string}" if console_url else f"version: {i.version}"
     elif state == "failed":
         state_ind = "\r[x]"
         fg = "red"

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -22,8 +22,6 @@ from flytekit.tools.script_mode import _find_project_root
 from flytekit.tools.serialize_helpers import get_registrable_entities, persist_registrable_entities
 from flytekit.tools.translator import FlyteControlPlaneEntity, Options
 
-REGISTRATION = "Registration"
-
 
 class NoSerializableEntitiesError(Exception):
     pass
@@ -69,16 +67,6 @@ def serialize_get_control_plane_entities(
     ctx_builder = FlyteContextManager.current_context().with_serialization_settings(settings)
     with FlyteContextManager.with_context(ctx_builder) as ctx:
         registrable_entities = get_registrable_entities(ctx, options=options)
-        if is_registration:
-            click.secho(
-                f"Serializing and registering {len(registrable_entities)} flyte entities",
-                fg="green",
-            )
-        else:
-            click.secho(
-                f"Successfully serialized {len(registrable_entities)} flyte entities",
-                fg="green",
-            )
         return registrable_entities
 
 
@@ -96,6 +84,10 @@ def serialize_to_folder(
         folder = "."
     serialize_load_only(pkgs, settings, local_source_root)
     loaded_entities = serialize_get_control_plane_entities(settings, local_source_root, options=options)
+    click.secho(
+        f"Successfully serialized {len(loaded_entities)} flyte entities",
+        fg="green",
+    )
     persist_registrable_entities(loaded_entities, folder)
 
 
@@ -157,6 +149,10 @@ def serialize_and_package(
     """
     serialize_load_only(pkgs, settings, source)
     serializable_entities = serialize_get_control_plane_entities(settings, source, options=options)
+    click.secho(
+        f"Successfully serialized {len(serializable_entities)} flyte entities",
+        fg="green",
+    )
     package(serializable_entities, source, output, deref_symlinks, fast_options)
 
 
@@ -319,6 +315,10 @@ def register(
 
     registrable_entities = serialize_get_control_plane_entities(
         serialization_settings, str(detected_root), options, is_registration=True
+    )
+    click.secho(
+        f"Serializing and registering {len(registrable_entities)} flyte entities",
+        fg="green",
     )
 
     FlyteContextManager.pop_context()

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -211,7 +211,7 @@ def secho(i: Identifier, state: str = "success", reason: str = None, op: str = "
         nl = True
         if not reason:
             url_string = click.style(console_url, fg="cyan")
-            reason = f"successful: {url_string}" if console_url else f"version: {i.version}"
+            reason = f"successful: {url_string}" if console_url else f"successful. Version: {i.version}"
     elif state == "failed":
         state_ind = "\r[x]"
         fg = "red"


### PR DESCRIPTION
## Why are the changes needed?

When entities are registered there is no helpful link to the UI like there is when entities are run. This helps users navigate to the entity in the UI after they register something in the CLI.

## What changes were proposed in this pull request?

When registering we fetch the entity with flyte remote and then get the console url for the entity.

## How was this patch tested?

`union register docs_examples/flyte_file.py`

Before:
```
Successfully serialized 4 flyte objects
[✔] Registration flyte_file.t1 type TASK successful with version GxQbXiMnIdiRYRxg6I_B2Q
[✔] Registration flyte_file.t2 type TASK successful with version GxQbXiMnIdiRYRxg6I_B2Q
[✔] Registration flyte_file.wf type WORKFLOW successful with version GxQbXiMnIdiRYRxg6I_B2Q
[✔] Registration flyte_file.wf type LAUNCH_PLAN successful with version GxQbXiMnIdiRYRxg6I_B2Q
Successfully registered 4 entities
```

After:
```
Serializing and registering 4 flyte entities
[✔] Task: flyte_file.t1
[✔] Task: flyte_file.t2
[✔] Workflow: flyte_file.wf
[✔] Launch Plan: flyte_file.wf
Successfully registered 4 entities
```
Note that entity names are clickable and underlined (see image). 
<img width="350" alt="image" src="https://github.com/user-attachments/assets/bcdece07-05e2-4f86-88af-b98f5191d212">



### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
