### PR TITLE
Remove misleading address field from Ray Task

### DIFF
--- a/plugins/flytekit-ray/flytekitplugins/ray/task.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/task.py
@@ -43,7 +43,6 @@ class RayJobConfig:
     head_node_config: typing.Optional[HeadNodeConfig] = None
     enable_autoscaling: bool = False
     runtime_env: typing.Optional[dict] = None
-    address: typing.Optional[str] = None
     shutdown_after_job_finishes: bool = False
     ttl_seconds_after_finished: typing.Optional[int] = None
 
@@ -65,7 +64,7 @@ class RayFunctionTask(PythonFunctionTask):
         self._task_config = task_config
 
     def pre_execute(self, user_params: ExecutionParameters) -> ExecutionParameters:
-        init_params = {"address": self._task_config.address}
+        init_params = {}
 
         ctx = FlyteContextManager.current_context()
         if not ctx.execution_state.is_local_execution():


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/5877

## Why are the changes needed?
The documentation implies that you can run a ray job on an existing cluster by configuring the address but this is not  true since the task still requires users to configure details for a new and dynamically created Ray Cluster. And ray jobs will run on the dynamically created Ray Cluster even if an address is configured. 

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flytesnacks/pull/1765