### PR TITLE
create flytekit.cwd, add support for pathlib.Path paths in FlyteFile …

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -205,6 +205,7 @@ Documentation
 
 import os
 import sys
+from pathlib import Path
 from typing import Generator
 
 from rich import traceback
@@ -279,6 +280,15 @@ def current_context() -> ExecutionParameters:
 def new_context() -> Generator[FlyteContext, None, None]:
     return FlyteContextManager.with_context(FlyteContextManager.current_context().new_builder())
 
+def cwd() -> Path:
+    """
+    Use this method to get a pathlib.Path of the current working directory of the task execution.
+
+    Usage
+    .. code-block:: python
+        path = flytekit.cwd() / 'my_file.txt'
+    """
+    return Path(FlyteContextManager.current_context().working_directory)
 
 def load_implicit_plugins():
     """

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -280,6 +280,7 @@ def current_context() -> ExecutionParameters:
 def new_context() -> Generator[FlyteContext, None, None]:
     return FlyteContextManager.with_context(FlyteContextManager.current_context().new_builder())
 
+
 def cwd() -> Path:
     """
     Use this method to get a pathlib.Path of the current working directory of the task execution.
@@ -289,6 +290,7 @@ def cwd() -> Path:
         path = flytekit.cwd() / 'my_file.txt'
     """
     return Path(FlyteContextManager.current_context().working_directory)
+
 
 def load_implicit_plugins():
     """

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -168,7 +168,7 @@ class FlyteDirectory(SerializableType, DataClassJsonMixin, os.PathLike, typing.G
         """
         # Make this field public, so that the dataclass transformer can set a value for it
         # https://github.com/flyteorg/flytekit/blob/bcc8541bd6227b532f8462563fe8aac902242b21/flytekit/core/type_engine.py#L298
-        self.path = path
+        self.path = path if not isinstance(pathlib.Path, str) else str(path)
         self._downloader = downloader or noop
         self._downloaded = False
         self._remote_directory = remote_directory

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -266,7 +266,7 @@ class FlyteFile(SerializableType, os.PathLike, typing.Generic[T], DataClassJSONM
         """
         # Make this field public, so that the dataclass transformer can set a value for it
         # https://github.com/flyteorg/flytekit/blob/bcc8541bd6227b532f8462563fe8aac902242b21/flytekit/core/type_engine.py#L298
-        self.path = path
+        self.path = path if not isinstance(pathlib.Path, str) else str(path)
         self._downloader = downloader
         self._downloaded = False
         self._remote_path = remote_path

--- a/tests/flytekit/unit/types/directory/test_types.py
+++ b/tests/flytekit/unit/types/directory/test_types.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import mock
 
 from flytekit import FlyteContext
@@ -17,6 +18,17 @@ def test_new_file_dir():
     assert isinstance(f, FlyteFile)
     assert f.path == "s3://my-bucket/test/test"
 
+def test_new_file_dir_pathlib():
+    fd = FlyteDirectory(path=Path("s3://my-bucket"))
+    assert fd.sep == "/"
+    inner_dir = fd.new_dir("test")
+    assert inner_dir.path == "s3://my-bucket/test"
+    fd = FlyteDirectory(path=Path("s3://my-bucket"))
+    inner_dir = fd.new_dir("test")
+    assert inner_dir.path == "s3://my-bucket/test"
+    f = inner_dir.new_file("test")
+    assert isinstance(f, FlyteFile)
+    assert f.path == "s3://my-bucket/test/test"
 
 def test_new_remote_dir():
     fd = FlyteDirectory.new_remote()

--- a/tests/flytekit/unit/types/directory/test_types.py
+++ b/tests/flytekit/unit/types/directory/test_types.py
@@ -18,17 +18,8 @@ def test_new_file_dir():
     assert isinstance(f, FlyteFile)
     assert f.path == "s3://my-bucket/test/test"
 
-def test_new_file_dir_pathlib():
-    fd = FlyteDirectory(path=Path("s3://my-bucket"))
-    assert fd.sep == "/"
-    inner_dir = fd.new_dir("test")
-    assert inner_dir.path == "s3://my-bucket/test"
-    fd = FlyteDirectory(path=Path("s3://my-bucket"))
-    inner_dir = fd.new_dir("test")
-    assert inner_dir.path == "s3://my-bucket/test"
-    f = inner_dir.new_file("test")
-    assert isinstance(f, FlyteFile)
-    assert f.path == "s3://my-bucket/test/test"
+def test_new_dir_from_pathlib():
+    FlyteDirectory(path=Path("my_directory"))
 
 def test_new_remote_dir():
     fd = FlyteDirectory.new_remote()

--- a/tests/flytekit/unit/types/file/test_types.py
+++ b/tests/flytekit/unit/types/file/test_types.py
@@ -8,7 +8,5 @@ def test_new_remote_alt():
     assert "my-alt-prefix" in ff.path
     assert "my-file.txt" in ff.path
 
-def test_new_remote_alt_pathlib():
-    ff = FlyteFile.new_remote_file(alt="my-alt-prefix", name=Path("my-file.txt"))
-    assert "my-alt-prefix" in ff.path
-    assert "my-file.txt" in ff.path
+def test_new_remote_from_pathlib():
+    ff = FlyteFile(path=Path("my-file.txt"))

--- a/tests/flytekit/unit/types/file/test_types.py
+++ b/tests/flytekit/unit/types/file/test_types.py
@@ -1,7 +1,14 @@
+from pathlib import Path
+
 from flytekit.types.file import FlyteFile
 from flytekit import FlyteContextManager
 
 def test_new_remote_alt():
     ff = FlyteFile.new_remote_file(alt="my-alt-prefix", name="my-file.txt")
+    assert "my-alt-prefix" in ff.path
+    assert "my-file.txt" in ff.path
+
+def test_new_remote_alt_pathlib():
+    ff = FlyteFile.new_remote_file(alt="my-alt-prefix", name=Path("my-file.txt"))
     assert "my-alt-prefix" in ff.path
     assert "my-file.txt" in ff.path


### PR DESCRIPTION
Users may access the current working directory within a task like so:

```python
flytekit.cwd()
```

This will return a Path object for convenience, such that one may create a FlyteFile / FlyteDirectory with ease:

```python
FlyteFile(flytekit.cwd() / "my_file.txt")
```

This is significantly less cumbersome than the current approach:
```python

FlyteFile(f"{flytekit.current_context().working_directory}/my_file.txt")

Additionally, this commit adds support for using a `pathlib.Path` object to create a FlyteFile / FlyteDirectory, which, while was documented to work, resulted in unexpected behavior.

Tests have been added for this new functionality.
