### PR TITLE
Updated jupyter interaction

### DIFF
--- a/flytekit/models/core/execution.py
+++ b/flytekit/models/core/execution.py
@@ -147,6 +147,9 @@ class ExecutionError(_common.FlyteIdlEntity):
         """
         return cls(code=p.code, message=p.message, error_uri=p.error_uri, kind=p.kind)
 
+    def _repr_html_(self) -> str:
+        return f"<b>{self.code}</b> <pre>{self.message}</pre>"
+
 
 class TaskLog(_common.FlyteIdlEntity):
     class MessageFormat(object):

--- a/flytekit/remote/executions.py
+++ b/flytekit/remote/executions.py
@@ -181,13 +181,15 @@ class FlyteWorkflowExecution(RemoteExecutionBase, execution_models.Execution):
 
     def _repr_html_(self) -> str:
         if self.execution_url:
-            v = "<b>Execution is in-progress. </b> "
+            u = f"<a href='{self.execution_url}'>{self.execution_url}</a>"
+            s = "<b>Execution is in-progress. </b> "
+            e = ""
             if self.is_done:
                 p = core_execution_models.WorkflowExecutionPhase.enum_to_string(self.closure.phase)
-                v = f"<b>Execution {p}</b>"
+                s = f"<b>Execution {p}. </b>"
                 if self.error:
-                    v += f"<pre>{self.error.message}</pre>"
-            v += f"<a href='{self.execution_url}'>View Execution: {self.execution_url}</a>"
+                    e = f"<pre>{self.error.message}</pre>"
+            return s + u + e
         return super()._repr_html_()
 
 

--- a/flytekit/remote/executions.py
+++ b/flytekit/remote/executions.py
@@ -166,17 +166,15 @@ class FlyteWorkflowExecution(RemoteExecutionBase, execution_models.Execution):
     ) -> "FlyteWorkflowExecution":
         """
         Wait for the execution to complete. This is a blocking call.
+
         :param timeout: The maximum amount of time to wait for the execution to complete. It can be a timedelta or
-         a duration in seconds as int.
+            a duration in seconds as int.
         :param poll_interval: The amount of time to wait between polling the state of the execution. It can be a
             timedelta or a duration in seconds as int.
+        :param sync_nodes: Whether to sync the state of the nodes as well.
         """
         if self._remote is None:
             raise user_exceptions.FlyteAssertion("Cannot wait without a remote")
-        if poll_interval is not None and not isinstance(poll_interval, timedelta):
-            poll_interval = timedelta(seconds=poll_interval)
-        if timeout is not None and not isinstance(timeout, timedelta):
-            timeout = timedelta(seconds=timeout)
         return self._remote.wait(self, timeout=timeout, poll_interval=poll_interval, sync_nodes=sync_nodes)
 
     def _repr_html_(self) -> str:

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -245,7 +245,7 @@ class FlyteRemote(object):
         default_project: typing.Optional[str] = None,
         default_domain: typing.Optional[str] = None,
         data_upload_location: str = "flyte://my-s3-bucket/",
-        interactive_mode_enabled: bool = False,
+        interactive_mode_enabled: typing.Optional[bool] = None,
         **kwargs,
     ):
         """Initialize a FlyteRemote object.
@@ -256,10 +256,15 @@ class FlyteRemote(object):
         :param default_domain: default domain to use when fetching or executing flyte entities.
         :param data_upload_location: this is where all the default data will be uploaded when providing inputs.
             The default location - `s3://my-s3-bucket/data` works for sandbox/demo environment. Please override this for non-sandbox cases.
-        :param interactive_mode_enabled: If set to True, the FlyteRemote will pickle the task/workflow.
+        :param interactive_mode_enabled: If set to True, the FlyteRemote will pickle the task/workflow, if False,
+         it will not. If set to None, then it will automatically detect if it is running in an interactive environment
+         like a Jupyter notebook and enable interactive mode.
         """
         if config is None or config.platform is None or config.platform.endpoint is None:
             raise user_exceptions.FlyteAssertion("Flyte endpoint should be provided.")
+
+        if interactive_mode_enabled is None:
+            interactive_mode_enabled = ipython_check()
 
         if interactive_mode_enabled is True:
             logger.warning("Jupyter notebook and interactive task support is still alpha.")
@@ -2106,18 +2111,25 @@ class FlyteRemote(object):
     def wait(
         self,
         execution: FlyteWorkflowExecution,
-        timeout: typing.Optional[timedelta] = None,
-        poll_interval: typing.Optional[timedelta] = None,
+        timeout: typing.Optional[typing.Union[timedelta, int]] = None,
+        poll_interval: typing.Optional[typing.Union[timedelta, int]] = None,
         sync_nodes: bool = True,
     ) -> FlyteWorkflowExecution:
         """Wait for an execution to finish.
 
         :param execution: execution object to wait on
-        :param timeout: maximum amount of time to wait
-        :param poll_interval: sync workflow execution at this interval
+        :param timeout: maximum amount of time to wait. It can be a timedelta or a
+            duration in seconds as int.
+        :param poll_interval: sync workflow execution at this interval. It can be a
+            timedelta or a duration in seconds as int.
         :param sync_nodes: passed along to the sync call for the workflow execution
         """
+        if poll_interval is not None and not isinstance(poll_interval, timedelta):
+            poll_interval = timedelta(seconds=poll_interval)
         poll_interval = poll_interval or timedelta(seconds=30)
+
+        if timeout is not None and not isinstance(timeout, timedelta):
+            timeout = timedelta(seconds=timeout)
         time_to_give_up = datetime.max if timeout is None else datetime.now() + timeout
 
         while datetime.now() < time_to_give_up:


### PR DESCRIPTION
Simplified interaction with executions from Jupyter.

1. Automatic detection of Interactive Mode / Jupyter Environment, with ability to Force disable
2. for exe = remote.execute(...)
3. Explicitly get execution url  `exe.execution_url`
4. Jupyter automatically pretty prints execution to point to URL and if failed shows error
5. Wait for execution to complete `exe = exe.wait(poll_interval=1)`
6. OR sync manually `exe.sync`
