### PR TITLE
Always print traceback

### DIFF
--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -363,6 +363,7 @@ class RawSynchronousFlyteClient(object):
         :param flyteidl.admin.execution_pb2.ExecutionCreateRequest create_execution_request:
         :rtype: flyteidl.admin.execution_pb2.ExecutionCreateResponse
         """
+        raise grpc.RpcError("123123123123123123")
         return self._stub.CreateExecution(create_execution_request, metadata=self._metadata)
 
     def recover_execution(self, recover_execution_request):

--- a/flytekit/clis/sdk_in_container/utils.py
+++ b/flytekit/clis/sdk_in_container/utils.py
@@ -82,7 +82,8 @@ def pretty_print_grpc_error(e: grpc.RpcError):
     if isinstance(e, grpc._channel._InactiveRpcError):  # noqa
         click.secho(f"RPC Failed, with Status: {e.code()}", fg="red", bold=True)
         click.secho(f"\tDetails: {e.details()}", fg="magenta", bold=True)
-    return
+    else:
+        click.secho(f"RPC Failed, with Error: {e}", fg="red", bold=True)
 
 
 def remove_unwanted_traceback_frames(
@@ -161,19 +162,11 @@ def pretty_print_exception(e: Exception, verbosity: int = 1):
     if isinstance(e, FlyteException):
         if isinstance(e, FlyteInvalidInputException):
             click.secho("Request rejected by the API, due to Invalid input.", fg="red")
-        cause = e.__cause__
-        if cause:
-            if isinstance(cause, grpc.RpcError):
-                pretty_print_grpc_error(cause)
-            else:
-                pretty_print_traceback(e, verbosity)
-        else:
-            pretty_print_traceback(e, verbosity)
-        return
+        if e.__cause__ and isinstance(e.__cause__, grpc.RpcError):
+            pretty_print_grpc_error(e.__cause__)
 
     if isinstance(e, grpc.RpcError):
         pretty_print_grpc_error(e)
-        return
 
     pretty_print_traceback(e, verbosity)
 


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
It’s difficult to identify which function failed when encountering a gRPC error

## What changes were proposed in this pull request?
Always print the traceback after we get a grpc error.

## How was this patch tested?
Raise a grpc error in the create_execution method in raw.py


