### PR TITLE
[Docs] Flytekit README link not working in the File an Issue section

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can find the detailed contribution guide [here](https://docs.flyte.org/en/la
 Please see the [contributor's guide](https://docs.flyte.org/en/latest/api/flytekit/contributing.html) for a quick summary of how this code is structured.
 
 ## 🐞 File an Issue
-Refer to the [issues](https://docs.flyte.org/en/latest/community/contribute.html#file-an-issue) section in the contribution guide if you'd like to file an issue.
+Refer to the [issues](https://github.com/flyteorg/flyte/issues) section in the contribution guide if you'd like to file an issue.
 
 ## 🔌 Flytekit Plugins
 Refer to [plugins/README.md](plugins/README.md) for a list of available plugins.


### PR DESCRIPTION
## Tracking issue
Related to flyteorg/flyte#5894
<!-- Remove this section if not applicable -->

## Why are the changes needed?

The link here is not working, so I proposed this PR to change it.

## What changes were proposed in this pull request?

Change the not working link to [this](https://github.com/flyteorg/flyte/issues)

### Setup process

### Screenshots

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

flyteorg/flyte#5894

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
