### PR TITLE
The container image of spark task should be immutable

### DIFF
--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -1,3 +1,4 @@
+import dataclasses
 import os
 import shutil
 from dataclasses import dataclass
@@ -134,6 +135,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         self.sess: Optional[SparkSession] = None
         self._default_executor_path: str = task_config.executor_path
         self._default_applications_path: str = task_config.applications_path
+        self._container_image = container_image
 
         if isinstance(container_image, ImageSpec):
             if container_image.base_image is None:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -1,4 +1,3 @@
-import dataclasses
 import os
 import shutil
 from dataclasses import dataclass

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -1,3 +1,4 @@
+import dataclasses
 import os
 import shutil
 from dataclasses import dataclass
@@ -138,7 +139,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
         if isinstance(container_image, ImageSpec):
             if container_image.base_image is None:
                 img = f"cr.flyte.org/flyteorg/flytekit:spark-{DefaultImages.get_version_suffix()}"
-                container_image.base_image = img
+                self._container_image = dataclasses.replace(container_image, base_image=img)
                 # default executor path and applications path in apache/spark-py:3.3.1
                 self._default_executor_path = self._default_executor_path or "/usr/bin/python3"
                 self._default_applications_path = (
@@ -154,7 +155,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
             task_config=task_config,
             task_type=task_type,
             task_function=task_function,
-            container_image=container_image,
+            container_image=self._container_image,
             **kwargs,
         )
 

--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -12,7 +12,7 @@ from pyspark.sql import SparkSession
 
 import flytekit
 from flytekit import StructuredDataset, StructuredDatasetTransformerEngine, task, ImageSpec
-from flytekit.configuration import Image, ImageConfig, SerializationSettings, FastSerializationSettings
+from flytekit.configuration import Image, ImageConfig, SerializationSettings, FastSerializationSettings, DefaultImages
 from flytekit.core.context_manager import ExecutionParameters, FlyteContextManager, ExecutionState
 
 
@@ -185,6 +185,6 @@ def test_spark_with_image_spec():
         print("Starting Spark with Partitions: {}".format(partitions))
         return 1.0
 
-    assert spark2.container_image.base_image == "cr.flyte.org/flyteorg/flytekit:spark-3.0.0"
+    assert spark2.container_image.base_image == f"cr.flyte.org/flyteorg/flytekit:spark-{DefaultImages.get_version_suffix()}"
     assert spark2._default_executor_path == "/usr/bin/python3"
     assert spark2._default_applications_path == "local:///usr/local/bin/entrypoint.py"

--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -185,6 +185,6 @@ def test_spark_with_image_spec():
         print("Starting Spark with Partitions: {}".format(partitions))
         return 1.0
 
-    assert spark2.container_image.base_image == "cr.flyte.org/flyteorg/flytekit:spark-latest"
+    assert spark2.container_image.base_image == "cr.flyte.org/flyteorg/flytekit:spark-3.0.0"
     assert spark2._default_executor_path == "/usr/bin/python3"
     assert spark2._default_applications_path == "local:///usr/local/bin/entrypoint.py"

--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -11,7 +11,7 @@ from flytekitplugins.spark.task import Databricks, new_spark_session
 from pyspark.sql import SparkSession
 
 import flytekit
-from flytekit import StructuredDataset, StructuredDatasetTransformerEngine, task
+from flytekit import StructuredDataset, StructuredDatasetTransformerEngine, task, ImageSpec
 from flytekit.configuration import Image, ImageConfig, SerializationSettings, FastSerializationSettings
 from flytekit.core.context_manager import ExecutionParameters, FlyteContextManager, ExecutionState
 
@@ -157,3 +157,34 @@ def test_spark_addPyFile(mock_add_pyfile):
         my_spark.pre_execute(new_ctx.user_space_params)
         mock_add_pyfile.assert_called_once()
         os.remove(os.path.join(os.getcwd(), "flyte_wf.zip"))
+
+
+def test_spark_with_image_spec():
+    custom_image = ImageSpec(
+        registry="ghcr.io/flyteorg",
+        packages=["flytekitplugins-spark"],
+    )
+
+    @task(
+        task_config=Spark(spark_conf={"spark.driver.memory": "1000M"}),
+        container_image=custom_image,
+    )
+    def spark1(partitions: int) -> float:
+        print("Starting Spark with Partitions: {}".format(partitions))
+        return 1.0
+
+    assert spark1.container_image.base_image == "cr.flyte.org/flyteorg/flytekit:spark-latest"
+    assert spark1._default_executor_path == "/usr/bin/python3"
+    assert spark1._default_applications_path == "local:///usr/local/bin/entrypoint.py"
+
+    @task(
+        task_config=Spark(spark_conf={"spark.driver.memory": "1000M"}),
+        container_image=custom_image,
+    )
+    def spark2(partitions: int) -> float:
+        print("Starting Spark with Partitions: {}".format(partitions))
+        return 1.0
+
+    assert spark2.container_image.base_image == "cr.flyte.org/flyteorg/flytekit:spark-latest"
+    assert spark2._default_executor_path == "/usr/bin/python3"
+    assert spark2._default_applications_path == "local:///usr/local/bin/entrypoint.py"

--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -173,7 +173,7 @@ def test_spark_with_image_spec():
         print("Starting Spark with Partitions: {}".format(partitions))
         return 1.0
 
-    assert spark1.container_image.base_image == "cr.flyte.org/flyteorg/flytekit:spark-latest"
+    assert spark1.container_image.base_image == f"cr.flyte.org/flyteorg/flytekit:spark-{DefaultImages.get_version_suffix()}"
     assert spark1._default_executor_path == "/usr/bin/python3"
     assert spark1._default_applications_path == "local:///usr/local/bin/entrypoint.py"
 


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
flytekit overwrites the `default_executor_path` when the base_image of ImageSpec is None.

When running two Spark tasks in a workflow, flytekit overwrites the `default_executor_path` only for the first task. This happens because flytekit modifies the base_image of the imageSpec during the compilation of the first task. As a result, when compiling the second task, the base_image is no longer None, preventing Flytekit from overwriting the default_executor_path for the second task.



## What changes were proposed in this pull request?
Deep copy the image spec and modify it.

## How was this patch tested?
```python
import datetime
import random
import time
from operator import add
from flytekit import ImageSpec, Resources, task, workflow
import flytekit

from flytekitplugins.spark import Spark
custom_image = ImageSpec(registry="ghcr.io/flyteorg", packages=["flytekitplugins-spark"])


@task(
    task_config=Spark(
        # This configuration is applied to the Spark cluster
        spark_conf={
            "spark.driver.memory": "1000M",
            "spark.executor.memory": "1000M",
            "spark.executor.cores": "1",
            "spark.executor.instances": "2",
            "spark.driver.cores": "1",
            "spark.ui.proxyRedirectUri": "https://dogfood.cloud-staging.union.ai",
            "spark.jars": "https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop3-latest.jar",
        }
    ),
    limits=Resources(mem="2000M"),
    container_image=custom_image,
)
def hello_spark1(partitions: int) -> float:
    print("Starting Spark with Partitions: {}".format(partitions))

    n = 1 * partitions
    sess = flytekit.current_context().spark_session
    count = sess.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)

    pi_val = 4.0 * count / n
    time.sleep(360)
    return pi_val


def f(_):
    x = random.random() * 2 - 1
    y = random.random() * 2 - 1
    return 1 if x**2 + y**2 <= 1 else 0


@task(
    task_config=Spark(
        # This configuration is applied to the Spark cluster
        spark_conf={
            "spark.driver.memory": "1000M",
            "spark.executor.memory": "1000M",
            "spark.executor.cores": "1",
            "spark.executor.instances": "2",
            "spark.driver.cores": "1",
            "spark.ui.proxyRedirectUri": "https://dogfood.cloud-staging.union.ai",
            "spark.jars": "https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop3-latest.jar",
        }
    ),
    limits=Resources(mem="2000M"),
    container_image=custom_image,
)
def hello_spark2(partitions: int) -> float:
    print("Starting Spark with Partitions: {}".format(partitions))

    n = 1 * partitions
    sess = flytekit.current_context().spark_session
    count = sess.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)

    pi_val = 4.0 * count / n
    time.sleep(360)
    return pi_val


@workflow
def my_spark2(triggered_date: datetime.datetime = datetime.datetime.now()) -> float:
    """
    Using the workflow is still as any other workflow. As image is a property of the task, the workflow does not care
    about how the image is configured.
    """
    pi1 = hello_spark1(partitions=1)
    pi2 = hello_spark2(partitions=1)
    return pi1
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
