### PR TITLE
[BUG] Consider each site_package

### DIFF
--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -217,7 +217,9 @@ def list_imported_modules_as_files(source_path: str, modules: List[ModuleType]) 
             if os.path.commonpath([flytekit_root, mod_file]) == flytekit_root:
                 continue
 
-            if os.path.commonpath(site_packages + [mod_file]) in site_packages_set:
+            if any(
+                (os.path.commonpath([site_package, mod_file]) == site_package for site_package in site_packages_set)
+            ):
                 # Do not upload files from site-packages
                 continue
 

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -183,7 +183,7 @@ def list_all_files(source_path: str, deref_symlinks, ignore_group: Optional[Igno
     return all_files
 
 
-def __drive_safe_commonpath(paths):
+def _drive_safe_commonpath(paths):
     """A wrapper aound os.path.commonpath that defaults to returning an empty string instead of raising a ValueError"""
     try:
         return os.path.commonpath(paths)
@@ -203,7 +203,6 @@ def list_imported_modules_as_files(source_path: str, modules: List[ModuleType]) 
     # identify a common root amongst the packages listed?
 
     site_packages = site.getsitepackages()
-    site_packages_set = set(site_packages)
     bin_directory = os.path.dirname(sys.executable)
     files = []
     flytekit_root = os.path.dirname(flytekit.__file__)
@@ -235,9 +234,7 @@ def list_imported_modules_as_files(source_path: str, modules: List[ModuleType]) 
             # in the site-packages or bin directory.
             pass
 
-        if any(
-            (__drive_safe_commonpath([site_package, mod_file]) == site_package for site_package in site_packages_set)
-        ):
+        if any((_drive_safe_commonpath([site_package, mod_file]) == site_package for site_package in site_packages)):
             # Do not upload files from site-packages
             continue
 

--- a/tests/flytekit/unit/tools/test_script_mode.py
+++ b/tests/flytekit/unit/tools/test_script_mode.py
@@ -1,7 +1,9 @@
 import os
+import platform
 import subprocess
 import sys
 import unittest.mock as mock
+from pathlib import Path
 from types import ModuleType
 
 import flytekit
@@ -244,15 +246,16 @@ def test_get_all_modules(tmp_path):
 
 def test_list_imported_modules_as_files():
 
-    source_path = "/home/username/project"
-    bin_directory = os.path.dirname(sys.executable)
-    flytekit_root = os.path.dirname(flytekit.__file__)
+    bin_directory = Path(os.path.dirname(sys.executable))
+    flytekit_root = Path(os.path.dirname(flytekit.__file__))
+    root_dir = Path("C:\\") if platform.system() == "Windows" else Path("/")
+    source_path = root_dir / "home" / "username" / "project"
 
     site_packages = [
-        f"{source_path}/.venv/lib/python3.10/site-packages",
-        f"{source_path}/.venv/local/lib/python3.10/dist-packages",
-        f"{source_path}/.venv/lib/python3/dist-packages",
-        f"{source_path}/.venv/lib/python3.10/dist-packages",
+        str(source_path / ".venv" / "lib" / "python3.10" / "site-packages"),
+        str(source_path / ".venv" / "local" / "lib" / "python3.10" / "dist-packages"),
+        str(source_path / ".venv" / "lib" / "python3" / "dist-packages"),
+        str(source_path / ".venv" / "lib" / "python3.10" / "dist-packages"),
     ]
 
     # Setup mock module objects
@@ -264,24 +267,24 @@ def test_list_imported_modules_as_files():
         ModuleType("local_module_4")
     ]
     local_module_paths = [
-        f"{source_path}/package_a/module_1.py",
-        f"{source_path}/package_a/module_2.py",
-        f"{source_path}/package_b/module_3.py",
-        f"{source_path}/package_b/module_4.py"
+        str(source_path / "package_a" / "module_1.py"),
+        str(source_path / "package_a" / "module_2.py"),
+        str(source_path / "package_b" / "module_3.py"),
+        str(source_path / "package_b" / "module_4.py"),
     ]
     # Flyte module that should be excluded
     flyte_modules = [
         ModuleType("flyte_module")
     ]
     flyte_module_paths = [
-        f"{flytekit_root}/package/module.py"
+        str(flytekit_root / "package" / "module.py"),
     ]
     # bin module that should be excluded
     bin_modules = [
         ModuleType("bin_module")
     ]
     bin_module_paths = [
-        f"{bin_directory}/package/module.py",
+        str(bin_directory / "package" / "module.py"),
     ]
     # site modules that should be excluded
     site_modules = [
@@ -291,10 +294,10 @@ def test_list_imported_modules_as_files():
         ModuleType("site_module_4"),
     ]
     site_module_paths = [
-        f"{site_packages[0]}/package/module_1.py",
-        f"{site_packages[1]}/package/module_2.py",
-        f"{site_packages[2]}/package/module_3.py",
-        f"{site_packages[3]}/package/module_4.py",
+        str(Path(site_packages[0]) / "package" / "module_1.py"),
+        str(Path(site_packages[1]) / "package" / "module_2.py"),
+        str(Path(site_packages[2]) / "package" / "module_3.py"),
+        str(Path(site_packages[3]) / "package" / "module_4.py"),
     ]
 
     modules = local_modules + flyte_modules + bin_modules + site_modules
@@ -304,6 +307,6 @@ def test_list_imported_modules_as_files():
         m.__file__ = p
 
     with mock.patch("site.getsitepackages", new=lambda: site_packages):
-        file_list = list_imported_modules_as_files(source_path, modules)
+        file_list = list_imported_modules_as_files(str(source_path), modules)
 
     assert sorted(file_list) == sorted(local_module_paths)

--- a/tests/flytekit/unit/tools/test_script_mode.py
+++ b/tests/flytekit/unit/tools/test_script_mode.py
@@ -300,7 +300,7 @@ def test_list_imported_modules_as_files():
     modules = local_modules + flyte_modules + bin_modules + site_modules
     module_paths = local_module_paths + flyte_module_paths + bin_module_paths + site_module_paths
 
-    for m, p in zip(modules, module_paths, strict=True):
+    for m, p in zip(modules, module_paths):
         m.__file__ = p
 
     with mock.patch("site.getsitepackages", new=lambda: site_packages):


### PR DESCRIPTION
## Why are the changes needed?

`site.getsitepackages()` was returning
```
[
    '/home/username/project/python/.venv/lib/python3.10/site-packages',
    '/home/username/project/python/.venv/local/lib/python3.10/dist-packages',
    '/home/username/project/python/.venv/lib/python3/dist-packages',
    '/home/username/project/python/.venv/lib/python3.10/dist-packages'
]
```
which when run through `os.path.commonpath` is
```
'/home/username/project/python/.venv'
```
This makes it so that any `mod_file` compared to the site packages set, will never be a string in the site packages set, thus being included in the list of filed to be packaged for fast serialization.

## What changes were proposed in this pull request?

Compare the common path of the module file to each site package in the site package set to see if the mosule file should be skipped.

## How was this patch tested?

No tests added, all tests passed in Python 3.12.7

Manually inspected the file tree generated by a `pyflyte -v run --remote ...` command and the contents of the resulting `.tar.gz` file.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
