### PR TITLE
[BUG] Timezone difference in error timestamp unit tests

### DIFF
--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -518,7 +518,12 @@ def test_get_traceback_str():
     assert expected_error_re.match(traceback_str) is not None
 
 
-def test_get_container_error_timestamp() -> None:
+def test_get_container_error_timestamp(monkeypatch) -> None:
+    # Set the timezone to UTC
+    monkeypatch.setenv("TZ", "UTC")
+    if hasattr(time, 'tzset'):
+        time.tzset()
+
     assert get_container_error_timestamp(FlyteException("foo", timestamp=10.5)) == Timestamp(seconds=10, nanos=500000000)
 
     current_dtime = datetime.now()


### PR DESCRIPTION
## Tracking issue
None
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?
While running CI tests locally, it turns out that the time from `datatime.now()` is not using UTC timezone, causing errors while comparing current time and error time.

![image](https://github.com/user-attachments/assets/6557b18f-2601-4beb-a003-1a33c0be2f5d)

## What changes were proposed in this pull request?
1. Set the timezone to UTC using monkeypatch.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
1. Using `make unit_test` to make sure all existing tests pass.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
```
git clone https://github.com/flytorg/flytekit.git
gh pr checkout 2952
pip install -e .
```
### Screenshots
![image](https://github.com/user-attachments/assets/acf2fd90-501d-401e-ab4a-9cff04b86910)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs
None
<!-- Add related pull requests for reviewers to check -->

## Docs link
None
<!-- Add documentation link built by CI jobs here, and specify the changed place -->
