### PR TITLE
[BUG] Use models literal StructuredDataset to enable sd bypass task

### DIFF
--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -198,8 +198,8 @@ class StructuredDataset(SerializableType, DataClassJSONMixin):
 
         For details, please refer to this issue: https://github.com/flyteorg/flyte/issues/5954.
 
-        2. Need access to self._literal_sd when converting task output back to flyteidl, please see:
-        https://github.com/flyteorg/flytekit/blob/master/flytekit/bin/entrypoint.py#L326
+        2. Need access to self._literal_sd when converting task output LiteralMap back to flyteidl, please see:
+        https://github.com/flyteorg/flytekit/blob/f938661ff8413219d1bea77f6914a58c302d5c6c/flytekit/bin/entrypoint.py#L326
 
         For details, please refer to this issue: https://github.com/flyteorg/flyte/issues/5956.
         """

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -813,13 +813,7 @@ class StructuredDatasetTransformerEngine(AsyncTypeTransformer[StructuredDataset]
         # Hence, _literal_sd must have to_flyte_idl method
         # See https://github.com/flyteorg/flytekit/blob/f938661ff8413219d1bea77f6914a58c302d5c6c/flytekit/bin/entrypoint.py#L326
         # For details, please refer to this issue: https://github.com/flyteorg/flyte/issues/5956.
-        expected_python_type, column_dict, storage_fmt, pa_schema = extract_cols_and_format(expected_python_type)
-
-        final_dataset_columns = []
-        if column_dict is not None and len(column_dict) != 0:
-            final_dataset_columns = self._convert_ordered_dict_of_columns_to_list(column_dict)
-        sdt = StructuredDatasetType(columns=final_dataset_columns, format=file_format)
-
+        sdt = StructuredDatasetType(format=file_format)
         metad = literals.StructuredDatasetMetadata(structured_dataset_type=sdt)
         sd_literal = literals.StructuredDataset(uri=uri, metadata=metad)
 


### PR DESCRIPTION
## Tracking issue
Closes [flyteorg/flyte#5956](https://github.com/flyteorg/flyte/issues/5956).

## Why are the changes needed?
For a flyte task with python `StructuredDataset` as an input from `dataclass` attribute access (i.e., `dc.sd`), it fails to convert the task output `LiteralMap` back to flyte idl. On the highest level, the process of calling `_dispatch_execute` ([here](https://github.com/flyteorg/flytekit/blob/master/flytekit/bin/entrypoint.py#L134)) is illustrated as follows:

![pythontask_sd_io](https://github.com/user-attachments/assets/6078b29d-c882-47fb-960f-28df640422e4)

As can be observed, the problem (marked as orange) occurs when the input `LiteralMap` is converted to python natives, during which a `Literal` is built with python native `StructuredDataset`, instead of using the correct `literals.StructuredDataset` (please refer to this [code snippet](https://github.com/flyteorg/flytekit/blob/2e40e76d8a5614a7eedcac8399ca877e64612640/flytekit/types/structured/structured_dataset.py#L800-L809)).

This makes conversion from the task output `LiteralMap` back to flyte idl fail because python native `StructuredDataset` has no `to_flyte_idl` method.


## What changes were proposed in this pull request?
Directly construct a `literals.StructuredDataset` within `dict_to_structured_dataset` method of `StructuredDatasetTransformerEngine`.

## How was this patch tested?
1. Execute the command run in the K8s pod, as suggested by @pingsutw:
    * Describe the pod executing the remote task in the [reported issue](https://github.com/flyteorg/flyte/issues/5956).
    * Copy the command in the pod and reproduce locally.

After fixing, `outputs.pb` now can be successfully written to s3 storage.
![Screenshot 2024-11-26 at 9 52 57 PM](https://github.com/user-attachments/assets/5018b811-a90f-49cc-9f32-3dec66d8f8ed)

![Screenshot 2024-11-26 at 9 54 19 PM](https://github.com/user-attachments/assets/5acd7675-786d-41c6-9c1f-352d95570cf4)

2. Do remote sandbox test with `flytekit` installed by commit sha in this PR.
```python
from dataclasses import dataclass, field

from flytekit import task, workflow, ImageSpec
from flytekit.types.structured import StructuredDataset


# Build docker image and push to the local registry
flytekit_hash = "d5d8620cc0494a148adb6bb4a13978d810d9673a"  # Refer to this PR
flytekit = f"git+https://github.com/flyteorg/flytekit.git@{flytekit_hash}"
image = ImageSpec(
    packages=[
        flytekit,
        "pandas",
        "pyarrow"
    ],
    apt_packages=["git"],
    registry="localhost:30000",
)


@dataclass
class DC:
    sd: StructuredDataset = field(
        default_factory=lambda: StructuredDataset(
            uri="s3://my-s3-bucket/s3_flyte_dir/df.parquet", 
            file_format="parquet"
        )
    )


@task(container_image=image)
def t_sd_attr(sd: StructuredDataset) -> StructuredDataset:
    return sd


@workflow
def wf(dc: DC):
    t_sd_attr(sd=dc.sd)
```

Run the following command:
```
pyflyte run --remote reprod.py wf --dc '{"dc": {"sd": {"uri": "s3://my-s3-bucket/s3_flyte_dir/df.parquet", "file_format": "parquet"}}}'
```

The remote sandbox test result is shown as follows:

![Screenshot 2024-11-26 at 10 14 03 PM](https://github.com/user-attachments/assets/83642f53-992f-43fd-871d-8fddb3c656b7)

### Setup process
```
git clone https://github.com/flyteorg/flytekit.git
gh pr checkout 2954
make setup && pip install -e .
```

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flytekit/pull/2914

## Docs link
