### PR TITLE
Kill the vscode server itself when resume the task

### DIFF
--- a/flytekit/interactive/vscode_lib/decorator.py
+++ b/flytekit/interactive/vscode_lib/decorator.py
@@ -67,7 +67,7 @@ def exit_handler(
     delta = 0
 
     logger.info("waiting for task to resume...")
-    while child_process.is_alive() and not resume_task.is_set():
+    while child_process.is_alive():
         if not os.path.exists(HEARTBEAT_PATH):
             delta = time.time() - start_time
             logger.info(f"Code server has not been connected since {delta} seconds ago.")
@@ -464,7 +464,7 @@ class vscode(ClassDecorator):
         prepare_resume_task_python(child_process.pid)
 
         # 6. Register the signal handler for task resumption. This should be after creating the subprocess so that the subprocess won't inherit the signal handler.
-        signal.signal(signal.SIGTERM, resume_task_handler)
+        # signal.signal(signal.SIGTERM, resume_task_handler)
 
         return exit_handler(
             child_process=child_process,

--- a/flytekit/interactive/vscode_lib/decorator.py
+++ b/flytekit/interactive/vscode_lib/decorator.py
@@ -439,6 +439,7 @@ class vscode(ClassDecorator):
         # 2. Prepare the interactive debugging Python script and launch.json.
         prepare_interactive_python(self.task_function)  # type: ignore
 
+        logger.info(f"pid, {os.getpid()}")
         # 3. Prepare the task resumption Python script.
         prepare_resume_task_python()
 

--- a/flytekit/interactive/vscode_lib/decorator.py
+++ b/flytekit/interactive/vscode_lib/decorator.py
@@ -275,7 +275,7 @@ if __name__ == "__main__":
         file.write(python_script)
 
 
-def prepare_resume_task_python():
+def prepare_resume_task_python(pid: int):
     """
     Generate a Python script for users to resume the task.
     """
@@ -287,8 +287,7 @@ if __name__ == "__main__":
     print("Terminating server and resuming task.")
     answer = input("This operation will kill the server. All unsaved data will be lost, and you will no longer be able to connect to it. Do you really want to terminate? (Y/N): ").strip().upper()
     if answer == 'Y':
-        PID = os.getpid()
-        os.kill(PID, signal.SIGTERM)
+        os.kill({pid}, signal.SIGTERM)
         print(f"The server has been terminated and the task has been resumed.")
     else:
         print("Operation canceled.")
@@ -443,7 +442,7 @@ class vscode(ClassDecorator):
 
         logger.info(f"pid, {os.getpid()}")
         # 3. Prepare the task resumption Python script.
-        prepare_resume_task_python()
+        # prepare_resume_task_python()
 
         # 4. Prepare the launch.json
         prepare_launch_json()
@@ -461,6 +460,8 @@ class vscode(ClassDecorator):
             },
         )
         child_process.start()
+
+        prepare_resume_task_python(child_process.pid)
 
         # 6. Register the signal handler for task resumption. This should be after creating the subprocess so that the subprocess won't inherit the signal handler.
         signal.signal(signal.SIGTERM, resume_task_handler)

--- a/flytekit/interactive/vscode_lib/decorator.py
+++ b/flytekit/interactive/vscode_lib/decorator.py
@@ -8,7 +8,6 @@ import subprocess
 import sys
 import tarfile
 import time
-from multiprocessing import Event
 from typing import Callable, List, Optional
 
 import fsspec
@@ -25,7 +24,6 @@ from flytekit.interactive.vscode_lib.config import VscodeConfig
 from flytekit.interactive.vscode_lib.vscode_constants import (
     DOWNLOAD_DIR,
     EXECUTABLE_NAME,
-    HEARTBEAT_CHECK_SECONDS,
     HEARTBEAT_PATH,
     INTERACTIVE_DEBUGGING_FILE_NAME,
     RESUME_TASK_FILE_NAME,
@@ -339,14 +337,6 @@ def prepare_launch_json():
         json.dump(launch_json, file, indent=4)
 
 
-def resume_task_handler(signum, frame):
-    """
-    The signal handler for task resumption.
-    """
-    resume_task.set()
-
-
-resume_task = Event()
 VSCODE_TYPE_VALUE = "vscode"
 
 

--- a/flytekit/interactive/vscode_lib/decorator.py
+++ b/flytekit/interactive/vscode_lib/decorator.py
@@ -68,6 +68,7 @@ def exit_handler(
     while child_process.is_alive():
         current_time = time.time()
         if current_time - last_heartbeat_check >= check_interval:
+            last_heartbeat_check = current_time
             if not os.path.exists(HEARTBEAT_PATH):
                 delta = current_time - start_time
                 logger.info(f"Code server has not been connected since {delta} seconds ago.")

--- a/flytekit/interactive/vscode_lib/decorator.py
+++ b/flytekit/interactive/vscode_lib/decorator.py
@@ -86,9 +86,6 @@ def exit_handler(
 
         time.sleep(1)
 
-        # Wait for HEARTBEAT_CHECK_SECONDS seconds, but return immediately when resume_task is set.
-        # resume_task.wait(timeout=HEARTBEAT_CHECK_SECONDS)
-
     # User has resumed the task.
     terminate_process()
 
@@ -441,17 +438,7 @@ class vscode(ClassDecorator):
         # 1. Downloads the VSCode server from Internet to local.
         download_vscode(self._config)
 
-        # 2. Prepare the interactive debugging Python script and launch.json.
-        prepare_interactive_python(self.task_function)  # type: ignore
-
-        logger.info(f"pid, {os.getpid()}")
-        # 3. Prepare the task resumption Python script.
-        # prepare_resume_task_python()
-
-        # 4. Prepare the launch.json
-        prepare_launch_json()
-
-        # 5. Launches and monitors the VSCode server.
+        # 2. Launches and monitors the VSCode server.
         #    Run the function in the background.
         #    Make the task function's source file directory the default directory.
         task_function_source_dir = os.path.dirname(
@@ -465,10 +452,14 @@ class vscode(ClassDecorator):
         )
         child_process.start()
 
+        # 3. Prepare the interactive debugging Python script and launch.json.
+        prepare_interactive_python(self.task_function)  # type: ignore
+
+        # 4. Prepare the task resumption Python script
         prepare_resume_task_python(child_process.pid)
 
-        # 6. Register the signal handler for task resumption. This should be after creating the subprocess so that the subprocess won't inherit the signal handler.
-        # signal.signal(signal.SIGTERM, resume_task_handler)
+        # 5. Prepare the launch.json
+        prepare_launch_json()
 
         return exit_handler(
             child_process=child_process,

--- a/flytekit/interactive/vscode_lib/decorator.py
+++ b/flytekit/interactive/vscode_lib/decorator.py
@@ -195,14 +195,14 @@ def download_vscode(config: VscodeConfig):
 
     # If the code server already exists in the container, skip downloading
     executable_path = shutil.which(EXECUTABLE_NAME)
-    if executable_path is not None:
+    if executable_path is not None or os.path.exists(DOWNLOAD_DIR):
         logger.info(f"Code server binary already exists at {executable_path}")
         logger.info("Skipping downloading code server...")
     else:
         logger.info("Code server is not in $PATH, start downloading code server...")
         # Create DOWNLOAD_DIR if not exist
         logger.info(f"DOWNLOAD_DIR: {DOWNLOAD_DIR}")
-        os.makedirs(DOWNLOAD_DIR, exist_ok=True)
+        os.makedirs(DOWNLOAD_DIR)
 
         logger.info(f"Start downloading files to {DOWNLOAD_DIR}")
         # Download remote file to local
@@ -213,9 +213,9 @@ def download_vscode(config: VscodeConfig):
         with tarfile.open(code_server_tar_path, "r:gz") as tar:
             tar.extractall(path=DOWNLOAD_DIR)
 
+    if os.path.exists(DOWNLOAD_DIR):
         code_server_dir_name = get_code_server_info(config.code_server_dir_names)
         code_server_bin_dir = os.path.join(DOWNLOAD_DIR, code_server_dir_name, "bin")
-
         # Add the directory of code-server binary to $PATH
         os.environ["PATH"] = code_server_bin_dir + os.pathsep + os.environ["PATH"]
 

--- a/plugins/flytekit-flyteinteractive/flytekitplugins/flyteinteractive/vscode_lib/decorator.py
+++ b/plugins/flytekit-flyteinteractive/flytekitplugins/flyteinteractive/vscode_lib/decorator.py
@@ -11,7 +11,5 @@ from flytekit.interactive.vscode_lib.decorator import (  # noqa: F401
     prepare_interactive_python,
     prepare_launch_json,
     prepare_resume_task_python,
-    resume_task,
-    resume_task_handler,
     vscode,
 )

--- a/plugins/flytekit-flyteinteractive/tests/test_flyteinteractive_vscode.py
+++ b/plugins/flytekit-flyteinteractive/tests/test_flyteinteractive_vscode.py
@@ -202,7 +202,6 @@ def test_vscode_run_task_first_fail(vscode_patches, mock_remote_execution):
     mock_process.assert_called_once()
     mock_exit_handler.assert_called_once()
     mock_prepare_interactive_python.assert_called_once()
-    assert mock_signal.call_count >= 1
     mock_prepare_resume_task_python.assert_called_once()
     mock_prepare_launch_json.assert_called_once()
 

--- a/plugins/flytekit-flyteinteractive/tests/test_flyteinteractive_vscode.py
+++ b/plugins/flytekit-flyteinteractive/tests/test_flyteinteractive_vscode.py
@@ -96,7 +96,6 @@ def test_vscode_remote_execution(vscode_patches, mock_remote_execution):
     mock_process.assert_called_once()
     mock_exit_handler.assert_called_once()
     mock_prepare_interactive_python.assert_called_once()
-    mock_signal.assert_called_once()
     mock_prepare_resume_task_python.assert_called_once()
     mock_prepare_launch_json.assert_called_once()
 
@@ -288,7 +287,6 @@ def test_vscode_with_args(vscode_patches, mock_remote_execution):
     mock_process.assert_called_once()
     mock_exit_handler.assert_called_once()
     mock_prepare_interactive_python.assert_called_once()
-    mock_signal.assert_called_once()
     mock_prepare_resume_task_python.assert_called_once()
     mock_prepare_launch_json.assert_called_once()
 

--- a/tests/flytekit/unit/interactive/test_flyteinteractive_vscode.py
+++ b/tests/flytekit/unit/interactive/test_flyteinteractive_vscode.py
@@ -91,7 +91,6 @@ def test_vscode_remote_execution(vscode_patches, mock_remote_execution):
     mock_process.assert_called_once()
     mock_exit_handler.assert_called_once()
     mock_prepare_interactive_python.assert_called_once()
-    assert mock_signal.call_count >=1
     mock_prepare_resume_task_python.assert_called_once()
     mock_prepare_launch_json.assert_called_once()
 

--- a/tests/flytekit/unit/interactive/test_flyteinteractive_vscode.py
+++ b/tests/flytekit/unit/interactive/test_flyteinteractive_vscode.py
@@ -121,7 +121,6 @@ def test_vscode_remote_execution_but_disable(vscode_patches, mock_remote_executi
     mock_process.assert_not_called()
     mock_exit_handler.assert_not_called()
     mock_prepare_interactive_python.assert_not_called()
-    assert mock_signal.call_count == 0
     mock_prepare_resume_task_python.assert_not_called()
     mock_prepare_launch_json.assert_not_called()
 

--- a/tests/flytekit/unit/interactive/test_flyteinteractive_vscode.py
+++ b/tests/flytekit/unit/interactive/test_flyteinteractive_vscode.py
@@ -197,7 +197,6 @@ def test_vscode_run_task_first_fail(vscode_patches, mock_remote_execution):
     mock_process.assert_called_once()
     mock_exit_handler.assert_called_once()
     mock_prepare_interactive_python.assert_called_once()
-    assert mock_signal.call_count >= 1
     mock_prepare_resume_task_python.assert_called_once()
     mock_prepare_launch_json.assert_called_once()
 
@@ -250,7 +249,6 @@ def test_vscode_with_args(vscode_patches, mock_remote_execution):
     mock_process.assert_called_once()
     mock_exit_handler.assert_called_once()
     mock_prepare_interactive_python.assert_called_once()
-    assert mock_signal.call_count >= 1
     mock_prepare_resume_task_python.assert_called_once()
     mock_prepare_launch_json.assert_called_once()
 


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
When we resume the task in the vscode, it will send a `SIGTERM` to flytekit (main process), then flytekit will [kill](https://github.com/flyteorg/flytekit/blob/5bf0acd22623f02293a75d41952dd4ec26e025ae/flytekit/interactive/vscode_lib/decorator.py#L61) the vscode server. However, if the main process is down for some reason, the VSCode server won't shut down even if we resume the task.

## What changes were proposed in this pull request?
Kill the vscode server itself when resuming the task.

## How was this patch tested?
```python
from union.actor import ActorEnvironment
from flytekit import ImageSpec, Resources, task, workflow
from flytekit import logger
from flytekit.interactive import vscode

new_flytekit = "git+https://github.com/flyteorg/flytekit.git@3a9afb1a88753fe3c783da91fc501b8fc7838fb8"
image_spec = ImageSpec(name="actor", registry="pingsutw", packages=["panda", "numpy", "union", new_flytekit], apt_packages=["git"], env={"FLYTE_SDK_LOGGING_LEVEL": "10"})


actor1 = ActorEnvironment(
    name="foo17",
    container_image=image_spec,
    replica_count=1,
    ttl_seconds=600,
    requests=Resources(cpu="2", mem="2000Mi"),
)


@actor1.task(enable_deck=True)
@vscode(port=8080)
def t1(a: int = 3, b: int = 4) -> int:
    print("print---------------------------------------------")
    # vs = os.getenv("_F_E_VS", "None")
    # logger.info(f"_F_E_VS: {vs}")
    logger.info("logger-----------------------------------")
    raise ValueError("This is an error")
    return a + b

@workflow
def wf():
    t1()
```
### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

