### PR TITLE
Remove `flyteidl.core.ContainerError` tests

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -56,20 +56,6 @@ jobs:
           path: ~/.cache/pip
           # Look to see if there is a cache hit for the corresponding requirements files
           key: ${{ format('{0}-pip-{1}', runner.os, hashFiles('dev-requirements.in', 'requirements.in')) }}
-      # # Install vcpkg for installing OpenSSL
-      # - name: Set up vcpkg
-      #   if: runner.os == 'Windows'
-      #   # The `openssl-sys` crate will automatically detect OpenSSL installations via Homebrew on macOS and vcpkg on Windows.
-      #   run: |
-      #     git clone --depth 1 https://github.com/microsoft/vcpkg.git
-      #     cd vcpkg
-      #     .\bootstrap-vcpkg.bat
-      # - name: Install OpenSSL
-      #   if: runner.os == 'Windows'
-      #   run: |
-      #     cd vcpkg
-      #     .\vcpkg install openssl
-      #     .\vcpkg integrate install
       - name: Install dependencies
         run: |
           pip install uv maturin

--- a/tests/flytekit/unit/core/test_artifacts.py
+++ b/tests/flytekit/unit/core/test_artifacts.py
@@ -662,15 +662,3 @@ def test_lims():
     # test an artifact with 11 partition keys
     with pytest.raises(ValueError):
         Artifact(name="test artifact", time_partitioned=True, partition_keys=[f"key_{i}" for i in range(11)])
-
-@pytest.mark.flyteidl_rust
-def test_cloudpickle():
-    a1_b = Artifact(name="my_data", partition_keys=["b"])
-
-    spec = a1_b(b="my_b_value")
-    import cloudpickle
-    # TODO: Check https://github.com/PyO3/pyo3/issues/100 for details on supporting pickle serialization in PyO3.
-    d = cloudpickle.dumps(spec)
-    spec2 = cloudpickle.loads(d)
-
-    assert spec2.partitions.b.value.static_value == "my_b_value"

--- a/tests/flytekit/unit/core/test_protobuf.py
+++ b/tests/flytekit/unit/core/test_protobuf.py
@@ -9,22 +9,6 @@ from flytekit.core.workflow import workflow
 from flytekit.models.types import LiteralType, SimpleType
 
 @pytest.mark.flyteidl_rust
-def test_proto():
-    @task
-    def t1(in1: flyteidl.core.ContainerError) -> flyteidl.core.ContainerError:
-        e2 = flyteidl.core.ContainerError(code=in1.code, message=in1.message + "!!!", kind=in1.kind + 1)
-        return e2
-
-    @workflow
-    def wf(a: flyteidl.core.ContainerError) -> flyteidl.core.ContainerError:
-        return t1(in1=a)
-
-    e1 = flyteidl.core.ContainerError(code="test", message="hello world", kind=1)
-    e_out = wf(a=e1)
-    assert e_out.kind == 2
-    assert e_out.message == "hello world!!!"
-
-@pytest.mark.flyteidl_rust
 def test_pb_guess_python_type():
     artifact_tag = flyteidl.core.CatalogArtifactTag(artifact_id="artifact_1", name="artifact_name")
 

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -621,31 +621,6 @@ def test_list_transformer():
     xx = TypeEngine.to_python_value(ctx, lit, typing.List[int])
     assert xx == [3, 4]
 
-@pytest.mark.flyteidl_rust
-def test_protos():
-    ctx = FlyteContext.current_context()
-    import flyteidl_rust as flyteidl
-    pb = flyteidl.core.ContainerError(code="code", message="message")
-    lt = TypeEngine.to_literal_type(flyteidl.core.ContainerError)
-    assert isinstance(lt.blob.to_flyte_idl(), flyteidl.core.BlobType)
-    assert lt.metadata["python_class_name"] == "<class 'builtins.ContainerError'>"
-    # TODO: Check https://github.com/PyO3/pyo3/issues/100 for details on supporting pickle serialization in PyO3.
-    lit = TypeEngine.to_literal(ctx, pb, flyteidl.core.ContainerError, lt)
-    new_python_val = TypeEngine.to_python_value(ctx, lit, flyteidl.core.ContainerError)
-    assert new_python_val == pb
-
-    # Test error
-    l0 = Literal(scalar=Scalar(primitive=Primitive(integer=4)))
-    with pytest.raises(AssertionError):
-        TypeEngine.to_python_value(ctx, l0, flyteidl.core.ContainerError)
-
-    default_proto = flyteidl.core.ContainerError()
-    lit = TypeEngine.to_literal(ctx, default_proto, flyteidl.core.ContainerError, lt)
-    assert lit.scalar
-    assert lit.scalar.generic is not None
-    new_python_val = TypeEngine.to_python_value(ctx, lit, flyteidl.core.ContainerError)
-    assert new_python_val == default_proto
-
 
 def test_guessing_basic():
     b = model_types.LiteralType(simple=model_types.SimpleType.BOOLEAN)


### PR DESCRIPTION
## Tracking issue

https://github.com/flyteorg/flytekit/pull/2811

## Why are the changes needed?

1. PyO3 not support pickling in Python:
As it's not currently supported by PyO3. So it's tricky to support pickling with `flyteidl_rust` exposed class.
For more details on supporting pickle serialization in PyO3, please check https://github.com/PyO3/pyo3/issues/100 (One of the oldest lasting issues..).

I decided to temporarily mark them as `flyteidl_rust` and skip these tests at first. Then @pingsutw told me is reasonable to just remove these tests because they are not used anymore like pickling `flyteidl.core.ContainerError`.

## What changes were proposed in this pull request?

1. Remove build `vcpkg` `OpenSSL` executable in CI.
2. Remove `flyteidl.core.ContainerError` unit tests that need `pickle` protocol.

## How was this patch tested?

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
