### PR TITLE
Type Mismatching while Serializing Dataclass with Union 

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -683,7 +683,9 @@ class DataclassTransformer(TypeTransformer[object]):
 
             def get_expected_type(python_val: T, types: tuple) -> Type[T | None]:
                 if len(set(types) & {FlyteFile, FlyteDirectory, StructuredDataset}) > 1:
-                    raise ValueError("Cannot have two Flyte types in a Union type")
+                    raise ValueError(
+                        "Cannot have more than one Flyte type in the Union when attempting to use the string shortcut. Please specify the full object (e.g. FlyteFile(...)) instead of just passing a string."
+                    )
 
                 for t in types:
                     try:

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -676,11 +676,15 @@ class DataclassTransformer(TypeTransformer[object]):
         """
         from flytekit.types.directory import FlyteDirectory
         from flytekit.types.file import FlyteFile
+        from flytekit.types.structured import StructuredDataset
 
         # Handle Optional
         if UnionTransformer.is_optional_type(python_type):
 
             def get_expected_type(python_val: T, types: tuple) -> Type[T | None]:
+                if len(set(types) & {FlyteFile, FlyteDirectory, StructuredDataset}) > 1:
+                    raise ValueError("Cannot have two Flyte types in a Union type")
+
                 for t in types:
                     try:
                         trans = TypeEngine.get_transformer(t)  # type: ignore

--- a/tests/flytekit/unit/core/test_dataclass.py
+++ b/tests/flytekit/unit/core/test_dataclass.py
@@ -1118,3 +1118,17 @@ def test_pure_frozen_dataclasses_with_flyte_types(local_dummy_txt_file, local_du
 
     empty_nested_flyte_types = empty_nested_dc_wf()
     DataclassTransformer().assert_type(NestedFlyteTypes, empty_nested_flyte_types)
+
+def test_dataclass_serialize_with_multiple_dataclass_union():
+    @dataclass
+    class A():
+        x: int
+
+    @dataclass
+    class B():
+        x: FlyteFile
+
+    b = B(x="s3://my-bucket/my-file")
+    res = DataclassTransformer()._make_dataclass_serializable(b, Union[None, A, B])
+
+    assert res.x.path == "s3://my-bucket/my-file"

--- a/tests/flytekit/unit/core/test_flytetypes.py
+++ b/tests/flytekit/unit/core/test_flytetypes.py
@@ -14,4 +14,3 @@ def test_dataclass_union_with_multiple_flytetypes_error():
     dc = DC(x="s3://my-bucket/my-file")
     with pytest.raises(ValueError, match="Cannot have two Flyte types in a Union type"):
         DataclassTransformer()._make_dataclass_serializable(dc, DC)
-

--- a/tests/flytekit/unit/core/test_flytetypes.py
+++ b/tests/flytekit/unit/core/test_flytetypes.py
@@ -14,4 +14,4 @@ def test_dataclass_union_with_multiple_flytetypes_error():
     dc = DC(x="s3://my-bucket/my-file")
     with pytest.raises(ValueError, match="Cannot have two Flyte types in a Union type"):
         DataclassTransformer()._make_dataclass_serializable(dc, DC)
-    
+

--- a/tests/flytekit/unit/core/test_flytetypes.py
+++ b/tests/flytekit/unit/core/test_flytetypes.py
@@ -4,13 +4,14 @@ from flytekit.types.structured.structured_dataset import StructuredDataset
 from flytekit.core.type_engine import DataclassTransformer
 from typing import Union
 import pytest
+import re
 
 def test_dataclass_union_with_multiple_flytetypes_error():
     @dataclass
     class DC():
-        x: Union[None, FlyteFile, StructuredDataset]
+        x: Union[None, StructuredDataset, FlyteFile]
 
 
     dc = DC(x="s3://my-bucket/my-file")
-    with pytest.raises(ValueError, match="Cannot have two Flyte types in a Union type"):
+    with pytest.raises(ValueError, match=re.escape("Cannot have more than one Flyte type in the Union when attempting to use the string shortcut. Please specify the full object (e.g. FlyteFile(...)) instead of just passing a string.")):
         DataclassTransformer()._make_dataclass_serializable(dc, DC)

--- a/tests/flytekit/unit/core/test_flytetypes.py
+++ b/tests/flytekit/unit/core/test_flytetypes.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+from flytekit.types.file import FlyteFile
+from flytekit.types.structured.structured_dataset import StructuredDataset
+from flytekit.core.type_engine import DataclassTransformer
+from typing import Union
+import pytest
+
+def test_dataclass_union_with_multiple_flytetypes_error():
+    @dataclass
+    class DC():
+        x: Union[None, FlyteFile, StructuredDataset]
+
+
+    dc = DC(x="s3://my-bucket/my-file")
+    with pytest.raises(ValueError, match="Cannot have two Flyte types in a Union type"):
+        DataclassTransformer()._make_dataclass_serializable(dc, DC)
+    

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -967,6 +967,7 @@ def test_optional_flytefile_in_dataclass(mock_upload_dir):
         b: typing.Optional[FlyteFile]
         b_prime: typing.Optional[FlyteFile]
         c: typing.Union[FlyteFile, None]
+        c_prime: typing.Union[None, FlyteFile]
         d: typing.List[FlyteFile]
         e: typing.List[typing.Optional[FlyteFile]]
         e_prime: typing.List[typing.Optional[FlyteFile]]
@@ -989,6 +990,7 @@ def test_optional_flytefile_in_dataclass(mock_upload_dir):
             b=f1,
             b_prime=None,
             c=f1,
+            c_prime=f1,
             d=[f1],
             e=[f1],
             e_prime=[None],
@@ -1011,6 +1013,7 @@ def test_optional_flytefile_in_dataclass(mock_upload_dir):
         assert dict_obj["b"]["path"] == remote_path
         assert dict_obj["b_prime"] is None
         assert dict_obj["c"]["path"] == remote_path
+        assert dict_obj["c_prime"]["path"] == remote_path
         assert dict_obj["d"][0]["path"] == remote_path
         assert dict_obj["e"][0]["path"] == remote_path
         assert dict_obj["e_prime"][0] is None
@@ -1028,6 +1031,7 @@ def test_optional_flytefile_in_dataclass(mock_upload_dir):
         assert o.b.remote_path == ot.b.remote_source
         assert ot.b_prime is None
         assert o.c.remote_path == ot.c.remote_source
+        assert o.c_prime.remote_path == ot.c_prime.remote_source
         assert o.d[0].remote_path == ot.d[0].remote_source
         assert o.e[0].remote_path == ot.e[0].remote_source
         assert o.e_prime == [None]


### PR DESCRIPTION
## Tracking issue
Closes flyteorg/flyte#5910

## Why are the changes needed?
While converting dataclasses from Python types to literal types through the `to_literal` function, the dataclass will pass through the `_make_dataclass_serializable` function to ensure it can be serialized later. For dataclasses with `Union` properties, under the `if UnionTransformer.is_optional_type(python_type):` statement, it uses `get_args(python_type)[0]` as the type of the property without verifying its compatibility. This will cause an error if the first argument is not the expected type.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
1. Do typing matching instead of using the first type from `get_args(python_type)`
2. Add unit tests for more possible union types
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
3. If there is design documentation, please add the link.
-->

## How was this patch tested?
1. Run on local and remote execution

- Union[None, FlyteFile]
`flytefile_serialize.py`
```py
from dataclasses import dataclass
from flytekit import task
from flytekit.types.file import FlyteFile
from typing import Union
from flytekit.image_spec import ImageSpec

flytekit_hash = "f647bd3a1b727082210454c3f5d1e652a29b1083"
flytekit = f"git+https://github.com/mao3267/flytekit.git@{flytekit_hash}"

image_spec = ImageSpec(
    name="serialize-union-1",
    packages=[flytekit],
    builder="default",
    registry="localhost:30000",
    apt_packages=["git", "gh"],
)

@dataclass
class InnerDC:
    ff: Union[None, FlyteFile]

@dataclass
class DC:
    inner_dc: InnerDC

@task(container_image=image_spec)
def t_dc() -> DC:
    return DC(inner_dc=InnerDC(ff="s3://path"))
```
   - Union[None, int, str] 
`serialize_union.py`
```py
from dataclasses import dataclass
from flytekit import task
from typing import Union
from flytekit.image_spec import ImageSpec

flytekit_hash = "f647bd3a1b727082210454c3f5d1e652a29b1083"
flytekit = f"git+https://github.com/mao3267/flytekit.git@{flytekit_hash}"

image_spec = ImageSpec(
    name="serialize-union-1",
    packages=[flytekit],
    builder="default",
    registry="localhost:30000",
    apt_packages=["git", "gh"],
)

@dataclass
class InnerDC:
    ff: Union[None, int, str]

@dataclass
class DC:
    inner_dc: InnerDC

@task(container_image=image_spec)
def t_dc() -> DC:
    return DC(inner_dc=InnerDC(ff="string"))
```
2. Add unit tests in `test_type_engine.py`
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
```
git clone https://github.com/flyteorg/flytekit.git
gh pr checkout 2859
pip install -e .
```
### Screenshots
- Local
     - Union[None, FlyteFile]
![image](https://github.com/user-attachments/assets/b3242f92-ac60-4281-a3af-16cc15ce3aca)
     - Union[None, int, str]
![image](https://github.com/user-attachments/assets/d6e086e3-9a45-4c68-adeb-fa696e294f4e)
- Remote
    - Union[None, int, str] 
![image](https://github.com/user-attachments/assets/6e9e6b1c-0f00-4992-a8d7-a6b0d87d8437)

    - Union[None, int, str] 
![image](https://github.com/user-attachments/assets/18b6db16-9621-45a6-8732-8ed0a8bf7281)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
None
<!-- Add related pull requests for reviewers to check -->

## Docs link
None
<!-- Add documentation link built by CI jobs here, and specify the changed place -->
