### PR TITLE
Fix bug in FlyteDirectory.listdir on local files

### DIFF
--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -367,7 +367,7 @@ class FlyteDirectory(SerializableType, DataClassJsonMixin, os.PathLike, typing.G
         file_access = FlyteContextManager.current_context().file_access
         if not file_access.is_remote(final_path):
             for p in os.listdir(final_path):
-                joined_path = os.path.join(final_path, p) 
+                joined_path = os.path.join(final_path, p)
                 if os.path.isfile(joined_path):
                     paths.append(FlyteFile(joined_path))
                 else:

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -367,10 +367,11 @@ class FlyteDirectory(SerializableType, DataClassJsonMixin, os.PathLike, typing.G
         file_access = FlyteContextManager.current_context().file_access
         if not file_access.is_remote(final_path):
             for p in os.listdir(final_path):
-                if os.path.isfile(os.path.join(final_path, p)):
-                    paths.append(FlyteFile(p))
+                joined_path = os.path.join(final_path, p) 
+                if os.path.isfile(joined_path):
+                    paths.append(FlyteFile(joined_path))
                 else:
-                    paths.append(FlyteDirectory(p))
+                    paths.append(FlyteDirectory(joined_path))
             return paths
 
         def create_downloader(_remote_path: str, _local_path: str, is_multipart: bool):

--- a/tests/flytekit/unit/types/directory/test_listdir.py
+++ b/tests/flytekit/unit/types/directory/test_listdir.py
@@ -27,5 +27,5 @@ def test_listdir():
         tmpdir = setup()
         files = list_dir(dir=tmpdir)
         return map_task(read_file)(file=files)
-    
+
     assert wf() == ["Hello, World!"]

--- a/tests/flytekit/unit/types/directory/test_listdir.py
+++ b/tests/flytekit/unit/types/directory/test_listdir.py
@@ -1,0 +1,31 @@
+import tempfile
+from pathlib import Path
+
+from flytekit import FlyteDirectory, FlyteFile, map_task, task, workflow
+
+def test_listdir():
+    @task
+    def setup() -> FlyteDirectory:
+        tmpdir = Path(tempfile.mkdtemp())
+        (tmpdir / "file.txt").write_text("Hello, World!")
+        return FlyteDirectory(tmpdir)
+
+
+    @task
+    def read_file(file: FlyteFile) -> str:
+        with open(file, "r") as f:
+            return f.read()
+
+
+    @task
+    def list_dir(dir: FlyteDirectory) -> list[FlyteFile]:
+        return FlyteDirectory.listdir(dir)
+
+
+    @workflow
+    def wf() -> list[str]:
+        tmpdir = setup()
+        files = list_dir(dir=tmpdir)
+        return map_task(read_file)(file=files)
+    
+    assert wf() == ["Hello, World!"]


### PR DESCRIPTION
## Tracking issue
Closes flyteorg/flyte#6005

## Why are the changes needed?
Fixes bug that makes `FlyteDirectory.listdir` return file/directory names instead of paths.

## What changes were proposed in this pull request?
Instead of the file/directory name, return full path.

## How was this patch tested?
Added unittest to `tests/flytekit/unit/types/directory/test_listdir.py`

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
