### PR TITLE
Add support for refresh_token to device flow auth

### DIFF
--- a/flytekit/clients/auth/auth_client.py
+++ b/flytekit/clients/auth/auth_client.py
@@ -303,6 +303,7 @@ class AuthorizationClient(metaclass=_SingletonPerEndpoint):
         """
         response_body = auth_token_resp.json()
         refresh_token = None
+        expires_in = None
         id_token = None
         if "access_token" not in response_body:
             raise ValueError('Expected "access_token" in response from oauth server')

--- a/flytekit/clients/auth/keyring.py
+++ b/flytekit/clients/auth/keyring.py
@@ -13,7 +13,7 @@ class Credentials(object):
     """
 
     access_token: str
-    refresh_token: str = "na"
+    refresh_token: typing.Optional[str] = None
     for_endpoint: str = "flyte-default"
     expires_in: typing.Optional[int] = None
     id_token: typing.Optional[str] = None

--- a/flytekit/clients/auth/token_client.py
+++ b/flytekit/clients/auth/token_client.py
@@ -81,7 +81,7 @@ def get_token(
     session: typing.Optional[requests.Session] = None,
 ) -> typing.Tuple[str, str, int]:
     """
-    :rtype: (Text,Text, Int) The first element is the access token retrieved from the IDP, the second is the refresh token
+    :rtype: (Text,Text,Int) The first element is the access token retrieved from the IDP, the second is the refresh token
     retrieved from the IDP, the third is the expiration in seconds
     """
     headers = {

--- a/tests/flytekit/unit/clients/auth/test_authenticator.py
+++ b/tests/flytekit/unit/clients/auth/test_authenticator.py
@@ -12,7 +12,8 @@ from flytekit.clients.auth.authenticator import (
     PKCEAuthenticator,
     StaticClientConfigStore,
 )
-from flytekit.clients.auth.exceptions import AuthenticationError
+from flytekit.clients.auth.exceptions import AuthenticationError, AccessTokenNotFoundError
+from flytekit.clients.auth.keyring import Credentials
 from flytekit.clients.auth.token_client import DeviceCodeResponse
 
 ENDPOINT = "example.com"
@@ -95,7 +96,8 @@ def test_client_creds_authenticator(mock_session):
 @patch("flytekit.clients.auth.authenticator.KeyringStore")
 @patch("flytekit.clients.auth.token_client.get_device_code")
 @patch("flytekit.clients.auth.token_client.poll_token_endpoint")
-def test_device_flow_authenticator(poll_mock: MagicMock, device_mock: MagicMock, mock_keyring: MagicMock):
+@patch("flytekit.clients.auth.auth_client.AuthorizationClient.refresh_access_token")
+def test_device_flow_authenticator(mock_refresh: MagicMock, poll_mock: MagicMock, device_mock: MagicMock, mock_keyring: MagicMock):
     with pytest.raises(AuthenticationError):
         DeviceCodeAuthenticator(ENDPOINT, static_cfg_store, audience="x", verify=True)
 
@@ -113,9 +115,51 @@ def test_device_flow_authenticator(poll_mock: MagicMock, device_mock: MagicMock,
     )
 
     device_mock.return_value = DeviceCodeResponse("x", "y", "s", 1000, 0)
-    poll_mock.return_value = ("access", 100)
+    poll_mock.return_value = ("access", "refresh", 100)
+    mock_refresh.side_effect = AccessTokenNotFoundError("test") # ensure refresh token fails
+
     authn.refresh_credentials()
     assert authn._creds
+
+    # assert calls made to mocks
+    poll_mock.assert_called()
+    device_mock.assert_called()
+    mock_refresh.assert_called()
+
+@patch("flytekit.clients.auth.authenticator.KeyringStore")
+@patch("flytekit.clients.auth.token_client.get_device_code")
+@patch("flytekit.clients.auth.token_client.poll_token_endpoint")
+@patch("flytekit.clients.auth.auth_client.AuthorizationClient.refresh_access_token")
+def test_device_flow_authenticator_refresh_token(mock_refresh: MagicMock, poll_mock: MagicMock, device_mock: MagicMock, mock_keyring: MagicMock):
+    with pytest.raises(AuthenticationError):
+        DeviceCodeAuthenticator(ENDPOINT, static_cfg_store, audience="x", verify=True)
+
+    cfg_store = StaticClientConfigStore(
+        ClientConfig(
+            token_endpoint="token_endpoint",
+            authorization_endpoint="auth_endpoint",
+            redirect_uri="redirect_uri",
+            client_id="client",
+            device_authorization_endpoint="dev",
+        )
+    )
+    authn = DeviceCodeAuthenticator(
+        ENDPOINT, cfg_store, audience="x", http_proxy_url="http://my-proxy:9000", verify=False
+    )
+
+    mock_refresh.return_value = Credentials(
+        access_token="access", refresh_token="refresh", expires_in=100
+    )
+
+    authn.refresh_credentials()
+    assert authn._creds
+
+    # Full login flow should not happen
+    poll_mock.assert_not_called()
+    device_mock.assert_not_called()
+
+    # assert calls made to mocks
+    mock_refresh.assert_called()
 
 
 @patch("flytekit.clients.auth.token_client.requests.Session")


### PR DESCRIPTION
## Tracking issue
Closes flyteorg/flyte#6044

## Why are the changes needed?
Device flow auth did not support refresh tokens which makes the pyflyte user experience less enjoyable since you may need to login often. 

## What changes were proposed in this pull request?
Passes along the refresh token from the token response to the code which writes it to the keyring. Also updates the device flow authenticator to attempt to refresh the access token.

## How was this patch tested?
Unit tests as well as in our production environment. 

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
