### PR TITLE
Adds actual current working directory path

### DIFF
--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -150,7 +150,7 @@ class PickleParamType(click.ParamType):
                 click.echo(f"Did not receive a string in the expected format <MODULE>:<VAR>, falling back to: {value}")
             return value
         try:
-            sys.path.insert(0, "")
+            sys.path.insert(0, os.getcwd())
             m = importlib.import_module(parts[0])
             return m.__getattribute__(parts[1])
         except ModuleNotFoundError as e:


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->
Follow up to https://github.com/flyteorg/flytekit/pull/2830

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
I think it's slightly better to add the absolute path for the current working directory. Also as a maintainer, it's easier to see what the code is doing with `os.getcwd()`.