### PR TITLE
Config for_endpoint doesn't respect config file

### DIFF
--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -777,7 +777,11 @@ class Config(object):
         :return: Config
         """
         c = cls.auto(config_file)
-        return c.with_params(platform=PlatformConfig.for_endpoint(endpoint, insecure), data_config=data_config)
+        from dataclasses import replace
+        pp = replace(c.platform, endpoint=endpoint, insecure=insecure) if config_file and c.platform else PlatformConfig.for_endpoint(
+            endpoint, insecure
+        )
+        return c.with_params(platform=pp, data_config=data_config)
 
 
 @dataclass

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -779,12 +779,12 @@ class Config(object):
         c = cls.auto(config_file)
         from dataclasses import replace
 
-        pp = (
+        p = (
             replace(c.platform, endpoint=endpoint, insecure=insecure)
             if config_file and c.platform
             else PlatformConfig.for_endpoint(endpoint, insecure)
         )
-        return c.with_params(platform=pp, data_config=data_config)
+        return c.with_params(platform=p, data_config=data_config)
 
 
 @dataclass

--- a/flytekit/configuration/__init__.py
+++ b/flytekit/configuration/__init__.py
@@ -778,8 +778,11 @@ class Config(object):
         """
         c = cls.auto(config_file)
         from dataclasses import replace
-        pp = replace(c.platform, endpoint=endpoint, insecure=insecure) if config_file and c.platform else PlatformConfig.for_endpoint(
-            endpoint, insecure
+
+        pp = (
+            replace(c.platform, endpoint=endpoint, insecure=insecure)
+            if config_file and c.platform
+            else PlatformConfig.for_endpoint(endpoint, insecure)
         )
         return c.with_params(platform=pp, data_config=data_config)
 

--- a/tests/flytekit/unit/configuration/test_file.py
+++ b/tests/flytekit/unit/configuration/test_file.py
@@ -7,7 +7,7 @@ import pytest
 from pathlib import Path
 from pytimeparse.timeparse import timeparse
 
-from flytekit.configuration import ConfigEntry, get_config_file, set_if_exists
+from flytekit.configuration import ConfigEntry, get_config_file, set_if_exists, Config
 from flytekit.configuration.file import LegacyConfigEntry, _exists, FLYTECTL_CONFIG_ENV_VAR, FLYTECTL_CONFIG_ENV_VAR_OVERRIDE
 from flytekit.configuration.internal import Platform
 
@@ -160,3 +160,12 @@ def test_use_ssl():
     config_file = get_config_file(os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/good.config"))
     res = Platform.INSECURE.read(config_file)
     assert res is False
+
+
+def test_config_for_endpoint_with_file():
+    cfg_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "configs/creds_secret_env_var.yaml")
+
+    with mock.patch.dict(os.environ, {"FAKE_SECRET_NAME": "fake_secret_value"}):
+        cfg = Config.for_endpoint("main", config_file=cfg_path)
+        assert cfg.platform.client_id == "propeller"
+        assert cfg.platform.endpoint == "main"

--- a/tests/flytekit/unit/configuration/test_file.py
+++ b/tests/flytekit/unit/configuration/test_file.py
@@ -169,3 +169,7 @@ def test_config_for_endpoint_with_file():
         cfg = Config.for_endpoint("main", config_file=cfg_path)
         assert cfg.platform.client_id == "propeller"
         assert cfg.platform.endpoint == "main"
+
+        cfg2 = Config.auto(config_file=cfg_path)
+        assert cfg2.platform.client_id == "propeller"
+        assert cfg2.platform.client_credentials_secret == cfg.platform.client_credentials_secret


### PR DESCRIPTION
## Why are the changes needed?
The `Config.for_endpoint` function was not respecting values passed in via a config file for the platform config, overriding it with just an endpoint and insecure setting.  If the `config_file` argument is going to be there, it should be respected.

## What changes were proposed in this pull request?
Fixing to pull in values other than endpoint and insecure.

## How was this patch tested?
Unit tested.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
