### PR TITLE
Read inputs file from stdin iff the last argument to `pyflyte run` is a dash

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -941,7 +941,9 @@ class YamlFileReadingCommand(click.RichCommand):
             f = args.pop(idx)
             with open(f, "r") as f:
                 inputs = load_inputs(f.read())
-        elif not sys.stdin.isatty():
+        # If the last argument is a dash, read from stdin
+        elif len(args) > 0 and args[-1] == "-":
+            args.pop(-1)
             f = sys.stdin.read()
             if f != "":
                 inputs = load_inputs(f)

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -309,6 +309,7 @@ def test_all_types_with_pipe_input(monkeypatch):
             "run",
             os.path.join(DIR_NAME, "workflow.py"),
             "my_wf",
+            "-",
         ],
         input=input,
         catch_exceptions=False,


### PR DESCRIPTION
## Why are the changes needed?
One of the two ways to define inputs to `pyflyte run` introduced by https://github.com/flyteorg/flytekit/pull/2552 was to read them from stdin. The initial implementation attempts to read from stdin in case `pyflyte run` is not in an interactive, unfortunately, this ends up blocking if we use `pyflyte run` in a pipeline.

This PR introduces the convention of only reading from stdin iff `-` is passed to the invocation of `pyflyte run`.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
We check if the last argument passed to `pyflyte run` is a dash (i.e. a `-`).

There are obvious limitations to this, e.g. multiple dashes as arguments, but we're counting on click to catch the majority of the cases.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Unit tests and local tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
