### PR TITLE
Add to_string method to literal

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1605,7 +1605,7 @@ class ListTransformer(AsyncTypeTransformer[T]):
         except AttributeError:
             raise TypeTransformerFailedError(
                 (
-                    f"The expected python type is '{expected_python_type}' but the received Flyte literal value "
+                    f"The expected python type is '{expected_python_type}' but the received Flyte literal value '{lv}' "
                     f"is not a collection (Flyte's representation of Python lists)."
                 )
             )

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1605,7 +1605,7 @@ class ListTransformer(AsyncTypeTransformer[T]):
         except AttributeError:
             raise TypeTransformerFailedError(
                 (
-                    f"The expected python type is '{expected_python_type}' but the received Flyte literal value '{lv}' "
+                    f"The expected python type is '{expected_python_type}' but the received {lv} "
                     f"is not a collection (Flyte's representation of Python lists)."
                 )
             )

--- a/flytekit/models/common.py
+++ b/flytekit/models/common.py
@@ -11,6 +11,8 @@ from flyteidl.core import literals_pb2 as _literals_pb2
 from google.protobuf import json_format as _json_format
 from google.protobuf import struct_pb2 as _struct
 
+DEFAULT_REPR_MAX_LENGTH = 80
+
 
 class FlyteABCMeta(abc.ABCMeta):
     def __instancecheck__(cls, instance):
@@ -59,7 +61,7 @@ def _repr_idl_yaml_like(idl, indent=0) -> str:
                     out.write(_repr_idl_yaml_like(field, indent + 2))
             except AttributeError:
                 # No ListFields -> Must be a scalar
-                str_repr = shorten(str(field).strip(), width=80)
+                str_repr = shorten(str(field).strip(), width=DEFAULT_REPR_MAX_LENGTH)
                 if str_repr:
                     out.write(" " * indent + descriptor.name + ": " + str_repr + os.linesep)
 
@@ -82,7 +84,7 @@ class FlyteIdlEntity(object, metaclass=FlyteType):
     def __hash__(self):
         return hash(self.to_flyte_idl().SerializeToString(deterministic=True))
 
-    def short_string(self):
+    def short_string(self) -> str:
         """
         :rtype: Text
         """
@@ -90,7 +92,7 @@ class FlyteIdlEntity(object, metaclass=FlyteType):
         type_str = type(self).__name__
         return f"Flyte Serialized object ({type_str}):" + os.linesep + str_repr
 
-    def verbose_string(self):
+    def verbose_string(self) -> str:
         """
         :rtype: Text
         """

--- a/flytekit/models/literals.py
+++ b/flytekit/models/literals.py
@@ -1035,9 +1035,24 @@ class Literal(_common.FlyteIdlEntity):
         :rtype: str
         """
         if self.scalar:
+            if self.scalar.primitive:
+                return self.scalar.primitive.value
+            if self.scalar.blob:
+                return self.scalar.blob.uri
+            if self.scalar.binary:
+                return self.scalar.binary.value
+            if self.scalar.schema:
+                return self.scalar.schema.uri
             if self.scalar.union:
                 return self.scalar.union.value._get_literal_value_str()
-            return str(self.scalar.value)
+            if self.scalar.none_type:
+                return "None"
+            if self.scalar.error:
+                return self.scalar.error.message
+            if self.scalar.generic:
+                return str(self.scalar.generic)
+            if self.scalar.structured_dataset:
+                return self.scalar.structured_dataset.uri
         elif self.collection:
             return shorten(str([literal._get_literal_value_str() for literal in self.collection.literals]), width=DEFAULT_REPR_MAX_LENGTH)
         elif self.map:
@@ -1055,9 +1070,9 @@ class Literal(_common.FlyteIdlEntity):
                 return f"{self.scalar.primitive.value.__class__.__name__}"
             return str(self.scalar.value.__class__.__name__)
         elif self.collection:
-            return f"List[{self.collection.literals[0]._get_literal_type_str()}]"
+            return f"Collection[{self.collection.literals[0]._get_literal_type_str()}]"
         elif self.map:
-            return f"Dict[str, {list(self.map.literals.values())[0]._get_literal_type_str()}]"
+            return f"Map[str, {list(self.map.literals.values())[0]._get_literal_type_str()}]"
         return "Unknown Literal Type"
 
     def short_string(self) -> str:
@@ -1065,3 +1080,4 @@ class Literal(_common.FlyteIdlEntity):
         :rtype: Text
         """
         return f"Flyte Serialized object ({self._get_literal_type_str()}): {self._get_literal_value_str()}"
+

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -1787,7 +1787,7 @@ def test_union_type(exec_prefix):
         TypeError,
         match=re.escape(
             f"Error encountered while converting inputs of '{exec_prefix}tests.flytekit.unit.core.test_type_hints.t2':\n"
-            r'  Cannot convert from Flyte Serialized object (Literal):'
+            r'  Cannot convert from Flyte Serialized object (Union[str]):'
         ),
     ):
         assert wf2(a="2") == "2"

--- a/tests/flytekit/unit/models/test_common.py
+++ b/tests/flytekit/unit/models/test_common.py
@@ -191,23 +191,23 @@ def test_short_string_literal():
 
     small_list = Literal(collection=LiteralCollection([Literal(scalar=Scalar(primitive=Primitive(integer=1))), Literal(scalar=Scalar(primitive=Primitive(integer=2)))]))
     assert repr(small_list) == small_list.short_string()
-    assert repr(small_list) == "Flyte Serialized object (List[int]): ['1', '2']"
+    assert repr(small_list) == "Flyte Serialized object (Collection[int]): [1, 2]"
 
     large_list = Literal(collection=LiteralCollection([Literal(scalar=Scalar(primitive=Primitive(integer=i))) for i in range(100)]))
     assert repr(large_list) == large_list.short_string()
-    assert repr(large_list) == "Flyte Serialized object (List[int]): ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', [...]"
+    assert repr(large_list) == "Flyte Serialized object (Collection[int]): [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, [...]"
 
     small_dict = Literal(map=LiteralMap({"a": Literal(scalar=Scalar(primitive=Primitive(integer=1))), "b": Literal(scalar=Scalar(primitive=Primitive(integer=2)))}))
     assert repr(small_dict) == small_dict.short_string()
-    assert repr(small_dict) == "Flyte Serialized object (Dict[str, int]): {'a': '1', 'b': '2'}"
+    assert repr(small_dict) == "Flyte Serialized object (Map[str, int]): {'a': 1, 'b': 2}"
 
     large_dict = Literal(map=LiteralMap({str(i): Literal(scalar=Scalar(primitive=Primitive(integer=i))) for i in range(100)}))
     assert repr(large_dict) == large_dict.short_string()
-    assert repr(large_dict) == "Flyte Serialized object (Dict[str, int]): {'0': '0', '1': '1', '2': '2', '3': '3', '4': '4', '5': '5', '6': '6', [...]"
+    assert repr(large_dict) == "Flyte Serialized object (Map[str, int]): {'0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, [...]"
 
     union_literal = Literal(scalar=Scalar(union=Union(large_list, LiteralType(collection_type=SimpleType.INTEGER))))
     assert repr(union_literal) == union_literal.short_string()
-    assert repr(union_literal) == "Flyte Serialized object (Union[List[int]]): ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', [...]"
+    assert repr(union_literal) == "Flyte Serialized object (Union[Collection[int]]): [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, [...]"
 
 
 def test_short_string_entities_TaskMetadata():

--- a/tests/flytekit/unit/models/test_common.py
+++ b/tests/flytekit/unit/models/test_common.py
@@ -179,30 +179,35 @@ def test_short_string_entities_Primitive():
 def test_short_string_literal():
     int_literal = Literal(scalar=Scalar(primitive=Primitive(integer=1)))
     assert repr(int_literal) == int_literal.short_string()
-    assert repr(int_literal) == "1"
+    assert repr(int_literal) == "Flyte Serialized object (int): 1"
+
+    datetime_literal = Literal(scalar=Scalar(primitive=Primitive(datetime=timedelta(days=1))))
+    assert repr(datetime_literal) == datetime_literal.short_string()
+    assert repr(datetime_literal) == "Flyte Serialized object (datetime): 1970-01-01 00:00:00+00:00"
 
     str_literal = Literal(scalar=Scalar(primitive=Primitive(string_value="hello")))
     assert repr(str_literal) == str_literal.short_string()
-    assert repr(str_literal) == "hello"
+    assert repr(str_literal) == "Flyte Serialized object (str): hello"
 
     small_list = Literal(collection=LiteralCollection([Literal(scalar=Scalar(primitive=Primitive(integer=1))), Literal(scalar=Scalar(primitive=Primitive(integer=2)))]))
     assert repr(small_list) == small_list.short_string()
-    assert repr(small_list) == "[1, 2]"
+    assert repr(small_list) == "Flyte Serialized object (List[int]): ['1', '2']"
 
     large_list = Literal(collection=LiteralCollection([Literal(scalar=Scalar(primitive=Primitive(integer=i))) for i in range(100)]))
     assert repr(large_list) == large_list.short_string()
-    assert repr(large_list) == "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, [...]"
+    assert repr(large_list) == "Flyte Serialized object (List[int]): ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', [...]"
 
     small_dict = Literal(map=LiteralMap({"a": Literal(scalar=Scalar(primitive=Primitive(integer=1))), "b": Literal(scalar=Scalar(primitive=Primitive(integer=2)))}))
     assert repr(small_dict) == small_dict.short_string()
-    assert repr(small_dict) == "{'a': 1, 'b': 2}"
+    assert repr(small_dict) == "Flyte Serialized object (Dict[str, int]): {'a': '1', 'b': '2'}"
 
     large_dict = Literal(map=LiteralMap({str(i): Literal(scalar=Scalar(primitive=Primitive(integer=i))) for i in range(100)}))
     assert repr(large_dict) == large_dict.short_string()
-    assert repr(large_dict) == "{'0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, [...]"
+    assert repr(large_dict) == "Flyte Serialized object (Dict[str, int]): {'0': '0', '1': '1', '2': '2', '3': '3', '4': '4', '5': '5', '6': '6', [...]"
 
     union_literal = Literal(scalar=Scalar(union=Union(large_list, LiteralType(collection_type=SimpleType.INTEGER))))
-    assert repr(union_literal) == large_list.short_string()
+    assert repr(union_literal) == union_literal.short_string()
+    assert repr(union_literal) == "Flyte Serialized object (Union[List[int]]): ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', [...]"
 
 
 def test_short_string_entities_TaskMetadata():

--- a/tests/flytekit/unit/models/test_common.py
+++ b/tests/flytekit/unit/models/test_common.py
@@ -2,16 +2,18 @@ import datetime
 from datetime import timezone, timedelta
 import textwrap
 
+from flytekit import LiteralType
 from flytekit.models import common as _common
 from flytekit.models.core import execution as _execution
 
 from flytekit.models.execution import ExecutionClosure
 
 from flytekit.models.execution import LiteralMapBlob
-from flytekit.models.literals import LiteralMap, Scalar, Primitive, Literal, RetryStrategy
+from flytekit.models.literals import LiteralMap, Scalar, Primitive, Literal, RetryStrategy, LiteralCollection, Union
 from flytekit.models.core.execution import WorkflowExecutionPhase
 from flytekit.models.task import TaskMetadata, RuntimeMetadata
 from flytekit.models.project import Project
+from flytekit.models.types import SimpleType
 
 
 def test_notification_email():
@@ -172,6 +174,35 @@ def test_short_string_entities_Primitive():
 
     assert repr(obj) == expected_result
     assert obj.short_string() == expected_result
+
+
+def test_short_string_literal():
+    int_literal = Literal(scalar=Scalar(primitive=Primitive(integer=1)))
+    assert repr(int_literal) == int_literal.short_string()
+    assert repr(int_literal) == "1"
+
+    str_literal = Literal(scalar=Scalar(primitive=Primitive(string_value="hello")))
+    assert repr(str_literal) == str_literal.short_string()
+    assert repr(str_literal) == "hello"
+
+    small_list = Literal(collection=LiteralCollection([Literal(scalar=Scalar(primitive=Primitive(integer=1))), Literal(scalar=Scalar(primitive=Primitive(integer=2)))]))
+    assert repr(small_list) == small_list.short_string()
+    assert repr(small_list) == "[1, 2]"
+
+    large_list = Literal(collection=LiteralCollection([Literal(scalar=Scalar(primitive=Primitive(integer=i))) for i in range(100)]))
+    assert repr(large_list) == large_list.short_string()
+    assert repr(large_list) == "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, [...]"
+
+    small_dict = Literal(map=LiteralMap({"a": Literal(scalar=Scalar(primitive=Primitive(integer=1))), "b": Literal(scalar=Scalar(primitive=Primitive(integer=2)))}))
+    assert repr(small_dict) == small_dict.short_string()
+    assert repr(small_dict) == "{'a': 1, 'b': 2}"
+
+    large_dict = Literal(map=LiteralMap({str(i): Literal(scalar=Scalar(primitive=Primitive(integer=i))) for i in range(100)}))
+    assert repr(large_dict) == large_dict.short_string()
+    assert repr(large_dict) == "{'0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, [...]"
+
+    union_literal = Literal(scalar=Scalar(union=Union(large_list, LiteralType(collection_type=SimpleType.INTEGER))))
+    assert repr(union_literal) == large_list.short_string()
 
 
 def test_short_string_entities_TaskMetadata():


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
It's hard to read `Literal.__str__`.

## What changes were proposed in this pull request?
Add to_string to `Literal` to customize the representational string

## How was this patch tested?
```python
int_literal = Literal(scalar=Scalar(primitive=Primitive(integer=1)))
print(int_literal)
large_dict = Literal(map=LiteralMap({str(i): Literal(scalar=Scalar(primitive=Primitive(integer=i))) for i in range(100)}))
print(large_dict)
union_literal = Literal(scalar=Scalar(union=Union(value=large_dict, stored_type=LiteralType(SimpleType.INTEGER))))
print(union_literal)
```
Before:
<img width="1232" alt="Screenshot 2024-11-05 at 3 39 10 PM" src="https://github.com/user-attachments/assets/46401d50-1d11-4a4c-a237-6d4cf006f88e">


After:
<img width="1232" alt="Screenshot 2024-11-05 at 3 38 35 PM" src="https://github.com/user-attachments/assets/6018793d-07c2-4928-8667-bdb8e8a701de">


