### PR TITLE
Expose all settings in ydata-profiling ProfileReport

### DIFF
--- a/plugins/flytekit-deck-standard/dev-requirements.in
+++ b/plugins/flytekit-deck-standard/dev-requirements.in
@@ -3,3 +3,4 @@ pandas
 plotly
 pygments
 ydata-profiling
+lxml

--- a/plugins/flytekit-deck-standard/flytekitplugins/deck/renderer.py
+++ b/plugins/flytekit-deck-standard/flytekitplugins/deck/renderer.py
@@ -53,12 +53,21 @@ class FrameProfilingRenderer:
     Generate a ProfileReport based on a pandas DataFrame
     """
 
-    def __init__(self, title: str = "Pandas Profiling Report"):
+    def __init__(self, title: Optional[str] = None):
         self._title = title
 
-    def to_html(self, df: "pd.DataFrame") -> str:
+    def to_html(self, df: "pd.DataFrame", **kwargs) -> str:
+        """
+        Generate a ydata_profiling.ProfileReport based on a pandas DataFrame
+        """
         assert isinstance(df, pd.DataFrame)
-        profile = ydata_profiling.ProfileReport(df, title=self._title)
+        if kwargs is None:
+            kwargs = {}
+        # For backwards compatibility, if title is None, it will be set to "Pandas Profiling Report".
+        # Also, if title in kwargs, it will overwrite the title in the constructor.
+        if "title" not in kwargs:
+            kwargs["title"] = "Pandas Profiling Report" if self._title is None else self._title
+        profile = ydata_profiling.ProfileReport(df, **kwargs)
         return profile.to_html()
 
 

--- a/plugins/flytekit-deck-standard/setup.py
+++ b/plugins/flytekit-deck-standard/setup.py
@@ -9,11 +9,11 @@ plugin_requires = ["flytekit"]
 extras = {
     "pandas": ["pandas"],
     "pillow": ["pillow"],
-    "ydata-profiling": ["ydata-profiling"],
+    "ydata-profiling": ["ydata-profiling>=2.4.0"],
     "markdown": ["markdown"],
     "plotly": ["plotly"],
     "pygments": ["pygments"],
-    "all": ["pandas", "pillow", "ydata-profiling", "markdown", "plotly", "pygments"],
+    "all": ["pandas", "pillow", "ydata-profiling>=2.4.0", "markdown", "plotly", "pygments"],
 }
 
 __version__ = "0.0.0+develop"


### PR DESCRIPTION
## Why are the changes needed?
ydata-profiling `ProfileReport` has a rich set of [settings](https://docs.profiling.ydata.ai/latest/advanced_settings/available_settings/) that should be exposed in flyte decks.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Expose `kwargs` passed directly to the constructor of `ProfileReport`.

I set the minimal version of `ydata-profiling` to `2.4.0` to support [minimal-mode](https://docs.profiling.ydata.ai/latest/features/big_data/#minimal-mode).

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
