### PR TITLE
Supports importing modules in current path

### DIFF
--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import pathlib
+import sys
 import typing
 import typing as t
 from typing import cast, get_args
@@ -149,6 +150,7 @@ class PickleParamType(click.ParamType):
                 click.echo(f"Did not receive a string in the expected format <MODULE>:<VAR>, falling back to: {value}")
             return value
         try:
+            sys.path.insert(0, "")
             m = importlib.import_module(parts[0])
             return m.__getattribute__(parts[1])
         except ModuleNotFoundError as e:


### PR DESCRIPTION
In case when we use a python pickle object from a local path, we have to insert the current directory as the first lookup path for importlib to work
