### PR TITLE
Copy ca-certificates from micromamba

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -39,13 +39,13 @@ RUN --mount=type=cache,sharing=locked,mode=0777,target=/var/cache/apt,id=apt \
 DOCKER_FILE_TEMPLATE = Template("""\
 #syntax=docker/dockerfile:1.5
 FROM ghcr.io/astral-sh/uv:0.2.37 as uv
-FROM mambaorg/micromamba:1.5.8-bookworm-slim as micromamba
+FROM mambaorg/micromamba:2.0.3-debian12-slim as micromamba
 
 FROM $BASE_IMAGE
 
 USER root
 $APT_INSTALL_COMMAND
-RUN update-ca-certificates
+COPY --from=micromamba /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 RUN id -u flytekit || useradd --create-home --shell /bin/bash flytekit
 RUN chown -R flytekit /root && chown -R flytekit /home
@@ -166,11 +166,14 @@ def create_docker_context(image_spec: ImageSpec, tmp_dir: Path):
 
     env = " ".join(f"{k}={v}" for k, v in env_dict.items())
 
-    apt_packages = ["ca-certificates"]
+    apt_packages = []
     if image_spec.apt_packages:
         apt_packages.extend(image_spec.apt_packages)
 
-    apt_install_command = APT_INSTALL_COMMAND_TEMPLATE.substitute(APT_PACKAGES=" ".join(apt_packages))
+    if apt_packages:
+        apt_install_command = APT_INSTALL_COMMAND_TEMPLATE.substitute(APT_PACKAGES=" ".join(apt_packages))
+    else:
+        apt_install_command = ""
 
     if image_spec.source_copy_mode is not None and image_spec.source_copy_mode != CopyFileDetection.NO_COPY:
         if not image_spec.source_root:


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
For macOS using Rosetta, sometimes installing `ca-certificates` or running `update-ca-certificates` can run into errors.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
1. With this PR, we copy over the certificates from the `micromamba` image, which avoids installing `ca-certificate` and running `update-ca-certificates` all together.
2. Without the apt command + `update-ca-certifcates` the builds are faster.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I ran a simple script with the sandbox:

```python
from flytekit import ImageSpec, task

image_spec = ImageSpec(
    name="flytekit-check-2",
    packages=["numpy"],
    registry="localhost:30000",
)


@task(container_image=image_spec)
def wow() -> float:
    import numpy as np
    return np.ones((30, 10)).sum().item()
```