### PR TITLE
add class methods, unit tests for flytefile and flytedirectory

### DIFF
--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -206,6 +206,23 @@ class FlyteDirectory(SerializableType, DataClassJsonMixin, os.PathLike, typing.G
         remote_path = ctx.file_access.generate_new_custom_path(alt=alt, stem=stem)
         return cls(path=remote_path)
 
+    @classmethod
+    def new(cls, dirname: str | os.PathLike) -> FlyteFile:
+        """
+        Create a new FlyteDirectory object in current Flyte working directory.
+        """
+
+        if os.path.isabs(dirname):
+            raise ValueError("Path should be relative.")
+
+        ctx = FlyteContextManager.current_context()
+
+        path = os.path.join(ctx.user_space_params.working_directory, dirname)
+
+        os.makedirs(path, exist_ok=False)
+
+        return cls(path=path)
+
     def __class_getitem__(cls, item: typing.Union[typing.Type, str]) -> typing.Type[FlyteDirectory]:
         if item is None:
             return cls
@@ -405,6 +422,13 @@ class FlyteDirectory(SerializableType, DataClassJsonMixin, os.PathLike, typing.G
 
     def __str__(self):
         return str(self.path)
+
+    def __truediv__(self, other: str | os.PathLike) -> Path:
+        """
+        This is a convenience method to allow for easy concatenation of paths.
+        """
+
+        return Path(self.path) / other
 
 
 class FlyteDirToMultipartBlobTransformer(AsyncTypeTransformer[FlyteDirectory]):

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -214,6 +214,21 @@ class FlyteFile(SerializableType, os.PathLike, typing.Generic[T], DataClassJSONM
         t = FlyteFilePathTransformer()
         return t.to_python_value(ctx, lit, cls)
 
+    @classmethod
+    def new(cls, filename: str | os.PathLike) -> FlyteFile:
+        """
+        Create a new FlyteFile object in the current Flyte working directory
+        """
+
+        if os.path.isabs(filename):
+            raise ValueError("Path should be relative.")
+
+        ctx = FlyteContextManager.current_context()
+
+        path = os.path.join(ctx.user_space_params.working_directory, filename)
+
+        return cls(path=path)
+
     def __class_getitem__(cls, item: typing.Union[str, typing.Type]) -> typing.Type[FlyteFile]:
         from flytekit.types.file import FileExt
 

--- a/tests/flytekit/unit/types/directory/test_types.py
+++ b/tests/flytekit/unit/types/directory/test_types.py
@@ -1,6 +1,6 @@
 import mock
 
-from flytekit import FlyteContext
+from flytekit import FlyteContext, FlyteContextManager
 from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import FlyteFile
 
@@ -26,6 +26,16 @@ def test_new_remote_dir_alt():
     ff = FlyteDirectory.new_remote(alt="my-alt-bucket", stem="my-stem")
     assert "my-alt-bucket" in ff.path
     assert "my-stem" in ff.path
+
+def test_new_auto_new_dir():
+    fd = FlyteDirectory.new("my_dir")
+    assert FlyteContextManager.current_context().user_space_params.working_directory in fd.path
+
+def test_add_path_to_dir():
+    fd = FlyteDirectory.new("my_other_dir")
+    cwd = FlyteContextManager.current_context().user_space_params.working_directory
+    assert cwd in str(fd / "myfile.txt")
+
 
 @mock.patch("flytekit.types.directory.types.os.name", "nt")
 def test_sep_nt():

--- a/tests/flytekit/unit/types/file/test_types.py
+++ b/tests/flytekit/unit/types/file/test_types.py
@@ -5,3 +5,8 @@ def test_new_remote_alt():
     ff = FlyteFile.new_remote_file(alt="my-alt-prefix", name="my-file.txt")
     assert "my-alt-prefix" in ff.path
     assert "my-file.txt" in ff.path
+
+def test_new_auto_file():
+    ff = FlyteFile.new("my-file.txt")
+    cwd = FlyteContextManager.current_context().user_space_params.working_directory
+    assert cwd in ff.path


### PR DESCRIPTION
I feel like it is verbose to get the working directory (`flytekit.current_context().working_directory`) in a task. I find myself doing this very, very frequently, primarily to write files. I use the working directory so that files won’t get written to my local working directory during local execution.

I had thought about this for a while, and the more I thought about what exactly I wanted to accomplish, I feel like it should be accomplished with a few new classmethod for `FlyteFile` / `FlyteDirectory`...

-----

This task...

```python
@task
def my_task() -> FlyteFile:
    local_path = os.path.join(current_context().working_directory, "data.txt")
    with open(local_path, mode="w") as file:
        file.write("Here is some sample data.")
    return FlyteFile(path=local_path)
```

Should ideally be replaced with something like this:

```python
@task
def my_task() -> FlyteFile:

    ff = FlyteFile.new('myfile.txt')

    with open(ff, mode="w") as file:
        file.write("Here is some sample data.")

    return ff
```

In this case, `FlyteFile.new` will create a FlyteFile with a path of the filename inside of the working directory (`current_context().working_directory`).

-----

The same goes for FlyteDirectory...

```python
@task
def my_task() -> FlyteDirectory:

    p = os.path.join(current_context().working_directory, "my_new_directory")

    os.makedirs(p)

    with open(os.path.join(p, "file_1.txt"), 'w') as file:
        file.write("This is file 1.")

    return FlyteDirectory(p)
```

Should be replaced with:

```python
@task
def my_task() -> FlyteDirectory:

    dir = FlyteDirectory.new('my_new_directory')

    with open(dir / "file_1.txt", 'w') as file:
        file.write("This is file 1.")

    return dir
```

In this case, `FlyteDirectory.new` will create the directory `my_new_directory` under `current_context().working_directory`, and ensure that it exists (`os.makedirs(dir.path)`)

Additionally, I am overloading the `__truedivide__` operator to `FlyteDirectory` for convenience:

```python

class FlyteDirectory:

    ...

    def __truedivide__(self, other: str | os.PathLike) -> Path:
        """
        This is a convenience method to allow for easy concatenation of paths.
        """
        return Path(self.path) / other
```
