### PR TITLE
Make it easier to use commands with uv

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -26,9 +26,7 @@ UV_PYTHON_INSTALL_COMMAND_TEMPLATE = Template(
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
     --mount=from=uv,source=/uv,target=/usr/bin/uv \
     --mount=type=bind,target=requirements_uv.txt,src=requirements_uv.txt \
-    /usr/bin/uv \
-    pip install --python /opt/micromamba/envs/runtime/bin/python $PIP_EXTRA \
-    --requirement requirements_uv.txt
+    uv pip install $PIP_INSTALL_ARGS
 """
 )
 
@@ -65,6 +63,7 @@ ENV PATH="/opt/micromamba/envs/runtime/bin:$$PATH" \
     UV_LINK_MODE=copy \
     FLYTE_SDK_RICH_TRACEBACKS=0 \
     SSL_CERT_DIR=/etc/ssl/certs \
+    UV_PYTHON=/opt/micromamba/envs/runtime/bin/python \
     $ENV
 
 $UV_PYTHON_INSTALL_COMMAND
@@ -76,7 +75,11 @@ ENV PATH="$$PATH:/usr/local/nvidia/bin:/usr/local/cuda/bin" \
 $ENTRYPOINT
 
 $COPY_COMMAND_RUNTIME
-RUN $RUN_COMMANDS
+
+RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
+    --mount=from=uv,source=/uv,target=/usr/bin/uv \
+    $RUN_COMMANDS
+
 $EXTRA_COPY_CMDS
 
 WORKDIR /root
@@ -145,17 +148,17 @@ def create_docker_context(image_spec: ImageSpec, tmp_dir: Path):
     requirements_uv_path = tmp_dir / "requirements_uv.txt"
     requirements_uv_path.write_text("\n".join(requirements))
 
-    pip_extra_args = []
+    pip_install_args = ["--requirement", "requirements_uv.txt"]
 
     if image_spec.pip_index:
-        pip_extra_args.append(f"--index-url {image_spec.pip_index}")
+        pip_install_args.append(f"--index-url {image_spec.pip_index}")
     if image_spec.pip_extra_index_url:
         extra_urls = [f"--extra-index-url {url}" for url in image_spec.pip_extra_index_url]
-        pip_extra_args.extend(extra_urls)
+        pip_install_args.extend(extra_urls)
 
-    pip_extra_args = " ".join(pip_extra_args)
+    pip_install_args = " ".join(pip_install_args)
 
-    uv_python_install_command = UV_PYTHON_INSTALL_COMMAND_TEMPLATE.substitute(PIP_EXTRA=pip_extra_args)
+    uv_python_install_command = UV_PYTHON_INSTALL_COMMAND_TEMPLATE.substitute(PIP_INSTALL_ARGS=pip_install_args)
 
     env_dict = {"PYTHONPATH": "/root", _F_IMG_ID: image_spec.id}
 

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -77,8 +77,7 @@ $ENTRYPOINT
 $COPY_COMMAND_RUNTIME
 
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
-    --mount=from=uv,source=/uv,target=/usr/bin/uv \
-    $RUN_COMMANDS
+    --mount=from=uv,source=/uv,target=/usr/bin/uv $RUN_COMMANDS
 
 $EXTRA_COPY_CMDS
 

--- a/tests/flytekit/unit/core/image_spec/test_default_builder.py
+++ b/tests/flytekit/unit/core/image_spec/test_default_builder.py
@@ -56,7 +56,7 @@ def test_create_docker_context(tmp_path):
     assert "--index-url" in dockerfile_content
     assert "--extra-index-url" in dockerfile_content
     assert "COPY --chown=flytekit ./src /root" in dockerfile_content
-    assert "RUN mkdir my_dir" in dockerfile_content
+    assert "mkdir my_dir" in dockerfile_content
     assert "ENTRYPOINT [\"/bin/bash\"]" in dockerfile_content
     assert "mkdir -p $HOME" in dockerfile_content
     assert f"COPY --chown=flytekit {tmp_file.relative_to(Path.cwd()).as_posix()} /root/" in dockerfile_content

--- a/tests/flytekit/unit/core/image_spec/test_default_builder.py
+++ b/tests/flytekit/unit/core/image_spec/test_default_builder.py
@@ -1,3 +1,4 @@
+import re
 import os
 from unittest.mock import patch, Mock
 
@@ -56,7 +57,9 @@ def test_create_docker_context(tmp_path):
     assert "--index-url" in dockerfile_content
     assert "--extra-index-url" in dockerfile_content
     assert "COPY --chown=flytekit ./src /root" in dockerfile_content
-    assert "mkdir my_dir" in dockerfile_content
+
+    run_match = re.search(r"RUN.+mkdir my_dir", dockerfile_content)
+    assert run_match
     assert "ENTRYPOINT [\"/bin/bash\"]" in dockerfile_content
     assert "mkdir -p $HOME" in dockerfile_content
     assert f"COPY --chown=flytekit {tmp_file.relative_to(Path.cwd()).as_posix()} /root/" in dockerfile_content


### PR DESCRIPTION
## Tracking issue
Related to https://github.com/flyteorg/flyte/issues/5597

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
It's hard to use `uv` in `commands`. With this PR, using `uv` targets the install python environment and it's simple to use. For example, we can now write:

```python
image_spec = ImageSpec(
    name="myimage",
    registry="localhost:30000",
    packages=["numpy"],
    commands=["uv pip install scikit-learn"],
)
```

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
With this PR the `run_commands` automatically mounts the 

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

I ran the following workflow:

```python
from flytekit import task, workflow, ImageSpec

image_spec = ImageSpec(
    name="myimage",
    registry="localhost:30000",
    packages=["scikit-learn"],
    pip_extra_index_url=[
        "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
    ],
    env={"UV_PRERELEASE": "allow"},
)


@task(container_image=image_spec)
def sklearn_version() -> str:
    import sklearn

    return sklearn.__version__


@workflow
def main() -> str:
    return sklearn_version()

```