### PR TITLE
Make Flytefile and Flytedirectory's copilot local execution work correctly

### DIFF
--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -144,7 +144,9 @@ class ContainerTask(PythonTask):
             if type(input_val) in [FlyteFile, FlyteDirectory]:
                 if not path_k:
                     raise AssertionError(
-                        "FlyteFile and FlyteDirectory commands should not use the syntax: {{.inputs.infile}}"
+                        "FlyteFile and FlyteDirectory commands should not use the template syntax like this: {{.inputs.infile}}\n"
+                        "Please use a path-like syntax, such as: /var/inputs/infile.\n"
+                        "This requirement is due to how Flyte Propeller processes template syntax inputs."
                     )
                 local_flyte_file_or_dir_path = str(input_val)
                 remote_flyte_file_or_dir_path = os.path.join(self._input_data_dir, k)  # type: ignore

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -119,7 +119,7 @@ class ContainerTask(PythonTask):
         import re
 
         input_data_dir = input_data_dir or ""
-        input_regex = fr"{re.escape(input_data_dir)}/(.+)$"
+        input_regex = rf"{re.escape(input_data_dir)}/(.+)$"
         match = re.match(input_regex, cmd)
         if match:
             return match.group(1)
@@ -143,9 +143,11 @@ class ContainerTask(PythonTask):
             input_val = kwargs.get(k)
             if type(input_val) in [FlyteFile, FlyteDirectory]:
                 if not path_k:
-                    raise AssertionError("FlyteFile and FlyteDirectory commands should not use the syntax: {{.inputs.infile}}")
+                    raise AssertionError(
+                        "FlyteFile and FlyteDirectory commands should not use the syntax: {{.inputs.infile}}"
+                    )
                 local_flyte_file_or_dir_path = str(input_val)
-                remote_flyte_file_or_dir_path = os.path.join(self._input_data_dir, k) # type: ignore
+                remote_flyte_file_or_dir_path = os.path.join(self._input_data_dir, k)  # type: ignore
                 volume_binding[local_flyte_file_or_dir_path] = {
                     "bind": remote_flyte_file_or_dir_path,
                     "mode": "rw",

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -118,6 +118,7 @@ class ContainerTask(PythonTask):
         """
         import re
 
+        input_data_dir = input_data_dir or ""
         input_regex = fr"{re.escape(input_data_dir)}/(.+)$"
         match = re.match(input_regex, cmd)
         if match:

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -129,8 +129,7 @@ class ContainerTask(PythonTask):
         """
         We support template-style references to inputs, e.g., "{{.inputs.infile}}".
 
-        For FlyteFile and FlyteDirectory commands, e.g., "/var/inputs/inputs", we extract the key from strings that begin with the specified 
-        `input_data_dir`.
+        For FlyteFile and FlyteDirectory commands, e.g., "/var/inputs/inputs", we extract the key from strings that begin with the specified `input_data_dir`.
         """
         from flytekit.types.directory import FlyteDirectory
         from flytekit.types.file import FlyteFile

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -112,7 +112,7 @@ class ContainerTask(PythonTask):
             return match.group(1)
         return None
 
-    def _extract_path_command_key(self, cmd: str, input_data_dir: str) -> Optional[str]:
+    def _extract_path_command_key(self, cmd: str, input_data_dir: Optional[str]) -> Optional[str]:
         """
         Extract the key from the path-like command using regex.
         """
@@ -145,7 +145,7 @@ class ContainerTask(PythonTask):
                 if not path_k:
                     raise AssertionError("FlyteFile and FlyteDirectory commands should not use the syntax: {{.inputs.infile}}")
                 local_flyte_file_or_dir_path = str(input_val)
-                remote_flyte_file_or_dir_path = os.path.join(self._input_data_dir, k)
+                remote_flyte_file_or_dir_path = os.path.join(self._input_data_dir, k) # type: ignore
                 volume_binding[local_flyte_file_or_dir_path] = {
                     "bind": remote_flyte_file_or_dir_path,
                     "mode": "rw",

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -112,22 +112,40 @@ class ContainerTask(PythonTask):
             return match.group(1)
         return None
 
+    def _extract_path_command_key(self, cmd: str, input_data_dir: str) -> Optional[str]:
+        """
+        Extract the key from the path-like command using regex.
+        """
+        import re
+
+        input_regex = fr"{re.escape(input_data_dir)}/(.+)$"
+        match = re.match(input_regex, cmd)
+        if match:
+            return match.group(1)
+        return None
+
     def _render_command_and_volume_binding(self, cmd: str, **kwargs) -> Tuple[str, Dict[str, Dict[str, str]]]:
         """
         We support template-style references to inputs, e.g., "{{.inputs.infile}}".
+
+        For FlyteFile and FlyteDirectory commands, e.g., "/var/inputs/inputs", we extract the key from strings that begin with the specified 
+        `input_data_dir`.
         """
         from flytekit.types.directory import FlyteDirectory
         from flytekit.types.file import FlyteFile
 
         command = ""
         volume_binding = {}
-        k = self._extract_command_key(cmd)
+        path_k = self._extract_path_command_key(cmd, self._input_data_dir)
+        k = path_k if path_k else self._extract_command_key(cmd)
 
         if k:
             input_val = kwargs.get(k)
             if type(input_val) in [FlyteFile, FlyteDirectory]:
+                if not path_k:
+                    raise AssertionError("FlyteFile and FlyteDirectory commands should not use the syntax: {{.inputs.infile}}")
                 local_flyte_file_or_dir_path = str(input_val)
-                remote_flyte_file_or_dir_path = os.path.join(self._input_data_dir, k.replace(".", "/"))  # type: ignore
+                remote_flyte_file_or_dir_path = os.path.join(self._input_data_dir, k)
                 volume_binding[local_flyte_file_or_dir_path] = {
                     "bind": remote_flyte_file_or_dir_path,
                     "mode": "rw",

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -99,7 +99,10 @@ def test_flytefile_wrong_syntax():
         return flyte_file_io(inputs=ff)
 
     with pytest.raises(
-        AssertionError, match="FlyteFile and FlyteDirectory commands should not use the syntax: {{.inputs.infile}}"
+            AssertionError,
+            match="FlyteFile and FlyteDirectory commands should not use the template syntax like this: {{.inputs.infile}}\n"
+                  "Please use a path-like syntax, such as: /var/inputs/infile.\n"
+                  "This requirement is due to how Flyte Propeller processes template syntax inputs."
     ):
         flyte_file_io_wf()
 

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -70,23 +70,38 @@ def test_flytefile_wrong_syntax():
     dockerfile_name = "Dockerfile.raw_container"
     client.images.build(path=path_to_dockerfile, dockerfile=dockerfile_name, tag="flytekit:rawcontainer")
 
+    flyte_file_io = ContainerTask(
+        name="flyte_file_io",
+        input_data_dir="/var/inputs",
+        output_data_dir="/var/outputs",
+        inputs=kwtypes(inputs=FlyteFile),
+        outputs=kwtypes(out=FlyteFile),
+        image="flytekit:rawcontainer",
+        command=[
+            "python",
+            "write_flytefile.py",
+            "{{.inputs.inputs}}",
+            "/var/outputs/out",
+        ],
+    )
+
+    @task
+    def flyte_file_task() -> FlyteFile:
+        working_dir = flytekit.current_context().working_directory
+        write_file = os.path.join(working_dir, "flyte_file.txt")
+        with open(write_file, "w") as file:
+            file.write("This is flyte_file.txt file.")
+        return FlyteFile(path=write_file)
+
+    @workflow
+    def flyte_file_io_wf() -> FlyteFile:
+        ff = flyte_file_task()
+        return flyte_file_io(inputs=ff)
+
     with pytest.raises(
         AssertionError, match="FlyteFile and FlyteDirectory commands should not use the syntax: {{.inputs.infile}}"
     ):
-        ContainerTask(
-            name="flyte_file_io",
-            input_data_dir="/var/inputs",
-            output_data_dir="/var/outputs",
-            inputs=kwtypes(inputs=FlyteFile),
-            outputs=kwtypes(out=FlyteFile),
-            image="flytekit:rawcontainer",
-            command=[
-                "python",
-                "write_flytefile.py",
-                "{{.inputs.inputs}}",
-                "/var/outputs/out",
-            ],
-        )
+        flyte_file_io_wf()
 
 
 @pytest.mark.skipif(
@@ -149,23 +164,41 @@ def test_flytedir_wrong_syntax():
     dockerfile_name = "Dockerfile.raw_container"
     client.images.build(path=path_to_dockerfile, dockerfile=dockerfile_name, tag="flytekit:rawcontainer")
 
+    flyte_dir_io = ContainerTask(
+        name="flyte_dir_io",
+        input_data_dir="/var/inputs",
+        output_data_dir="/var/outputs",
+        inputs=kwtypes(inputs=FlyteDirectory),
+        outputs=kwtypes(out=FlyteDirectory),
+        image="flytekit:rawcontainer",
+        command=[
+            "python",
+            "write_flytedir.py",
+            "{{.inputs.inputs}}",
+            "/var/outputs/out",
+        ],
+    )
+
+    @task
+    def flyte_dir_task() -> FlyteDirectory:
+        working_dir = flytekit.current_context().working_directory
+        local_dir = Path(os.path.join(working_dir, "csv_files"))
+        local_dir.mkdir(exist_ok=True)
+        write_file = os.path.join(local_dir, "flyte_dir.txt")
+        with open(write_file, "w") as file:
+            file.write("This is for flyte dir.")
+
+        return FlyteDirectory(path=str(local_dir))
+
+    @workflow
+    def flyte_dir_io_wf() -> FlyteDirectory:
+        fd = flyte_dir_task()
+        return flyte_dir_io(inputs=fd)
+
     with pytest.raises(
         AssertionError, match="FlyteFile and FlyteDirectory commands should not use the syntax: {{.inputs.infile}}"
     ):
-        ContainerTask(
-            name="flyte_dir_io",
-            input_data_dir="/var/inputs",
-            output_data_dir="/var/outputs",
-            inputs=kwtypes(inputs=FlyteDirectory),
-            outputs=kwtypes(out=FlyteDirectory),
-            image="flytekit:rawcontainer",
-            command=[
-                "python",
-                "write_flytedir.py",
-                "{{.inputs.inputs}}",
-                "/var/outputs/out",
-            ],
-        )
+        flyte_dir_io_wf()
 
 
 @pytest.mark.skipif(

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -33,7 +33,7 @@ def test_flytefile_wf():
         command=[
             "python",
             "write_flytefile.py",
-            "{{.inputs.inputs}}",
+            "/var/inputs/inputs",
             "/var/outputs/out",
         ],
     )
@@ -80,7 +80,7 @@ def test_flytedir_wf():
         command=[
             "python",
             "write_flytedir.py",
-            "{{.inputs.inputs}}",
+            "/var/inputs/inputs",
             "/var/outputs/out",
         ],
     )

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -100,12 +100,13 @@ def test_flytefile_wrong_syntax():
 
     with pytest.raises(
             AssertionError,
-            match=r"FlyteFile and FlyteDirectory commands should not use the template syntax like this: {{.inputs.infile}}\n"
+            match=(
+                    r"FlyteFile and FlyteDirectory commands should not use the template syntax like this: \{\{\.inputs\.infile\}\}\n"
                     r"Please use a path-like syntax, such as: /var/inputs/infile.\n"
                     r"This requirement is due to how Flyte Propeller processes template syntax inputs."
+            )
     ):
         flyte_file_io_wf()
-
 
 @pytest.mark.skipif(
     sys.platform in ["darwin", "win32"],

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -100,9 +100,9 @@ def test_flytefile_wrong_syntax():
 
     with pytest.raises(
             AssertionError,
-            match="FlyteFile and FlyteDirectory commands should not use the template syntax like this: {{.inputs.infile}}\n"
-                  "Please use a path-like syntax, such as: /var/inputs/infile.\n"
-                  "This requirement is due to how Flyte Propeller processes template syntax inputs."
+            match=r"FlyteFile and FlyteDirectory commands should not use the template syntax like this: {{.inputs.infile}}\n"
+                    r"Please use a path-like syntax, such as: /var/inputs/infile.\n"
+                    r"This requirement is due to how Flyte Propeller processes template syntax inputs."
     ):
         flyte_file_io_wf()
 

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -64,6 +64,35 @@ def test_flytefile_wf():
     sys.platform in ["darwin", "win32"],
     reason="Skip if running on windows or macos due to CI Docker environment setup failure",
 )
+def test_flytefile_wrong_syntax():
+    client = docker.from_env()
+    path_to_dockerfile = "tests/flytekit/unit/core/"
+    dockerfile_name = "Dockerfile.raw_container"
+    client.images.build(path=path_to_dockerfile, dockerfile=dockerfile_name, tag="flytekit:rawcontainer")
+
+    with pytest.raises(
+        AssertionError, match="FlyteFile and FlyteDirectory commands should not use the syntax: {{.inputs.infile}}"
+    ):
+        ContainerTask(
+            name="flyte_file_io",
+            input_data_dir="/var/inputs",
+            output_data_dir="/var/outputs",
+            inputs=kwtypes(inputs=FlyteFile),
+            outputs=kwtypes(out=FlyteFile),
+            image="flytekit:rawcontainer",
+            command=[
+                "python",
+                "write_flytefile.py",
+                "{{.inputs.inputs}}",
+                "/var/outputs/out",
+            ],
+        )
+
+
+@pytest.mark.skipif(
+    sys.platform in ["darwin", "win32"],
+    reason="Skip if running on windows or macos due to CI Docker environment setup failure",
+)
 def test_flytedir_wf():
     client = docker.from_env()
     path_to_dockerfile = "tests/flytekit/unit/core/"
@@ -108,6 +137,35 @@ def test_flytedir_wf():
         content = file.read()
 
     assert content == "This is for flyte dir."
+
+
+@pytest.mark.skipif(
+    sys.platform in ["darwin", "win32"],
+    reason="Skip if running on windows or macos due to CI Docker environment setup failure",
+)
+def test_flytedir_wrong_syntax():
+    client = docker.from_env()
+    path_to_dockerfile = "tests/flytekit/unit/core/"
+    dockerfile_name = "Dockerfile.raw_container"
+    client.images.build(path=path_to_dockerfile, dockerfile=dockerfile_name, tag="flytekit:rawcontainer")
+
+    with pytest.raises(
+        AssertionError, match="FlyteFile and FlyteDirectory commands should not use the syntax: {{.inputs.infile}}"
+    ):
+        ContainerTask(
+            name="flyte_dir_io",
+            input_data_dir="/var/inputs",
+            output_data_dir="/var/outputs",
+            inputs=kwtypes(inputs=FlyteDirectory),
+            outputs=kwtypes(out=FlyteDirectory),
+            image="flytekit:rawcontainer",
+            command=[
+                "python",
+                "write_flytedir.py",
+                "{{.inputs.inputs}}",
+                "/var/outputs/out",
+            ],
+        )
 
 
 @pytest.mark.skipif(

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -200,7 +200,12 @@ def test_flytedir_wrong_syntax():
         return flyte_dir_io(inputs=fd)
 
     with pytest.raises(
-        AssertionError, match="FlyteFile and FlyteDirectory commands should not use the syntax: {{.inputs.infile}}"
+            AssertionError,
+            match=(
+                    r"FlyteFile and FlyteDirectory commands should not use the template syntax like this: \{\{\.inputs\.infile\}\}\n"
+                    r"Please use a path-like syntax, such as: /var/inputs/infile.\n"
+                    r"This requirement is due to how Flyte Propeller processes template syntax inputs."
+            )
     ):
         flyte_dir_io_wf()
 


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
https://github.com/flyteorg/flyte/issues/5929
<!-- Remove this section if not applicable -->

## Why are the changes needed?
To make copilot task local execution syntax aligned with remote execution and avoid the not expected behaviors.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
For flyte directory and flyte file,
make /var/inputs work and make "{{.inputs.inputs}}" doesn't.


<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots
- Assertion Error: Raised when using {{.inputs.inputs}} with FlyteFile and FlyteDirectory.

<img width="1058" alt="Screenshot 2024-10-31 at 7 04 54 PM" src="https://github.com/user-attachments/assets/dd61c5f4-ce59-4687-9f21-6f59015ef909">

- Successful Run: Indicates the expected behavior when valid commands are provided.

<img width="1066" alt="Screenshot 2024-10-31 at 7 05 26 PM" src="https://github.com/user-attachments/assets/fdbd8a7c-bdda-42f5-8b77-69bb20de3157">


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flytekit/pull/2258
https://github.com/flyteorg/flyte/pull/5715

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
