### PR TITLE
Add Flyte Backend Version to pyflyte info command

### DIFF
--- a/flytekit/clis/version.py
+++ b/flytekit/clis/version.py
@@ -8,7 +8,8 @@ from flytekit.remote import FlyteRemote
 Content = """
 This CLI is meant to be used within a virtual environment that has Flytekit installed. Ideally it is used to iterate on your Flyte workflows and tasks.
 
-Flytekit Version: [cyan]{version}[reset]
+Flytekit Version: [cyan]{flytekit_version}[reset]
+Flyte Backend Version: [cyan]{backend_version}[reset]
 Flyte Backend Endpoint: [cyan]{endpoint}
 """
 
@@ -17,11 +18,14 @@ Flyte Backend Endpoint: [cyan]{endpoint}
 @click.pass_context
 def info(ctx: click.Context):
     """
-    Print out information about the current Flyte Python CLI environment - like the version of Flytekit, backend endpoint
-    currently configured, etc.
+    Print out information about the current Flyte Python CLI environment - like the version of Flytekit, the version of Flyte Backend Version,
+    backend endpoint currently configured, etc.
     """
     import flytekit
 
     remote: FlyteRemote = get_and_save_remote_with_click_context(ctx, project="flytesnacks", domain="development")
-    c = Content.format(version=flytekit.__version__, endpoint=remote.client.url)
+    backend_version = remote.client.get_control_plane_version()
+    c = Content.format(
+        flytekit_version=flytekit.__version__, backend_version=backend_version, endpoint=remote.client.url
+    )
     rich.print(Panel(c, title="Flytekit CLI Info", border_style="purple", padding=(1, 1, 1, 1)))

--- a/tests/flytekit/integration/clis/test_version.py
+++ b/tests/flytekit/integration/clis/test_version.py
@@ -1,0 +1,32 @@
+import subprocess
+import re
+
+def run_info_command() -> str:
+    """
+    Runs the `pyflyte info` command and returns its output.
+    """
+    out = subprocess.run(
+        ["pyflyte", "info"],
+        capture_output=True,  # Capture the output streams
+        text=True,  # Return outputs as strings (not bytes)
+    )
+    # Ensure the command ran successfully
+    assert out.returncode == 0, (f"Command failed with return code {out.returncode}.\n"
+                                 f"Standard Output: {out.stdout}\n"
+                                 f"Standard Error: {out.stderr}\n")
+    return out.stdout
+
+def test_info_command_versions():
+    """
+    Tests that the `pyflyte info` command outputs the correct version information.
+    """
+    output = run_info_command()
+
+    # Check that Flytekit Version is displayed
+    assert re.search(r"Flytekit Version: \S+", output), "Flytekit Version not found in output."
+
+    # Check that Flyte Backend Version is displayed
+    assert re.search(r"Flyte Backend Version: \S+", output), "Flyte Backend Version not found in output."
+
+    # Check that Flyte Backend Endpoint is displayed
+    assert re.search(r"Flyte Backend Endpoint: \S+", output), "Flyte Backend Endpoint not found in output."


### PR DESCRIPTION
## Tracking issue
Closes flyteorg/flyte#5984

## Why are the changes needed?
When users run `pyflyte info`, they currently can't see the backend version of flyteadmin. This information is crucial for debugging and understanding the environment setup. Adding the Flyte Backend Version to the output will make it easier for users to:
1. Verify their backend version
2. Debug version-specific issues
3. Ensure compatibility between their client and server

## What changes were proposed in this pull request?
The following changes have been made to enhance the `pyflyte info` command:

1. Added a new line `Flyte Backend Version: [cyan]{backend_version}[reset]` to the CLI output
2. Integrated with the Flyte Remote API to fetch the backend version using `remote.client.get_control_plane_version()`
3. Updated the info command's content template to display the backend version between Flytekit Version and Backend Endpoint

Before:
```
Flytekit Version: 1.999.0dev0
Flyte Backend Endpoint: localhost:30080
```

After:
```
Flytekit Version: 1.999.0dev0
Flyte Backend Version: vXXX
Flyte Backend Endpoint: localhost:30080
```

## How was this patch tested?
Created automated tests in `test_version.py` that verify:

1. The `pyflyte info` command runs successfully and returns expected output
2. The output contains all required version information:
   - Flytekit Version
   - Flyte Backend Version
   - Flyte Backend Endpoint

The test uses regex patterns to ensure each version field is present and properly formatted in the command output. The test implementation:
```python
def test_info_command_versions():
    output = run_info_command()
    assert re.search(r"Flytekit Version: \S+", output)
    assert re.search(r"Flyte Backend Version: \S+", output)
    assert re.search(r"Flyte Backend Endpoint: \S+", output)
```

## Check all applicable boxes
- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
Related to flyteorg/flytekit#2874 (API implementation PR)

## Docs link
<!-- To be added after CI builds the documentation -->
