### PR TITLE
fix enum type assertion with python versions less than 3.12

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -937,7 +937,7 @@ class EnumTransformer(TypeTransformer[enum.Enum]):
             return
 
         val = v.value if isinstance(v, enum.Enum) else v
-        if val not in t:
+        if val not in [t_item.value for t_item in t]:
             raise TypeTransformerFailedError(f"Value {v} is not in Enum {t}")
 
 

--- a/tests/flytekit/unit/core/test_enum_type.py
+++ b/tests/flytekit/unit/core/test_enum_type.py
@@ -1,0 +1,22 @@
+from enum import Enum
+
+from flytekit import task
+
+
+def test_dynamic_local():
+    class Color(Enum):
+        RED = 'red'
+        GREEN = 'green'
+        BLUE = 'blue'
+
+    @task
+    def my_task(c: Color) -> Color:
+        print(c)
+        return c
+
+    @workflow
+    def wf(c: Color) -> Color:
+        return my_task(c=c)
+
+    res = wf(c=Color.RED)
+    assert res == Color.RED

--- a/tests/flytekit/unit/core/test_enum_type.py
+++ b/tests/flytekit/unit/core/test_enum_type.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from flytekit import task
+from flytekit import task, workflow
 
 
 def test_dynamic_local():


### PR DESCRIPTION
## Why are the changes needed?

Follow up on: https://github.com/flyteorg/flytekit/pull/2845

Python versions less than 3.12 don't support using `in` with an `Enum` ([link](https://docs.python.org/3/library/enum.html#enum.EnumType.__contains__)).
> Changed in version 3.12: Before Python 3.12, a TypeError is raised if a non-Enum-member is used in a containment check. 

As a result, the linked previous PR results in a `Reason unsupported operand type(s) for 'in': 'str' and 'EnumType'` error.


## What changes were proposed in this pull request?

Rather than checking the python version, just convert the enum items to a list and use `in` from there.

## How was this patch tested?

```
from enum import Enum

from flytekit import task, workflow


class Color(Enum):
    RED = 'red'
    GREEN = 'green'
    BLUE = 'blue'

@task
def my_task(c: Color) -> Color:
    print(c)
    return c


@workflow
def wf(c: Color) -> Color:
    return my_task(c=c)
```

`union run wf.py wf --c red`

Success with python 3.12 but error with python 3.11.

https://github.com/flyteorg/flyte/issues/5904

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flytekit/pull/2845
