### PR TITLE
Auto activating launchplans that have been marked to be auto activated

### DIFF
--- a/flytekit/models/launch_plan.py
+++ b/flytekit/models/launch_plan.py
@@ -373,15 +373,24 @@ class LaunchPlanClosure(_common.FlyteIdlEntity):
 
 
 class LaunchPlan(_common.FlyteIdlEntity):
-    def __init__(self, id, spec, closure):
+    # TODO shall we add auto_activate here? this is client side only and breaks the contract
+    def __init__(self, id, spec, closure, auto_activate=False):
         """
         :param flytekit.models.core.identifier.Identifier id:
         :param LaunchPlanSpec spec:
         :param LaunchPlanClosure closure:
+        :param bool auto_activate: Whether to automatically activate the launch plan, this is a client side only
+            parameter and does not affect the actual launch plan. Also cannot be used from flytectl, only available
+            from the python SDK or pyflyte register.
         """
         self._id = id
         self._spec = spec
         self._closure = closure
+        self._auto_activate = auto_activate
+
+    @property
+    def should_auto_activate(self) -> bool:
+        return self._auto_activate
 
     @property
     def id(self):

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -825,6 +825,9 @@ class FlyteRemote(object):
                 self.client.create_launch_plan(launch_plan_identifer=ident, launch_plan_spec=cp_entity.spec)
             except FlyteEntityAlreadyExistsException:
                 logger.debug(f" {ident} Already Exists!")
+
+            if cp_entity.should_auto_activate:
+                self.client.update_launch_plan(ident, launch_plan_models.LaunchPlanState.ACTIVE)
             return ident
 
         raise AssertionError(f"Unknown entity of type {type(cp_entity)}")

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -341,9 +341,12 @@ def register(
                     )
                     console_url = remote.generate_console_url(i)
                     print_activation_message = False
-                    if is_lp and activate_launchplans:
-                        remote.activate_launchplan(i)
-                        print_activation_message = True
+                    if is_lp:
+                        if activate_launchplans:
+                            remote.activate_launchplan(i)
+                            print_activation_message = True
+                        if cp_entity.should_auto_activate:
+                            print_activation_message = True
                     print_registration_status(
                         i, console_url=console_url, verbosity=verbosity, activation=print_activation_message
                     )

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -381,6 +381,7 @@ def get_serializable_launch_plan(
             expected_inputs=interface_models.ParameterMap({}),
             expected_outputs=interface_models.VariableMap({}),
         ),
+        auto_activate=entity.should_auto_activate,
     )
 
     return lp_model


### PR DESCRIPTION
This PR supports automatically activating any launchplan within the python sdk, as long as it is marked so. This will use a secondary api call, so this is not atomic and may need to be retried.

```python
example_launch_plan = LaunchPlan.get_or_create(
    name="talk-every-minute",
    workflow=talker,
    default_inputs={"name": "Flyte"},
    schedule=CronSchedule(
        schedule="* * * * *",  # Following schedule runs every min
        kickoff_time_input_arg="t",
    ),
)

example_2 = LaunchPlan.get_or_create(
    name="talk-every-hour",
    workflow=talker,
    default_inputs={"name": "Hello"},
    schedule=CronSchedule(
        schedule="* 1 * * *",  # Following schedule runs every min
        kickoff_time_input_arg="t",
    ),
    auto_activate=True,
)
```

In the above example using

```bash
pyflyte register
```

Only the `talk-every-hour` launchplan will be auto activate

if
```bash
pyflyte register x.py --activate-launchplans
```
is involed then both `talk-every-hour` and `talk-every-minute` will be activated as they have schedules associated.

