### PR TITLE
Default nb task resolver msg

### DIFF
--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -339,8 +339,8 @@ class DefaultNotebookTaskResolver(TrackedInstance, TaskResolverMixin):
         # verify the loaded_data is of the correct type
         if not isinstance(loaded_data, PickledEntity):
             raise RuntimeError(
-                f"The loaded data is not of the correct type. Expected PickledEntity, found {type(loaded_data)}. "
-                "Please ensure that the pickle file is not corrupted."
+                f"The loaded data is not of the correct type. Expected PickledEntity, found {loaded_data} of type "
+                f"{type(loaded_data)}. Please ensure that the pickle file is not corrupted."
             )
         pickled_object: PickledEntity = loaded_data
 

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -339,8 +339,8 @@ class DefaultNotebookTaskResolver(TrackedInstance, TaskResolverMixin):
         # verify the loaded_data is of the correct type
         if not isinstance(loaded_data, PickledEntity):
             raise RuntimeError(
-                f"The loaded data is not of the correct type. Expected PickledEntity, found {loaded_data} of type "
-                f"{type(loaded_data)}. Please ensure that the pickle file is not corrupted."
+                f"The loaded data is not of the correct type. Expected PickledEntity, found {type(loaded_data)}. "
+                f"Please ensure that the pickle file is not corrupted. Loaded data: {loaded_data}"
             )
         pickled_object: PickledEntity = loaded_data
 

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -339,7 +339,8 @@ class DefaultNotebookTaskResolver(TrackedInstance, TaskResolverMixin):
         # verify the loaded_data is of the correct type
         if not isinstance(loaded_data, PickledEntity):
             raise RuntimeError(
-                "The loaded data is not of the correct type. Please ensure that the pickle file is not corrupted."
+                f"The loaded data is not of the correct type. Expected PickledEntity, found {type(loaded_data)}. "
+                "Please ensure that the pickle file is not corrupted."
             )
         pickled_object: PickledEntity = loaded_data
 


### PR DESCRIPTION
## Why are the changes needed?

It's useful to the know the unpickled object and its type when loading the task with the default notebook task resolver. This just eases the debugging experience.

## What changes were proposed in this pull request?

Updates the error message when the unpickled file is of the unexpected type.
