### PR TITLE
Decouple ray submitter, worker, and head resources

### DIFF
--- a/flytekit/models/task.py
+++ b/flytekit/models/task.py
@@ -1018,7 +1018,7 @@ class K8sPod(_common.FlyteIdlEntity):
 
     def to_flyte_idl(self) -> _core_task.K8sPod:
         return _core_task.K8sPod(
-            metadata=self._metadata.to_flyte_idl(),
+            metadata=self._metadata.to_flyte_idl() if self.metadata else None,
             pod_spec=_json_format.Parse(_json.dumps(self.pod_spec), _struct.Struct()) if self.pod_spec else None,
             data_config=self.data_config.to_flyte_idl() if self.data_config else None,
         )

--- a/plugins/flytekit-ray/flytekitplugins/ray/models.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/models.py
@@ -3,6 +3,7 @@ import typing
 from flyteidl.plugins import ray_pb2 as _ray_pb2
 
 from flytekit.models import common as _common
+from flytekit.models.task import K8sPod
 
 
 class WorkerGroupSpec(_common.FlyteIdlEntity):
@@ -13,12 +14,14 @@ class WorkerGroupSpec(_common.FlyteIdlEntity):
         min_replicas: typing.Optional[int] = None,
         max_replicas: typing.Optional[int] = None,
         ray_start_params: typing.Optional[typing.Dict[str, str]] = None,
+        k8s_pod: typing.Optional[K8sPod] = None,
     ):
         self._group_name = group_name
         self._replicas = replicas
         self._max_replicas = max(replicas, max_replicas) if max_replicas is not None else replicas
         self._min_replicas = min(replicas, min_replicas) if min_replicas is not None else replicas
         self._ray_start_params = ray_start_params
+        self._k8s_pod = k8s_pod
 
     @property
     def group_name(self):
@@ -60,6 +63,14 @@ class WorkerGroupSpec(_common.FlyteIdlEntity):
         """
         return self._ray_start_params
 
+    @property
+    def k8s_pod(self):
+        """
+        Additional pod specs for the worker node pods.
+        :rtype: K8sPod
+        """
+        return self._k8s_pod
+
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.plugins._ray_pb2.WorkerGroupSpec
@@ -70,6 +81,7 @@ class WorkerGroupSpec(_common.FlyteIdlEntity):
             min_replicas=self.min_replicas,
             max_replicas=self.max_replicas,
             ray_start_params=self.ray_start_params,
+            k8s_pod=self.k8s_pod.to_flyte_idl() if self.k8s_pod else None,
         )
 
     @classmethod
@@ -84,6 +96,7 @@ class WorkerGroupSpec(_common.FlyteIdlEntity):
             min_replicas=proto.min_replicas,
             max_replicas=proto.max_replicas,
             ray_start_params=proto.ray_start_params,
+            k8s_pod=K8sPod.from_flyte_idl(proto.k8s_pod) if proto.HasField("k8s_pod") else None,
         )
 
 
@@ -91,16 +104,26 @@ class HeadGroupSpec(_common.FlyteIdlEntity):
     def __init__(
         self,
         ray_start_params: typing.Optional[typing.Dict[str, str]] = None,
+        k8s_pod: typing.Optional[K8sPod] = None,
     ):
         self._ray_start_params = ray_start_params
+        self._k8s_pod = k8s_pod
 
     @property
     def ray_start_params(self):
         """
-        The ray start params of worker node group.
+        The ray start params of head node group.
         :rtype: typing.Dict[str, str]
         """
         return self._ray_start_params
+
+    @property
+    def k8s_pod(self):
+        """
+        Additional pod specs for the head node pod.
+        :rtype: K8sPod
+        """
+        return self._k8s_pod
 
     def to_flyte_idl(self):
         """
@@ -108,6 +131,7 @@ class HeadGroupSpec(_common.FlyteIdlEntity):
         """
         return _ray_pb2.HeadGroupSpec(
             ray_start_params=self.ray_start_params if self.ray_start_params else {},
+            k8s_pod=self.k8s_pod.to_flyte_idl() if self.k8s_pod else None,
         )
 
     @classmethod
@@ -118,6 +142,7 @@ class HeadGroupSpec(_common.FlyteIdlEntity):
         """
         return cls(
             ray_start_params=proto.ray_start_params,
+            k8s_pod=K8sPod.from_flyte_idl(proto.k8s_pod) if proto.HasField("k8s_pod") else None,
         )
 
 

--- a/plugins/flytekit-ray/flytekitplugins/ray/task.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/task.py
@@ -19,6 +19,7 @@ from flytekit.configuration import SerializationSettings
 from flytekit.core.context_manager import ExecutionParameters, FlyteContextManager
 from flytekit.core.python_function_task import PythonFunctionTask
 from flytekit.extend import TaskPlugins
+from flytekit.models.task import K8sPod
 
 ray = lazy_module("ray")
 
@@ -26,6 +27,7 @@ ray = lazy_module("ray")
 @dataclass
 class HeadNodeConfig:
     ray_start_params: typing.Optional[typing.Dict[str, str]] = None
+    k8s_pod: typing.Optional[K8sPod] = None
 
 
 @dataclass
@@ -35,6 +37,7 @@ class WorkerNodeConfig:
     min_replicas: typing.Optional[int] = None
     max_replicas: typing.Optional[int] = None
     ray_start_params: typing.Optional[typing.Dict[str, str]] = None
+    k8s_pod: typing.Optional[K8sPod] = None
 
 
 @dataclass
@@ -89,7 +92,9 @@ class RayFunctionTask(PythonFunctionTask):
         ray_job = RayJob(
             ray_cluster=RayCluster(
                 head_group_spec=(
-                    HeadGroupSpec(cfg.head_node_config.ray_start_params) if cfg.head_node_config else None
+                    HeadGroupSpec(cfg.head_node_config.ray_start_params, cfg.head_node_config.k8s_pod)
+                    if cfg.head_node_config
+                    else None
                 ),
                 worker_group_spec=[
                     WorkerGroupSpec(
@@ -98,6 +103,7 @@ class RayFunctionTask(PythonFunctionTask):
                         c.min_replicas,
                         c.max_replicas,
                         c.ray_start_params,
+                        c.k8s_pod,
                     )
                     for c in cfg.worker_node_config
                 ],

--- a/plugins/flytekit-ray/setup.py
+++ b/plugins/flytekit-ray/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "ray"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["ray[default]", "flytekit>=1.3.0b2,<2.0.0", "flyteidl>=1.1.10"]
+plugin_requires = ["ray[default]", "flytekit>=1.3.0b2,<2.0.0", "flyteidl>=1.13.6"]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
## Tracking issue
Related to https://github.com/flyteorg/flyte/issues/5666

## Why are the changes needed?
These changes update the flytekit-ray package such that users can configure pod specs for worker and head workloads. 

## What changes were proposed in this pull request?
Updating the version of flyteidl and plumb k8s pods through worker and head config. 

## How was this patch tested?
See unit tests.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flyte/pull/5933
