### PR TITLE
improved output handling in notebooks

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -908,7 +908,7 @@ class FlyteRemote(object):
             ident.name,
             ident.version,
         )
-        ft._python_interface = entity.python_interface
+        ft.python_interface = entity.python_interface
         return ft
 
     def register_workflow(
@@ -943,7 +943,7 @@ class FlyteRemote(object):
         )
 
         fwf = self.fetch_workflow(ident.project, ident.domain, ident.name, ident.version)
-        fwf._python_interface = entity.python_interface
+        fwf.python_interface = entity.python_interface
         return fwf
 
     def fast_register_workflow(
@@ -1255,7 +1255,7 @@ class FlyteRemote(object):
             False,
         )
         flp = self.fetch_launch_plan(ident.project, ident.domain, ident.name, ident.version)
-        flp._python_interface = entity.python_interface
+        flp.python_interface = entity.python_interface
         return flp
 
     ####################
@@ -1909,7 +1909,7 @@ class FlyteRemote(object):
         not_found = False
         try:
             flyte_task: FlyteTask = self.fetch_task(**resolved_identifiers_dict)
-            flyte_task._python_interface = entity.python_interface
+            flyte_task.python_interface = entity.python_interface
         except FlyteEntityNotExistException:
             not_found = True
 
@@ -2015,7 +2015,7 @@ class FlyteRemote(object):
 
         try:
             flyte_lp = self.fetch_launch_plan(**resolved_identifiers_dict)
-            flyte_lp._python_interface = entity.python_interface
+            flyte_lp.python_interface = entity.python_interface
         except FlyteEntityNotExistException:
             logger.info("Try to register default launch plan because it wasn't found in Flyte Admin!")
             default_lp = LaunchPlan.get_default_launch_plan(self.context, entity)
@@ -2087,7 +2087,7 @@ class FlyteRemote(object):
         domain = resolved_identifiers.domain
         try:
             flyte_launchplan: FlyteLaunchPlan = self.fetch_launch_plan(**resolved_identifiers_dict)
-            flyte_launchplan._python_interface = entity.python_interface
+            flyte_launchplan.python_interface = entity.python_interface
         except FlyteEntityNotExistException:
             flyte_launchplan: FlyteLaunchPlan = self.register_launch_plan(
                 entity,

--- a/flytekit/remote/remote_callable.py
+++ b/flytekit/remote/remote_callable.py
@@ -72,3 +72,7 @@ class RemoteEntity(ABC):
     @property
     def python_interface(self) -> Optional["Interface"]:
         return self._python_interface
+
+    @python_interface.setter
+    def python_interface(self, i: Optional["Interface"]):
+        self._python_interface = i

--- a/flytekit/remote/remote_callable.py
+++ b/flytekit/remote/remote_callable.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, Tuple, Type, Union
+from typing import Any, Optional, Tuple, Union
 
 from flytekit.core.context_manager import BranchEvalMode, ExecutionState, FlyteContext
 from flytekit.core.promise import Promise, VoidPromise, create_and_link_node_from_remote, extract_obj_name
@@ -12,7 +12,7 @@ class RemoteEntity(ABC):
     def __init__(self, *args, **kwargs):
         # In cases where we make a FlyteTask/Workflow/LaunchPlan from a locally created Python object (i.e. an @task
         # or an @workflow decorated function), we actually have the Python interface, so
-        self._python_interface: Optional[Dict[str, Type]] = None
+        self._python_interface: Optional["Interface"] = None
 
         super().__init__(*args, **kwargs)
 
@@ -70,5 +70,5 @@ class RemoteEntity(ABC):
         raise AssertionError(f"Remotely fetched entities cannot be run locally. Please mock the {self.name}.execute.")
 
     @property
-    def python_interface(self) -> Optional[Dict[str, Type]]:
+    def python_interface(self) -> Optional["Interface"]:
         return self._python_interface


### PR DESCRIPTION
This adds native capability of retrieving outputs in the right type - for example a dataframe or a tensor as the notebook remembers the original interface.

For example if you have a method that produces a dataframe
![Screenshot 2024-10-25 at 5 26 22 PM](https://github.com/user-attachments/assets/acddfbfa-9b07-4841-8f85-c891c7144961)

it can be directly accessed in correct type - it is also possible to retrieve it as another type like - polars dataframe etc
![Screenshot 2024-10-25 at 5 25 59 PM](https://github.com/user-attachments/assets/46a62fe8-6ab2-40df-9ebc-39163d1ffd5c)

and can be passed to a downstream function
