### PR TITLE
Support overriding node metadata for array node

### DIFF
--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -587,6 +587,7 @@ def get_serializable_array_node(
     options: Optional[Options] = None,
 ) -> ArrayNodeModel:
     array_node = node.flyte_entity
+    # pass in parent node metadata to be set for subnode
     array_node.metadata = node.metadata
     return ArrayNodeModel(
         node=get_serializable_node(entity_mapping, settings, array_node, options=options),

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -429,7 +429,7 @@ def get_serializable_node(
     if isinstance(entity.flyte_entity, ArrayNode):
         node_model = workflow_model.Node(
             id=_dnsify(entity.id),
-            metadata=entity.flyte_entity.construct_node_metadata(),
+            metadata=entity.metadata,
             inputs=entity.bindings,
             upstream_node_ids=[n.id for n in upstream_nodes],
             output_aliases=[],
@@ -587,6 +587,7 @@ def get_serializable_array_node(
     options: Optional[Options] = None,
 ) -> ArrayNodeModel:
     array_node = node.flyte_entity
+    array_node.metadata = node.metadata
     return ArrayNodeModel(
         node=get_serializable_node(entity_mapping, settings, array_node, options=options),
         parallelism=array_node.concurrency,

--- a/tests/flytekit/unit/core/test_array_node.py
+++ b/tests/flytekit/unit/core/test_array_node.py
@@ -94,23 +94,23 @@ def test_lp_serialization(target, overrides_metadata, serialization_settings):
     wf_spec = get_serializable(OrderedDict(), serialization_settings, target(serialization_settings))
     assert len(wf_spec.template.nodes) == 1
 
-    top_level = wf_spec.template.nodes[0]
-    assert top_level.inputs[0].var == "a"
-    assert len(top_level.inputs[0].binding.collection.bindings) == 3
-    for binding in top_level.inputs[0].binding.collection.bindings:
+    parent_node = wf_spec.template.nodes[0]
+    assert parent_node.inputs[0].var == "a"
+    assert len(parent_node.inputs[0].binding.collection.bindings) == 3
+    for binding in parent_node.inputs[0].binding.collection.bindings:
         assert binding.scalar.primitive.integer is not None
-    assert top_level.inputs[1].var == "b"
-    for binding in top_level.inputs[1].binding.collection.bindings:
+    assert parent_node.inputs[1].var == "b"
+    for binding in parent_node.inputs[1].binding.collection.bindings:
         assert (binding.scalar.union is not None or
                 binding.scalar.primitive.integer is not None or
                 binding.scalar.primitive.string_value is not None)
-    assert len(top_level.inputs[1].binding.collection.bindings) == 3
-    assert top_level.inputs[2].var == "c"
-    assert len(top_level.inputs[2].binding.collection.bindings) == 3
-    for binding in top_level.inputs[2].binding.collection.bindings:
+    assert len(parent_node.inputs[1].binding.collection.bindings) == 3
+    assert parent_node.inputs[2].var == "c"
+    assert len(parent_node.inputs[2].binding.collection.bindings) == 3
+    for binding in parent_node.inputs[2].binding.collection.bindings:
         assert binding.scalar.primitive.integer is not None
 
-    serialized_array_node = top_level.array_node
+    serialized_array_node = parent_node.array_node
     assert (
             serialized_array_node.node.workflow_node.launchplan_ref.resource_type
             == identifier_models.ResourceType.LAUNCH_PLAN
@@ -123,12 +123,16 @@ def test_lp_serialization(target, overrides_metadata, serialization_settings):
     assert serialized_array_node._parallelism == 10
 
     subnode = serialized_array_node.node
-    assert subnode.inputs == top_level.inputs
+    assert subnode.inputs == parent_node.inputs
 
     if overrides_metadata:
+        assert parent_node.metadata.cacheable
+        assert parent_node.metadata.cache_version == "1.0"
         assert subnode.metadata.cacheable
         assert subnode.metadata.cache_version == "1.0"
     else:
+        assert not parent_node.metadata.cacheable
+        assert not parent_node.metadata.cache_version
         assert not subnode.metadata.cacheable
         assert not subnode.metadata.cache_version
 


### PR DESCRIPTION
## Tracking issue
fixes: https://linear.app/unionai/issue/COR-2090/enable-caching-when-mapping-over-launchplans

## Why are the changes needed?
with_overrides doesn't work for array node. 

solution:
`map_task(my_wf_lp)(a=[1, 2, 3], b=[4, 5, 6]).with_overrides(cache=True, cache_version="3.0")`

overrides node metadata for the node that encompasses the array node. This is then copied down into the array node's subnode causing for the node metadata to then be utilized when the nodes are executed. Note, the parent node's node metadata isn't utilized in propeller.

```
class NodeMetadata(_common.FlyteIdlEntity):
    def __init__(
        self,
        name,
        timeout=None,
        retries=None,
        interruptible: typing.Optional[bool] = None,
        cacheable: typing.Optional[bool] = None,
        cache_version: typing.Optional[str] = None,
        cache_serializable: typing.Optional[bool] = None,
```
NodeMetadata also doesn't really apply to the parent ArrayNode


Alternative could be to set something like:
`map_task(my_wf_lp.with_overrides(cache=True, cache_version="3.0")`)(a=[1, 2, 3], b=[4, 5, 6])
but that would require some substantial changes with LaunchPlan and differs from the current understanding of with_overrides


## What changes were proposed in this pull request?
- pass in parent node metadata to be set for subnode

cleaned up a little code:
- clean up setting passed in metadata for array node (not used atm)

## How was this patch tested?
- added unit test
- ran E2E in sandbox + [test clusters](https://dogfood.cloud-staging.union.ai/console/projects/flytesnacks/domains/development/executions/ats84xsdqwtj6mxghkg4)

```
@task
def add(a: int, b: int) -> int:
    return a + b


@workflow
def my_wf(a: int, b: int) -> int:
    return add(a=a, b=b)


my_wf_lp = LaunchPlan.get_default_launch_plan(current_context(), my_wf)


@workflow
def parent_wf_3():
    map_task(my_wf_lp)(a=[1, 2, 3], b=[4, 5, 6]).with_overrides(cache=True, cache_version="3.0")
```

```
remote = FlyteRemote(config=Config.auto(), default_project="flytesnacks", default_domain="development")
lp1 = remote.fetch_launch_plan(name="advanced_composition.subworkflow.regression_line_wf",
                               version="k9cgEFiW1sCkKqQhLYbn0Q")


@workflow
def test_wf1_remote():

    val = [1, 2, 3]
    x = [[-3, 0, 3], [-8, 2, 4], [7, 3, 1]]
    y = [[7, 4, -2], [-2, 4, 7], [3, 6, 4]]
    map_task(lp1)(val=val, x=x, y=y).with_overrides(cache=True, cache_version="2.0")

```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
