### PR TITLE
pod template inplace operations

### DIFF
--- a/flytekit/core/task.py
+++ b/flytekit/core/task.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import datetime
 import os
 from functools import update_wrapper
@@ -372,7 +373,7 @@ def task(
             enable_deck=enable_deck,
             deck_fields=deck_fields,
             docs=docs,
-            pod_template=pod_template,
+            pod_template=copy.deepcopy(pod_template),
             pod_template_name=pod_template_name,
             accelerator=accelerator,
         )

--- a/flytekit/core/task.py
+++ b/flytekit/core/task.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import datetime
 import os
 from functools import update_wrapper
@@ -373,7 +372,7 @@ def task(
             enable_deck=enable_deck,
             deck_fields=deck_fields,
             docs=docs,
-            pod_template=copy.deepcopy(pod_template),
+            pod_template=pod_template,
             pod_template_name=pod_template_name,
             accelerator=accelerator,
         )

--- a/flytekit/core/utils.py
+++ b/flytekit/core/utils.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import inspect
 import os
@@ -147,6 +148,9 @@ def _serialize_pod_spec(
 
     if pod_template.pod_spec is None:
         return {}
+
+    pod_template = copy.deepcopy(pod_template)
+
     containers = cast(V1PodSpec, pod_template.pod_spec).containers
     primary_exists = False
 


### PR DESCRIPTION
## Why are the changes needed?

When a constant is used for a pod template, subsequent uses of that pod template will contain information from other tasks that use the same pod template and will overwrite information in the task decorator. Mutation of the pod template object the user passes happens here: https://github.com/flyteorg/flytekit/blob/0662bc6546278154605f5f544782db0110bd463d/flytekit/core/utils.py#L195

## What changes were proposed in this pull request?

In `_serialize_pod_spec` we use a deep copy of the pod template rather than making in place operations on the pod template that the user passes.

## How was this patch tested?

```
import flytekit as fk

POD_TEMPLATE = fk.PodTemplate(
    labels={"lKeyA": "lValA", "lKeyB": "lValB"},
)

image_x = fk.ImageSpec(
    registry="ghcr.io/dansola",
    name="test-image",
    packages=["sqlalchemy", "kubernetes"]
)

image_y = fk.ImageSpec(
    registry="ghcr.io/dansola",
    name="test-image",
    packages=["pandas", "kubernetes"]
)

@fk.task(container_image=image_x, pod_template=POD_TEMPLATE)
def do_x():
    import sqlalchemy
    print(sqlalchemy.__version__)


@fk.task(container_image=image_y, pod_template=POD_TEMPLATE)
def do_y():
    import pandas
    print(pandas.__version__)

@fk.workflow
def wf():
    x = do_x()
    y = do_y()

    x >> y
```
Right now the above workflow fails because `do_y` uses `image_x` and does not have `pandas`. 

After the deep copy, `do_y` actually uses `image_y`.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
