### PR TITLE
Add FLYTE_FAIL_ON_ERROR env to the databricks job

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -222,14 +222,14 @@ def _dispatch_execute(
 
     logger.debug("Finished _dispatch_execute")
 
-    """
-    If the environment variable FLYTE_FAIL_ON_ERROR is set to true, the task execution will fail if an error file is
-    generated. This environment variable is set to true by the plugin author if they want the task to fail on error.
-    Otherwise, the task will always succeed, and just write the error file to the blob store.
-    
-    For example, you can see the task fails on Databricks or AWS batch UI by setting this environment variable to true.
-    """
     if str2bool(os.getenv(FLYTE_FAIL_ON_ERROR)) and _constants.ERROR_FILE_NAME in output_file_dict:
+        """
+        If the environment variable FLYTE_FAIL_ON_ERROR is set to true, the task execution will fail if an error file is
+        generated. This environment variable is set to true by the plugin author if they want the task to fail on error.
+        Otherwise, the task will always succeed and just write the error file to the blob store.
+
+        For example, you can see the task fails on Databricks or AWS batch UI by setting this environment variable to true.
+        """
         exit(1)
 
 

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -27,6 +27,7 @@ from flytekit.core import constants as _constants
 from flytekit.core import utils
 from flytekit.core.base_task import IgnoreOutputs, PythonTask
 from flytekit.core.checkpointer import SyncCheckpoint
+from flytekit.core.constants import FLYTE_FAIL_ON_ERROR
 from flytekit.core.context_manager import (
     ExecutionParameters,
     ExecutionState,
@@ -36,6 +37,7 @@ from flytekit.core.context_manager import (
 )
 from flytekit.core.data_persistence import FileAccessProvider
 from flytekit.core.promise import VoidPromise
+from flytekit.core.utils import str2bool
 from flytekit.deck.deck import _output_deck
 from flytekit.exceptions.system import FlyteNonRecoverableSystemException
 from flytekit.exceptions.user import FlyteRecoverableException, FlyteUserRuntimeException
@@ -220,10 +222,14 @@ def _dispatch_execute(
 
     logger.debug("Finished _dispatch_execute")
 
-    if os.environ.get("FLYTE_FAIL_ON_ERROR", "").lower() == "true" and _constants.ERROR_FILE_NAME in output_file_dict:
-        # This env is set by the flytepropeller
-        # AWS batch job get the status from the exit code, so once we catch the error,
-        # we should return the error code here
+    """
+    If the environment variable FLYTE_FAIL_ON_ERROR is set to true, the task execution will fail if an error file is
+    generated. This environment variable is set to true by the plugin author if they want the task to fail on error.
+    Otherwise, the task will always succeed, and just write the error file to the blob store.
+    
+    For example, you can see the task fails on Databricks or AWS batch UI by setting this environment variable to true.
+    """
+    if str2bool(os.getenv(FLYTE_FAIL_ON_ERROR)) and _constants.ERROR_FILE_NAME in output_file_dict:
         exit(1)
 
 

--- a/flytekit/core/constants.py
+++ b/flytekit/core/constants.py
@@ -16,3 +16,6 @@ FLYTE_INTERNAL_IMAGE_ENV_VAR = "FLYTE_INTERNAL_IMAGE"
 
 # Binary IDL Serialization Format
 MESSAGEPACK = "msgpack"
+
+# Set this environment variable to true to force the task to return non-zero exit code on failure.
+FLYTE_FAIL_ON_ERROR = "FLYTE_FAIL_ON_ERROR"

--- a/flytekit/models/task.py
+++ b/flytekit/models/task.py
@@ -898,7 +898,7 @@ class Container(_common.FlyteIdlEntity):
         return self._resources
 
     @property
-    def env(self):
+    def env(self) -> typing.Dict[str, str]:
         """
         A definition of key-value pairs for environment variables.  Currently, only str->str is
             supported.

--- a/plugins/flytekit-spark/flytekitplugins/spark/agent.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/agent.py
@@ -25,6 +25,40 @@ class DatabricksJobMetadata(ResourceMeta):
     run_id: str
 
 
+def _get_databricks_job_spec(task_template: TaskTemplate) -> dict:
+    custom = task_template.custom
+    container = task_template.container
+    envs = task_template.container.env
+    envs[FLYTE_FAIL_ON_ERROR] = "true"
+    databricks_job = custom["databricksConf"]
+    if databricks_job.get("existing_cluster_id") is None:
+        new_cluster = databricks_job.get("new_cluster")
+        if new_cluster is None:
+            raise ValueError("Either existing_cluster_id or new_cluster must be specified")
+        if not new_cluster.get("docker_image"):
+            new_cluster["docker_image"] = {"url": container.image}
+        if not new_cluster.get("spark_conf"):
+            new_cluster["spark_conf"] = custom["sparkConf"]
+        if not new_cluster.get("spark_env_vars"):
+            new_cluster["spark_env_vars"] = {k: v for k, v in envs.items()}
+        else:
+            new_cluster["spark_env_vars"].update({k: v for k, v in envs.items()})
+    # https://docs.databricks.com/api/workspace/jobs/submit
+    databricks_job["spark_python_task"] = {
+        "python_file": "flytekitplugins/databricks/entrypoint.py",
+        "source": "GIT",
+        "parameters": container.args,
+    }
+    databricks_job["git_source"] = {
+        "git_url": "https://github.com/flyteorg/flytetools",
+        "git_provider": "gitHub",
+        # https://github.com/flyteorg/flytetools/commit/572298df1f971fb58c258398bd70a6372f811c96
+        "git_commit": "572298df1f971fb58c258398bd70a6372f811c96",
+    }
+
+    return databricks_job
+
+
 class DatabricksAgent(AsyncAgentBase):
     name = "Databricks Agent"
 
@@ -34,39 +68,9 @@ class DatabricksAgent(AsyncAgentBase):
     async def create(
         self, task_template: TaskTemplate, inputs: Optional[LiteralMap] = None, **kwargs
     ) -> DatabricksJobMetadata:
-        custom = task_template.custom
-        container = task_template.container
-        envs = task_template.container.env
-        envs[FLYTE_FAIL_ON_ERROR] = "true"
-        databricks_job = custom["databricksConf"]
-        if databricks_job.get("existing_cluster_id") is None:
-            new_cluster = databricks_job.get("new_cluster")
-            if new_cluster is None:
-                raise ValueError("Either existing_cluster_id or new_cluster must be specified")
-            if not new_cluster.get("docker_image"):
-                new_cluster["docker_image"] = {"url": container.image}
-            if not new_cluster.get("spark_conf"):
-                new_cluster["spark_conf"] = custom["sparkConf"]
-            if not new_cluster["spark_env_vars"]:
-                new_cluster["spark_env_vars"] = {k: v for k, v in envs.items()}
-            else:
-                new_cluster["spark_env_vars"].update({k: v for k, v in envs.items()})
-        # https://docs.databricks.com/api/workspace/jobs/submit
-        databricks_job["spark_python_task"] = {
-            "python_file": "flytekitplugins/databricks/entrypoint.py",
-            "source": "GIT",
-            "parameters": container.args,
-        }
-        databricks_job["git_source"] = {
-            "git_url": "https://github.com/flyteorg/flytetools",
-            "git_provider": "gitHub",
-            # https://github.com/flyteorg/flytetools/commit/572298df1f971fb58c258398bd70a6372f811c96
-            "git_commit": "572298df1f971fb58c258398bd70a6372f811c96",
-        }
-
-        databricks_instance = custom["databricksInstance"]
+        data = json.dumps(_get_databricks_job_spec(task_template))
+        databricks_instance = task_template.custom["databricksInstance"]
         databricks_url = f"https://{databricks_instance}{DATABRICKS_API_ENDPOINT}/runs/submit"
-        data = json.dumps(databricks_job)
 
         async with aiohttp.ClientSession() as session:
             async with session.post(databricks_url, headers=get_header(), data=data) as resp:

--- a/plugins/flytekit-spark/setup.py
+++ b/plugins/flytekit-spark/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "spark"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>1.13.5", "pyspark>=3.0.0", "aiohttp", "flyteidl>=1.11.0b1", "pandas"]
+plugin_requires = ["flytekit>1.13.8", "pyspark>=3.0.0", "aiohttp", "flyteidl>=1.11.0b1", "pandas"]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
The task status shows failed on Flyte Console, but succeeded on the Databricks UI. That's because `pyflyte-execute` always returns an exit code 0, whether the job succeeds or fails.

## What changes were proposed in this pull request?
Set `FLYTE_FAIL_ON_ERROR` in the databricks job, and it will force flytekit to return a non-zero exit code on failure.

## How was this patch tested?
Run a dummy databricks task that raises an error and then check if the task fails on databricks UI.

### Setup process

### Screenshots
![image](https://github.com/user-attachments/assets/114af22f-4284-45d1-ba9c-1161923986ae)


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
