### PR TITLE
added node index to current_context

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -300,7 +300,9 @@ def setup_execution(
     if checkpoint_path is not None:
         checkpointer = SyncCheckpoint(checkpoint_dest=checkpoint_path, checkpoint_src=prev_checkpoint)
         logger.debug(f"Checkpointer created with source {prev_checkpoint} and dest {checkpoint_path}")
-
+    
+    node_index = _compute_array_job_index()
+    
     execution_parameters = ExecutionParameters(
         execution_id=_identifier.WorkflowExecutionIdentifier(
             project=exe_project,
@@ -328,6 +330,7 @@ def setup_execution(
         output_metadata_prefix=output_metadata_prefix,
         checkpoint=checkpointer,
         task_id=_identifier.Identifier(_identifier.ResourceType.TASK, tk_project, tk_domain, tk_name, tk_version),
+        node_index=node_index,
     )
 
     metadata = {


### PR DESCRIPTION
## Tracking issue
Closes flyteorg/flyte#5534
## Why are the changes needed?
In Flyte, when working with map tasks, outputs often risk being overwritten if they share the same static name. For example, if multiple nodes generate output files with the same name, only the last file would remain, as previous ones would be overwritten. By adding the array node index, it becomes possible to uniquely name these outputs, avoiding conflicts.


## What changes were proposed in this pull request?

**The key goal of this PR is to include the index of an array node in map_tasks within the current_context() returned value. This feature is especially useful when multiple nodes within a map task could potentially overwrite outputs**


