### PR TITLE
Remove pickle batching

### DIFF
--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -7,7 +7,6 @@ import os  # TODO: use flytekit logger
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union, cast
 
-import typing_extensions
 from flyteidl.core import tasks_pb2
 
 from flytekit.configuration import SerializationSettings
@@ -18,7 +17,7 @@ from flytekit.core.context_manager import ExecutionState, FlyteContext, FlyteCon
 from flytekit.core.interface import transform_interface_to_list_interface
 from flytekit.core.launch_plan import LaunchPlan
 from flytekit.core.python_function_task import PythonFunctionTask, PythonInstanceTask
-from flytekit.core.type_engine import TypeEngine, TypeTransformer, is_annotated
+from flytekit.core.type_engine import TypeEngine
 from flytekit.core.utils import timeit
 from flytekit.loggers import logger
 from flytekit.models import literals as _literal_models
@@ -27,8 +26,6 @@ from flytekit.models.core.workflow import NodeMetadata
 from flytekit.models.interface import Variable
 from flytekit.models.task import Container, K8sPod, Sql, Task
 from flytekit.tools.module_loader import load_object_from_module
-from flytekit.types.pickle import pickle
-from flytekit.types.pickle.pickle import FlytePickleTransformer
 from flytekit.utils.asyn import loop_manager
 
 if TYPE_CHECKING:
@@ -76,16 +73,6 @@ class ArrayNodeMapTask(PythonTask):
             raise ValueError(
                 "Only PythonFunctionTask with default execution mode (not @dynamic or @eager) and PythonInstanceTask are supported in map tasks."
             )
-
-        for k, v in actual_task.python_interface.inputs.items():
-            if bound_inputs and k in bound_inputs:
-                continue
-            transformer: TypeTransformer = TypeEngine.get_transformer(v)
-            if isinstance(transformer, FlytePickleTransformer):
-                if is_annotated(v):
-                    for annotation in typing_extensions.get_args(v)[1:]:
-                        if isinstance(annotation, pickle.BatchSize):
-                            raise ValueError("Choosing a BatchSize for map tasks inputs is not supported.")
 
         n_outputs = len(actual_task.python_interface.outputs)
         if n_outputs > 1:

--- a/flytekit/types/pickle/__init__.py
+++ b/flytekit/types/pickle/__init__.py
@@ -10,4 +10,4 @@ Flytekit Pickle Type
    FlytePickle
 """
 
-from .pickle import BatchSize, FlytePickle
+from .pickle import FlytePickle

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -13,19 +13,6 @@ from flytekit.models.types import LiteralType
 T = typing.TypeVar("T")
 
 
-class BatchSize:
-    """
-    Flyte-specific object used to wrap the hash function for a specific type
-    """
-
-    def __init__(self, val: int):
-        self._val = val
-
-    @property
-    def val(self) -> int:
-        return self._val
-
-
 class FlytePickle(typing.Generic[T]):
     """
     This type is only used by flytekit internally. User should not use this type.

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -25,7 +25,6 @@ from flytekit.models.literals import (
     LiteralOffloadedMetadata,
 )
 from flytekit.tools.translator import get_serializable, Options
-from flytekit.types.pickle import BatchSize
 
 
 @pytest.fixture
@@ -102,13 +101,6 @@ def test_remote_execution(serialization_settings):
 
 
 def test_map_task_with_pickle():
-    @task
-    def say_hello(name: Annotated[typing.Any, BatchSize(10)]) -> str:
-        return f"hello {name}!"
-
-    with pytest.raises(ValueError, match="Choosing a BatchSize for map tasks inputs is not supported."):
-        map_task(say_hello)(name=["abc", "def"])
-
     @task
     def say_hello(name: typing.Any) -> str:
         return f"hello {name}!"

--- a/tests/flytekit/unit/core/test_promise.py
+++ b/tests/flytekit/unit/core/test_promise.py
@@ -23,7 +23,6 @@ from flytekit.core.type_engine import TypeEngine
 from flytekit.exceptions.user import FlyteAssertion, FlytePromiseAttributeResolveException
 from flytekit.models import literals as literal_models
 from flytekit.models.types import LiteralType, SimpleType, TypeStructure
-from flytekit.types.pickle.pickle import BatchSize
 
 
 def test_create_and_link_node():
@@ -141,7 +140,7 @@ class MyDataclass(DataClassJsonMixin):
 )
 def test_translate_inputs_to_literals(input):
     @task
-    def t1(a: typing.Union[float, MyDataclass, Annotated[typing.List[typing.Any], BatchSize(2)]]):
+    def t1(a: typing.Union[float, MyDataclass, typing.List[typing.Any]]):
         print(a)
 
     ctx = context_manager.FlyteContext.current_context()

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -77,7 +77,7 @@ from flytekit.types.file.file import FlyteFile, FlyteFilePathTransformer, noop
 from flytekit.types.iterator.iterator import IteratorTransformer
 from flytekit.types.iterator.json_iterator import JSONIterator, JSONIteratorTransformer, JSON
 from flytekit.types.pickle import FlytePickle
-from flytekit.types.pickle.pickle import BatchSize, FlytePickleTransformer
+from flytekit.types.pickle.pickle import FlytePickleTransformer
 from flytekit.types.schema import FlyteSchema
 from flytekit.types.structured.structured_dataset import StructuredDataset, StructuredDatasetTransformerEngine, PARQUET
 
@@ -441,16 +441,6 @@ def test_dir_no_downloader_default():
     pv = transformer.to_python_value(ctx, lv, expected_python_type=FlyteDirectory)
     assert isinstance(pv, FlyteDirectory)
     assert pv.download() == local_dir
-
-
-def test_dir_with_batch_size():
-    flyte_dir = Annotated[FlyteDirectory, BatchSize(100)]
-    val = flyte_dir("s3://bucket/key")
-    transformer = TypeEngine.get_transformer(flyte_dir)
-    ctx = FlyteContext.current_context()
-    lt = transformer.get_literal_type(flyte_dir)
-    lv = transformer.to_literal(ctx, val, flyte_dir, lt)
-    assert val.path == transformer.to_python_value(ctx, lv, flyte_dir).remote_source
 
 
 def test_dict_transformer():
@@ -2723,78 +2713,6 @@ def test_file_ext_with_flyte_file_wrong_type():
     with pytest.raises(ValueError) as e:
         FlyteFile[WRONG_TYPE]
     assert str(e.value) == "Underlying type of File Extension must be of type <str>"
-
-
-def test_is_batchable():
-    assert ListTransformer.is_batchable(typing.List[int]) is False
-    assert ListTransformer.is_batchable(typing.List[str]) is False
-    assert ListTransformer.is_batchable(typing.List[typing.Dict]) is False
-    assert ListTransformer.is_batchable(typing.List[typing.Dict[str, FlytePickle]]) is False
-    assert ListTransformer.is_batchable(typing.List[typing.List[FlytePickle]]) is False
-
-    assert ListTransformer.is_batchable(typing.List[FlytePickle]) is True
-    assert ListTransformer.is_batchable(Annotated[typing.List[FlytePickle], BatchSize(3)]) is True
-    assert (
-            ListTransformer.is_batchable(Annotated[typing.List[FlytePickle], HashMethod(function=str), BatchSize(3)])
-            is True
-    )
-
-
-@pytest.mark.parametrize(
-    "python_val, python_type, expected_list_length",
-    [
-        # Case 1: List of FlytePickle objects with default batch size.
-        # (By default, the batch_size is set to the length of the whole list.)
-        # After converting to literal, the result will be [batched_FlytePickle(5 items)].
-        # Therefore, the expected list length is [1].
-        ([{"foo"}] * 5, typing.List[FlytePickle], [1]),
-        # Case 2: List of FlytePickle objects with batch size 2.
-        # After converting to literal, the result will be
-        # [batched_FlytePickle(2 items), batched_FlytePickle(2 items), batched_FlytePickle(1 item)].
-        # Therefore, the expected list length is [3].
-        (
-                ["foo"] * 5,
-                Annotated[typing.List[FlytePickle], HashMethod(function=str), BatchSize(2)],
-                [3],
-        ),
-        # Case 3: Nested list of FlytePickle objects with batch size 2.
-        # After converting to literal, the result will be
-        # [[batched_FlytePickle(3 items)], [batched_FlytePickle(3 items)]]
-        # Therefore, the expected list length is [2, 1] (the length of the outer list remains the same, the inner list is batched).
-        (
-                [["foo", "foo", "foo"]] * 2,
-                typing.List[Annotated[typing.List[FlytePickle], BatchSize(3)]],
-                [2, 1],
-        ),
-        # Case 4: Empty list
-        ([[], typing.List[FlytePickle], []]),
-    ],
-)
-def test_batch_pickle_list(python_val, python_type, expected_list_length):
-    ctx = FlyteContext.current_context()
-    expected = TypeEngine.to_literal_type(python_type)
-    lv = TypeEngine.to_literal(ctx, python_val, python_type, expected)
-
-    tmp_lv = lv
-    for length in expected_list_length:
-        # Check that after converting to literal, the length of the literal list is equal to:
-        # - the length of the original list divided by the batch size if not nested
-        # - the length of the original list if it contains a nested list
-        assert len(tmp_lv.collection.literals) == length
-        tmp_lv = tmp_lv.collection.literals[0]
-
-    pv = TypeEngine.to_python_value(ctx, lv, python_type)
-    # Check that after converting literal to Python value, the result is equal to the original python values.
-    assert pv == python_val
-    if get_origin(python_type) is Annotated:
-        pv = TypeEngine.to_python_value(ctx, lv, get_args(python_type)[0])
-        # Remove the annotation and check that after converting to Python value, the result is equal
-        # to the original input values. This is used to simulate the following case:
-        # @workflow
-        # def wf():
-        #     data = task0()  # task0() -> Annotated[typing.List[FlytePickle], BatchSize(2)]
-        #     task1(data=data)  # task1(data: typing.List[FlytePickle])
-        assert pv == python_val
 
 
 @pytest.mark.parametrize(

--- a/tests/flytekit/unit/types/pickle/test_flyte_pickle.py
+++ b/tests/flytekit/unit/types/pickle/test_flyte_pickle.py
@@ -16,7 +16,7 @@ from flytekit.models.core.types import BlobType
 from flytekit.models.literals import BlobMetadata
 from flytekit.models.types import LiteralType
 from flytekit.tools.translator import get_serializable
-from flytekit.types.pickle.pickle import BatchSize, FlytePickle, FlytePickleTransformer
+from flytekit.types.pickle.pickle import FlytePickle, FlytePickleTransformer
 
 default_img = Image(name="default", fqn="test", tag="tag")
 serialization_settings = flytekit.configuration.SerializationSettings(
@@ -57,11 +57,6 @@ def test_get_literal_type():
     )
     expected_lt.metadata = {"python_class_name": str(FlytePickle)}
     assert lt == expected_lt
-
-
-def test_batch_size():
-    bs = BatchSize(5)
-    assert bs.val == 5
 
 
 def test_nested():


### PR DESCRIPTION
## Why are the changes needed?
Removing support for the BatchSize in the list of flyte pickle use-case.  This is a breaking change, but we think this feature was rarely used, and should be less needed now that the uploading/downloading of pickles is done through async.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
