### PR TITLE
[Bug][TypeEngine] Unit tests for dataclass in union with more than two non-None variants

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -2332,9 +2332,12 @@ def generate_attribute_list_from_dataclass_json(schema: dict, schema_name: typin
                     )
                 )
             elif property_val.get("additionalProperties"):
-                attribute_list.append(
-                    (property_key, Dict[str, _get_element_type(property_val["additionalProperties"])])  # type: ignore[misc,index]
-                )
+                if property_val["additionalProperties"] == {}:
+                    attribute_list.append((property_key, dict))  # type: ignore
+                else:
+                    attribute_list.append(
+                        (property_key, Dict[str, _get_element_type(property_val["additionalProperties"])])  # type: ignore[misc,index]
+                    )
         # Handle int, float, bool or str
         else:
             attribute_list.append([property_key, _get_element_type(property_val)])  # type: ignore

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -2335,9 +2335,6 @@ def generate_attribute_list_from_dataclass_json(schema: dict, schema_name: typin
                 attribute_list.append(
                     (property_key, Dict[str, _get_element_type(property_val["additionalProperties"])])  # type: ignore[misc,index]
                 )
-
-            else:
-                attribute_list.append((property_key, Dict[str, _get_element_type(property_val)]))  # type: ignore[misc,index]
         # Handle int, float, bool or str
         else:
             attribute_list.append([property_key, _get_element_type(property_val)])  # type: ignore

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -2323,6 +2323,7 @@ def generate_attribute_list_from_dataclass_json(schema: dict, schema_name: typin
             attribute_list.append((property_key, List[_get_element_type(property_val["items"])]))  # type: ignore[misc,index]
         # Handle dataclass and dict
         elif property_type == "object":
+            # dataclass
             if property_val.get("$ref"):
                 name = property_val["$ref"].split("/")[-1]
                 attribute_list.append(
@@ -2331,14 +2332,17 @@ def generate_attribute_list_from_dataclass_json(schema: dict, schema_name: typin
                         typing.cast(GenericAlias, convert_marshmallow_json_schema_to_python_class(schema, name)),
                     )
                 )
+            # typed dict and untyped dict
             elif property_val.get("additionalProperties"):
-                if property_val["additionalProperties"] == {}:
+                # untyped dict
+                if property_val["additionalProperties"] == dict():
                     attribute_list.append((property_key, dict))  # type: ignore
                 else:
+                    # typed dict
                     attribute_list.append(
                         (property_key, Dict[str, _get_element_type(property_val["additionalProperties"])])  # type: ignore[misc,index]
                     )
-        # Handle int, float, bool or str
+        # Handle primitive types like int, float, bool or str
         else:
             attribute_list.append([property_key, _get_element_type(property_val)])  # type: ignore
     return attribute_list

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -2333,8 +2333,9 @@ def generate_attribute_list_from_dataclass_json(schema: dict, schema_name: typin
                 )
             elif property_val.get("additionalProperties"):
                 attribute_list.append(
-                    (property_key, typing.cast(GenericAlias, _get_element_type(property_val["additionalProperties"]))),
+                    (property_key, Dict[str, _get_element_type(property_val["additionalProperties"])])  # type: ignore[misc,index]
                 )
+
             else:
                 attribute_list.append((property_key, Dict[str, _get_element_type(property_val)]))  # type: ignore[misc,index]
         # Handle int, float, bool or str

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -2331,7 +2331,7 @@ def generate_attribute_list_from_dataclass_json(schema: dict, schema_name: typin
             attribute_list.append((property_key, List[_get_element_type(property_val["items"])]))  # type: ignore[misc,index]
         # Handle dataclass and dict
         elif property_type == "object":
-            # dataclass
+            # For nested dataclass
             if property_val.get("$ref"):
                 name = property_val["$ref"].split("/")[-1]
                 attribute_list.append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "markdown-it-py",
     "marshmallow-enum",
     "marshmallow-jsonschema>=0.12.0",
-    "mashumaro>=3.11,!=3.15",
+    "mashumaro>=3.11",
     "msgpack>=1.1.0",
     "protobuf!=4.25.0",
     "pygments",

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -957,7 +957,7 @@ def test_optional_flytefile_in_dataclass(mock_upload_dir):
         b: typing.Optional[FlyteFile]
         b_prime: typing.Optional[FlyteFile]
         c: typing.Union[FlyteFile, None]
-        c_prime: typing.Union[None, int, FlyteFile]
+        c_prime: typing.Union[None, int, bool, FlyteFile]
         d: typing.List[FlyteFile]
         e: typing.List[typing.Optional[FlyteFile]]
         e_prime: typing.List[typing.Optional[FlyteFile]]

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -957,7 +957,7 @@ def test_optional_flytefile_in_dataclass(mock_upload_dir):
         b: typing.Optional[FlyteFile]
         b_prime: typing.Optional[FlyteFile]
         c: typing.Union[FlyteFile, None]
-        c_prime: typing.Union[None, FlyteFile]
+        c_prime: typing.Union[None, int, FlyteFile]
         d: typing.List[FlyteFile]
         e: typing.List[typing.Optional[FlyteFile]]
         e_prime: typing.List[typing.Optional[FlyteFile]]

--- a/tests/flytekit/unit/core/test_unions.py
+++ b/tests/flytekit/unit/core/test_unions.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 import sys
 import pytest
+import mock
 
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.type_engine import TypeEngine, TypeTransformerFailedError
@@ -93,4 +94,49 @@ def test_with_remote():
     r.execute(lp, inputs={"x": val})
 
 # Issue Link: https://github.com/flyteorg/flyte/issues/5986
-# def test_union_in_dataclass():
+@mock.patch("flytekit.core.data_persistence.FileAccessProvider.async_put_data")
+def test_union_in_dataclass(mock_upload_dir):
+    mock_upload_dir.return_value = True
+
+    from dataclasses_json import DataClassJsonMixin
+    from flytekit.core.type_engine import DataclassTransformer
+    import msgpack
+    from flytekit.types.file import FlyteFile
+
+    remote_path = "s3://my-bucket"
+    f1 = FlyteFile("f1", remote_path=remote_path)
+    mock_upload_dir.return_value = remote_path
+
+    @dataclass
+    class A(DataClassJsonMixin):
+        a: int
+
+    @dataclass
+    class TestDataclass(DataClassJsonMixin):
+        a: typing.Union[A, str, bool, int, float, None]
+        b: typing.Union[A, FlyteFile, bool, int, float, None]
+        c: typing.Union[A, typing.Dict[str, str], typing.List[int], None]
+        d: typing.Union[A, FlyteFile, int, bool, float, None]
+
+    o = TestDataclass(a=A(a=1), b=f1, c={"a": "value"}, d=remote_path)
+    ctx = FlyteContextManager.current_context()
+
+    tf = DataclassTransformer()
+    lt = tf.get_literal_type(TestDataclass)
+    lv = tf.to_literal(ctx, o, TestDataclass, lt)
+
+    msgpack_bytes = lv.scalar.binary.value
+    dict_obj = msgpack.loads(msgpack_bytes)
+
+    assert dict_obj["a"]["a"] == 1
+    assert dict_obj["b"]["path"] == remote_path
+    assert dict_obj["c"]["a"] == "value"
+    assert dict_obj["d"]["path"] == remote_path
+
+    # Convert back to python object
+    ot = tf.to_python_value(ctx, lv, TestDataclass)
+
+    assert o.a.a == ot.a.a
+    assert o.b.remote_path == ot.b.remote_source
+    assert o.c["a"] == ot.c["a"]
+    assert o.d == FlyteFile(remote_path)

--- a/tests/flytekit/unit/core/test_unions.py
+++ b/tests/flytekit/unit/core/test_unions.py
@@ -91,3 +91,6 @@ def test_with_remote():
     guessed_enum = get_args(guessed_union_type)[0]
     val = guessed_enum("one")
     r.execute(lp, inputs={"x": val})
+
+# Issue Link: https://github.com/flyteorg/flyte/issues/5986
+# def test_union_in_dataclass():


### PR DESCRIPTION
## Tracking issue

Related to flyteorg/flyte#5986

## Why are the changes needed?
After mashumaro release version `3.15`, it supports messagepack robust decoding with the correct type in Union. Therefore, we would like to add a unit test to show it works. Also, we should fix errors to support changes in mashumaro to version `3.15`.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
1. Update the unit test for dataclass in Union to include more than two non-None variants.
2. Fix bugs while generating attribute list from `dataclass_json` in `generate_attribute_list_from_dataclass_json` function.
    - Initially, we thought we should use `additionalProperties` to generate dataclass properties. However, both dataclass and dictionary type can have an `additionalProperties` field. This mismatch causes the bug of generating an incorrect attribute list for dictionaries.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
4. If there is design documentation, please add the link.
-->

## How was this patch tested?
1. Passing existing and modified unit tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
```
git clone https://github.com/flytorg/flytekit.git
gh pr checkout 2952
pip install -e .
```
### Screenshots
None
## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flytekit/pull/2859
https://github.com/Fatal1ty/mashumaro/pull/256
<!-- Add related pull requests for reviewers to check -->

## Docs link
None
<!-- Add documentation link built by CI jobs here, and specify the changed place -->


## Note
1. We can not distinguish between dict and dataclass with json schema. So the current implementation will fail to handle dataclass with additionalProperties.
