### PR TITLE
Grantham/new methods flytefile and flytedirectory

### DIFF
--- a/docs/source/design/control_plane.rst
+++ b/docs/source/design/control_plane.rst
@@ -30,15 +30,13 @@ A :class:`~flytekit.remote.remote.FlyteRemote` object can be created in various 
 Auto
 ====
 
-The :py:class:`~flytekit.configuration.Config` class's :py:meth:`~flytekit.configuration.Config.auto` method can be used to automatically
-construct the ``Config`` object.
+The :py:class:`~flytekit.remote.remote.FlyteRemote` class's :py:meth:`~flytekit.remote.remote.FlyteRemote.auto` method can be used to automatically construct the ``Config`` object.
 
 .. code-block:: python
 
-    from flytekit.remote import FlyteRemote
-    from flytekit.configuration import Config
+    from flytekit import FlyteRemote
 
-    remote = FlyteRemote(config=Config.auto())
+    remote = FlyteRemote.auto()
 
 ``auto`` also accepts a ``config_file`` argument, which is the path to the configuration file to use.
 The order of precedence that ``auto`` follows is:
@@ -50,17 +48,15 @@ The order of precedence that ``auto`` follows is:
 Sandbox
 =======
 
-The :py:class:`~flytekit.configuration.Config` class's :py:meth:`~flytekit.configuration.Config.for_sandbox` method can be used to
-construct the ``Config`` object, specifically to connect to the Flyte cluster.
+The :py:class:`~flytekit.remote.remote.FlyteRemote` class's :py:meth:`~flytekit.remote.remote.FlyteRemote.for_sandbox` method can be used to construct the ``Config`` object, specifically to connect to the Flyte cluster.
 
 .. code-block:: python
 
-    from flytekit.remote import FlyteRemote
-    from flytekit.configuration import Config
+    from flytekit import FlyteRemote
 
-    remote = FlyteRemote(config=Config.for_sandbox())
+    remote = FlyteRemote.for_sandbox()
 
-The initialization is as simple as calling ``for_sandbox()`` on the ``Config`` class!
+The initialization is as simple as calling ``for_sandbox()`` on the ``FlyteRemote`` class!
 This, by default, uses ``localhost:30081`` as the endpoint, and the default minio credentials.
 
 If the sandbox is in a hosted-like environment, then *port-forward* or *ingress URLs* need to be taken care of.
@@ -68,16 +64,14 @@ If the sandbox is in a hosted-like environment, then *port-forward* or *ingress 
 Any Endpoint
 ============
 
-The :py:class:`~flytekit.configuration.Config` class's :py:meth:`~flytekit.configuration.Config.for_endpoint` method can be used to
-construct the ``Config`` object to connect to a specific endpoint.
+The :py:class:`~flytekit.remote.remote.FlyteRemote` class's :py:meth:`~flytekit.remote.remote.FlyteRemote.for_endpoint` method can be used to construct the ``FlyteRemote`` object to connect to a specific endpoint.
 
 .. code-block:: python
 
-    from flytekit.remote import FlyteRemote
-    from flytekit.configuration import Config
+    from flytekit import FlyteRemote
 
-    remote = FlyteRemote(
-        config=Config.for_endpoint(endpoint="flyte.example.net"),
+    remote = FlyteRemote.for_endpoint(
+        endpoint="flyte.example.net",
         default_project="flytesnacks",
         default_domain="development",
     )

--- a/flytekit/__init__.py
+++ b/flytekit/__init__.py
@@ -217,6 +217,7 @@ else:
     from importlib.metadata import entry_points
 
 from flytekit._version import __version__
+from flytekit.configuration import Config
 from flytekit.core.array_node_map_task import map_task
 from flytekit.core.artifact import Artifact
 from flytekit.core.base_sql_task import SQLTask
@@ -250,8 +251,11 @@ from flytekit.models.core.types import BlobType
 from flytekit.models.documentation import Description, Documentation, SourceCode
 from flytekit.models.literals import Blob, BlobMetadata, Literal, Scalar
 from flytekit.models.types import LiteralType
+from flytekit.remote import FlyteRemote
 from flytekit.sensor.sensor_engine import SensorEngine
 from flytekit.types import directory, file, iterator
+from flytekit.types.directory import FlyteDirectory
+from flytekit.types.file import FlyteFile
 from flytekit.types.structured.structured_dataset import (
     StructuredDataset,
     StructuredDatasetFormat,

--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -18,7 +18,7 @@ from mashumaro.codecs.json import JSONEncoder
 from rich.progress import Progress, TextColumn, TimeElapsedColumn
 from typing_extensions import get_origin
 
-from flytekit import Annotations, FlyteContext, FlyteContextManager, Labels, Literal, WorkflowExecutionPhase
+from flytekit import Annotations, FlyteContext, FlyteContextManager, Labels, LaunchPlan, Literal, WorkflowExecutionPhase
 from flytekit.clis.sdk_in_container.helpers import (
     parse_copy,
     patch_image_config,
@@ -369,12 +369,24 @@ class Entities(typing.NamedTuple):
 
     workflows: typing.List[str]
     tasks: typing.List[str]
+    launch_plans: typing.List[typing.Tuple[str, str]]  # LP is stored as a tuple of name, the variable name in the file
 
     def all(self) -> typing.List[str]:
         e = []
         e.extend(self.workflows)
         e.extend(self.tasks)
+        for i in self.launch_plans:
+            e.append(i[0])
         return e
+
+    def matching_lp(self, lp_name: str) -> typing.Optional[str]:
+        """
+        Returns the variable name of the launch plan in the file
+        """
+        for i in self.launch_plans:
+            if i[0] == lp_name:
+                return i[1]
+        return None
 
 
 def get_entities_in_file(filename: pathlib.Path, should_delete: bool) -> Entities:
@@ -393,6 +405,7 @@ def get_entities_in_file(filename: pathlib.Path, should_delete: bool) -> Entitie
 
     workflows = []
     tasks = []
+    launch_plans = []
     module = importlib.import_module(module_name)
     for name in dir(module):
         o = module.__dict__[name]
@@ -400,10 +413,17 @@ def get_entities_in_file(filename: pathlib.Path, should_delete: bool) -> Entitie
             workflows.append(name)
         elif isinstance(o, PythonTask):
             tasks.append(name)
+        elif isinstance(o, LaunchPlan):
+            varname = name
+            if o.name:
+                # name refers to the variable name, while o.name refers to the launch plan name if the user has
+                # specified one
+                name = o.name
+            launch_plans.append((varname, name))
 
     if should_delete and os.path.exists(filename):
         os.remove(filename)
-    return Entities(workflows, tasks)
+    return Entities(workflows, tasks, launch_plans)
 
 
 def to_click_option(
@@ -592,7 +612,7 @@ def is_optional(_type):
     return typing.get_origin(_type) is typing.Union and type(None) in typing.get_args(_type)
 
 
-def run_command(ctx: click.Context, entity: typing.Union[PythonFunctionWorkflow, PythonTask]):
+def run_command(ctx: click.Context, entity: typing.Union[PythonFunctionWorkflow, PythonTask, LaunchPlan]):
     """
     Returns a function that is used to implement WorkflowCommand and execute a flyte workflow.
     """
@@ -604,7 +624,11 @@ def run_command(ctx: click.Context, entity: typing.Union[PythonFunctionWorkflow,
         # By the time we get to this function, all the loading has already happened
 
         run_level_params: RunLevelParams = ctx.obj
-        entity_type = "workflow" if isinstance(entity, PythonFunctionWorkflow) else "task"
+        entity_type = "workflow"
+        if isinstance(entity, LaunchPlan):
+            entity_type = "launch plan"
+        elif isinstance(entity, PythonTask):
+            entity_type = "task"
         logger.debug(f"Running {entity_type} {entity.name} with input {kwargs}")
 
         click.secho(
@@ -981,7 +1005,7 @@ class WorkflowCommand(click.RichGroup):
         else:
             self._filename = pathlib.Path(filename).resolve()
             self._should_delete = False
-        self._entities = None
+        self._entities: typing.Optional[Entities] = None
 
     def list_commands(self, ctx):
         if self._entities:
@@ -995,8 +1019,8 @@ class WorkflowCommand(click.RichGroup):
         ctx: click.Context,
         entity_name: str,
         run_level_params: RunLevelParams,
-        loaded_entity: [PythonTask, WorkflowBase],
-        is_workflow: bool,
+        loaded_entity: [PythonTask, WorkflowBase, LaunchPlan],
+        entity_type: str,
     ):
         """
         Delegate that creates the command for a given entity.
@@ -1014,10 +1038,12 @@ class WorkflowCommand(click.RichGroup):
             required = type(None) not in get_args(python_type) and default_val is None
             params.append(to_click_option(ctx, flyte_ctx, input_name, literal_var, python_type, default_val, required))
 
-        entity_type = "Workflow" if is_workflow else "Task"
         h = f"{click.style(entity_type, bold=True)} ({run_level_params.computed_params.module}.{entity_name})"
-        if loaded_entity.__doc__:
-            h = h + click.style(f"{loaded_entity.__doc__}", dim=True)
+        if isinstance(loaded_entity, LaunchPlan):
+            h = h + click.style(f" (LP Name: {loaded_entity.name})", fg="yellow")
+        else:
+            if loaded_entity.__doc__:
+                h = h + click.style(f"{loaded_entity.__doc__}", dim=True)
         cmd = YamlFileReadingCommand(
             name=entity_name,
             params=params,
@@ -1036,9 +1062,14 @@ class WorkflowCommand(click.RichGroup):
           function.
         :return:
         """
-        is_workflow = False
+        entity_type = "task"
         if self._entities:
-            is_workflow = exe_entity in self._entities.workflows
+            if exe_entity in self._entities.workflows:
+                entity_type = "workflow"
+            else:
+                lp_name = self._entities.matching_lp(exe_entity)
+                if lp_name:
+                    entity_type = "launch plan"
         if not os.path.exists(self._filename):
             click.secho(f"File {self._filename} does not exist.", fg="red")
             exit(1)
@@ -1062,7 +1093,7 @@ class WorkflowCommand(click.RichGroup):
 
         entity = load_naive_entity(module, exe_entity, project_root)
 
-        return self._create_command(ctx, exe_entity, run_level_params, entity, is_workflow)
+        return self._create_command(ctx, exe_entity, run_level_params, entity, entity_type)
 
 
 class RunCommand(click.RichGroup):
@@ -1106,7 +1137,7 @@ class RunCommand(click.RichGroup):
             return RemoteEntityGroup(RemoteEntityGroup.WORKFLOW_COMMAND)
         elif filename == RemoteEntityGroup.TASK_COMMAND:
             return RemoteEntityGroup(RemoteEntityGroup.TASK_COMMAND)
-        return WorkflowCommand(filename, name=filename, help=f"Run a [workflow|task] from {filename}")
+        return WorkflowCommand(filename, name=filename, help=f"Run a [workflow|task|launch plan] from {filename}")
 
 
 _run_help = """

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -777,7 +777,14 @@ class Config(object):
         :return: Config
         """
         c = cls.auto(config_file)
-        return c.with_params(platform=PlatformConfig.for_endpoint(endpoint, insecure), data_config=data_config)
+        from dataclasses import replace
+
+        p = (
+            replace(c.platform, endpoint=endpoint, insecure=insecure)
+            if config_file and c.platform
+            else PlatformConfig.for_endpoint(endpoint, insecure)
+        )
+        return c.with_params(platform=p, data_config=data_config)
 
 
 @dataclass

--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -743,7 +743,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 raise
             except Exception as e:
                 if is_local_execution:
-                    e.args = (f"Error encountered while converting inputs of '{self.name}':\n  {e.args[0]}",)
+                    e.args = (f"Error encountered while converting inputs of '{self.name}':\n  {e}",)
                     raise
                 raise FlyteNonRecoverableSystemException(e) from e
             # TODO: Logger should auto inject the current context information to indicate if the task is running within
@@ -755,7 +755,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
                 except Exception as e:
                     if is_local_execution:
                         # If the task is being executed locally, we want to raise the original exception
-                        e.args = (f"Error encountered while executing '{self.name}':\n  {e.args[0]}",)
+                        e.args = (f"Error encountered while executing '{self.name}':\n  {e}",)
                         raise
                     raise FlyteUserRuntimeException(e) from e
 

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -346,6 +346,7 @@ class SecretsManager(object):
     def __init__(self, secrets_cfg: typing.Optional[SecretsConfig] = None):
         if secrets_cfg is None:
             secrets_cfg = SecretsConfig.auto()
+
         self._base_dir = secrets_cfg.default_dir.strip()
         self._file_prefix = secrets_cfg.file_prefix.strip()
         self._env_prefix = secrets_cfg.env_prefix.strip()
@@ -373,11 +374,22 @@ class SecretsManager(object):
         if not get_plugin().secret_requires_group():
             group, group_version = None, None
 
-        env_var = self.get_secrets_env_var(group, key, group_version)
+        env_prefixes = [self._env_prefix]
+
+        # During local execution check for the key without a prefix
+        ctx = FlyteContextManager.current_context()
+        if ctx.execution_state is None or ctx.execution_state.is_local_execution():
+            env_prefixes.append("")
+
+        for env_prefix in env_prefixes:
+            env_var = self._get_secrets_env_var(
+                group=group, key=key, group_version=group_version, env_prefix=env_prefix
+            )
+            v = os.environ.get(env_var)
+            if v is not None:
+                return v.strip()
+
         fpath = self.get_secrets_file(group, key, group_version)
-        v = os.environ.get(env_var)
-        if v is not None:
-            return v.strip()
         if os.path.exists(fpath):
             with open(fpath, encode_mode) as f:
                 return f.read().strip()
@@ -392,8 +404,17 @@ class SecretsManager(object):
         """
         Returns a string that matches the ENV Variable to look for the secrets
         """
+        return self._get_secrets_env_var(group=group, key=key, group_version=group_version, env_prefix=self._env_prefix)
+
+    def _get_secrets_env_var(
+        self,
+        group: Optional[str] = None,
+        key: Optional[str] = None,
+        group_version: Optional[str] = None,
+        env_prefix: str = "",
+    ):
         l = [k.upper() for k in filter(None, (group, group_version, key))]
-        return f"{self._env_prefix}{'_'.join(l)}"
+        return f"{env_prefix}{'_'.join(l)}"
 
     def get_secrets_file(
         self, group: Optional[str] = None, key: Optional[str] = None, group_version: Optional[str] = None

--- a/flytekit/core/task.py
+++ b/flytekit/core/task.py
@@ -302,6 +302,13 @@ def task(
                      Possible options for secret stores are - Vault, Confidant, Kube secrets, AWS KMS etc
                      Refer to :py:class:`Secret` to understand how to specify the request for a secret. It
                      may change based on the backend provider.
+
+                     .. note::
+
+                         During local execution, the secrets will be pulled from the local environment variables
+                         with the format `{GROUP}_{GROUP_VERSION}_{KEY}`, where all the characters are capitalized
+                         and the prefix is not used.
+
     :param execution_mode: This is mainly for internal use. Please ignore. It is filled in automatically.
     :param node_dependency_hints: A list of tasks, launchplans, or workflows that this task depends on. This is only
         for dynamic tasks/workflows, where flyte cannot automatically determine the dependencies prior to runtime.

--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -59,9 +59,12 @@ def print_ls_tree(source: os.PathLike, ls: typing.List[str]):
             current = tree_root
             current_path = pathlib.Path(source)
             for subdir in fpp.parent.relative_to(source).parts:
-                current = current.add(f"{subdir}", guide_style="bold bright_blue")
                 current_path = current_path / subdir
-                trees[current_path] = current
+                if current_path not in trees:
+                    current = current.add(f"{subdir}", guide_style="bold bright_blue")
+                    trees[current_path] = current
+                else:
+                    current = trees[current_path]
         trees[fpp.parent].add(f"{fpp.name}", guide_style="bold bright_blue")
     rich_print(tree_root)
 

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -423,10 +423,11 @@ class FlyteDirectory(SerializableType, DataClassJsonMixin, os.PathLike, typing.G
     def __str__(self):
         return str(self.path)
 
-    def __truedivide__(self, other: str | os.PathLike) -> Path:
+    def __truediv__(self, other: str | os.PathLike) -> Path:
         """
         This is a convenience method to allow for easy concatenation of paths.
         """
+
         return Path(self.path) / other
 
 

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -206,6 +206,23 @@ class FlyteDirectory(SerializableType, DataClassJsonMixin, os.PathLike, typing.G
         remote_path = ctx.file_access.generate_new_custom_path(alt=alt, stem=stem)
         return cls(path=remote_path)
 
+    @classmethod
+    def new(cls, path: str | os.PathLike) -> FlyteFile:
+        """
+        Create a new FlyteDirectory object in current Flyte working directory.
+        """
+
+        if os.path.isabs(path):
+            raise ValueError("Path should be relative.")
+
+        ctx = FlyteContextManager.current_context()
+
+        full_path = os.path.join(ctx.user_space_params.working_directory, path)
+
+        os.makedirs(full_path, exist_ok=False)
+
+        return cls(path=full_path)
+
     def __class_getitem__(cls, item: typing.Union[typing.Type, str]) -> typing.Type[FlyteDirectory]:
         if item is None:
             return cls

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -423,6 +423,12 @@ class FlyteDirectory(SerializableType, DataClassJsonMixin, os.PathLike, typing.G
     def __str__(self):
         return str(self.path)
 
+    def __truedivide__(self, other: str | os.PathLike) -> Path:
+        """
+        This is a convenience method to allow for easy concatenation of paths.
+        """
+        return Path(self.path) / other
+
 
 class FlyteDirToMultipartBlobTransformer(TypeTransformer[FlyteDirectory]):
     """

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -214,6 +214,21 @@ class FlyteFile(SerializableType, os.PathLike, typing.Generic[T], DataClassJSONM
         t = FlyteFilePathTransformer()
         return t.to_python_value(ctx, lit, cls)
 
+    @classmethod
+    def new(cls, path: str | os.PathLike) -> FlyteFile:
+        """
+        Create a new FlyteFile object in the current Flyte working directory
+        """
+
+        if os.path.isabs(path):
+            raise ValueError("Path should be relative.")
+
+        ctx = FlyteContextManager.current_context()
+
+        full_path = os.path.join(ctx.user_space_params.working_directory, path)
+
+        return cls(path=full_path)
+
     def __class_getitem__(cls, item: typing.Union[str, typing.Type]) -> typing.Type[FlyteFile]:
         from flytekit.types.file import FileExt
 

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -607,6 +607,13 @@ class StructuredDatasetTransformerEngine(TypeTransformer[StructuredDataset]):
         # In case it's a FlyteSchema
         sdt = StructuredDatasetType(format=self.DEFAULT_FORMATS.get(python_type, GENERIC_FORMAT))
 
+        if issubclass(python_type, StructuredDataset) and not isinstance(python_val, StructuredDataset):
+            # Catch a common mistake
+            raise TypeTransformerFailedError(
+                f"Expected a StructuredDataset instance, but got {type(python_val)} instead."
+                f" Did you forget to wrap your dataframe in a StructuredDataset instance?"
+            )
+
         if expected and expected.structured_dataset_type:
             sdt = StructuredDatasetType(
                 columns=expected.structured_dataset_type.columns,

--- a/plugins/flytekit-greatexpectations/setup.py
+++ b/plugins/flytekit-greatexpectations/setup.py
@@ -8,7 +8,7 @@ plugin_requires = [
     "flytekit>=1.5.0",
     "great-expectations>=0.13.30,<1.0.0",
     "sqlalchemy>=1.4.23",
-    "pyspark==3.3.1",
+    "pyspark==3.3.2",
     "s3fs<2023.6.0",
 ]
 

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -3692,3 +3692,16 @@ def test_structured_dataset_collection():
     lv = TypeEngine.to_literal(FlyteContext.current_context(), [[StructuredDataset(df)]],
                                WineTypeListList, lt)
     assert lv is not None
+
+
+@pytest.mark.skipif("pandas" not in sys.modules, reason="Pandas is not installed.")
+def test_structured_dataset_mismatch():
+    import pandas as pd
+
+    df = pd.DataFrame({"alcohol": [1.0, 2.0], "malic_acid": [2.0, 3.0]})
+    transformer = TypeEngine.get_transformer(StructuredDataset)
+    with pytest.raises(TypeTransformerFailedError):
+        transformer.to_literal(FlyteContext.current_context(), df, StructuredDataset, TypeEngine.to_literal_type(StructuredDataset))
+
+    with pytest.raises(TypeTransformerFailedError):
+        TypeEngine.to_literal(FlyteContext.current_context(), df, StructuredDataset, TypeEngine.to_literal_type(StructuredDataset))

--- a/tests/flytekit/unit/core/test_unions.py
+++ b/tests/flytekit/unit/core/test_unions.py
@@ -1,0 +1,93 @@
+import typing
+from dataclasses import dataclass
+from enum import Enum
+import sys
+import pytest
+
+from flytekit.core.context_manager import FlyteContextManager
+from flytekit.core.type_engine import TypeEngine, TypeTransformerFailedError
+
+
+def test_asserting():
+    @dataclass
+    class A:
+        a: str = None
+
+    @dataclass
+    class B:
+        b: str = None
+
+    @dataclass
+    class C:
+        c: str = None
+
+    ctx = FlyteContextManager.current_context()
+
+    pt = typing.Union[A, B, str]
+    lt = TypeEngine.to_literal_type(pt)
+    # mimic a register/remote fetch
+    guessed = TypeEngine.guess_python_type(lt)
+
+    TypeEngine.to_literal(ctx, A("a"), guessed, lt)
+    TypeEngine.to_literal(ctx, B(b="bb"), guessed, lt)
+    TypeEngine.to_literal(ctx, "hello", guessed, lt)
+
+    with pytest.raises(TypeTransformerFailedError):
+        TypeEngine.to_literal(ctx, C("cc"), guessed, lt)
+
+    with pytest.raises(TypeTransformerFailedError):
+        TypeEngine.to_literal(ctx, 3, guessed, lt)
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10), reason="enum checking only works in 3.10+"
+)
+def test_asserting_enum():
+    class Color(Enum):
+        RED = "one"
+        GREEN = "two"
+        BLUE = "blue"
+
+    lt = TypeEngine.to_literal_type(Color)
+    guessed = TypeEngine.guess_python_type(lt)
+    tf = TypeEngine.get_transformer(guessed)
+    tf.assert_type(guessed, "one")
+    tf.assert_type(guessed, guessed("two"))
+    tf.assert_type(Color, "one")
+
+    guessed2 = TypeEngine.guess_python_type(lt)
+    tf.assert_type(guessed, guessed2("two"))
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 10), reason="3.9 enum testing"
+)
+def test_asserting_enum_39():
+    class Color(Enum):
+        RED = "one"
+        GREEN = "two"
+        BLUE = "blue"
+
+    lt = TypeEngine.to_literal_type(Color)
+    guessed = TypeEngine.guess_python_type(lt)
+    tf = TypeEngine.get_transformer(guessed)
+    tf.assert_type(guessed, guessed("two"))
+    tf.assert_type(Color, Color.GREEN)
+
+
+@pytest.mark.sandbox_test
+def test_with_remote():
+    from flytekit.remote.remote import FlyteRemote
+    from typing_extensions import Annotated, get_args
+    from flytekit.configuration import Config, Image, ImageConfig, SerializationSettings
+
+    r = FlyteRemote(
+        Config.auto(config_file="/Users/ytong/.flyte/config-sandbox.yaml"),
+        default_project="flytesnacks",
+        default_domain="development",
+    )
+    lp = r.fetch_launch_plan(name="yt_dbg.scratchpad.union_enums.wf", version="oppOd5jst-LWExhTLM0F2w")
+    guessed_union_type = TypeEngine.guess_python_type(lp.interface.inputs["x"].type)
+    guessed_enum = get_args(guessed_union_type)[0]
+    val = guessed_enum("one")
+    r.execute(lp, inputs={"x": val})

--- a/tests/flytekit/unit/interaction/test_click_types.py
+++ b/tests/flytekit/unit/interaction/test_click_types.py
@@ -1,6 +1,7 @@
 import os
 from dataclasses import field
 import json
+import sys
 import tempfile
 import typing
 from datetime import datetime, timedelta
@@ -501,6 +502,9 @@ def test_nested_dataclass_with_optional_fields():
     assert v.w[0].b == "list_item"
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 10), reason="handling for windows is nicer with delete_on_close, which doesn't exist in 3.9"
+)
 def test_pickle_type():
     t = PickleParamType()
     value = {"a": "b"}
@@ -518,9 +522,10 @@ def test_pickle_type():
         t.convert("typing:not_exists", None, None)
 
     # test that it can load a variable from a module
-    with tempfile.NamedTemporaryFile("w", dir=".", suffix=".py", delete=False) as f:
+    with tempfile.NamedTemporaryFile("w", dir=".", suffix=".py", delete=True, delete_on_close=False) as f:
         f.write("a = 1")
         f.flush()
+        f.close()
         # find the base name of the file
         basename = os.path.basename(f.name).split(".")[0]
         assert t.convert(f"{basename}:a", None, None) == 1

--- a/tests/flytekit/unit/types/directory/test_types.py
+++ b/tests/flytekit/unit/types/directory/test_types.py
@@ -28,7 +28,7 @@ def test_new_remote_dir_alt():
 
 def test_new_auto_new_dir():
     fd = FlyteDirectory.new("my_dir")
-    assert FlyteContext.current_context().working_directory in fd.path
+    assert FlyteContextManager.current_context().working_directory in fd.path
 
 def test_add_path_to_dir():
     fd = FlyteDirectory.new("my_dir")

--- a/tests/flytekit/unit/types/directory/test_types.py
+++ b/tests/flytekit/unit/types/directory/test_types.py
@@ -28,7 +28,7 @@ def test_new_remote_dir_alt():
 
 def test_new_auto_new_dir():
     fd = FlyteDirectory.new("my_dir")
-    assert FlyteContextManager.current_context().working_directory in fd.path
+    assert FlyteContextManager.current_context().user_space_params.working_directory in fd.path
 
 def test_add_path_to_dir():
     fd = FlyteDirectory.new("my_other_dir")

--- a/tests/flytekit/unit/types/directory/test_types.py
+++ b/tests/flytekit/unit/types/directory/test_types.py
@@ -1,6 +1,6 @@
 import mock
 
-from flytekit import FlyteContext
+from flytekit import FlyteContext, FlyteContextManager
 from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import FlyteFile
 
@@ -32,7 +32,8 @@ def test_new_auto_new_dir():
 
 def test_add_path_to_dir():
     fd = FlyteDirectory.new("my_dir")
-    assert FlyteContext.current_context().working_directory in str(fd / "myfile.txt")
+    cwd = FlyteContextManager.current_context().user_space_params.working_directory
+    assert cwd in str(fd / "myfile.txt")
 
 @mock.patch("flytekit.types.directory.types.os.name", "nt")
 def test_sep_nt():

--- a/tests/flytekit/unit/types/directory/test_types.py
+++ b/tests/flytekit/unit/types/directory/test_types.py
@@ -31,7 +31,7 @@ def test_new_auto_new_dir():
     assert FlyteContextManager.current_context().working_directory in fd.path
 
 def test_add_path_to_dir():
-    fd = FlyteDirectory.new("my_dir")
+    fd = FlyteDirectory.new("my_other_dir")
     cwd = FlyteContextManager.current_context().user_space_params.working_directory
     assert cwd in str(fd / "myfile.txt")
 

--- a/tests/flytekit/unit/types/directory/test_types.py
+++ b/tests/flytekit/unit/types/directory/test_types.py
@@ -17,7 +17,6 @@ def test_new_file_dir():
     assert isinstance(f, FlyteFile)
     assert f.path == "s3://my-bucket/test/test"
 
-
 def test_new_remote_dir():
     fd = FlyteDirectory.new_remote()
     assert FlyteContext.current_context().file_access.raw_output_prefix in fd.path
@@ -26,6 +25,14 @@ def test_new_remote_dir_alt():
     ff = FlyteDirectory.new_remote(alt="my-alt-bucket", stem="my-stem")
     assert "my-alt-bucket" in ff.path
     assert "my-stem" in ff.path
+
+def test_new_auto_new_dir():
+    fd = FlyteDirectory.new("my_dir")
+    assert FlyteContext.current_context().working_directory in fd.path
+
+def test_add_path_to_dir():
+    fd = FlyteDirectory.new("my_dir")
+    assert FlyteContext.current_context().working_directory in str(fd / "myfile.txt")
 
 @mock.patch("flytekit.types.directory.types.os.name", "nt")
 def test_sep_nt():

--- a/tests/flytekit/unit/types/file/test_types.py
+++ b/tests/flytekit/unit/types/file/test_types.py
@@ -9,4 +9,5 @@ def test_new_remote_alt():
 
 def test_new_auto_file():
     ff = FlyteFile.new("my-file.txt")
-    assert FlyteContext.current_context().working_directory in ff.path
+    cwd = FlyteContextManager.current_context().user_space_params.working_directory
+    assert cwd in ff.path

--- a/tests/flytekit/unit/types/file/test_types.py
+++ b/tests/flytekit/unit/types/file/test_types.py
@@ -1,7 +1,12 @@
 from flytekit.types.file import FlyteFile
 from flytekit import FlyteContextManager
+from flytekit import FlyteContext
 
 def test_new_remote_alt():
     ff = FlyteFile.new_remote_file(alt="my-alt-prefix", name="my-file.txt")
     assert "my-alt-prefix" in ff.path
     assert "my-file.txt" in ff.path
+
+def test_new_auto_file():
+    ff = FlyteFile.new("my-file.txt")
+    assert FlyteContext.current_context().working_directory in ff.path


### PR DESCRIPTION
I feel like it is verbose to get the working directory (`flytekit.current_context().working_directory`) in a task. I find myself doing this very, very frequently, primarily to write files. I use the working directory so that files won’t get written to my local working directory during local execution.

I had thought about this for a while, and the more I thought about what exactly I wanted to accomplish, I feel like it should be accomplished with a few new classmethod for `FlyteFile` / `FlyteDirectory`...

-----

This task...

```python
@task
def my_task() -> FlyteFile:
    local_path = os.path.join(current_context().working_directory, "data.txt")
    with open(local_path, mode="w") as file:
        file.write("Here is some sample data.")
    return FlyteFile(path=local_path)
```

Should ideally be replaced with something like this:

```python
@task
def my_task() -> FlyteFile:

    ff = FlyteFile.new('myfile.txt')

    with open(ff, mode="w") as file:
        file.write("Here is some sample data.")

    return ff
```

In this case, `FlyteFile.new` will create a FlyteFile with a path of the filename inside of the working directory (`current_context().working_directory`).

-----

The same goes for FlyteDirectory...

```python
@task
def my_task() -> FlyteDirectory:

    p = os.path.join(current_context().working_directory, "my_new_directory")

    os.makedirs(p)

    with open(os.path.join(p, "file_1.txt"), 'w') as file:
        file.write("This is file 1.")

    return FlyteDirectory(p)
```

Should be replaced with:

```python
@task
def my_task() -> FlyteDirectory:

    dir = FlyteDirectory.new('my_new_directory')

    with open(dir / "file_1.txt", 'w') as file:
        file.write("This is file 1.")

    return dir
```

In this case, `FlyteDirectory.new` will create the directory `my_new_directory` under `current_context().working_directory`, and ensure that it exists (`os.makedirs(dir.path)`)

Additionally, I am overloading the `__truedivide__` operator to `FlyteDirectory` for convenience:

```python

class FlyteDirectory:

    ...

    def __truedivide__(self, other: str | os.PathLike) -> Path:
        """
        This is a convenience method to allow for easy concatenation of paths.
        """
        return Path(self.path) / other
```
