### PR TITLE
ensure a space is added if both args are set in ImageSpec

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -145,15 +145,20 @@ def create_docker_context(image_spec: ImageSpec, tmp_dir: Path):
     requirements_uv_path = tmp_dir / "requirements_uv.txt"
     requirements_uv_path.write_text("\n".join(requirements))
 
-    pip_extra_args = ""
+    pip_extra_args = []
 
     if image_spec.pip_index:
-        pip_extra_args += f"--index-url {image_spec.pip_index}"
+        pip_extra_args.append(f"--index-url {image_spec.pip_index}")
     if image_spec.pip_extra_index_url:
         extra_urls = [f"--extra-index-url {url}" for url in image_spec.pip_extra_index_url]
-        pip_extra_args += " ".join(extra_urls)
+        pip_extra_args.extend(extra_urls)
+
+    pip_extra_args = " ".join(pip_extra_args)
 
     uv_python_install_command = UV_PYTHON_INSTALL_COMMAND_TEMPLATE.substitute(PIP_EXTRA=pip_extra_args)
+
+    # Normalize whitespace to remove any extra spaces
+    uv_python_install_command = " ".join(uv_python_install_command.split())
 
     env_dict = {"PYTHONPATH": "/root", _F_IMG_ID: image_spec.id}
 

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -157,9 +157,6 @@ def create_docker_context(image_spec: ImageSpec, tmp_dir: Path):
 
     uv_python_install_command = UV_PYTHON_INSTALL_COMMAND_TEMPLATE.substitute(PIP_EXTRA=pip_extra_args)
 
-    # Normalize whitespace to remove any extra spaces
-    uv_python_install_command = " ".join(uv_python_install_command.split())
-
     env_dict = {"PYTHONPATH": "/root", _F_IMG_ID: image_spec.id}
 
     if image_spec.env:

--- a/tests/flytekit/unit/core/image_spec/test_default_builder.py
+++ b/tests/flytekit/unit/core/image_spec/test_default_builder.py
@@ -37,6 +37,7 @@ def test_create_docker_context(tmp_path):
             source_root=os.fspath(source_root),
             commands=["mkdir my_dir"],
             entrypoint=["/bin/bash"],
+            pip_index="https://url.com",
             pip_extra_index_url=["https://extra-url.com"],
             source_copy_mode=CopyFileDetection.ALL,
             copy=[tmp_file.relative_to(Path.cwd()).as_posix()],
@@ -52,6 +53,7 @@ def test_create_docker_context(tmp_path):
     assert "scipy==1.13.0 numpy" in dockerfile_content
     assert "python=3.12" in dockerfile_content
     assert "--requirement requirements_uv.txt" in dockerfile_content
+    assert "--index-url" in dockerfile_content
     assert "--extra-index-url" in dockerfile_content
     assert "COPY --chown=flytekit ./src /root" in dockerfile_content
     assert "RUN mkdir my_dir" in dockerfile_content


### PR DESCRIPTION
## Why are the changes needed?
If both `--index-url` and `--extra-index-url` are set, a space is missing between the 2, resulting in an error.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

Added unit test and visualized the docker command output.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
