### PR TITLE
[Test] Use context manager for auto tmp dirs cleanup

### DIFF
--- a/tests/flytekit/unit/types/directory/test_dir.py
+++ b/tests/flytekit/unit/types/directory/test_dir.py
@@ -12,20 +12,14 @@ N_FILES_PER_DIR = 3
 
 @pytest.fixture
 def local_tmp_dirs():
-    # Create a source directory
-    src_dir = tempfile.TemporaryDirectory()
-    for file_idx in range(N_FILES_PER_DIR):
-        with open(Path(src_dir.name) / f"{file_idx}.txt", "w") as f:
-            f.write(str(file_idx))
+    # Create a source and an empty destination directory
+    with (tempfile.TemporaryDirectory() as src_dir,
+          tempfile.TemporaryDirectory() as dst_dir):
+        for file_idx in range(N_FILES_PER_DIR):
+            with open(Path(src_dir) / f"{file_idx}.txt", "w") as f:
+                f.write(str(file_idx))
 
-    # Create an empty directory as the destination
-    dst_dir = tempfile.TemporaryDirectory()
-
-    yield src_dir.name, dst_dir.name
-
-    # Cleanup
-    src_dir.cleanup()
-    dst_dir.cleanup()
+        yield src_dir, dst_dir
 
 
 def test_src_path_with_different_types(local_tmp_dirs) -> None:


### PR DESCRIPTION
## Why are the changes needed?
Remove temporary directories after the unit test is passed in a neat way.

## What changes were proposed in this pull request?
Use context manager to support automatic temporary directory cleanup on the completion of the context. The test result is shown as follows:

![Screenshot 2024-11-12 at 8 20 06 PM](https://github.com/user-attachments/assets/4d7555d9-5b36-4590-9eb7-12b707205c90)

## How was this patch tested?
Pass unit test locally.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
[flyteorg/flytekit#2881](https://github.com/flyteorg/flytekit/pull/2881) & [flyteorg/flytekit#2917](https://github.com/flyteorg/flytekit/pull/2917)

## Docs link
