### PR TITLE
chore: Replace print statement with logger.debug in type_engine.py

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1905,7 +1905,7 @@ class UnionTransformer(AsyncTypeTransformer[T]):
                 else:
                     res = trans.to_literal(ctx, python_val, t, expected.union_type.variants[i])
                 if found_res:
-                    print(f"Current type {get_args(python_type)[i]} old res {res_type}")
+                    logger.debug(f"Current type {get_args(python_type)[i]} old res {res_type}")
                     is_ambiguous = True
                 res_type = _add_tag_to_type(trans.get_literal_type(t), trans.name)
                 found_res = True


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
This change replaces a print statement with logger.debug to improve logging practices in the codebase.
## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
The changes involve:
1. Removing the line:
`print(f"Current type {get_args(python_type)[i]} old res {res_type}")`
2. Replacing it with:
`logger.debug(f"Current type {get_args(python_type)[i]} old res {res_type}")`
## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
No testing was performed as this is a minimal-risk change from print statement to logger.debug. Will add tests if needed - please let me know.
## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

