### PR TITLE
Support Identifier in generate_console_url

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2492,6 +2492,7 @@ class FlyteRemote(object):
             FlyteWorkflow,
             FlyteTask,
             WorkflowExecutionIdentifier,
+            Identifier,
             FlyteLaunchPlan,
         ],
     ):
@@ -2506,11 +2507,11 @@ class FlyteRemote(object):
                 entity = entity.id
             return f"{self.generate_console_http_domain()}/console/projects/{entity.project}/domains/{entity.domain}/executions/{entity.name}"  # noqa
 
-        if not isinstance(entity, (FlyteWorkflow, FlyteTask, FlyteLaunchPlan)):
+        if not isinstance(entity, (FlyteWorkflow, FlyteTask, FlyteLaunchPlan, Identifier)):
             raise ValueError(f"Only remote entities can be looked at in the console, got type {type(entity)}")
-        return self.generate_url_from_id(id=entity.id)
 
-    def generate_url_from_id(self, id: Identifier):
+        id = entity if isinstance(entity, Identifier) else entity.id
+
         rt = "workflow"
         if id.resource_type == ResourceType.TASK:
             rt = "task"

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -339,7 +339,7 @@ def register(
                     i = remote.raw_register(
                         cp_entity, serialization_settings, version=version, create_default_launchplan=False
                     )
-                    console_url = remote.generate_url_from_id(id=i)
+                    console_url = remote.generate_console_url(i)
                     print_activation_message = False
                     if is_lp and activate_launchplans:
                         remote.activate_launchplan(i)


### PR DESCRIPTION
## Tracking issue
Follow up to https://github.com/flyteorg/flytekit/pull/2804

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
I do not think we should have another `generate_url_from_*` public API in `FlyteRemote`. We can add `Identifier` support into `generate_console_url`

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR adds identity support to `generate_console_url`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Ran `pyflyte register` and returned the correct URLs.