### PR TITLE
add `__hash__` method to `FlyteFile` to fix bug during interactive mode

### DIFF
--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -372,6 +372,9 @@ class FlyteFile(SerializableType, os.PathLike, typing.Generic[T], DataClassJSONM
     def __str__(self):
         return self.path
 
+    def __hash__(self):
+        return hash(self._serialize()["path"])
+
 
 class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
     def __init__(self):


### PR DESCRIPTION
This task will fail only in a notebook. It will not fail when running locally as a python script, running locally via pyflyte, or running remotely.

```python
import flytekit as fk

@fk.task
def write_file(message: str) -> fk.FlyteFile:

    ff = fk.FlyteFile(path='myfile.txt')

    with open(ff, mode="w") as file:
        file.write(message)

    return ff

write_file(message='hello world')
```

```
> TypeError: Error encountered while executing '968396757.write_file':
  unhashable type: 'FlyteFile'
```

This can be fixed by adding the `__hash__` method to `FlyteFile`. I am creating the hash from the serialized representation of the `FlyteFile`.