### PR TITLE
Add support for remote.fetch much like `pyflyte fetch`

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -387,6 +387,14 @@ class FlyteRemote(object):
 
         logger.info(f"Nothing found from {flyte_uri}")
 
+    def fetch(self, uri: str, download_to: str, recursive: bool = False):
+        """
+        Much like `pyflyte fetch` this downloads the literals from a "flyte://..." flyte data URI.
+        This URI can be retrireved from the Flyte Console or by invoking the get_data API.
+        """
+        literal = self.get(uri)
+        return self.download(literal, download_to, recursive)
+
     def remote_context(self):
         """Context manager with remote-specific configuration."""
         return FlyteContextManager.with_context(


### PR DESCRIPTION
## Why are the changes needed?
I think it's nice to have parity here. We could also choose to extend this in the future to support not just the `flyte://` URI protocol but to actually support s3/gcs/etc paths too.

## What changes were proposed in this pull request?

See PR title.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
