### PR TITLE
fix: catch API errors for tags as well as whole image repos

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -240,7 +240,10 @@ class ImageSpec:
             if e.response.status_code == 404:
                 return False
 
-            if re.match(f"unknown: repository .*{self.name} not found", e.explanation):
+            if re.match(
+                f"unknown: (artifact|repository) .*{self.name}(|:{self.tag}) not found",
+                e.explanation,
+            ):
                 click.secho(f"Received 500 error with explanation: {e.explanation}", fg="yellow")
                 return False
 


### PR DESCRIPTION
## Tracking issue

Related to flyteorg/flytekit#2696

## Why are the changes needed?

The prior fix only addressed the scenario where an entire image repo did not exist on the registry. This adds coverage for when the repo exists, but the tag is missing.

## What changes were proposed in this pull request?

Modify the regular expression that I had added on the prior PR.

## How was this patch tested?

Same as flyteorg/flytekit#2696
