### PR TITLE
Fix docs URL in pyflyte init

### DIFF
--- a/flytekit/clis/sdk_in_container/init.py
+++ b/flytekit/clis/sdk_in_container/init.py
@@ -58,5 +58,5 @@ def init(template, project_name):
                 dest_file.write(processed_contents)
 
     click.echo(
-        f"Visit the {project_name} directory and follow the next steps in the Getting started guide (https://docs.flyte.org/en/latest/getting_started_with_workflow_development/index.html) to proceed."
+        f"Visit the {project_name} directory and follow the next steps in the Getting started guide (https://docs.flyte.org/en/latest/user_guide/getting_started_with_workflow_development/index.html) to proceed."
     )


### PR DESCRIPTION
## Why are the changes needed?

The docs link from `pyflyte init` is a 404!

## What changes were proposed in this pull request?

Fix the docs link.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [ ] All commits are signed-off.
