### PR TITLE
Add top-level access to FlyteRemote, FlyteFile, and FlyteDirectory and convenience class methods for FlyteRemote

### DIFF
--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -217,6 +217,7 @@ else:
     from importlib.metadata import entry_points
 
 from flytekit._version import __version__
+from flytekit.configuration import Config
 from flytekit.core.array_node_map_task import map_task
 from flytekit.core.artifact import Artifact
 from flytekit.core.base_sql_task import SQLTask
@@ -250,8 +251,11 @@ from flytekit.models.core.types import BlobType
 from flytekit.models.documentation import Description, Documentation, SourceCode
 from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
+from flytekit.remote import FlyteRemote
 from flytekit.sensor.sensor_engine import SensorEngine
 from flytekit.types import directory, file, iterator
+from flytekit.types.directory import FlyteDirectory
+from flytekit.types.file import FlyteFile
 from flytekit.types.structured.structured_dataset import (
     StructuredDataset,
     StructuredDatasetFormat,

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -35,7 +35,8 @@ from flyteidl.core import literals_pb2
 from flytekit import ImageSpec
 from flytekit.clients.friendly import SynchronousFlyteClient
 from flytekit.clients.helpers import iterate_node_executions, iterate_task_executions
-from flytekit.configuration import Config, FastSerializationSettings, ImageConfig, SerializationSettings
+from flytekit.configuration import Config, DataConfig, FastSerializationSettings, ImageConfig, SerializationSettings
+from flytekit.configuration.file import ConfigFile
 from flytekit.constants import CopyFileDetection
 from flytekit.core import constants, utils
 from flytekit.core.array_node_map_task import ArrayNodeMapTask
@@ -2617,3 +2618,67 @@ class FlyteRemote(object):
             md5_bytes, native_url = self.upload_file(dest)
 
         return md5_bytes, FastSerializationSettings(enabled=True, distribution_location=native_url, destination_dir=".")
+
+    @classmethod
+    def for_endpoint(
+        cls,
+        endpoint: str,
+        insecure: bool = False,
+        data_config: typing.Optional[DataConfig] = None,
+        config_file: typing.Union[str, ConfigFile] = None,
+        default_project: typing.Optional[str] = None,
+        default_domain: typing.Optional[str] = None,
+        data_upload_location: str = "flyte://my-s3-bucket/",
+        interactive_mode_enabled: bool = False,
+        **kwargs,
+    ) -> "FlyteRemote":
+        return cls(
+            config=Config.for_endpoint(
+                endpoint=endpoint,
+                insecure=insecure,
+                data_config=data_config,
+                config_file=config_file,
+            ),
+            default_project=default_project,
+            default_domain=default_domain,
+            data_upload_location=data_upload_location,
+            interactive_mode_enabled=interactive_mode_enabled,
+            **kwargs,
+        )
+
+    @classmethod
+    def auto(
+        cls,
+        config_file: typing.Union[str, ConfigFile] = None,
+        default_project: typing.Optional[str] = None,
+        default_domain: typing.Optional[str] = None,
+        data_upload_location: str = "flyte://my-s3-bucket/",
+        interactive_mode_enabled: bool = False,
+        **kwargs,
+    ) -> "FlyteRemote":
+        return cls(
+            config=Config.auto(config_file=config_file),
+            default_project=default_project,
+            default_domain=default_domain,
+            data_upload_location=data_upload_location,
+            interactive_mode_enabled=interactive_mode_enabled,
+            **kwargs,
+        )
+
+    @classmethod
+    def for_sandbox(
+        cls,
+        default_project: typing.Optional[str] = None,
+        default_domain: typing.Optional[str] = None,
+        data_upload_location: str = "flyte://my-s3-bucket/",
+        interactive_mode_enabled: bool = False,
+        **kwargs,
+    ) -> "FlyteRemote":
+        return cls(
+            config=Config.for_sandbox(),
+            default_project=default_project,
+            default_domain=default_domain,
+            data_upload_location=data_upload_location,
+            interactive_mode_enabled=interactive_mode_enabled,
+            **kwargs,
+        )


### PR DESCRIPTION
FlyteRemote, FlyteFile and FlyteDirectory are all very commonly used, but are not available as top-level imports.

This commit exposes them to the top-level of flytekit.

Additionally, it adds support for FlyteRemote classmethods. 

```python
FlyteRemote.for_endpoint
FlyteRemote.auto
FlyteRemote.for_sandbox
```
