### PR TITLE
[Flytekit][BUG] Failed to serialize FlyteTypes within Union alongside other non-None variants

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -784,7 +784,7 @@ class DataclassTransformer(TypeTransformer[object]):
         from flytekit.types.structured import StructuredDataset
 
         # Handle Optional and Union Types
-        if UnionTransformer.is_optional_type(python_type) or _is_union_type(python_type):
+        if _is_union_type(python_type):
 
             def get_expected_type(python_val: T, types: tuple) -> Type[T | None]:
                 if len(set(types) & {FlyteFile, FlyteDirectory, StructuredDataset}) > 1:

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -783,8 +783,8 @@ class DataclassTransformer(TypeTransformer[object]):
         from flytekit.types.file import FlyteFile
         from flytekit.types.structured import StructuredDataset
 
-        # Handle Optional
-        if UnionTransformer.is_optional_type(python_type):
+        # Handle Optional and Union Types
+        if UnionTransformer.is_optional_type(python_type) or _is_union_type(python_type):
 
             def get_expected_type(python_val: T, types: tuple) -> Type[T | None]:
                 if len(set(types) & {FlyteFile, FlyteDirectory, StructuredDataset}) > 1:

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -968,7 +968,7 @@ def test_optional_flytefile_in_dataclass(mock_upload_dir):
         h_prime: typing.Optional[FlyteFile] = None
         i: typing.Optional[A] = None
         i_prime: typing.Optional[A] = field(default_factory=lambda: A(a=99))
-        j: typing.Union[int, FlyteFile] = None
+        j: typing.Union[int, FlyteFile] = 0
 
     remote_path = "s3://tmp/file"
     # set the return value to the remote path since that's what put_data does

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -968,6 +968,7 @@ def test_optional_flytefile_in_dataclass(mock_upload_dir):
         h_prime: typing.Optional[FlyteFile] = None
         i: typing.Optional[A] = None
         i_prime: typing.Optional[A] = field(default_factory=lambda: A(a=99))
+        j: typing.Union[int, FlyteFile] = None
 
     remote_path = "s3://tmp/file"
     # set the return value to the remote path since that's what put_data does
@@ -989,6 +990,7 @@ def test_optional_flytefile_in_dataclass(mock_upload_dir):
             g_prime={"a": None},
             h=f1,
             i=A(a=42),
+            j=remote_path,
         )
 
         ctx = FlyteContext.current_context()
@@ -1014,6 +1016,7 @@ def test_optional_flytefile_in_dataclass(mock_upload_dir):
         assert dict_obj["h_prime"] is None
         assert dict_obj["i"]["a"] == 42
         assert dict_obj["i_prime"]["a"] == 99
+        assert dict_obj["j"]["path"] == remote_path
 
         ot = tf.to_python_value(ctx, lv=lv, expected_python_type=TestFileStruct)
 
@@ -1032,6 +1035,7 @@ def test_optional_flytefile_in_dataclass(mock_upload_dir):
         assert ot.h_prime is None
         assert o.i == ot.i
         assert o.i_prime == A(a=99)
+        assert o.j == FlyteFile(remote_path)
 
 
 @mock.patch("flytekit.core.data_persistence.FileAccessProvider.async_put_data")


### PR DESCRIPTION
## Tracking issue
Closes flyteorg/flyte#5988

## Why are the changes needed?
When using strings as input for `FlyteTypes`, we need to convert them into `FlyteTypes` within the `_make_dataclass_serializable` function. However, this function currently fails for Union types that include a `FlyteType` alongside other non-None variants.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
1. Modify the if statement to handle Union types with non-None variants for `FlyteTypes` as well
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
1. Test simple example on local and remote

```py
from dataclasses import dataclass
from flytekit import task
from flytekit.types.file import FlyteFile
from typing import Union
from flytekit.image_spec import ImageSpec


flytekit_hash = "d4171c3cd79ed406988d4213e4e79ee2b0bd2a93"
flytekit = f"git+https://github.com/mao3267/flytekit.git@{flytekit_hash}"

image_spec = ImageSpec(
    name="serialize-union-1",
    packages=[flytekit],
    builder="default",
    registry="localhost:30000",
    apt_packages=["git", "gh"],
)

@dataclass
class DC:
    ff: Union[int, FlyteFile]

@task(container_image=image_spec)
def t_dc() -> DC:
    return DC(ff="s3://path")
```

2. Add unit tests in test_type_engine.py
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
```
git clone https://github.com/flyteorg/flytekit.git
gh checkout pr 2918
pip install -e .
```
### Screenshots
1. Test simple example on local and remote

- Local

![image](https://github.com/user-attachments/assets/8d0a15cf-b732-436f-9f07-93e0f97b3bb2)

- Remote

![image](https://github.com/user-attachments/assets/45733be9-5ce6-450a-a3bb-7c8110a178f9)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
None
<!-- Add related pull requests for reviewers to check -->

## Docs link
None
<!-- Add documentation link built by CI jobs here, and specify the changed place -->
