### PR TITLE
Add error message when docker isn't running

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -227,7 +227,7 @@ class ImageSpec:
         Return None if failed to check if the image exists due to the permission issue or other reasons.
         """
         import docker
-        from docker.errors import APIError, ImageNotFound
+        from docker.errors import APIError, DockerException, ImageNotFound
 
         try:
             client = docker.from_env()
@@ -277,6 +277,16 @@ class ImageSpec:
                     f"You can upgrade the package by running:\n"
                     f"    pip install --upgrade docker"
                 )
+
+            if isinstance(e, DockerException) and "Error while fetching server API version" in str(e):
+                click.secho(
+                    "Unable to connect to Docker daemon. Please ensure Docker is installed and running.\n"
+                    "You can start Docker by:\n"
+                    "  - Windows/Mac: Start the Docker Desktop application\n"
+                    "  - Linux: Run 'sudo systemctl start docker'",
+                    fg="red",
+                )
+                return None
 
             click.secho(f"Failed to check if the image exists with error:\n {e}", fg="red")
             return None


### PR DESCRIPTION
## Why are the changes needed?

When a user isn't running docker, it is unclear when they see the logs:
```
Running Execution on Remote.
Failed to check if the image exists with error:
 Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory'))
Flytekit assumes the image ghcr.io/dansola/test-image:ppjeS9H6wavg5FvXbowKEQ already exists.
```

Ideally we'd have more clear logs when we can narrow down that the issue is that docker isn't running.

## What changes were proposed in this pull request?

Added additional logging.

## How was this patch tested?

Did not run docker, ran pyflyte run --remote with an ImangeSpec, observed the log message:
```
Running Execution on Remote.
Unable to connect to Docker daemon. Please ensure Docker is installed and running.
You can start Docker by:
  - Windows/Mac: Start the Docker Desktop application
  - Linux: Run 'sudo systemctl start docker'
Flytekit assumes the image ghcr.io/dansola/test-image:ORI1BZVtVKVludLUJsq_Rg already exists.
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
