### PR TITLE
Update pytest skip condition for delete_on_close to Python 3.12

### DIFF
--- a/tests/flytekit/unit/interaction/test_click_types.py
+++ b/tests/flytekit/unit/interaction/test_click_types.py
@@ -503,7 +503,7 @@ def test_nested_dataclass_with_optional_fields():
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 10), reason="handling for windows is nicer with delete_on_close, which doesn't exist in 3.9"
+    sys.version_info < (3, 12), reason="handling for windows is nicer with delete_on_close, which doesn't exist before 3.12"
 )
 def test_pickle_type():
     t = PickleParamType()


### PR DESCRIPTION
## Why are the changes needed?
While developing another feature using Python 3.11.5, I ran `make test`, which resulted in the following error:

<img width="1790" alt="Screenshot 2024-11-18 at 19 29 47" src="https://github.com/user-attachments/assets/abe61b67-500e-4252-94df-0270555fc185">

According to the [Python Docs](https://docs.python.org/3/library/tempfile.html), the `delete_on_close` parameter was introduced in version 3.12.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Originally:
```python
@pytest.mark.skipif(
    sys.version_info < (3, 10), reason="handling for windows is nicer with delete_on_close, which doesn't exist in 3.9"
)
```

After changes:
```python
@pytest.mark.skipif(
    sys.version_info < (3, 12), reason="handling for windows is nicer with delete_on_close, which doesn't exist before 3.12"
)
```

This change ensures compatibility by updating the condition to skip tests for Python versions earlier than 3.12, where delete_on_close is unavailable.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

### Setup process
Run `make test`

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
