### PR TITLE
Restrict Python Version Mismatch between Pickled Object and Remote Envrionment

### DIFF
--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -330,7 +330,7 @@ class DefaultNotebookTaskResolver(TrackedInstance, TaskResolverMixin):
                 loaded_data = cloudpickle.load(f)
         except TypeError:
             raise RuntimeError(
-                "The Python version is smaller than the version used to create the pickle file. "
+                "The Python version is different from the version used to create the pickle file. "
                 f"Current Python version: {sys.version_info.major}.{sys.version_info.minor}. "
                 "Please try using the same Python version to create the pickle file or use another "
                 "container image with a matching version."

--- a/flytekit/remote/executions.py
+++ b/flytekit/remote/executions.py
@@ -43,7 +43,10 @@ class RemoteExecutionBase(object):
                 "Please wait until the execution has completed before requesting the outputs."
             )
         if self.error:
-            raise user_exceptions.FlyteAssertion("Outputs could not be found because the execution ended in failure.")
+            raise user_exceptions.FlyteAssertion(
+                "Outputs could not be found because the execution ended in failure. Error message: "
+                f"{self.error.message}"
+            )
 
         return self._outputs
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -147,13 +147,9 @@ if typing.TYPE_CHECKING:
     except ImportError:
         ...
 
-ExecutionDataResponse = typing.Union[
-    WorkflowExecutionGetDataResponse, NodeExecutionGetDataResponse
-]
+ExecutionDataResponse = typing.Union[WorkflowExecutionGetDataResponse, NodeExecutionGetDataResponse]
 
-MOST_RECENT_FIRST = admin_common_models.Sort(
-    "created_at", admin_common_models.Sort.Direction.DESCENDING
-)
+MOST_RECENT_FIRST = admin_common_models.Sort("created_at", admin_common_models.Sort.Direction.DESCENDING)
 
 
 class RegistrationSkipped(Exception):
@@ -172,9 +168,7 @@ class ResolvedIdentifiers:
     version: str
 
 
-def _get_latest_version(
-    list_entities_method: typing.Callable, project: str, domain: str, name: str
-):
+def _get_latest_version(list_entities_method: typing.Callable, project: str, domain: str, name: str):
     named_entity = common_models.NamedEntityIdentifier(project, domain, name)
     entity_list, _ = list_entities_method(
         named_entity,
@@ -183,9 +177,7 @@ def _get_latest_version(
     )
     admin_entity = None if not entity_list else entity_list[0]
     if not admin_entity:
-        raise user_exceptions.FlyteEntityNotExistException(
-            "Named entity {} not found".format(named_entity)
-        )
+        raise user_exceptions.FlyteEntityNotExistException("Named entity {} not found".format(named_entity))
     return admin_entity.id.version
 
 
@@ -202,11 +194,7 @@ def _get_entity_identifier(
         project,
         domain,
         name,
-        (
-            version
-            if version is not None
-            else _get_latest_version(list_entities_method, project, domain, name)
-        ),
+        (version if version is not None else _get_latest_version(list_entities_method, project, domain, name)),
     )
 
 
@@ -239,15 +227,11 @@ def _get_git_repo_url(source_path: str):
             raise ValueError("Unable to parse url")
 
     except Exception as e:
-        logger.debug(
-            f"unable to find the git config in {source_path} with error: {str(e)}"
-        )
+        logger.debug(f"unable to find the git config in {source_path} with error: {str(e)}")
         return ""
 
 
-def _get_pickled_target_dict(
-    root_entity: typing.Union[WorkflowBase, PythonTask]
-) -> typing.Dict[str, typing.Any]:
+def _get_pickled_target_dict(root_entity: typing.Union[WorkflowBase, PythonTask]) -> typing.Dict[str, typing.Any]:
     """
     Get the pickled target dictionary for the entity.
     :param root_entity: The entity to get the pickled target for.
@@ -311,22 +295,14 @@ class FlyteRemote(object):
             The default location - `s3://my-s3-bucket/data` works for sandbox/demo environment. Please override this for non-sandbox cases.
         :param interactive_mode_enabled: If set to True, the FlyteRemote will pickle the task/workflow.
         """
-        if (
-            config is None
-            or config.platform is None
-            or config.platform.endpoint is None
-        ):
+        if config is None or config.platform is None or config.platform.endpoint is None:
             raise user_exceptions.FlyteAssertion("Flyte endpoint should be provided.")
 
         if interactive_mode_enabled is True:
-            logger.warning(
-                "Jupyter notebook and interactive task support is still alpha."
-            )
+            logger.warning("Jupyter notebook and interactive task support is still alpha.")
 
         if data_upload_location is None:
-            data_upload_location = (
-                FlyteContext.current_context().file_access.raw_output_prefix
-            )
+            data_upload_location = FlyteContext.current_context().file_access.raw_output_prefix
         self._kwargs = kwargs
         self._client_initialized = False
         self._config = config
@@ -337,19 +313,13 @@ class FlyteRemote(object):
         fsspec.register_implementation("flyte", get_flyte_fs(remote=self), clobber=True)
 
         self._file_access = FileAccessProvider(
-            local_sandbox_dir=os.path.join(
-                config.local_sandbox_path, "control_plane_metadata"
-            ),
+            local_sandbox_dir=os.path.join(config.local_sandbox_path, "control_plane_metadata"),
             raw_output_prefix=data_upload_location,
             data_config=config.data_config,
         )
 
         # Save the file access object locally, build a context for it and save that as well.
-        self._ctx = (
-            FlyteContextManager.current_context()
-            .with_file_access(self._file_access)
-            .build()
-        )
+        self._ctx = FlyteContextManager.current_context().with_file_access(self._file_access).build()
         self._interactive_mode_enabled = interactive_mode_enabled
 
     @property
@@ -410,9 +380,7 @@ class FlyteRemote(object):
                 return Literal.from_flyte_idl(data_response.literal)
             elif data_response.HasField("pre_signed_urls"):
                 if len(data_response.pre_signed_urls.signed_url) == 0:
-                    raise ValueError(
-                        f"Flyte url {flyte_uri} resolved to empty download link"
-                    )
+                    raise ValueError(f"Flyte url {flyte_uri} resolved to empty download link")
                 d = data_response.pre_signed_urls.signed_url[0]
                 logger.debug(f"Download link is {d}")
                 fs = ctx.file_access.get_filesystem_for_path(d)
@@ -427,15 +395,11 @@ class FlyteRemote(object):
                         return html
                 # If not return bytes
                 else:
-                    logger.debug(
-                        f"IPython not found, returning HTML as bytes from {flyte_uri}"
-                    )
+                    logger.debug(f"IPython not found, returning HTML as bytes from {flyte_uri}")
                     return fs.open(d, "rb").read()
 
         except user_exceptions.FlyteUserException as e:
-            logger.info(
-                f"Error from Flyte backend when trying to fetch data: {e.__cause__}"
-            )
+            logger.info(f"Error from Flyte backend when trying to fetch data: {e.__cause__}")
 
         logger.info(f"Nothing found from {flyte_uri}")
 
@@ -456,14 +420,10 @@ class FlyteRemote(object):
         Similar to fetch_task, just that it returns a LazyEntity, which will fetch the workflow lazily.
         """
         if name is None:
-            raise user_exceptions.FlyteAssertion(
-                "the 'name' argument must be specified."
-            )
+            raise user_exceptions.FlyteAssertion("the 'name' argument must be specified.")
 
         def _fetch():
-            return self.fetch_task(
-                project=project, domain=domain, name=name, version=version
-            )
+            return self.fetch_task(project=project, domain=domain, name=name, version=version)
 
         return LazyEntity(name=name, getter=_fetch)
 
@@ -485,9 +445,7 @@ class FlyteRemote(object):
         :raises: FlyteAssertion if name is None
         """
         if name is None:
-            raise user_exceptions.FlyteAssertion(
-                "the 'name' argument must be specified."
-            )
+            raise user_exceptions.FlyteAssertion("the 'name' argument must be specified.")
         task_id = _get_entity_identifier(
             self.client.list_tasks_paginated,
             ResourceType.TASK,
@@ -497,9 +455,7 @@ class FlyteRemote(object):
             version,
         )
         admin_task = self.client.get_task(task_id)
-        flyte_task = FlyteTask.promote_from_model(
-            admin_task.closure.compiled_task.template
-        )
+        flyte_task = FlyteTask.promote_from_model(admin_task.closure.compiled_task.template)
         flyte_task.template._id = task_id
         return flyte_task
 
@@ -514,9 +470,7 @@ class FlyteRemote(object):
         Similar to fetch_workflow, just that it returns a LazyEntity, which will fetch the workflow lazily.
         """
         if name is None:
-            raise user_exceptions.FlyteAssertion(
-                "the 'name' argument must be specified."
-            )
+            raise user_exceptions.FlyteAssertion("the 'name' argument must be specified.")
 
         def _fetch():
             return self.fetch_workflow(project, domain, name, version)
@@ -539,9 +493,7 @@ class FlyteRemote(object):
         :raises: FlyteAssertion if name is None
         """
         if name is None:
-            raise user_exceptions.FlyteAssertion(
-                "the 'name' argument must be specified."
-            )
+            raise user_exceptions.FlyteAssertion("the 'name' argument must be specified.")
         workflow_id = _get_entity_identifier(
             self.client.list_workflows_paginated,
             ResourceType.WORKFLOW,
@@ -569,35 +521,23 @@ class FlyteRemote(object):
 
         for wf_template in wf_templates:
             for node in FlyteWorkflow.get_non_system_nodes(wf_template.nodes):
-                if (
-                    node.workflow_node is not None
-                    and node.workflow_node.launchplan_ref is not None
-                ):
+                if node.workflow_node is not None and node.workflow_node.launchplan_ref is not None:
                     lp_ref = node.workflow_node.launchplan_ref
                     find_launch_plan(lp_ref, node_launch_plans)
 
                 # Inspect conditional branch nodes for launch plans
                 def get_launch_plan_from_branch(
                     branch_node: BranchNode,
-                    node_launch_plans: Dict[
-                        id_models, launch_plan_models.LaunchPlanSpec
-                    ],
+                    node_launch_plans: Dict[id_models, launch_plan_models.LaunchPlanSpec],
                 ) -> None:
                     def get_launch_plan_from_then_node(
                         child_then_node: Node,
-                        node_launch_plans: Dict[
-                            id_models, launch_plan_models.LaunchPlanSpec
-                        ],
+                        node_launch_plans: Dict[id_models, launch_plan_models.LaunchPlanSpec],
                     ) -> None:
                         #  then_node could have nested branch_node or be a normal then_node
                         if child_then_node.branch_node:
-                            get_launch_plan_from_branch(
-                                child_then_node.branch_node, node_launch_plans
-                            )
-                        elif (
-                            child_then_node.workflow_node
-                            and child_then_node.workflow_node.launchplan_ref
-                        ):
+                            get_launch_plan_from_branch(child_then_node.branch_node, node_launch_plans)
+                        elif child_then_node.workflow_node and child_then_node.workflow_node.launchplan_ref:
                             lp_ref = child_then_node.workflow_node.launchplan_ref
                             find_launch_plan(lp_ref, node_launch_plans)
 
@@ -605,26 +545,17 @@ class FlyteRemote(object):
                         branch = branch_node.if_else
                         if branch.case and branch.case.then_node:
                             child_then_node = branch.case.then_node
-                            get_launch_plan_from_then_node(
-                                child_then_node, node_launch_plans
-                            )
+                            get_launch_plan_from_then_node(child_then_node, node_launch_plans)
                         if branch.other:
                             for o in branch.other:
                                 if o.then_node:
                                     child_then_node = o.then_node
-                                    get_launch_plan_from_then_node(
-                                        child_then_node, node_launch_plans
-                                    )
+                                    get_launch_plan_from_then_node(child_then_node, node_launch_plans)
                         if branch.else_node:
                             #  else_node could have nested conditional branch_node
                             if branch.else_node.branch_node:
-                                get_launch_plan_from_branch(
-                                    branch.else_node.branch_node, node_launch_plans
-                                )
-                            elif (
-                                branch.else_node.workflow_node
-                                and branch.else_node.workflow_node.launchplan_ref
-                            ):
+                                get_launch_plan_from_branch(branch.else_node.branch_node, node_launch_plans)
+                            elif branch.else_node.workflow_node and branch.else_node.workflow_node.launchplan_ref:
                                 lp_ref = branch.else_node.workflow_node.launchplan_ref
                                 find_launch_plan(lp_ref, node_launch_plans)
 
@@ -639,9 +570,7 @@ class FlyteRemote(object):
         """
         flyte_lp = FlyteLaunchPlan.promote_from_model(lp.id, lp.spec)
         wf_id = flyte_lp.workflow_id
-        workflow = self.fetch_workflow(
-            wf_id.project, wf_id.domain, wf_id.name, wf_id.version
-        )
+        workflow = self.fetch_workflow(wf_id.project, wf_id.domain, wf_id.name, wf_id.version)
         flyte_lp._interface = workflow.interface
         flyte_lp._flyte_workflow = workflow
         return flyte_lp
@@ -654,9 +583,7 @@ class FlyteRemote(object):
         """
         try:
             lp = self.client.get_active_launch_plan(
-                NamedEntityIdentifier(
-                    project or self.default_project, domain or self.default_domain, name
-                )
+                NamedEntityIdentifier(project or self.default_project, domain or self.default_domain, name)
             )
             if lp is not None:
                 return self._upgrade_launchplan(lp)
@@ -682,9 +609,7 @@ class FlyteRemote(object):
         :raises: FlyteAssertion if name is None
         """
         if name is None:
-            raise user_exceptions.FlyteAssertion(
-                "the 'name' argument must be specified."
-            )
+            raise user_exceptions.FlyteAssertion("the 'name' argument must be specified.")
         launch_plan_id = _get_entity_identifier(
             self.client.list_launch_plans_paginated,
             ResourceType.LAUNCH_PLAN,
@@ -696,9 +621,7 @@ class FlyteRemote(object):
         admin_launch_plan = self.client.get_launch_plan(launch_plan_id)
         return self._upgrade_launchplan(admin_launch_plan)
 
-    def fetch_execution(
-        self, project: str = None, domain: str = None, name: str = None
-    ) -> FlyteWorkflowExecution:
+    def fetch_execution(self, project: str = None, domain: str = None, name: str = None) -> FlyteWorkflowExecution:
         """Fetch a workflow execution entity from flyte admin.
 
         :param project: fetch entity from this project. If None, uses the default_project attribute.
@@ -709,9 +632,7 @@ class FlyteRemote(object):
         :raises: FlyteAssertion if name is None
         """
         if name is None:
-            raise user_exceptions.FlyteAssertion(
-                "the 'name' argument must be specified."
-            )
+            raise user_exceptions.FlyteAssertion("the 'name' argument must be specified.")
         execution = FlyteWorkflowExecution.promote_from_model(
             self.client.get_execution(
                 WorkflowExecutionIdentifier(
@@ -788,13 +709,9 @@ class FlyteRemote(object):
             lit = value
         else:
             lt = literal_type or (
-                TypeEngine.to_literal_type(python_type)
-                if python_type
-                else TypeEngine.to_literal_type(type(value))
+                TypeEngine.to_literal_type(python_type) if python_type else TypeEngine.to_literal_type(type(value))
             )
-            lit = TypeEngine.to_literal(
-                self.context, value, python_type or type(value), lt
-            )
+            lit = TypeEngine.to_literal(self.context, value, python_type or type(value), lt)
             logger.debug(f"Converted {value} to literal {lit} using literal type {lt}")
 
         req = SignalSetRequest(
@@ -842,18 +759,13 @@ class FlyteRemote(object):
             filters=[filter_models.Filter.from_python_std(f"eq(version,{version})")],
             limit=limit,
         )
-        return [
-            FlyteTask.promote_from_model(t.closure.compiled_task.template)
-            for t in t_models
-        ]
+        return [FlyteTask.promote_from_model(t.closure.compiled_task.template) for t in t_models]
 
     #####################
     # Register Entities #
     #####################
 
-    def _resolve_identifier(
-        self, t: int, name: str, version: str, ss: SerializationSettings
-    ) -> Identifier:
+    def _resolve_identifier(self, t: int, name: str, version: str, ss: SerializationSettings) -> Identifier:
         ident = Identifier(
             resource_type=t,
             project=ss.project if ss and ss.project else self.default_project,
@@ -893,19 +805,11 @@ class FlyteRemote(object):
         if isinstance(cp_entity, RemoteEntity):
             if isinstance(cp_entity, (FlyteWorkflow, FlyteTask)):
                 if not cp_entity.should_register:
-                    logger.debug(
-                        f"Skipping registration of remote entity: {cp_entity.name}"
-                    )
-                    raise RegistrationSkipped(
-                        f"Remote task/Workflow {cp_entity.name} is not registrable."
-                    )
+                    logger.debug(f"Skipping registration of remote entity: {cp_entity.name}")
+                    raise RegistrationSkipped(f"Remote task/Workflow {cp_entity.name} is not registrable.")
             else:
-                logger.debug(
-                    f"Skipping registration of remote entity: {cp_entity.name}"
-                )
-                raise RegistrationSkipped(
-                    f"Remote entity {cp_entity.name} is not registrable."
-                )
+                logger.debug(f"Skipping registration of remote entity: {cp_entity.name}")
+                raise RegistrationSkipped(f"Remote entity {cp_entity.name} is not registrable.")
 
         if isinstance(
             cp_entity,
@@ -920,17 +824,13 @@ class FlyteRemote(object):
             return None
 
         elif isinstance(cp_entity, ReferenceSpec):
-            logger.debug(
-                f"Skipping registration of Reference entity, name: {cp_entity.template.id.name}"
-            )
+            logger.debug(f"Skipping registration of Reference entity, name: {cp_entity.template.id.name}")
             return None
 
         if isinstance(cp_entity, task_models.TaskSpec):
             if isinstance(cp_entity, FlyteTask):
                 version = cp_entity.id.version
-            ident = self._resolve_identifier(
-                ResourceType.TASK, cp_entity.template.id.name, version, settings
-            )
+            ident = self._resolve_identifier(ResourceType.TASK, cp_entity.template.id.name, version, settings)
             try:
                 self.client.create_task(task_identifer=ident, task_spec=cp_entity)
             except FlyteEntityAlreadyExistsException:
@@ -940,13 +840,9 @@ class FlyteRemote(object):
         if isinstance(cp_entity, admin_workflow_models.WorkflowSpec):
             if isinstance(cp_entity, FlyteWorkflow):
                 version = cp_entity.id.version
-            ident = self._resolve_identifier(
-                ResourceType.WORKFLOW, cp_entity.template.id.name, version, settings
-            )
+            ident = self._resolve_identifier(ResourceType.WORKFLOW, cp_entity.template.id.name, version, settings)
             try:
-                self.client.create_workflow(
-                    workflow_identifier=ident, workflow_spec=cp_entity
-                )
+                self.client.create_workflow(workflow_identifier=ident, workflow_spec=cp_entity)
             except FlyteEntityAlreadyExistsException:
                 logger.debug(f" {ident} Already Exists!")
 
@@ -978,13 +874,9 @@ class FlyteRemote(object):
             return ident
 
         if isinstance(cp_entity, launch_plan_models.LaunchPlan):
-            ident = self._resolve_identifier(
-                ResourceType.LAUNCH_PLAN, cp_entity.id.name, version, settings
-            )
+            ident = self._resolve_identifier(ResourceType.LAUNCH_PLAN, cp_entity.id.name, version, settings)
             try:
-                self.client.create_launch_plan(
-                    launch_plan_identifer=ident, launch_plan_spec=cp_entity.spec
-                )
+                self.client.create_launch_plan(launch_plan_identifer=ident, launch_plan_spec=cp_entity.spec)
             except FlyteEntityAlreadyExistsException:
                 logger.debug(f" {ident} Already Exists!")
             return ident
@@ -1017,13 +909,9 @@ class FlyteRemote(object):
         if serialization_settings.version is None:
             serialization_settings.version = version
 
-        _ = get_serializable(
-            m, settings=serialization_settings, entity=entity, options=options
-        )
+        _ = get_serializable(m, settings=serialization_settings, entity=entity, options=options)
         # concurrent register
-        cp_task_entity_map = OrderedDict(
-            filter(lambda x: isinstance(x[1], task_models.TaskSpec), m.items())
-        )
+        cp_task_entity_map = OrderedDict(filter(lambda x: isinstance(x[1], task_models.TaskSpec), m.items()))
         tasks = []
         loop = asyncio.get_running_loop()
         for entity, cp_entity in cp_task_entity_map.items():
@@ -1041,9 +929,7 @@ class FlyteRemote(object):
             )
 
         identifiers_or_exceptions = []
-        identifiers_or_exceptions.extend(
-            await asyncio.gather(*tasks, return_exceptions=True)
-        )
+        identifiers_or_exceptions.extend(await asyncio.gather(*tasks, return_exceptions=True))
         # Check to make sure any exceptions are just registration skipped exceptions
         for ie in identifiers_or_exceptions:
             if isinstance(ie, RegistrationSkipped):
@@ -1052,15 +938,11 @@ class FlyteRemote(object):
             if isinstance(ie, Exception):
                 raise ie
         # serial register
-        cp_other_entities = OrderedDict(
-            filter(lambda x: not isinstance(x[1], task_models.TaskSpec), m.items())
-        )
+        cp_other_entities = OrderedDict(filter(lambda x: not isinstance(x[1], task_models.TaskSpec), m.items()))
         for entity, cp_entity in cp_other_entities.items():
             try:
                 identifiers_or_exceptions.append(
-                    self.raw_register(
-                        cp_entity, serialization_settings, version, og_entity=entity
-                    )
+                    self.raw_register(cp_entity, serialization_settings, version, og_entity=entity)
                 )
             except RegistrationSkipped as e:
                 logger.info(f"Skipping registration... {e}")
@@ -1146,9 +1028,7 @@ class FlyteRemote(object):
             default_launch_plan,
         )
 
-        fwf = self.fetch_workflow(
-            ident.project, ident.domain, ident.name, ident.version
-        )
+        fwf = self.fetch_workflow(ident.project, ident.domain, ident.name, ident.version)
         fwf._python_interface = entity.python_interface
         return fwf
 
@@ -1177,27 +1057,21 @@ class FlyteRemote(object):
                 "Please use register_script for other types of workflows"
             )
         if not isinstance(entity._module_file, pathlib.Path):
-            raise ValueError(
-                f"entity._module_file should be pathlib.Path object, got {type(entity._module_file)}"
-            )
+            raise ValueError(f"entity._module_file should be pathlib.Path object, got {type(entity._module_file)}")
 
         mod_name = ".".join(entity.name.split(".")[:-1])
         # get the path representation of the module
         module_path = f"{os.sep}".join(entity.name.split(".")[:-1])
         module_file = str(entity._module_file.with_suffix(""))
         if not module_file.endswith(module_path):
-            raise ValueError(
-                f"Module file path should end with entity.__module__, got {module_file} and {module_path}"
-            )
+            raise ValueError(f"Module file path should end with entity.__module__, got {module_file} and {module_path}")
 
         # remove module suffix to get the root
         module_root = str(pathlib.Path(module_file[: -len(module_path)]))
 
         return self.register_script(
             entity,
-            image_config=(
-                serialization_settings.image_config if serialization_settings else None
-            ),
+            image_config=(serialization_settings.image_config if serialization_settings else None),
             project=serialization_settings.project if serialization_settings else None,
             domain=serialization_settings.domain if serialization_settings else None,
             version=version,
@@ -1245,9 +1119,7 @@ class FlyteRemote(object):
         :return: The uploaded location.
         """
         if not to_upload.is_file():
-            raise ValueError(
-                f"{to_upload} is not a single file, upload arg must be a single file."
-            )
+            raise ValueError(f"{to_upload} is not a single file, upload arg must be a single file.")
         md5_bytes, str_digest, _ = hash_file(to_upload)
 
         upload_location = self.client.get_upload_signed_url(
@@ -1332,12 +1204,8 @@ class FlyteRemote(object):
         # and does not increase entropy of the hash while making it very inconvenient to copy-and-paste.
         return base64.urlsafe_b64encode(h.digest()).decode("ascii").rstrip("=")
 
-    def _get_image_names(
-        self, entity: typing.Union[PythonAutoContainerTask, WorkflowBase]
-    ) -> typing.List[str]:
-        if isinstance(entity, PythonAutoContainerTask) and isinstance(
-            entity.container_image, ImageSpec
-        ):
+    def _get_image_names(self, entity: typing.Union[PythonAutoContainerTask, WorkflowBase]) -> typing.List[str]:
+        if isinstance(entity, PythonAutoContainerTask) and isinstance(entity.container_image, ImageSpec):
             return [entity.container_image.image_name()]
         if isinstance(entity, WorkflowBase):
             image_names = []
@@ -1385,29 +1253,20 @@ class FlyteRemote(object):
                 " the copy_style field in fast_package_options instead."
             )
             if not fast_package_options:
-                fast_package_options = FastPackageOptions(
-                    [], copy_style=CopyFileDetection.ALL
-                )
+                fast_package_options = FastPackageOptions([], copy_style=CopyFileDetection.ALL)
             else:
-                fast_package_options = dc_replace(
-                    fast_package_options, copy_style=CopyFileDetection.ALL
-                )
+                fast_package_options = dc_replace(fast_package_options, copy_style=CopyFileDetection.ALL)
 
         if image_config is None:
             image_config = ImageConfig.auto_default_image()
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            if (
-                fast_package_options
-                and fast_package_options.copy_style != CopyFileDetection.NO_COPY
-            ):
+            if fast_package_options and fast_package_options.copy_style != CopyFileDetection.NO_COPY:
                 md5_bytes, upload_native_url = self.fast_package(
                     pathlib.Path(source_path), False, tmp_dir, fast_package_options
                 )
             else:
-                archive_fname = pathlib.Path(
-                    os.path.join(tmp_dir, "script_mode.tar.gz")
-                )
+                archive_fname = pathlib.Path(os.path.join(tmp_dir, "script_mode.tar.gz"))
                 compress_scripts(
                     source_path,
                     str(archive_fname),
@@ -1452,14 +1311,10 @@ class FlyteRemote(object):
             return self.register_task(entity, serialization_settings, version)
 
         if isinstance(entity, WorkflowBase):
-            return self.register_workflow(
-                entity, serialization_settings, version, default_launch_plan, options
-            )
+            return self.register_workflow(entity, serialization_settings, version, default_launch_plan, options)
         if isinstance(entity, LaunchPlan):
             # If it's a launch plan, we need to register the workflow first
-            return self.register_launch_plan(
-                entity, version, project, domain, options, serialization_settings
-            )
+            return self.register_launch_plan(entity, version, project, domain, options, serialization_settings)
         raise ValueError(f"Unsupported entity type {type(entity)}")
 
     def register_launch_plan(
@@ -1499,9 +1354,7 @@ class FlyteRemote(object):
             options,
             False,
         )
-        flp = self.fetch_launch_plan(
-            ident.project, ident.domain, ident.name, ident.version
-        )
+        flp = self.fetch_launch_plan(ident.project, ident.domain, ident.name, ident.version)
         flp._python_interface = entity.python_interface
         return flp
 
@@ -1546,9 +1399,7 @@ class FlyteRemote(object):
         :returns: :class:`~flytekit.remote.workflow_execution.FlyteWorkflowExecution`
         """
         if execution_name is not None and execution_name_prefix is not None:
-            raise ValueError(
-                "Only one of execution_name and execution_name_prefix can be set, but got both set"
-            )
+            raise ValueError("Only one of execution_name and execution_name_prefix can be set, but got both set")
         # todo: The prefix should be passed to the backend
         if execution_name_prefix is not None:
             execution_name = execution_name_prefix + "-" + uuid.uuid4().hex[:19]
@@ -1576,19 +1427,13 @@ class FlyteRemote(object):
                 if isinstance(v, Literal):
                     lit = v
                 elif isinstance(v, Artifact):
-                    raise user_exceptions.FlyteValueException(
-                        v, "Running with an artifact object is not yet possible."
-                    )
+                    raise user_exceptions.FlyteValueException(v, "Running with an artifact object is not yet possible.")
                 else:
                     if k not in type_hints:
                         try:
-                            type_hints[k] = TypeEngine.guess_python_type(
-                                input_flyte_type_map[k].type
-                            )
+                            type_hints[k] = TypeEngine.guess_python_type(input_flyte_type_map[k].type)
                         except ValueError:
-                            logger.debug(
-                                f"Could not guess type for {input_flyte_type_map[k].type}, skipping..."
-                            )
+                            logger.debug(f"Could not guess type for {input_flyte_type_map[k].type}, skipping...")
                     variable = entity.interface.inputs.get(k)
                     hint = type_hints[k]
                     self.file_access._get_upload_signed_url_fn = functools.partial(
@@ -1629,15 +1474,9 @@ class FlyteRemote(object):
                     security_context=options.security_context,
                     envs=common_models.Envs(envs) if envs else None,
                     tags=tags,
-                    cluster_assignment=(
-                        ClusterAssignment(cluster_pool=cluster_pool)
-                        if cluster_pool
-                        else None
-                    ),
+                    cluster_assignment=(ClusterAssignment(cluster_pool=cluster_pool) if cluster_pool else None),
                     execution_cluster_label=(
-                        ExecutionClusterLabel(execution_cluster_label)
-                        if execution_cluster_label
-                        else None
+                        ExecutionClusterLabel(execution_cluster_label) if execution_cluster_label else None
                     ),
                 ),
                 literal_inputs,
@@ -1652,9 +1491,7 @@ class FlyteRemote(object):
                 domain=domain or self.default_domain,
                 name=execution_name,
             )
-        execution = FlyteWorkflowExecution.promote_from_model(
-            self.client.get_execution(exec_id)
-        )
+        execution = FlyteWorkflowExecution.promote_from_model(self.client.get_execution(exec_id))
 
         if wait:
             return self.wait(execution)
@@ -1893,9 +1730,7 @@ class FlyteRemote(object):
                 cluster_pool=cluster_pool,
                 execution_cluster_label=execution_cluster_label,
             )
-        raise NotImplementedError(
-            f"entity type {type(entity)} not recognized for execution"
-        )
+        raise NotImplementedError(f"entity type {type(entity)} not recognized for execution")
 
     # Flyte Remote Entities
     # ---------------------
@@ -1959,9 +1794,7 @@ class FlyteRemote(object):
 
         NOTE: the name and version arguments are currently not used and only there consistency in the function signature
         """
-        launch_plan = self.fetch_launch_plan(
-            entity.id.project, entity.id.domain, entity.id.name, entity.id.version
-        )
+        launch_plan = self.fetch_launch_plan(entity.id.project, entity.id.domain, entity.id.name, entity.id.version)
         return self.execute_remote_task_lp(
             launch_plan,
             inputs,
@@ -2061,9 +1894,7 @@ class FlyteRemote(object):
         try:
             flyte_lp = self.fetch_launch_plan(**resolved_identifiers_dict)
         except FlyteEntityNotExistException:
-            logger.info(
-                "Try to register default launch plan because it wasn't found in Flyte Admin!"
-            )
+            logger.info("Try to register default launch plan because it wasn't found in Flyte Admin!")
             default_lp = LaunchPlan.get_default_launch_plan(self.context, entity)
             self.register_launch_plan(
                 default_lp,
@@ -2115,9 +1946,7 @@ class FlyteRemote(object):
         )
         resolved_identifiers_dict = asdict(resolved_identifiers)
         try:
-            flyte_launchplan: FlyteLaunchPlan = self.fetch_launch_plan(
-                **resolved_identifiers_dict
-            )
+            flyte_launchplan: FlyteLaunchPlan = self.fetch_launch_plan(**resolved_identifiers_dict)
         except FlyteEntityNotExistException:
             raise ValueError(
                 f'missing entity of type ReferenceLaunchPlan with identifier project:"{entity.reference.project}" domain:"{entity.reference.domain}" name:"{entity.reference.name}" version:"{entity.reference.version}"'
@@ -2180,9 +2009,7 @@ class FlyteRemote(object):
         :param execution_cluster_label: Specify label of cluster(s) on which newly created execution should be placed.
         :return: FlyteWorkflowExecution object.
         """
-        resolved_identifiers = self._resolve_identifier_kwargs(
-            entity, project, domain, name, version
-        )
+        resolved_identifiers = self._resolve_identifier_kwargs(entity, project, domain, name, version)
         resolved_identifiers_dict = asdict(resolved_identifiers)
         not_found = False
         try:
@@ -2193,9 +2020,7 @@ class FlyteRemote(object):
         if not_found:
             fast_serialization_settings = None
             if self.interactive_mode_enabled:
-                md5_bytes, fast_serialization_settings = self._pickle_and_upload_entity(
-                    entity
-                )
+                md5_bytes, fast_serialization_settings = self._pickle_and_upload_entity(entity)
 
             ss = SerializationSettings(
                 image_config=image_config or ImageConfig.auto_default_image(),
@@ -2207,9 +2032,7 @@ class FlyteRemote(object):
 
             default_inputs = entity.python_interface.default_inputs_as_kwargs
             if version is None and self.interactive_mode_enabled:
-                version = self._version_from_hash(
-                    md5_bytes, ss, default_inputs, *self._get_image_names(entity)
-                )
+                version = self._version_from_hash(md5_bytes, ss, default_inputs, *self._get_image_names(entity))
 
             flyte_task: FlyteTask = self.register_task(entity, ss, version)
 
@@ -2267,18 +2090,14 @@ class FlyteRemote(object):
         :param execution_cluster_label:
         :return:
         """
-        resolved_identifiers = self._resolve_identifier_kwargs(
-            entity, project, domain, name, version
-        )
+        resolved_identifiers = self._resolve_identifier_kwargs(entity, project, domain, name, version)
         resolved_identifiers_dict = asdict(resolved_identifiers)
         if not image_config:
             image_config = ImageConfig.auto_default_image()
 
         fast_serialization_settings = None
         if self.interactive_mode_enabled:
-            md5_bytes, fast_serialization_settings = self._pickle_and_upload_entity(
-                entity
-            )
+            md5_bytes, fast_serialization_settings = self._pickle_and_upload_entity(entity)
 
         ss = SerializationSettings(
             image_config=image_config,
@@ -2295,17 +2114,13 @@ class FlyteRemote(object):
             logger.info("Registering workflow because it wasn't found in Flyte Admin.")
             default_inputs = entity.python_interface.default_inputs_as_kwargs
             if not version and self.interactive_mode_enabled:
-                version = self._version_from_hash(
-                    md5_bytes, ss, default_inputs, *self._get_image_names(entity)
-                )
+                version = self._version_from_hash(md5_bytes, ss, default_inputs, *self._get_image_names(entity))
             self.register_workflow(entity, ss, version=version, options=options)
 
         try:
             flyte_lp = self.fetch_launch_plan(**resolved_identifiers_dict)
         except FlyteEntityNotExistException:
-            logger.info(
-                "Try to register default launch plan because it wasn't found in Flyte Admin!"
-            )
+            logger.info("Try to register default launch plan because it wasn't found in Flyte Admin!")
             default_lp = LaunchPlan.get_default_launch_plan(self.context, entity)
             self.register_launch_plan(
                 default_lp,
@@ -2369,16 +2184,12 @@ class FlyteRemote(object):
         :param execution_cluster_label: Specify label of cluster(s) on which newly created execution should be placed.
         :return: FlyteWorkflowExecution object
         """
-        resolved_identifiers = self._resolve_identifier_kwargs(
-            entity, project, domain, name, version
-        )
+        resolved_identifiers = self._resolve_identifier_kwargs(entity, project, domain, name, version)
         resolved_identifiers_dict = asdict(resolved_identifiers)
         project = resolved_identifiers.project
         domain = resolved_identifiers.domain
         try:
-            flyte_launchplan: FlyteLaunchPlan = self.fetch_launch_plan(
-                **resolved_identifiers_dict
-            )
+            flyte_launchplan: FlyteLaunchPlan = self.fetch_launch_plan(**resolved_identifiers_dict)
         except FlyteEntityNotExistException:
             flyte_launchplan: FlyteLaunchPlan = self.register_launch_plan(
                 entity,
@@ -2430,9 +2241,7 @@ class FlyteRemote(object):
                 return execution
             time.sleep(poll_interval.total_seconds())
 
-        raise user_exceptions.FlyteTimeout(
-            f"Execution {self} did not complete before timeout."
-        )
+        raise user_exceptions.FlyteTimeout(f"Execution {self} did not complete before timeout.")
 
     ########################
     # Sync Execution State #
@@ -2456,9 +2265,7 @@ class FlyteRemote(object):
         :return: Returns the same execution object, but with additional information pulled in.
         """
         if not isinstance(execution, FlyteWorkflowExecution):
-            raise ValueError(
-                f"remote.sync should only be called on workflow executions, got {type(execution)}"
-            )
+            raise ValueError(f"remote.sync should only be called on workflow executions, got {type(execution)}")
         return self.sync_execution(execution, entity_definition, sync_nodes)
 
     def sync_execution(
@@ -2471,9 +2278,7 @@ class FlyteRemote(object):
         Sync a FlyteWorkflowExecution object with its corresponding remote state.
         """
         if entity_definition is not None:
-            raise ValueError(
-                "Entity definition arguments aren't supported when syncing workflow executions"
-            )
+            raise ValueError("Entity definition arguments aren't supported when syncing workflow executions")
 
         # Update closure, and then data, because we don't want the execution to finish between when we get the data,
         # and then for the closure to have is_done to be true.
@@ -2483,15 +2288,12 @@ class FlyteRemote(object):
         underlying_node_executions = []
         if sync_nodes:
             underlying_node_executions = [
-                FlyteNodeExecution.promote_from_model(n)
-                for n in iterate_node_executions(self.client, execution.id)
+                FlyteNodeExecution.promote_from_model(n) for n in iterate_node_executions(self.client, execution.id)
             ]
 
         # This condition is only true for single-task executions
         if execution.spec.launch_plan.resource_type == ResourceType.TASK:
-            flyte_entity = self.fetch_task(
-                lp_id.project, lp_id.domain, lp_id.name, lp_id.version
-            )
+            flyte_entity = self.fetch_task(lp_id.project, lp_id.domain, lp_id.name, lp_id.version)
             node_interface = flyte_entity.interface
             if sync_nodes:
                 # Need to construct the mapping. There should've been returned exactly three nodes, a start,
@@ -2499,8 +2301,7 @@ class FlyteRemote(object):
                 task_node_exec = [
                     x
                     for x in filter(
-                        lambda x: x.id.node_id != constants.START_NODE_ID
-                        and x.id.node_id != constants.END_NODE_ID,
+                        lambda x: x.id.node_id != constants.START_NODE_ID and x.id.node_id != constants.END_NODE_ID,
                         underlying_node_executions,
                     )
                 ]
@@ -2521,9 +2322,7 @@ class FlyteRemote(object):
                 )
         # This is the default case, an execution of a normal workflow through a launch plan
         else:
-            fetched_lp = self.fetch_launch_plan(
-                lp_id.project, lp_id.domain, lp_id.name, lp_id.version
-            )
+            fetched_lp = self.fetch_launch_plan(lp_id.project, lp_id.domain, lp_id.name, lp_id.version)
             node_interface = fetched_lp.flyte_workflow.interface
             execution._flyte_workflow = fetched_lp.flyte_workflow
             node_mapping = fetched_lp.flyte_workflow._node_map
@@ -2532,13 +2331,9 @@ class FlyteRemote(object):
         if sync_nodes:
             node_execs = {}
             for n in underlying_node_executions:
-                node_execs[n.id.node_id] = self.sync_node_execution(
-                    n, node_mapping
-                )  # noqa
+                node_execs[n.id.node_id] = self.sync_node_execution(n, node_mapping)  # noqa
             execution._node_executions = node_execs
-        return self._assign_inputs_and_outputs(
-            execution, execution_data, node_interface
-        )
+        return self._assign_inputs_and_outputs(execution, execution_data, node_interface)
 
     def sync_node_execution(
         self,
@@ -2566,11 +2361,7 @@ class FlyteRemote(object):
         # For single task execution - the metadata spec node id is missing. In these cases, revert to regular node id
         node_id = execution.metadata.spec_node_id
         # This case supports single-task execution compiled workflows.
-        if (
-            node_id
-            and node_id not in node_mapping
-            and execution.id.node_id in node_mapping
-        ):
+        if node_id and node_id not in node_mapping and execution.id.node_id in node_mapping:
             node_id = execution.id.node_id
             logger.debug(
                 f"Using node execution ID {node_id} instead of spec node id "
@@ -2592,19 +2383,14 @@ class FlyteRemote(object):
             raise ValueError(f"Missing node from mapping: {node_id}")
 
         # Get the node execution data
-        node_execution_get_data_response = self.client.get_node_execution_data(
-            execution.id
-        )
+        node_execution_get_data_response = self.client.get_node_execution_data(execution.id)
 
         # Calling a launch plan directly case
         # If a node ran a launch plan directly (i.e. not through a dynamic task or anything) then
         # the closure should have a workflow_node_metadata populated with the launched execution id.
         # The parent node flag should not be populated here
         # This is the simplest case
-        if (
-            not execution.metadata.is_parent_node
-            and execution.closure.workflow_node_metadata
-        ):
+        if not execution.metadata.is_parent_node and execution.closure.workflow_node_metadata:
             launched_exec_id = execution.closure.workflow_node_metadata.execution_id
             # This is a recursive call, basically going through the same process that brought us here in the first
             # place, but on the launched execution.
@@ -2635,30 +2421,21 @@ class FlyteRemote(object):
             # If this was a dynamic task, then there should be a CompiledWorkflowClosure inside the
             # NodeExecutionGetDataResponse
             if node_execution_get_data_response.dynamic_workflow is not None:
-                compiled_wf = (
-                    node_execution_get_data_response.dynamic_workflow.compiled_workflow
-                )
+                compiled_wf = node_execution_get_data_response.dynamic_workflow.compiled_workflow
                 node_launch_plans = {}
                 # TODO: Inspect branch nodes for launch plans
-                for template in [compiled_wf.primary.template] + [
-                    swf.template for swf in compiled_wf.sub_workflows
-                ]:
+                for template in [compiled_wf.primary.template] + [swf.template for swf in compiled_wf.sub_workflows]:
                     for node in FlyteWorkflow.get_non_system_nodes(template.nodes):
                         if (
                             node.workflow_node is not None
                             and node.workflow_node.launchplan_ref is not None
-                            and node.workflow_node.launchplan_ref
-                            not in node_launch_plans
+                            and node.workflow_node.launchplan_ref not in node_launch_plans
                         ):
-                            node_launch_plans[node.workflow_node.launchplan_ref] = (
-                                self.client.get_launch_plan(
-                                    node.workflow_node.launchplan_ref
-                                ).spec
-                            )
+                            node_launch_plans[node.workflow_node.launchplan_ref] = self.client.get_launch_plan(
+                                node.workflow_node.launchplan_ref
+                            ).spec
 
-                dynamic_flyte_wf = FlyteWorkflow.promote_from_closure(
-                    compiled_wf, node_launch_plans
-                )
+                dynamic_flyte_wf = FlyteWorkflow.promote_from_closure(compiled_wf, node_launch_plans)
                 execution._underlying_node_executions = [
                     self.sync_node_execution(
                         FlyteNodeExecution.promote_from_model(cne),
@@ -2667,8 +2444,7 @@ class FlyteRemote(object):
                     for cne in child_node_executions
                 ]
                 execution._task_executions = [
-                    node_exes.task_executions
-                    for node_exes in execution.subworkflow_node_executions.values()
+                    node_exes.task_executions for node_exes in execution.subworkflow_node_executions.values()
                 ]
 
                 execution._interface = dynamic_flyte_wf.interface
@@ -2678,9 +2454,7 @@ class FlyteRemote(object):
                 sub_flyte_workflow = execution._node.flyte_entity
                 sub_node_mapping = {n.id: n for n in sub_flyte_workflow.flyte_nodes}
                 execution._underlying_node_executions = [
-                    self.sync_node_execution(
-                        FlyteNodeExecution.promote_from_model(cne), sub_node_mapping
-                    )
+                    self.sync_node_execution(FlyteNodeExecution.promote_from_model(cne), sub_node_mapping)
                     for cne in child_node_executions
                 ]
                 execution._interface = sub_flyte_workflow.interface
@@ -2700,26 +2474,18 @@ class FlyteRemote(object):
                     if t.interface:
                         execution._interface = t.interface
                     else:
-                        logger.error(
-                            f"Fetched map task does not have an interface, skipping i/o {t}"
-                        )
+                        logger.error(f"Fetched map task does not have an interface, skipping i/o {t}")
                         return execution
                 else:
                     logger.error(f"Array node not over task, skipping i/o {t}")
                     return execution
             else:
-                logger.error(
-                    f"NE {execution} undeterminable, {type(execution._node)}, {execution._node}"
-                )
-                raise ValueError(
-                    f"Node execution undeterminable, entity has type {type(execution._node)}"
-                )
+                logger.error(f"NE {execution} undeterminable, {type(execution._node)}, {execution._node}")
+                raise ValueError(f"Node execution undeterminable, entity has type {type(execution._node)}")
 
         # Handle the case for gate nodes
         elif execution._node.gate_node is not None:
-            logger.info(
-                "Skipping gate node execution for now - gate nodes don't have inputs and outputs filled in"
-            )
+            logger.info("Skipping gate node execution for now - gate nodes don't have inputs and outputs filled in")
             return execution
 
         # This is the plain ol' task execution case
@@ -2751,12 +2517,8 @@ class FlyteRemote(object):
         execution_data = self.client.get_task_execution_data(execution.id)
         task_id = execution.id.task_id
         if entity_definition is None:
-            entity_definition = self.fetch_task(
-                task_id.project, task_id.domain, task_id.name, task_id.version
-            )
-        return self._assign_inputs_and_outputs(
-            execution, execution_data, entity_definition.interface
-        )
+            entity_definition = self.fetch_task(task_id.project, task_id.domain, task_id.name, task_id.version)
+        return self._assign_inputs_and_outputs(execution, execution_data, entity_definition.interface)
 
     #############################
     # Terminate Execution State #
@@ -2776,28 +2538,20 @@ class FlyteRemote(object):
 
     def _assign_inputs_and_outputs(
         self,
-        execution: typing.Union[
-            FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution
-        ],
+        execution: typing.Union[FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution],
         execution_data,
         interface: TypedInterface,
     ):
         """Helper for assigning synced inputs and outputs to an execution object."""
         input_literal_map = self._get_input_literal_map(execution_data)
-        execution._inputs = LiteralsResolver(
-            input_literal_map.literals, interface.inputs, self.context
-        )
+        execution._inputs = LiteralsResolver(input_literal_map.literals, interface.inputs, self.context)
 
         if execution.is_done and not execution.error:
             output_literal_map = self._get_output_literal_map(execution_data)
-            execution._outputs = LiteralsResolver(
-                output_literal_map.literals, interface.outputs, self.context
-            )
+            execution._outputs = LiteralsResolver(output_literal_map.literals, interface.outputs, self.context)
         return execution
 
-    def _get_input_literal_map(
-        self, execution_data: ExecutionDataResponse
-    ) -> literal_models.LiteralMap:
+    def _get_input_literal_map(self, execution_data: ExecutionDataResponse) -> literal_models.LiteralMap:
         # Inputs are returned inline unless they are too big, in which case a url blob pointing to them is returned.
         if bool(execution_data.full_inputs.literals):
             return execution_data.full_inputs
@@ -2810,9 +2564,7 @@ class FlyteRemote(object):
                 )
         return literal_models.LiteralMap({})
 
-    def _get_output_literal_map(
-        self, execution_data: ExecutionDataResponse
-    ) -> literal_models.LiteralMap:
+    def _get_output_literal_map(self, execution_data: ExecutionDataResponse) -> literal_models.LiteralMap:
         # Outputs are returned inline unless they are too big, in which case a url blob pointing to them is returned.
         if bool(execution_data.full_outputs.literals):
             return execution_data.full_outputs
@@ -2857,15 +2609,11 @@ class FlyteRemote(object):
         Generate a Flyteconsole URL for the given Flyte remote endpoint.
         This will automatically determine if this is an execution or an entity and change the type automatically
         """
-        if isinstance(
-            entity, (FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution)
-        ):
+        if isinstance(entity, (FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution)):
             return f"{self.generate_console_http_domain()}/console/projects/{entity.id.project}/domains/{entity.id.domain}/executions/{entity.id.name}"  # noqa
 
         if not isinstance(entity, (FlyteWorkflow, FlyteTask, FlyteLaunchPlan)):
-            raise ValueError(
-                f"Only remote entities can be looked at in the console, got type {type(entity)}"
-            )
+            raise ValueError(f"Only remote entities can be looked at in the console, got type {type(entity)}")
         return self.generate_url_from_id(id=entity.id)
 
     def generate_url_from_id(self, id: Identifier):
@@ -2922,9 +2670,7 @@ class FlyteRemote(object):
         :return: In case of dry-run, return WorkflowBase, else if no_execute return FlyteWorkflow else in the default
             case return a FlyteWorkflowExecution
         """
-        lp = self.fetch_launch_plan(
-            project=project, domain=domain, name=launchplan, version=launchplan_version
-        )
+        lp = self.fetch_launch_plan(project=project, domain=domain, name=launchplan, version=launchplan_version)
         wf, start, end = create_backfill_workflow(
             start_date=from_date,
             end_date=to_date,
@@ -2933,17 +2679,13 @@ class FlyteRemote(object):
             failure_policy=failure_policy,
         )
         if dry_run:
-            logger.warning(
-                "Dry Run enabled. Workflow will not be registered and or executed."
-            )
+            logger.warning("Dry Run enabled. Workflow will not be registered and or executed.")
             return wf
 
         unique_fingerprint = f"{start}-{end}-{launchplan}-{launchplan_version}"
         h = hashlib.md5()
         h.update(unique_fingerprint.encode("utf-8"))
-        unique_fingerprint_encoded = base64.urlsafe_b64encode(h.digest()).decode(
-            "ascii"
-        )
+        unique_fingerprint_encoded = base64.urlsafe_b64encode(h.digest()).decode("ascii")
         if not version:
             version = unique_fingerprint_encoded
         ss = SerializationSettings(
@@ -3002,9 +2744,7 @@ class FlyteRemote(object):
             download_literal(self.file_access, "data", data, download_to)
         else:
             if not recursive:
-                raise click.UsageError(
-                    "Please specify --recursive to download all variables in a literal map."
-                )
+                raise click.UsageError("Please specify --recursive to download all variables in a literal map.")
             if isinstance(data, LiteralsResolver):
                 lm = data.literals
             else:
@@ -3030,14 +2770,10 @@ class FlyteRemote(object):
                 raise ValueError(
                     "The size of the task to pickled exceeds the limit of 150MB. Please reduce the size of the task."
                 )
-            logger.debug(
-                f"Uploading Pickled representation of Workflow `{entity.name}` to remote storage..."
-            )
+            logger.debug(f"Uploading Pickled representation of Workflow `{entity.name}` to remote storage...")
             md5_bytes, native_url = self.upload_file(dest)
 
-        return md5_bytes, FastSerializationSettings(
-            enabled=True, distribution_location=native_url, destination_dir="."
-        )
+        return md5_bytes, FastSerializationSettings(enabled=True, distribution_location=native_url, destination_dir=".")
 
     @classmethod
     def for_endpoint(

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -35,13 +35,7 @@ from flyteidl.core import literals_pb2
 from flytekit import ImageSpec
 from flytekit.clients.friendly import SynchronousFlyteClient
 from flytekit.clients.helpers import iterate_node_executions, iterate_task_executions
-from flytekit.configuration import (
-    Config,
-    DataConfig,
-    FastSerializationSettings,
-    ImageConfig,
-    SerializationSettings,
-)
+from flytekit.configuration import Config, DataConfig, FastSerializationSettings, ImageConfig, SerializationSettings
 from flytekit.configuration.file import ConfigFile
 from flytekit.constants import CopyFileDetection
 from flytekit.core import constants, utils
@@ -62,12 +56,7 @@ from flytekit.core.reference_entity import ReferenceSpec
 from flytekit.core.task import ReferenceTask
 from flytekit.core.tracker import extract_task_module
 from flytekit.core.type_engine import LiteralsResolver, TypeEngine
-from flytekit.core.workflow import (
-    PythonFunctionWorkflow,
-    ReferenceWorkflow,
-    WorkflowBase,
-    WorkflowFailurePolicy,
-)
+from flytekit.core.workflow import PythonFunctionWorkflow, ReferenceWorkflow, WorkflowBase, WorkflowFailurePolicy
 from flytekit.exceptions import user as user_exceptions
 from flytekit.exceptions.user import (
     FlyteAssertion,
@@ -88,12 +77,7 @@ from flytekit.models.admin.common import Sort
 from flytekit.models.common import NamedEntityIdentifier
 from flytekit.models.core import identifier as id_models
 from flytekit.models.core import workflow as workflow_model
-from flytekit.models.core.identifier import (
-    Identifier,
-    ResourceType,
-    SignalIdentifier,
-    WorkflowExecutionIdentifier,
-)
+from flytekit.models.core.identifier import Identifier, ResourceType, SignalIdentifier, WorkflowExecutionIdentifier
 from flytekit.models.core.workflow import BranchNode, Node, NodeMetadata
 from flytekit.models.execution import (
     ClusterAssignment,
@@ -108,30 +92,15 @@ from flytekit.models.literals import Literal, LiteralMap
 from flytekit.models.matchable_resource import ExecutionClusterLabel
 from flytekit.remote.backfill import create_backfill_workflow
 from flytekit.remote.data import download_literal
-from flytekit.remote.entities import (
-    FlyteLaunchPlan,
-    FlyteNode,
-    FlyteTask,
-    FlyteTaskNode,
-    FlyteWorkflow,
-)
-from flytekit.remote.executions import (
-    FlyteNodeExecution,
-    FlyteTaskExecution,
-    FlyteWorkflowExecution,
-)
+from flytekit.remote.entities import FlyteLaunchPlan, FlyteNode, FlyteTask, FlyteTaskNode, FlyteWorkflow
+from flytekit.remote.executions import FlyteNodeExecution, FlyteTaskExecution, FlyteWorkflowExecution
 from flytekit.remote.interface import TypedInterface
 from flytekit.remote.lazy_entity import LazyEntity
 from flytekit.remote.remote_callable import RemoteEntity
 from flytekit.remote.remote_fs import get_flyte_fs
 from flytekit.tools.fast_registration import FastPackageOptions, fast_package
 from flytekit.tools.interactive import ipython_check
-from flytekit.tools.script_mode import (
-    _find_project_root,
-    compress_scripts,
-    get_all_modules,
-    hash_file,
-)
+from flytekit.tools.script_mode import _find_project_root, compress_scripts, get_all_modules, hash_file
 from flytekit.tools.translator import (
     FlyteControlPlaneEntity,
     FlyteLocalEntity,
@@ -194,7 +163,7 @@ def _get_entity_identifier(
         project,
         domain,
         name,
-        (version if version is not None else _get_latest_version(list_entities_method, project, domain, name)),
+        version if version is not None else _get_latest_version(list_entities_method, project, domain, name),
     )
 
 
@@ -418,11 +387,7 @@ class FlyteRemote(object):
         )
 
     def fetch_task_lazy(
-        self,
-        project: str = None,
-        domain: str = None,
-        name: str = None,
-        version: str = None,
+        self, project: str = None, domain: str = None, name: str = None, version: str = None
     ) -> LazyEntity:
         """
         Similar to fetch_task, just that it returns a LazyEntity, which will fetch the workflow lazily.
@@ -435,13 +400,7 @@ class FlyteRemote(object):
 
         return LazyEntity(name=name, getter=_fetch)
 
-    def fetch_task(
-        self,
-        project: str = None,
-        domain: str = None,
-        name: str = None,
-        version: str = None,
-    ) -> FlyteTask:
+    def fetch_task(self, project: str = None, domain: str = None, name: str = None, version: str = None) -> FlyteTask:
         """Fetch a task entity from flyte admin.
 
         :param project: fetch entity from this project. If None, uses the default_project attribute.
@@ -468,11 +427,7 @@ class FlyteRemote(object):
         return flyte_task
 
     def fetch_workflow_lazy(
-        self,
-        project: str = None,
-        domain: str = None,
-        name: str = None,
-        version: str = None,
+        self, project: str = None, domain: str = None, name: str = None, version: str = None
     ) -> LazyEntity[FlyteWorkflow]:
         """
         Similar to fetch_workflow, just that it returns a LazyEntity, which will fetch the workflow lazily.
@@ -486,11 +441,7 @@ class FlyteRemote(object):
         return LazyEntity(name=name, getter=_fetch)
 
     def fetch_workflow(
-        self,
-        project: str = None,
-        domain: str = None,
-        name: str = None,
-        version: str = None,
+        self, project: str = None, domain: str = None, name: str = None, version: str = None
     ) -> FlyteWorkflow:
         """
         Fetch a workflow entity from flyte admin.
@@ -520,8 +471,7 @@ class FlyteRemote(object):
         node_launch_plans = {}
 
         def find_launch_plan(
-            lp_ref: id_models,
-            node_launch_plans: Dict[id_models, launch_plan_models.LaunchPlanSpec],
+            lp_ref: id_models, node_launch_plans: Dict[id_models, launch_plan_models.LaunchPlanSpec]
         ) -> None:
             if lp_ref not in node_launch_plans:
                 admin_launch_plan = self.client.get_launch_plan(lp_ref)
@@ -535,12 +485,10 @@ class FlyteRemote(object):
 
                 # Inspect conditional branch nodes for launch plans
                 def get_launch_plan_from_branch(
-                    branch_node: BranchNode,
-                    node_launch_plans: Dict[id_models, launch_plan_models.LaunchPlanSpec],
+                    branch_node: BranchNode, node_launch_plans: Dict[id_models, launch_plan_models.LaunchPlanSpec]
                 ) -> None:
                     def get_launch_plan_from_then_node(
-                        child_then_node: Node,
-                        node_launch_plans: Dict[id_models, launch_plan_models.LaunchPlanSpec],
+                        child_then_node: Node, node_launch_plans: Dict[id_models, launch_plan_models.LaunchPlanSpec]
                     ) -> None:
                         #  then_node could have nested branch_node or be a normal then_node
                         if child_then_node.branch_node:
@@ -600,11 +548,7 @@ class FlyteRemote(object):
         return None
 
     def fetch_launch_plan(
-        self,
-        project: str = None,
-        domain: str = None,
-        name: str = None,
-        version: str = None,
+        self, project: str = None, domain: str = None, name: str = None, version: str = None
     ) -> FlyteLaunchPlan:
         """Fetch a launchplan entity from flyte admin.
 
@@ -672,15 +616,9 @@ class FlyteRemote(object):
         :param filters: Optional list of filters
         """
         wf_exec_id = WorkflowExecutionIdentifier(
-            project=project or self.default_project,
-            domain=domain or self.default_domain,
-            name=execution_name,
+            project=project or self.default_project, domain=domain or self.default_domain, name=execution_name
         )
-        req = SignalListRequest(
-            workflow_execution_id=wf_exec_id.to_flyte_idl(),
-            limit=limit,
-            filters=filters,
-        )
+        req = SignalListRequest(workflow_execution_id=wf_exec_id.to_flyte_idl(), limit=limit, filters=filters)
         resp = self.client.list_signals(req)
         s = resp.signals
         return s
@@ -708,9 +646,7 @@ class FlyteRemote(object):
             is not a Literal
         """
         wf_exec_id = WorkflowExecutionIdentifier(
-            project=project or self.default_project,
-            domain=domain or self.default_domain,
-            name=execution_name,
+            project=project or self.default_project, domain=domain or self.default_domain, name=execution_name
         )
         if isinstance(value, Literal):
             logger.debug(f"Using provided {value} as existing Literal value")
@@ -722,10 +658,7 @@ class FlyteRemote(object):
             lit = TypeEngine.to_literal(self.context, value, python_type or type(value), lt)
             logger.debug(f"Converted {value} to literal {lit} using literal type {lt}")
 
-        req = SignalSetRequest(
-            id=SignalIdentifier(signal_id, wf_exec_id).to_flyte_idl(),
-            value=lit.to_flyte_idl(),
-        )
+        req = SignalSetRequest(id=SignalIdentifier(signal_id, wf_exec_id).to_flyte_idl(), value=lit.to_flyte_idl())
 
         # Response is empty currently, nothing to give back to the user.
         self.client.set_signal(req)
@@ -863,9 +796,7 @@ class FlyteRemote(object):
                 # Let us also create a default launch-plan, ideally the default launchplan should be added
                 # to the orderedDict, but we do not.
                 self.file_access._get_upload_signed_url_fn = functools.partial(
-                    self.client.get_upload_signed_url,
-                    project=settings.project,
-                    domain=settings.domain,
+                    self.client.get_upload_signed_url, project=settings.project, domain=settings.domain
                 )
                 default_lp = LaunchPlan.get_default_launch_plan(self.context, og_entity)
                 lp_entity = get_serializable_launch_plan(
@@ -926,13 +857,7 @@ class FlyteRemote(object):
             tasks.append(
                 loop.run_in_executor(
                     None,
-                    functools.partial(
-                        self.raw_register,
-                        cp_entity,
-                        serialization_settings,
-                        version,
-                        og_entity=entity,
-                    ),
+                    functools.partial(self.raw_register, cp_entity, serialization_settings, version, og_entity=entity),
                 )
             )
 
@@ -984,12 +909,7 @@ class FlyteRemote(object):
                 domain=self.default_domain,
             )
 
-        ident = run_sync(
-            self._serialize_and_register,
-            entity=entity,
-            settings=serialization_settings,
-            version=version,
-        )
+        ident = run_sync(self._serialize_and_register, entity=entity, settings=serialization_settings, version=version)
 
         ft = self.fetch_task(
             ident.project,
@@ -1028,12 +948,7 @@ class FlyteRemote(object):
             )
 
         ident = run_sync(
-            self._serialize_and_register,
-            entity,
-            serialization_settings,
-            version,
-            options,
-            default_launch_plan,
+            self._serialize_and_register, entity, serialization_settings, version, options, default_launch_plan
         )
 
         fwf = self.fetch_workflow(ident.project, ident.domain, ident.name, ident.version)
@@ -1079,7 +994,7 @@ class FlyteRemote(object):
 
         return self.register_script(
             entity,
-            image_config=(serialization_settings.image_config if serialization_settings else None),
+            image_config=serialization_settings.image_config if serialization_settings else None,
             project=serialization_settings.project if serialization_settings else None,
             domain=serialization_settings.domain if serialization_settings else None,
             version=version,
@@ -1144,20 +1059,15 @@ class FlyteRemote(object):
         local_file_path = str(to_upload)
         content_length = os.stat(local_file_path).st_size
         with open(local_file_path, "+rb") as local_file:
-            headers = {
-                "Content-Length": str(content_length),
-                "Content-MD5": encoded_md5,
-            }
+            headers = {"Content-Length": str(content_length), "Content-MD5": encoded_md5}
             headers.update(extra_headers)
             rsp = requests.put(
                 upload_location.signed_url,
                 data=local_file,  # NOTE: We pass the file object directly to stream our upload.
                 headers=headers,
-                verify=(
-                    False
-                    if self._config.platform.insecure_skip_verify is True
-                    else self._config.platform.ca_cert_file_path
-                ),
+                verify=False
+                if self._config.platform.insecure_skip_verify is True
+                else self._config.platform.ca_cert_file_path,
             )
 
             # Check both HTTP 201 and 200, because some storage backends (e.g. Azure) return 201 instead of 200.
@@ -1275,15 +1185,9 @@ class FlyteRemote(object):
                 )
             else:
                 archive_fname = pathlib.Path(os.path.join(tmp_dir, "script_mode.tar.gz"))
-                compress_scripts(
-                    source_path,
-                    str(archive_fname),
-                    get_all_modules(source_path, module_name),
-                )
+                compress_scripts(source_path, str(archive_fname), get_all_modules(source_path, module_name))
                 md5_bytes, upload_native_url = self.upload_file(
-                    archive_fname,
-                    project or self.default_project,
-                    domain or self.default_domain,
+                    archive_fname, project or self.default_project, domain or self.default_domain
                 )
 
         serialization_settings = SerializationSettings(
@@ -1309,10 +1213,7 @@ class FlyteRemote(object):
             # but we don't have to use it when registering with the Flyte backend.
             # For that add the hash of the compilation settings to hash of file
             version = self._version_from_hash(
-                md5_bytes,
-                serialization_settings,
-                default_inputs,
-                *self._get_image_names(entity),
+                md5_bytes, serialization_settings, default_inputs, *self._get_image_names(entity)
             )
 
         if isinstance(entity, PythonTask):
@@ -1429,8 +1330,7 @@ class FlyteRemote(object):
             for k, v in inputs.items():
                 if input_flyte_type_map.get(k) is None:
                     raise user_exceptions.FlyteValueException(
-                        k,
-                        f"The {entity.__class__.__name__} doesn't have this input key.",
+                        k, f"The {entity.__class__.__name__} doesn't have this input key."
                     )
                 if isinstance(v, Literal):
                     lit = v
@@ -1482,10 +1382,10 @@ class FlyteRemote(object):
                     security_context=options.security_context,
                     envs=common_models.Envs(envs) if envs else None,
                     tags=tags,
-                    cluster_assignment=(ClusterAssignment(cluster_pool=cluster_pool) if cluster_pool else None),
-                    execution_cluster_label=(
-                        ExecutionClusterLabel(execution_cluster_label) if execution_cluster_label else None
-                    ),
+                    cluster_assignment=ClusterAssignment(cluster_pool=cluster_pool) if cluster_pool else None,
+                    execution_cluster_label=ExecutionClusterLabel(execution_cluster_label)
+                    if execution_cluster_label
+                    else None,
                 ),
                 literal_inputs,
             )
@@ -1495,9 +1395,7 @@ class FlyteRemote(object):
                 f"Assuming this is the same execution, returning!"
             )
             exec_id = WorkflowExecutionIdentifier(
-                project=project or self.default_project,
-                domain=domain or self.default_domain,
-                name=execution_name,
+                project=project or self.default_project, domain=domain or self.default_domain, name=execution_name
             )
         execution = FlyteWorkflowExecution.promote_from_model(self.client.get_execution(exec_id), remote=self)
 
@@ -1532,14 +1430,7 @@ class FlyteRemote(object):
 
     def execute(
         self,
-        entity: typing.Union[
-            FlyteTask,
-            FlyteLaunchPlan,
-            FlyteWorkflow,
-            PythonTask,
-            WorkflowBase,
-            LaunchPlan,
-        ],
+        entity: typing.Union[FlyteTask, FlyteLaunchPlan, FlyteWorkflow, PythonTask, WorkflowBase, LaunchPlan],
         inputs: typing.Dict[str, typing.Any],
         project: str = None,
         domain: str = None,
@@ -2027,10 +1918,7 @@ class FlyteRemote(object):
         if version is None and self.interactive_mode_enabled:
             md5_bytes, pickled_target_dict = _get_pickled_target_dict(entity)
             version = self._version_from_hash(
-                md5_bytes,
-                ss,
-                entity.python_interface.default_inputs_as_kwargs,
-                *self._get_image_names(entity),
+                md5_bytes, ss, entity.python_interface.default_inputs_as_kwargs, *self._get_image_names(entity)
             )
 
         resolved_identifiers = self._resolve_identifier_kwargs(entity, project, domain, name, version)
@@ -2109,10 +1997,7 @@ class FlyteRemote(object):
         if version is None and self.interactive_mode_enabled:
             md5_bytes, pickled_target_dict = _get_pickled_target_dict(entity)
             version = self._version_from_hash(
-                md5_bytes,
-                ss,
-                entity.python_interface.default_inputs_as_kwargs,
-                *self._get_image_names(entity),
+                md5_bytes, ss, entity.python_interface.default_inputs_as_kwargs, *self._get_image_names(entity)
             )
 
         resolved_identifiers = self._resolve_identifier_kwargs(entity, project, domain, name, version)
@@ -2413,9 +2298,7 @@ class FlyteRemote(object):
             # This is a recursive call, basically going through the same process that brought us here in the first
             # place, but on the launched execution.
             launched_exec = self.fetch_execution(
-                project=launched_exec_id.project,
-                domain=launched_exec_id.domain,
-                name=launched_exec_id.name,
+                project=launched_exec_id.project, domain=launched_exec_id.domain, name=launched_exec_id.name
             )
             self.sync_execution(launched_exec)
             if launched_exec.is_done:
@@ -2455,10 +2338,7 @@ class FlyteRemote(object):
 
                 dynamic_flyte_wf = FlyteWorkflow.promote_from_closure(compiled_wf, node_launch_plans)
                 execution._underlying_node_executions = [
-                    self.sync_node_execution(
-                        FlyteNodeExecution.promote_from_model(cne),
-                        dynamic_flyte_wf._node_map,
-                    )
+                    self.sync_node_execution(FlyteNodeExecution.promote_from_model(cne), dynamic_flyte_wf._node_map)
                     for cne in child_node_executions
                 ]
                 execution._task_executions = [
@@ -2510,8 +2390,7 @@ class FlyteRemote(object):
         else:
             execution._task_executions = [
                 self.sync_task_execution(
-                    FlyteTaskExecution.promote_from_model(t),
-                    node_mapping[node_id].task_node.flyte_task,
+                    FlyteTaskExecution.promote_from_model(t), node_mapping[node_id].task_node.flyte_task
                 )
                 for t in iterate_task_executions(self.client, execution.id)
             ]
@@ -2526,9 +2405,7 @@ class FlyteRemote(object):
         return execution
 
     def sync_task_execution(
-        self,
-        execution: FlyteTaskExecution,
-        entity_definition: typing.Optional[FlyteTask] = None,
+        self, execution: FlyteTaskExecution, entity_definition: typing.Optional[FlyteTask] = None
     ) -> FlyteTaskExecution:
         """Sync a FlyteTaskExecution object with its corresponding remote state."""
         execution._closure = self.client.get_task_execution(execution.id).closure
@@ -2630,13 +2507,7 @@ class FlyteRemote(object):
         This will automatically determine if this is an execution or an entity and change the type automatically
         """
         if isinstance(
-            entity,
-            (
-                FlyteWorkflowExecution,
-                FlyteNodeExecution,
-                FlyteTaskExecution,
-                WorkflowExecutionIdentifier,
-            ),
+            entity, (FlyteWorkflowExecution, FlyteNodeExecution, FlyteTaskExecution, WorkflowExecutionIdentifier)
         ):
             if not isinstance(entity, WorkflowExecutionIdentifier):
                 entity = entity.id
@@ -2702,11 +2573,7 @@ class FlyteRemote(object):
         """
         lp = self.fetch_launch_plan(project=project, domain=domain, name=launchplan, version=launchplan_version)
         wf, start, end = create_backfill_workflow(
-            start_date=from_date,
-            end_date=to_date,
-            for_lp=lp,
-            parallel=parallel,
-            failure_policy=failure_policy,
+            start_date=from_date, end_date=to_date, for_lp=lp, parallel=parallel, failure_policy=failure_policy
         )
         if dry_run:
             logger.warning("Dry Run enabled. Workflow will not be registered and or executed.")
@@ -2751,10 +2618,7 @@ class FlyteRemote(object):
         self.client.update_launch_plan(id=ident, state=LaunchPlanState.ACTIVE)
 
     def download(
-        self,
-        data: typing.Union[LiteralsResolver, Literal, LiteralMap],
-        download_to: str,
-        recursive: bool = True,
+        self, data: typing.Union[LiteralsResolver, Literal, LiteralMap], download_to: str, recursive: bool = True
     ):
         """
         Download the data to the specified location. If the data is a LiteralsResolver, LiteralMap and if recursive is

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2589,8 +2589,14 @@ class FlyteRemote(object):
         :param root_entity: The entity to get the pickled target for.
         :return: The pickled target dictionary.
         """
+        import sys
+
         queue = [root_entity]
-        pickled_target_dict = {}
+        pickled_target_dict = {
+            "metadata": {
+                "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+            }
+        }
         while queue:
             entity = queue.pop()
             if isinstance(entity, PythonTask):

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -48,6 +48,8 @@ from flytekit.core.launch_plan import LaunchPlan, ReferenceLaunchPlan
 from flytekit.core.node import Node as CoreNode
 from flytekit.core.python_auto_container import (
     PICKLE_FILE_PATH,
+    PickledEntity,
+    PickledEntityMetadata,
     PythonAutoContainerTask,
     default_notebook_task_resolver,
 )
@@ -202,7 +204,7 @@ def _get_git_repo_url(source_path: str):
 
 def _get_pickled_target_dict(
     root_entity: typing.Union[WorkflowBase, PythonTask],
-) -> typing.Tuple[bytes, typing.Dict[str, PythonAutoContainerTask]]:
+) -> typing.Tuple[bytes, PickledEntity]:
     """
     Get the pickled target dictionary for the entity.
     :param root_entity: The entity to get the pickled target for.
@@ -211,11 +213,12 @@ def _get_pickled_target_dict(
     import sys
 
     queue: typing.List[typing.Union[WorkflowBase, PythonTask, CoreNode]] = [root_entity]
-    pickled_target_dict = {
-        "metadata": {
-            "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
-        }
-    }
+    pickled_target_dict = PickledEntity(
+        metadata=PickledEntityMetadata(
+            python_version=f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+        ),
+        entities={},
+    )
     while queue:
         entity = queue.pop()
         if isinstance(entity, PythonFunctionTask):
@@ -228,10 +231,10 @@ def _get_pickled_target_dict(
             if isinstance(entity, (PythonAutoContainerTask, ArrayNodeMapTask)):
                 if isinstance(entity, ArrayNodeMapTask):
                     entity._run_task.set_resolver(default_notebook_task_resolver)
-                    pickled_target_dict[entity._run_task.name] = entity._run_task
+                    pickled_target_dict.entities[entity._run_task.name] = entity._run_task
                 else:
                     entity.set_resolver(default_notebook_task_resolver)
-                    pickled_target_dict[entity.name] = entity
+                    pickled_target_dict.entities[entity.name] = entity
         elif isinstance(entity, WorkflowBase):
             for task in entity.nodes:
                 queue.append(task)
@@ -2649,7 +2652,7 @@ class FlyteRemote(object):
     def _pickle_and_upload_entity(
         self,
         entity: typing.Union[PythonTask, WorkflowBase],
-        pickled_dict: typing.Optional[typing.Dict[str, PythonAutoContainerTask]] = None,
+        pickled_dict: typing.Optional[PickledEntity] = None,
     ) -> FastSerializationSettings:
         """
         Pickle the entity to the specified location. This is useful for debugging and for sharing entities across

--- a/tests/flytekit/unit/core/test_resolver.py
+++ b/tests/flytekit/unit/core/test_resolver.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 import cloudpickle
 import mock
 import pytest
+import sys
 
 import flytekit.configuration
 from flytekit.configuration import Image, ImageConfig
@@ -123,10 +124,28 @@ def test_notebook_resolver(mock_gzip_open, mock_cloudpickle):
 
     assert c.loader_args(None, t1) == ["entity-name", "tests.flytekit.unit.core.test_resolver.t1"]
 
-    pickled_dict = {"tests.flytekit.unit.core.test_resolver.t1": t1}
+    pickled_dict = {
+        "tests.flytekit.unit.core.test_resolver.t1": t1,
+        "metadata": {
+            "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        }
+    }
     custom_pickled_object = cloudpickle.dumps(pickled_dict)
     mock_gzip_open.return_value.read.return_value = custom_pickled_object
     mock_cloudpickle.return_value = pickled_dict
 
     t = c.load_task(["entity-name", "tests.flytekit.unit.core.test_resolver.t1"])
     assert t == t1
+
+    mismatched_pickled_dict = {
+        "tests.flytekit.unit.core.test_resolver.t1": t1,
+        "metadata": {
+            "python_version": f"{sys.version_info.major}.{sys.version_info.minor - 1}.{sys.version_info.micro}",
+        }
+    }
+    mismatched_custom_pickled_object = cloudpickle.dumps(mismatched_pickled_dict)
+    mock_gzip_open.return_value.read.return_value = mismatched_custom_pickled_object
+    mock_cloudpickle.return_value = mismatched_pickled_dict
+
+    with pytest.raises(RuntimeError):
+        c.load_task(["entity-name", "tests.flytekit.unit.core.test_resolver.t1"])

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -708,15 +708,15 @@ def test_get_pickled_target_dict():
         return t2(a=t1())
 
     _, target_dict = _get_pickled_target_dict(w)
-    assert len(target_dict) == 3
     assert (
-        target_dict["metadata"]["python_version"]
+        target_dict.metadata.python_version
         == f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     )
-    assert t1.name in target_dict
-    assert t2.name in target_dict
-    assert target_dict[t1.name] == t1
-    assert target_dict[t2.name] == t2
+    assert len(target_dict.entities) == 2
+    assert t1.name in target_dict.entities
+    assert t2.name in target_dict.entities
+    assert target_dict.entities[t1.name] == t1
+    assert target_dict.entities[t2.name] == t2
 
 def test_get_pickled_target_dict_with_map_task():
     @task
@@ -728,13 +728,13 @@ def test_get_pickled_target_dict_with_map_task():
         return map_task(partial(t1, y=2))(x=[1, 2, 3])
 
     _, target_dict = _get_pickled_target_dict(w)
-    assert len(target_dict) == 2
     assert (
-        target_dict["metadata"]["python_version"]
+        target_dict.metadata.python_version
         == f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     )
-    assert t1.name in target_dict
-    assert target_dict[t1.name] == t1
+    assert len(target_dict.entities) == 1
+    assert t1.name in target_dict.entities
+    assert target_dict.entities[t1.name] == t1
 
 def test_get_pickled_target_dict_with_dynamic():
     @task

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -17,24 +17,8 @@ from flyteidl.service import dataproxy_pb2
 from mock import ANY, MagicMock, patch
 
 import flytekit.configuration
-from flytekit import (
-    CronSchedule,
-    ImageSpec,
-    LaunchPlan,
-    WorkflowFailurePolicy,
-    task,
-    workflow,
-    reference_task,
-    map_task,
-    dynamic,
-)
-from flytekit.configuration import (
-    Config,
-    DefaultImages,
-    Image,
-    ImageConfig,
-    SerializationSettings,
-)
+from flytekit import CronSchedule, ImageSpec, LaunchPlan, WorkflowFailurePolicy, task, workflow, reference_task, map_task, dynamic
+from flytekit.configuration import Config, DefaultImages, Image, ImageConfig, SerializationSettings
 from flytekit.core.base_task import PythonTask
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.type_engine import TypeEngine
@@ -46,25 +30,13 @@ from flytekit.models.admin.workflow import Workflow, WorkflowClosure
 from flytekit.models.core import condition as _condition
 from flytekit.models.core import workflow as _workflow
 from flytekit.models.core.compiler import CompiledWorkflowClosure
-from flytekit.models.core.identifier import (
-    Identifier,
-    ResourceType,
-    WorkflowExecutionIdentifier,
-)
+from flytekit.models.core.identifier import Identifier, ResourceType, WorkflowExecutionIdentifier
 from flytekit.models.execution import Execution
 from flytekit.models.task import Task
 from flytekit.remote import FlyteTask
 from flytekit.remote.lazy_entity import LazyEntity
-from flytekit.remote.remote import (
-    FlyteRemote,
-    _get_git_repo_url,
-    _get_pickled_target_dict,
-)
-from flytekit.tools.translator import (
-    Options,
-    get_serializable,
-    get_serializable_launch_plan,
-)
+from flytekit.remote.remote import FlyteRemote, _get_git_repo_url, _get_pickled_target_dict
+from flytekit.tools.translator import Options, get_serializable, get_serializable_launch_plan
 from tests.flytekit.common.parameterizers import LIST_OF_TASK_CLOSURES
 
 CLIENT_METHODS = {
@@ -110,9 +82,7 @@ node1 = _workflow.Node(
 )
 nodes = [node1]
 
-obj2 = _workflow.Node(
-    id="some:node:id", metadata="1", inputs=[], upstream_node_ids=[], output_aliases=[]
-)
+obj2 = _workflow.Node(id="some:node:id", metadata="1", inputs=[], upstream_node_ids=[], output_aliases=[])
 
 node2 = node1 = _workflow.Node(
     id="some:node:id",
@@ -136,9 +106,7 @@ nodes2 = [node2]
 @pytest.fixture
 def remote():
     with patch("flytekit.clients.friendly.SynchronousFlyteClient") as mock_client:
-        flyte_remote = FlyteRemote(
-            config=Config.auto(), default_project="p1", default_domain="d1"
-        )
+        flyte_remote = FlyteRemote(config=Config.auto(), default_project="p1", default_domain="d1")
         flyte_remote._client_initialized = True
         flyte_remote._client = mock_client
         return flyte_remote
@@ -171,9 +139,7 @@ def test_underscore_execute_uses_launch_plan_attributes(remote, mock_wf_exec):
         execution_spec = args[3]
         assert execution_spec.security_context.run_as.k8s_service_account == "svc"
         assert execution_spec.labels == common_models.Labels({"a": "my_label_value"})
-        assert execution_spec.annotations == common_models.Annotations(
-            {"b": "my_annotation_value"}
-        )
+        assert execution_spec.annotations == common_models.Annotations({"b": "my_annotation_value"})
 
     mock_client.create_execution.side_effect = local_assertions
 
@@ -181,9 +147,7 @@ def test_underscore_execute_uses_launch_plan_attributes(remote, mock_wf_exec):
     options = Options(
         labels=common_models.Labels({"a": "my_label_value"}),
         annotations=common_models.Annotations({"b": "my_annotation_value"}),
-        security_context=security.SecurityContext(
-            run_as=security.Identity(k8s_service_account="svc")
-        ),
+        security_context=security.SecurityContext(run_as=security.Identity(k8s_service_account="svc")),
     )
 
     remote._execute(
@@ -223,20 +187,14 @@ def test_underscore_execute_fall_back_remote_attributes(remote, mock_wf_exec):
     remote._client = mock_client
 
     options = Options(
-        raw_output_data_config=common_models.RawOutputDataConfig(
-            output_location_prefix="raw_output"
-        ),
-        security_context=security.SecurityContext(
-            run_as=security.Identity(iam_role="iam:some:role")
-        ),
+        raw_output_data_config=common_models.RawOutputDataConfig(output_location_prefix="raw_output"),
+        security_context=security.SecurityContext(run_as=security.Identity(iam_role="iam:some:role")),
     )
 
     def local_assertions(*args, **kwargs):
         execution_spec = args[3]
         assert execution_spec.security_context.run_as.iam_role == "iam:some:role"
-        assert (
-            execution_spec.raw_output_data_config.output_location_prefix == "raw_output"
-        )
+        assert execution_spec.raw_output_data_config.output_location_prefix == "raw_output"
 
     mock_client.create_execution.side_effect = local_assertions
 
@@ -271,9 +229,7 @@ def test_execute_with_wrong_input_key(remote, mock_wf_exec):
 
 
 def test_form_config():
-    remote = FlyteRemote(
-        config=Config.auto(), default_project="p1", default_domain="d1"
-    )
+    remote = FlyteRemote(config=Config.auto(), default_project="p1", default_domain="d1")
     assert remote.default_project == "p1"
     assert remote.default_domain == "d1"
 
@@ -288,21 +244,14 @@ def test_passing_of_kwargs(mock_client):
         "root_certificates": 5,
         "certificate_chain": 6,
     }
-    FlyteRemote(
-        config=Config.auto(),
-        default_project="project",
-        default_domain="domain",
-        **additional_args,
-    ).client
+    FlyteRemote(config=Config.auto(), default_project="project", default_domain="domain", **additional_args).client
     assert mock_client.called
     assert mock_client.call_args[1] == additional_args
 
 
 @patch("flytekit.remote.remote.SynchronousFlyteClient")
 def test_more_stuff(mock_client):
-    r = FlyteRemote(
-        config=Config.auto(), default_project="project", default_domain="domain"
-    )
+    r = FlyteRemote(config=Config.auto(), default_project="project", default_domain="domain")
 
     # Can't upload a folder
     with pytest.raises(ValueError):
@@ -332,9 +281,7 @@ def test_more_stuff(mock_client):
 
 @patch("flytekit.remote.remote.SynchronousFlyteClient")
 def test_version_hash_special_characters(mock_client):
-    r = FlyteRemote(
-        config=Config.auto(), default_project="project", default_domain="domain"
-    )
+    r = FlyteRemote(config=Config.auto(), default_project="project", default_domain="domain")
 
     serialization_settings = flytekit.configuration.SerializationSettings(
         project="project",
@@ -374,9 +321,7 @@ def test_generate_console_http_domain_sandbox_rewrite(mock_client):
             f.write(flytectl_config_file)
 
         remote = FlyteRemote(
-            config=Config.auto(config_file=temp_filename),
-            default_project="project",
-            default_domain="domain",
+            config=Config.auto(config_file=temp_filename), default_project="project", default_domain="domain"
         )
         assert remote.generate_console_http_domain() == "https://example.com"
 
@@ -391,9 +336,7 @@ def test_generate_console_http_domain_sandbox_rewrite(mock_client):
             f.write(flytectl_config_file)
 
         remote = FlyteRemote(
-            config=Config.auto(config_file=temp_filename),
-            default_project="project",
-            default_domain="domain",
+            config=Config.auto(config_file=temp_filename), default_project="project", default_domain="domain"
         )
         assert remote.generate_console_http_domain() == "http://localhost:30081"
 
@@ -410,9 +353,7 @@ console:
             f.write(flytectl_config_file)
 
         remote = FlyteRemote(
-            config=Config.auto(config_file=temp_filename),
-            default_project="project",
-            default_domain="domain",
+            config=Config.auto(config_file=temp_filename), default_project="project", default_domain="domain"
         )
         assert remote.generate_console_http_domain() == "http://localhost:30090"
     finally:
@@ -429,9 +370,7 @@ def get_compiled_workflow_closure():
     cwc_pb = _compiler_pb2.CompiledWorkflowClosure()
     # So that tests that use this work when run from any directory
     basepath = os.path.dirname(__file__)
-    filepath = os.path.abspath(
-        os.path.join(basepath, "responses", "CompiledWorkflowClosure.pb")
-    )
+    filepath = os.path.abspath(os.path.join(basepath, "responses", "CompiledWorkflowClosure.pb"))
     with open(filepath, "rb") as fh:
         cwc_pb.ParseFromString(fh.read())
 
@@ -441,8 +380,7 @@ def get_compiled_workflow_closure():
 def test_fetch_lazy(remote):
     mock_client = remote._client
     mock_client.get_task.return_value = Task(
-        id=Identifier(ResourceType.TASK, "p", "d", "n", "v"),
-        closure=LIST_OF_TASK_CLOSURES[0],
+        id=Identifier(ResourceType.TASK, "p", "d", "n", "v"), closure=LIST_OF_TASK_CLOSURES[0]
     )
 
     mock_client.get_workflow.return_value = Workflow(
@@ -493,9 +431,7 @@ def test_launch_backfill(remote):
     start_date = datetime(2022, 12, 1, 8)
     end_date = start_date + timedelta(days=10)
 
-    ser_lp = get_serializable_launch_plan(
-        OrderedDict(), serialization_settings, daily_lp, recurse_downstream=False
-    )
+    ser_lp = get_serializable_launch_plan(OrderedDict(), serialization_settings, daily_lp, recurse_downstream=False)
     m = OrderedDict()
     ser_wf = get_serializable(m, serialization_settings, example_wf)
     tasks = []
@@ -507,9 +443,7 @@ def test_launch_backfill(remote):
     mock_client.get_workflow.return_value = Workflow(
         id=Identifier(ResourceType.WORKFLOW, "p", "d", "daily2", "v"),
         closure=WorkflowClosure(
-            compiled_workflow=CompiledWorkflowClosure(
-                primary=ser_wf, sub_workflows=[], tasks=tasks
-            )
+            compiled_workflow=CompiledWorkflowClosure(primary=ser_wf, sub_workflows=[], tasks=tasks)
         ),
     )
 
@@ -527,9 +461,7 @@ def test_launch_backfill(remote):
     assert wf.workflow_metadata.on_failure == WorkflowFailurePolicy.FAIL_IMMEDIATELY
 
 
-@patch(
-    "flytekit.remote.entities.FlyteWorkflow.get_non_system_nodes", return_value=nodes
-)
+@patch("flytekit.remote.entities.FlyteWorkflow.get_non_system_nodes", return_value=nodes)
 @patch("flytekit.remote.entities.FlyteWorkflow.promote_from_closure")
 def test_fetch_workflow_with_branch(mock_promote, mock_workflow, remote):
     mock_client = remote._client
@@ -547,9 +479,7 @@ def test_fetch_workflow_with_branch(mock_promote, mock_workflow, remote):
     mock_promote.assert_called_with(ANY, node_launch_plans)
 
 
-@patch(
-    "flytekit.remote.entities.FlyteWorkflow.get_non_system_nodes", return_value=nodes2
-)
+@patch("flytekit.remote.entities.FlyteWorkflow.get_non_system_nodes", return_value=nodes2)
 @patch("flytekit.remote.entities.FlyteWorkflow.promote_from_closure")
 def test_fetch_workflow_with_nested_branch(mock_promote, mock_workflow, remote):
     mock_client = remote._client
@@ -573,11 +503,7 @@ def test_fetch_workflow_with_nested_branch(mock_promote, mock_workflow, remote):
 @mock.patch("flytekit.remote.remote.compress_scripts")
 @pytest.mark.serial
 def test_get_image_names(
-    compress_scripts_mock,
-    upload_file_mock,
-    register_workflow_mock,
-    version_from_hash_mock,
-    read_bytes_mock,
+        compress_scripts_mock, upload_file_mock, register_workflow_mock, version_from_hash_mock, read_bytes_mock
 ):
     md5_bytes = bytes([1, 2, 3])
     read_bytes_mock.return_value = bytes([4, 5, 6])
@@ -598,14 +524,10 @@ def test_get_image_names(
     def wf(name: str = "union"):
         sub_wf(name=name)
 
-    flyte_remote = FlyteRemote(
-        config=Config.auto(), default_project="p1", default_domain="d1"
-    )
+    flyte_remote = FlyteRemote(config=Config.auto(), default_project="p1", default_domain="d1")
     flyte_remote.register_script(wf)
 
-    version_from_hash_mock.assert_called_once_with(
-        md5_bytes, mock.ANY, mock.ANY, image_spec.image_name()
-    )
+    version_from_hash_mock.assert_called_once_with(md5_bytes, mock.ANY, mock.ANY, image_spec.image_name())
     register_workflow_mock.assert_called_once()
 
     @reference_task(
@@ -614,15 +536,14 @@ def test_get_image_names(
         name="flytesnacks.examples.basics.basics.workflow.slope",
         version="v1",
     )
-    def ref_basic(x: typing.List[int], y: typing.List[int]) -> float: ...
+    def ref_basic(x: typing.List[int], y: typing.List[int]) -> float:
+        ...
 
     @workflow
     def wf1(name: str = "union") -> float:
         return ref_basic(x=[1, 2, 3], y=[4, 5, 6])
 
-    flyte_remote = FlyteRemote(
-        config=Config.auto(), default_project="p1", default_domain="d1"
-    )
+    flyte_remote = FlyteRemote(config=Config.auto(), default_project="p1", default_domain="d1")
     flyte_remote.register_script(wf1)
 
 
@@ -649,9 +570,7 @@ def test_local_server(mock_client):
 def test_execution_name(mock_client, mock_uuid):
     test_uuid = uuid.UUID("16fd2706-8baf-433b-82eb-8c7fada847da")
     mock_uuid.uuid4.return_value = test_uuid
-    remote = FlyteRemote(
-        config=Config.auto(), default_project="project", default_domain="domain"
-    )
+    remote = FlyteRemote(config=Config.auto(), default_project="project", default_domain="domain")
 
     default_img = Image(name="default", fqn="test", tag="tag")
     serialization_settings = SerializationSettings(
@@ -686,8 +605,7 @@ def test_execution_name(mock_client, mock_uuid):
         ]
     )
     with pytest.raises(
-        ValueError,
-        match="Only one of execution_name and execution_name_prefix can be set, but got both set",
+            ValueError, match="Only one of execution_name and execution_name_prefix can be set, but got both set"
     ):
         remote._execute(
             entity=ft,
@@ -737,9 +655,7 @@ def test_get_git_report_url_unknown_url(tmp_path):
     source_path = tmp_path / "repo_source"
     source_path.mkdir()
     subprocess.check_output([git_exec, "init"], cwd=source_path)
-    subprocess.check_output(
-        [git_exec, "remote", "add", "origin", "unknown"], cwd=source_path
-    )
+    subprocess.check_output([git_exec, "remote", "add", "origin", "unknown"], cwd=source_path)
 
     returned_url = _get_git_repo_url(source_path)
     assert returned_url == ""
@@ -749,9 +665,7 @@ def test_get_git_report_url_unknown_url(tmp_path):
 @mock.patch("flytekit.remote.remote.FlyteRemote.register_script")
 @mock.patch("flytekit.remote.remote.FlyteRemote.upload_file")
 @mock.patch("flytekit.remote.remote.compress_scripts")
-def test_register_wf_script_mode(
-    compress_scripts_mock, upload_file_mock, register_workflow_mock, read_bytes_mock
-):
+def test_register_wf_script_mode(compress_scripts_mock, upload_file_mock, register_workflow_mock, read_bytes_mock):
     from .resources import hello_wf
 
     md5_bytes = bytes([1, 2, 3])
@@ -776,9 +690,7 @@ def test_register_wf_script_mode(
 
 @mock.patch("flytekit.remote.remote.FlyteRemote.client")
 def test_fetch_active_launchplan_not_found(mock_client, remote):
-    mock_client.get_active_launch_plan.side_effect = FlyteEntityNotExistException(
-        "not found"
-    )
+    mock_client.get_active_launch_plan.side_effect = FlyteEntityNotExistException("not found")
     assert remote.fetch_active_launchplan(name="basic.list_float_wf.fake_wf") is None
 
 
@@ -806,7 +718,6 @@ def test_get_pickled_target_dict():
     assert target_dict[t1.name] == t1
     assert target_dict[t2.name] == t2
 
-
 def test_get_pickled_target_dict_with_map_task():
     @task
     def t1(x: int, y: int) -> int:
@@ -824,7 +735,6 @@ def test_get_pickled_target_dict_with_map_task():
     )
     assert t1.name in target_dict
     assert target_dict[t1.name] == t1
-
 
 def test_get_pickled_target_dict_with_dynamic():
     @task

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import shutil
 import subprocess
+import sys
 import tempfile
 import typing
 import uuid
@@ -707,7 +708,8 @@ def test_get_pickled_target_dict():
         return t2(a=t1())
 
     target_dict = _get_pickled_target_dict(w)
-    assert len(target_dict) == 2
+    assert len(target_dict) == 3
+    assert target_dict["metadata"]["python_version"] == f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     assert t1.name in target_dict
     assert t2.name in target_dict
     assert target_dict[t1.name] == t1
@@ -723,7 +725,8 @@ def test_get_pickled_target_dict_with_map_task():
         return map_task(partial(t1, y=2))(x=[1, 2, 3])
 
     target_dict = _get_pickled_target_dict(w)
-    assert len(target_dict) == 1
+    assert len(target_dict) == 2
+    assert target_dict["metadata"]["python_version"] == f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
     assert t1.name in target_dict
     assert target_dict[t1.name] == t1
 


### PR DESCRIPTION
## Tracking Issues
https://github.com/flyteorg/flyte/issues/5907

## Why are the changes needed?
In the Jupyter Notebook environment, we are using `cloudpickle` to package the entity at the binary level. When we load the pickled object with a different Python version, it will throw an unexpected error. Therefore, we should restrict loading pickled objects with the mismatched Python version.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Let's assume the Python version for the pickled object is X. 
1. If we load it in a Python version smaller than X, it is possible to crash. Therefore, we need to handle loading exceptions.
2. If we successfully load the object, we need to check whether the Python version is matched. I added a new metadata in the pickled object to store the Python version when pickling, and this will be used for validation after loading.
3. Enable logging error messages when trying to extract the output from remote execution so that the user doesn't need to go to Console to get the error message.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
4. If there is design documentation, please add the link.
-->

## How was this patch tested?
I set the Python version of Jupyter Notebook to 3.11 and built 3 images with different Python versions for remote execution, including 3.9, 3.11, and 3.12.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots
- Remote Python version = 3.12
![image](https://github.com/user-attachments/assets/541133d2-5a58-4999-b17b-762ba10c86eb)
- Remote Python version = 3.11
![image](https://github.com/user-attachments/assets/e734a66d-8672-4ad7-86a2-5416fcf708d6)
- Remote Python version = 3.9
![image](https://github.com/user-attachments/assets/8e9f7652-2928-4521-bfce-f219c8cf09e1)


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
