### PR TITLE
[BUG] fix is_optional_type to not return true for all union types

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1751,8 +1751,7 @@ class UnionTransformer(AsyncTypeTransformer[T]):
 
     @staticmethod
     def is_optional_type(t: Type) -> bool:
-        """Return True if `t` is a Union or Optional type."""
-        return _is_union_type(t) or type(None) in get_args(t)
+        return _is_union_type(t) and type(None) in get_args(t)
 
     @staticmethod
     def get_sub_type_in_optional(t: Type[T]) -> Type[T]:

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -1716,6 +1716,8 @@ def test_union_transformer():
     assert not UnionTransformer.is_optional_type(str)
     assert UnionTransformer.get_sub_type_in_optional(typing.Optional[int]) == int
     assert UnionTransformer.get_sub_type_in_optional(int | None) == int
+    assert not UnionTransformer.is_optional_type(typing.Union[int, str])
+    assert UnionTransformer.is_optional_type(typing.Union[int, None])
 
 
 def test_union_guess_type():


### PR DESCRIPTION
## Tracking issue
fixes: https://linear.app/unionai/issue/COR-2132/launch-plan-w-union-type-param-breaks

## Why are the changes needed?

registering a workflow fails if it contains param of type union 

```
@task
def calculate_interest(principal: int, rate: typing.Union[float, int], time: int) -> float:
    return (principal * rate * time) / 12


@workflow
def interest_workflow(principal: int, rate: typing.Union[float, int], time: int) -> float:
    return calculate_interest(principal=principal, rate=rate, time=time)
```

```
Request rejected by the API, due to Invalid input.
RPC Failed, with Status: StatusCode.INVALID_ARGUMENT
        Details: Type mismatch for Parameter rate in default_inputs has type union_type:{variants:{simple:FLOAT  structure:{tag:"float"}}  variants:{simple:INTEGER  structure:{tag:"int"}}}, expected simple:NONE
```

This occurs due to: https://github.com/flyteorg/flytekit/pull/2327 + https://github.com/flyteorg/flytekit/pull/2724

## What changes were proposed in this pull request?

fix is_optional_type to not return true for all union types


## How was this patch tested?

- updated unit tests
- ran workflows in sandbox to confirm registration issues are resolved

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
