### PR TITLE
handle case where error may not have args

### DIFF
--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -743,9 +743,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 raise
             except Exception as e:
                 if is_local_execution:
-                    e.args = (
-                        f"Error encountered while converting inputs of '{self.name}':\n  {e}",
-                    )
+                    e.args = (f"Error encountered while converting inputs of '{self.name}':\n  {e}",)
                     raise
                 raise FlyteNonRecoverableSystemException(e) from e
             # TODO: Logger should auto inject the current context information to indicate if the task is running within
@@ -757,9 +755,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 except Exception as e:
                     if is_local_execution:
                         # If the task is being executed locally, we want to raise the original exception
-                        e.args = (
-                            f"Error encountered while executing '{self.name}':\n  {e}",
-                        )
+                        e.args = (f"Error encountered while executing '{self.name}':\n  {e}",)
                         raise
                     raise FlyteUserRuntimeException(e) from e
 

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -743,7 +743,9 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 raise
             except Exception as e:
                 if is_local_execution:
-                    e.args = (f"Error encountered while converting inputs of '{self.name}':\n  {e.args[0]}",)
+                    e.args = (
+                        f"Error encountered while converting inputs of '{self.name}':\n  {e}",
+                    )
                     raise
                 raise FlyteNonRecoverableSystemException(e) from e
             # TODO: Logger should auto inject the current context information to indicate if the task is running within
@@ -755,7 +757,9 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 except Exception as e:
                     if is_local_execution:
                         # If the task is being executed locally, we want to raise the original exception
-                        e.args = (f"Error encountered while executing '{self.name}':\n  {e.args[0]}",)
+                        e.args = (
+                            f"Error encountered while executing '{self.name}':\n  {e}",
+                        )
                         raise
                     raise FlyteUserRuntimeException(e) from e
 


### PR DESCRIPTION
## Why are the changes needed?
Running a task locally, if an exception is thrown that does not have args, an `IndexError: tuple index out of range` is actually thrown.

A simple example that causes the issue:
```python
@task
def task_1(val: int) -> None:
    assert val > 0
```
If this assert fails and an `AssertionError` is thrown, it will not have any `args` and therefore cause the above behaviour.

## How was this patch tested?

Parameterized an existing test w/ more cases.


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->
The issue was first introduced here - https://github.com/flyteorg/flytekit/pull/2671
