### PR TITLE
[Client API] Get Control Plane Version

### DIFF
--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -1090,5 +1090,14 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
         )
 
     def get_control_plane_version(self) -> str:
+        """
+        Retrieve the Control Plane version from Flyteadmin.
+
+        This method calls Flyteadmin's GetVersion API to obtain the current version information of the control plane.
+        The retrieved version can be used to enable or disable specific features based on the Flyteadmin version.
+
+        Returns:
+            str: The version string of the control plane.
+        """
         version_response = self._stub.GetVersion(_version_pb2.GetVersionRequest(), metadata=self._metadata)
         return version_response.control_plane_version.Version

--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -11,6 +11,7 @@ from flyteidl.admin import project_domain_attributes_pb2 as _project_domain_attr
 from flyteidl.admin import project_pb2 as _project_pb2
 from flyteidl.admin import task_execution_pb2 as _task_execution_pb2
 from flyteidl.admin import task_pb2 as _task_pb2
+from flyteidl.admin import version_pb2 as _version_pb2
 from flyteidl.admin import workflow_attributes_pb2 as _workflow_attributes_pb2
 from flyteidl.admin import workflow_pb2 as _workflow_pb2
 from flyteidl.core import identifier_pb2 as _identifier_pb2
@@ -1087,3 +1088,7 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
                 expires_in=expires_in_pb,
             )
         )
+
+    def get_control_plane_version(self) -> str:
+        version_response = self._stub.GetVersion(_version_pb2.GetVersionRequest(), metadata=self._metadata)
+        return version_response.control_plane_version.Version

--- a/flytekit/clis/sdk_in_container/pyflyte.py
+++ b/flytekit/clis/sdk_in_container/pyflyte.py
@@ -56,6 +56,7 @@ from flytekit.loggers import logger
 )
 @click.pass_context
 def main(ctx, pkgs: typing.List[str], config: str, verbose: int):
+    # TODO: put context here
     """
     Entrypoint for all the user commands.
     """

--- a/flytekit/clis/sdk_in_container/pyflyte.py
+++ b/flytekit/clis/sdk_in_container/pyflyte.py
@@ -56,7 +56,6 @@ from flytekit.loggers import logger
 )
 @click.pass_context
 def main(ctx, pkgs: typing.List[str], config: str, verbose: int):
-    # TODO: put context here
     """
     Entrypoint for all the user commands.
     """

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -762,3 +762,8 @@ def test_register_wf_fast(register):
 def test_fetch_active_launchplan_not_found(register):
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
     assert remote.fetch_active_launchplan(name="basic.list_float_wf.fake_wf") is None
+
+def test_get_control_plane_version():
+    client = _SynchronousFlyteClient(PlatformConfig.for_endpoint("localhost:30080", True))
+    version = client.get_control_plane_version()
+    assert version == "unknown" or version.startswith("v")


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5318

## Design Doc
https://hackmd.io/@Future-Outlier/B1lBcbRgJe

## Why are the changes needed?
This is a part of the gate feature by backend version checking.

## What changes were proposed in this pull request?
add a method `get_control_plane_version` in `class SynchronousFlyteClient(_RawSynchronousFlyteClient)`.

## How was this patch tested?
local and integration test.

### Setup process
```python
from flytekit.configuration import PlatformConfig
from flytekit.clients.friendly import SynchronousFlyteClient as _SynchronousFlyteClient
config = PlatformConfig(endpoint="localhost:30080", insecure=True)
client = _SynchronousFlyteClient(config)
print("Control Plane Version:", client.get_control_plane_version())
```

### Screenshots
Unknown version
<img width="449" alt="image" src="https://github.com/user-attachments/assets/2c059dc5-07eb-488e-8e4e-4f7b8a506809">

Know Version
<img width="439" alt="image" src="https://github.com/user-attachments/assets/9c72c92d-cd2c-449e-a637-22cc78d2d6c0">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

## Docs link

