### PR TITLE
Add cache key metadata

### DIFF
--- a/flytekit/core/constants.py
+++ b/flytekit/core/constants.py
@@ -22,3 +22,8 @@ FLYTE_USE_OLD_DC_FORMAT = "FLYTE_USE_OLD_DC_FORMAT"
 
 # Set this environment variable to true to force the task to return non-zero exit code on failure.
 FLYTE_FAIL_ON_ERROR = "FLYTE_FAIL_ON_ERROR"
+
+# This is a special key used to store metadata about the cache key in a literal type.
+CACHE_KEY_METADATA = "cache-key-metadata"
+
+SERIALIZATION_FORMAT = "serialization-format"

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -2135,10 +2135,7 @@ class DictTransformer(AsyncTypeTransformer[dict]):
             if tp[0] == str:
                 try:
                     sub_type = TypeEngine.to_literal_type(cast(type, tp[1]))
-                    return _type_models.LiteralType(
-                        map_value_type=sub_type,
-                        annotation=TypeAnnotationModel({CACHE_KEY_METADATA: {SERIALIZATION_FORMAT: MESSAGEPACK}}),
-                    )
+                    return _type_models.LiteralType(map_value_type=sub_type)
                 except Exception as e:
                     raise ValueError(f"Type of Generic List type is not supported, {e}")
         return _type_models.LiteralType(

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -36,7 +36,7 @@ from mashumaro.mixins.json import DataClassJSONMixin
 from typing_extensions import Annotated, get_args, get_origin
 
 from flytekit.core.annotation import FlyteAnnotation
-from flytekit.core.constants import FLYTE_USE_OLD_DC_FORMAT, MESSAGEPACK
+from flytekit.core.constants import CACHE_KEY_METADATA, FLYTE_USE_OLD_DC_FORMAT, MESSAGEPACK, SERIALIZATION_FORMAT
 from flytekit.core.context_manager import FlyteContext
 from flytekit.core.hash import HashMethod
 from flytekit.core.type_helpers import load_type_from_tag
@@ -662,7 +662,12 @@ class DataclassTransformer(TypeTransformer[object]):
         # This is for attribute access in FlytePropeller.
         ts = TypeStructure(tag="", dataclass_type=literal_type)
 
-        return _type_models.LiteralType(simple=_type_models.SimpleType.STRUCT, metadata=schema, structure=ts)
+        return _type_models.LiteralType(
+            simple=_type_models.SimpleType.STRUCT,
+            metadata=schema,
+            structure=ts,
+            annotation=TypeAnnotationModel({CACHE_KEY_METADATA: {SERIALIZATION_FORMAT: MESSAGEPACK}}),
+        )
 
     def to_generic_literal(
         self, ctx: FlyteContext, python_val: T, python_type: Type[T], expected: LiteralType
@@ -1316,7 +1321,12 @@ class TypeEngine(typing.Generic[T]):
                     )
                 data = x.data
         if data is not None:
+            # Double-check that `data` does not contain a key called `cache-key-metadata`
+            if CACHE_KEY_METADATA in data:
+                raise AssertionError(f"FlyteAnnotation cannot contain `{CACHE_KEY_METADATA}`.")
             idl_type_annotation = TypeAnnotationModel(annotations=data)
+            if res.annotation:
+                idl_type_annotation = TypeAnnotationModel.merge_annotations(idl_type_annotation, res.annotation)
             res = LiteralType.from_flyte_idl(res.to_flyte_idl())
             res._annotation = idl_type_annotation
         return res

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -2135,10 +2135,16 @@ class DictTransformer(AsyncTypeTransformer[dict]):
             if tp[0] == str:
                 try:
                     sub_type = TypeEngine.to_literal_type(cast(type, tp[1]))
-                    return _type_models.LiteralType(map_value_type=sub_type)
+                    return _type_models.LiteralType(
+                        map_value_type=sub_type,
+                        annotation=TypeAnnotationModel({CACHE_KEY_METADATA: {SERIALIZATION_FORMAT: MESSAGEPACK}}),
+                    )
                 except Exception as e:
                     raise ValueError(f"Type of Generic List type is not supported, {e}")
-        return _type_models.LiteralType(simple=_type_models.SimpleType.STRUCT)
+        return _type_models.LiteralType(
+            simple=_type_models.SimpleType.STRUCT,
+            annotation=TypeAnnotationModel({CACHE_KEY_METADATA: {SERIALIZATION_FORMAT: MESSAGEPACK}}),
+        )
 
     async def async_to_literal(
         self, ctx: FlyteContext, python_val: typing.Any, python_type: Type[dict], expected: LiteralType

--- a/flytekit/extras/pydantic_transformer/transformer.py
+++ b/flytekit/extras/pydantic_transformer/transformer.py
@@ -8,11 +8,12 @@ from google.protobuf import struct_pb2 as _struct
 from pydantic import BaseModel
 
 from flytekit import FlyteContext
-from flytekit.core.constants import FLYTE_USE_OLD_DC_FORMAT, MESSAGEPACK
+from flytekit.core.constants import CACHE_KEY_METADATA, FLYTE_USE_OLD_DC_FORMAT, MESSAGEPACK, SERIALIZATION_FORMAT
 from flytekit.core.type_engine import TypeEngine, TypeTransformer, TypeTransformerFailedError
 from flytekit.core.utils import str2bool
 from flytekit.loggers import logger
 from flytekit.models import types
+from flytekit.models.annotation import TypeAnnotation as TypeAnnotationModel
 from flytekit.models.literals import Binary, Literal, Scalar
 from flytekit.models.types import LiteralType, TypeStructure
 
@@ -37,7 +38,12 @@ class PydanticTransformer(TypeTransformer[BaseModel]):
         # This is for attribute access in FlytePropeller.
         ts = TypeStructure(tag="", dataclass_type=literal_type)
 
-        return types.LiteralType(simple=types.SimpleType.STRUCT, metadata=schema, structure=ts)
+        return types.LiteralType(
+            simple=types.SimpleType.STRUCT,
+            metadata=schema,
+            structure=ts,
+            annotation=TypeAnnotationModel({CACHE_KEY_METADATA: {SERIALIZATION_FORMAT: MESSAGEPACK}}),
+        )
 
     def to_generic_literal(
         self,

--- a/flytekit/models/annotation.py
+++ b/flytekit/models/annotation.py
@@ -42,6 +42,19 @@ class TypeAnnotation:
 
         return cls(annotations=_json_format.MessageToDict(proto.annotations))
 
+    @classmethod
+    def merge_annotations(cls, annotation: "TypeAnnotation", other_annotation: "TypeAnnotation") -> "TypeAnnotation":
+        """
+        Merges two annotations together. If the same key exists in both annotations, the value in the other annotation
+        will be used.
+        :param TypeAnnotation annotation: The first annotation
+        :param TypeAnnotation other_annotation: The second annotation
+        :rtype: TypeAnnotation
+        """
+        merged_annotations = annotation.annotations.copy()
+        merged_annotations.update(other_annotation.annotations)
+        return cls(annotations=merged_annotations)
+
     def __eq__(self, x: object) -> bool:
         if not isinstance(x, self.__class__):
             return False

--- a/tests/flytekit/unit/core/test_generice_idl_type_engine.py
+++ b/tests/flytekit/unit/core/test_generice_idl_type_engine.py
@@ -2494,39 +2494,18 @@ class AnnotatedDataclassTest(DataClassJsonMixin):
             typing.Dict[str, int],
             LiteralType(
                 map_value_type=LiteralType(simple=SimpleType.INTEGER),
-                annotation=TypeAnnotation(
-                    {
-                        "cache-key-metadata": {
-                            "serialization-format": "msgpack",
-                        },
-                    },
-                ),
             ),
         ),
         (
             typing.Dict[str, str],
             LiteralType(
                 map_value_type=LiteralType(simple=SimpleType.STRING),
-                annotation=TypeAnnotation(
-                    {
-                        "cache-key-metadata": {
-                            "serialization-format": "msgpack",
-                        },
-                    },
-                ),
             ),
         ),
         (
             typing.Dict[str, typing.List[int]],
             LiteralType(
                 map_value_type=LiteralType(collection_type=LiteralType(simple=SimpleType.INTEGER)),
-                annotation=TypeAnnotation(
-                    {
-                        "cache-key-metadata": {
-                            "serialization-format": "msgpack",
-                        },
-                    },
-                ),
             ),
         ),
         (
@@ -2568,13 +2547,6 @@ class AnnotatedDataclassTest(DataClassJsonMixin):
                         },
                     ),
                 ),
-                annotation=TypeAnnotation(
-                    {
-                        "cache-key-metadata": {
-                            "serialization-format": "msgpack",
-                        },
-                    },
-                ),
             ),
         ),
         (
@@ -2584,20 +2556,6 @@ class AnnotatedDataclassTest(DataClassJsonMixin):
                     map_value_type=LiteralType(
                         simple=SimpleType.INTEGER,
                     ),
-                    annotation=TypeAnnotation(
-                        {
-                            "cache-key-metadata": {
-                                "serialization-format": "msgpack",
-                            },
-                        },
-                    ),
-                ),
-                annotation=TypeAnnotation(
-                    {
-                        "cache-key-metadata": {
-                            "serialization-format": "msgpack",
-                        },
-                    },
                 ),
             ),
         ),

--- a/tests/flytekit/unit/core/test_generice_idl_type_engine.py
+++ b/tests/flytekit/unit/core/test_generice_idl_type_engine.py
@@ -496,7 +496,10 @@ def test_dict_transformer():
     )
     recursive_assert(
         d.get_literal_type(typing.Dict[str, dict]),
-        LiteralType(simple=SimpleType.STRUCT),
+        LiteralType(
+            simple=SimpleType.STRUCT,
+            annotation=TypeAnnotation({"cache-key-metadata": {"serialization-format": "msgpack"}})
+        ),
     )
     recursive_assert(
         d.get_literal_type(typing.Dict[str, typing.Dict[str, str]]),
@@ -505,7 +508,10 @@ def test_dict_transformer():
     )
     recursive_assert(
         d.get_literal_type(typing.Dict[str, typing.Dict[int, str]]),
-        LiteralType(simple=SimpleType.STRUCT),
+        LiteralType(
+            simple=SimpleType.STRUCT,
+            annotation=TypeAnnotation({"cache-key-metadata": {"serialization-format": "msgpack"}})
+        ),
         expected_depth=2,
     )
     recursive_assert(
@@ -515,12 +521,18 @@ def test_dict_transformer():
     )
     recursive_assert(
         d.get_literal_type(typing.Dict[str, typing.Dict[str, typing.Dict[str, dict]]]),
-        LiteralType(simple=SimpleType.STRUCT),
+        LiteralType(
+            simple=SimpleType.STRUCT,
+            annotation=TypeAnnotation({"cache-key-metadata": {"serialization-format": "msgpack"}})
+        ),
         expected_depth=3,
     )
     recursive_assert(
         d.get_literal_type(typing.Dict[str, typing.Dict[str, typing.Dict[int, dict]]]),
-        LiteralType(simple=SimpleType.STRUCT),
+        LiteralType(
+            simple=SimpleType.STRUCT,
+            annotation=TypeAnnotation({"cache-key-metadata": {"serialization-format": "msgpack"}})
+        ),
         expected_depth=2,
     )
 
@@ -2352,10 +2364,6 @@ def test_annotated_simple_types():
         typing_extensions.Annotated[int, FlyteAnnotation({"d": {"test": "data"}, "l": ["nested", ["list"]]})],
         {"d": {"test": "data"}, "l": ["nested", ["list"]]},
     )
-    _check_annotation(
-        typing_extensions.Annotated[int, FlyteAnnotation(InnerStruct(a=1, b="fizz", c=[1]))],
-        InnerStruct(a=1, b="fizz", c=[1]),
-    )
 
 
 def test_annotated_list():
@@ -2441,112 +2449,265 @@ class AnnotatedDataclassTest(DataClassJsonMixin):
 @pytest.mark.parametrize(
     "t,expected_type",
     [
-        (dict, LiteralType(simple=SimpleType.STRUCT)),
-        # Annotations are not being copied over to the LiteralType
         (
-                typing_extensions.Annotated[dict, "a-tag"],
-                LiteralType(simple=SimpleType.STRUCT),
-        ),
-        (typing.Dict[int, str], LiteralType(simple=SimpleType.STRUCT)),
-        (
-                typing.Dict[str, int],
-                LiteralType(map_value_type=LiteralType(simple=SimpleType.INTEGER)),
-        ),
-        (
-                typing.Dict[str, str],
-                LiteralType(map_value_type=LiteralType(simple=SimpleType.STRING)),
-        ),
-        (
-                typing.Dict[str, typing.List[int]],
-                LiteralType(map_value_type=LiteralType(collection_type=LiteralType(simple=SimpleType.INTEGER))),
-        ),
-        (typing.Dict[int, typing.List[int]], LiteralType(simple=SimpleType.STRUCT)),
-        (
-                typing.Dict[int, typing.Dict[int, int]],
-                LiteralType(simple=SimpleType.STRUCT),
-        ),
-        (
-                typing.Dict[str, typing.Dict[int, int]],
-                LiteralType(map_value_type=LiteralType(simple=SimpleType.STRUCT)),
-        ),
-        (
-                typing.Dict[str, typing.Dict[str, int]],
-                LiteralType(map_value_type=LiteralType(map_value_type=LiteralType(simple=SimpleType.INTEGER))),
-        ),
-        (
-                DataclassTest,
-                LiteralType(
-                    simple=SimpleType.STRUCT,
-                    metadata={
-                        "type": "object",
-                        "title": "DataclassTest",
-                        "properties": {
-                            "a": {"type": "integer"},
-                            "b": {"type": "string"}
+            dict,
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
                         },
-                        "additionalProperties": False,
-                        "required": ["a", "b"]
                     },
-                    structure=TypeStructure(
-                        tag="",
-                        dataclass_type={
-                            "a": LiteralType(simple=SimpleType.INTEGER),
-                            "b": LiteralType(simple=SimpleType.STRING),
+                ),
+            ),
+        ),
+        # Only the special `cache-key-metadata` TypeAnnotations is copied over to the LiteralType
+        (
+            typing_extensions.Annotated[dict, "a-tag"],
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            typing.Dict[int, str],
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+
+            ),
+        ),
+        (
+            typing.Dict[str, int],
+            LiteralType(
+                map_value_type=LiteralType(simple=SimpleType.INTEGER),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            typing.Dict[str, str],
+            LiteralType(
+                map_value_type=LiteralType(simple=SimpleType.STRING),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            typing.Dict[str, typing.List[int]],
+            LiteralType(
+                map_value_type=LiteralType(collection_type=LiteralType(simple=SimpleType.INTEGER)),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            typing.Dict[int, typing.List[int]],
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            typing.Dict[int, typing.Dict[int, int]],
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            typing.Dict[str, typing.Dict[int, int]],
+            LiteralType(
+                map_value_type=LiteralType(
+                    simple=SimpleType.STRUCT,
+                    annotation=TypeAnnotation(
+                        {
+                            "cache-key-metadata": {
+                                "serialization-format": "msgpack",
+                            },
                         },
                     ),
                 ),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            typing.Dict[str, typing.Dict[str, int]],
+            LiteralType(
+                map_value_type=LiteralType(
+                    map_value_type=LiteralType(
+                        simple=SimpleType.INTEGER,
+                    ),
+                    annotation=TypeAnnotation(
+                        {
+                            "cache-key-metadata": {
+                                "serialization-format": "msgpack",
+                            },
+                        },
+                    ),
+                ),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            DataclassTest,
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                metadata={
+                    "type": "object",
+                    "title": "DataclassTest",
+                    "properties": {
+                        "a": {"type": "integer"},
+                        "b": {"type": "string"}
+                    },
+                    "additionalProperties": False,
+                    "required": ["a", "b"]
+                },
+                structure=TypeStructure(
+                    tag="",
+                    dataclass_type={
+                        "a": LiteralType(simple=SimpleType.INTEGER),
+                        "b": LiteralType(simple=SimpleType.STRING),
+                    },
+                ),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
         ),
         #  Similar to the dict[int, str] case, the annotation is not being copied over to the LiteralType
         (
-                Annotated[DataclassTest, "another-tag"],
-                LiteralType(
-                    simple=SimpleType.STRUCT,
-                    metadata={
-                        "type": "object",
-                        "title": "DataclassTest",
-                        "properties": {
-                            "a": {"type": "integer"},
-                            "b": {"type": "string"}
-                        },
-                        "additionalProperties": False,
-                        "required": ["a", "b"]
+            Annotated[DataclassTest, "another-tag"],
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                metadata={
+                    "type": "object",
+                    "title": "DataclassTest",
+                    "properties": {
+                        "a": {"type": "integer"},
+                        "b": {"type": "string"}
                     },
-                    structure=TypeStructure(
-                        tag="",
-                        dataclass_type={
-                            "a": LiteralType(simple=SimpleType.INTEGER),
-                            "b": LiteralType(simple=SimpleType.STRING),
-                        },
-                    ),
+                    "additionalProperties": False,
+                    "required": ["a", "b"]
+                },
+                structure=TypeStructure(
+                    tag="",
+                    dataclass_type={
+                        "a": LiteralType(simple=SimpleType.INTEGER),
+                        "b": LiteralType(simple=SimpleType.STRING),
+                    },
                 ),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
         ),
         # Notice how the annotation in the field is not carried over either
         (
-                Annotated[AnnotatedDataclassTest, "another-tag"],
-                LiteralType(
-                    simple=SimpleType.STRUCT,
-                    metadata={
-                        "type": "object",
-                        "title": "AnnotatedDataclassTest",
-                        "properties": {
-                            "a": {"type": "integer"},
-                            "b": {"type": "string"}
-                        },
-                        "additionalProperties": False,
-                        "required": ["a", "b"]
+            Annotated[AnnotatedDataclassTest, "another-tag"],
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                metadata={
+                    "type": "object",
+                    "title": "AnnotatedDataclassTest",
+                    "properties": {
+                        "a": {"type": "integer"},
+                        "b": {"type": "string"},
                     },
-                    structure=TypeStructure(
-                        tag="",
-                        dataclass_type={
-                            "a": LiteralType(simple=SimpleType.INTEGER),
-                            "b": LiteralType(simple=SimpleType.STRING),
-                        },
-                    ),
+                    "additionalProperties": False,
+                    "required": ["a", "b"],
+                },
+                structure=TypeStructure(
+                    tag="",
+                    dataclass_type={
+                        "a": LiteralType(simple=SimpleType.INTEGER),
+                        "b": LiteralType(simple=SimpleType.STRING),
+                    },
                 ),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        # Notice how the `FlyteAnnotation` is carried over
+        (
+            Annotated[int, FlyteAnnotation({"some-annotation": "a value"})],
+            LiteralType(
+                simple=SimpleType.INTEGER,
+                annotation=TypeAnnotation(
+                    {
+                        "some-annotation": "a value",
+                    },
+                ),
+            ),
         ),
     ],
 )
-def test_annotated_dicts(t, expected_type):
+def test_annotated(t, expected_type):
     assert TypeEngine.to_literal_type(t) == expected_type
 
 

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -16,6 +16,7 @@ from flytekit.core.workflow import workflow
 from flytekit.exceptions.user import FlyteAssertion, FlyteMissingTypeException
 from flytekit.image_spec.image_spec import ImageBuildEngine
 from flytekit.models.admin.workflow import WorkflowSpec
+from flytekit.models.annotation import TypeAnnotation
 from flytekit.models.literals import (
     BindingData,
     BindingDataCollection,
@@ -830,7 +831,14 @@ def test_default_args_task_dict_type():
     )
 
     assert wf_with_input_spec.template.interface.outputs["o0"].type == LiteralType(
-        map_value_type=LiteralType(simple=SimpleType.INTEGER)
+        map_value_type=LiteralType(simple=SimpleType.INTEGER),
+        annotation=TypeAnnotation(
+            {
+                "cache-key-metadata": {
+                    "serialization-format": "msgpack",
+                },
+            },
+        ),
     )
 
     assert wf_with_input() == input_val

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -830,16 +830,7 @@ def test_default_args_task_dict_type():
         }
     )
 
-    assert wf_with_input_spec.template.interface.outputs["o0"].type == LiteralType(
-        map_value_type=LiteralType(simple=SimpleType.INTEGER),
-        annotation=TypeAnnotation(
-            {
-                "cache-key-metadata": {
-                    "serialization-format": "msgpack",
-                },
-            },
-        ),
-    )
+    assert wf_with_input_spec.template.interface.outputs["o0"].type == LiteralType(map_value_type=LiteralType(simple=SimpleType.INTEGER))
 
     assert wf_with_input() == input_val
 

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -2499,39 +2499,18 @@ class AnnotatedDataclassTest(DataClassJsonMixin):
             typing.Dict[str, int],
             LiteralType(
                 map_value_type=LiteralType(simple=SimpleType.INTEGER),
-                annotation=TypeAnnotation(
-                    {
-                        "cache-key-metadata": {
-                            "serialization-format": "msgpack",
-                        },
-                    },
-                ),
             ),
         ),
         (
             typing.Dict[str, str],
             LiteralType(
                 map_value_type=LiteralType(simple=SimpleType.STRING),
-                annotation=TypeAnnotation(
-                    {
-                        "cache-key-metadata": {
-                            "serialization-format": "msgpack",
-                        },
-                    },
-                ),
             ),
         ),
         (
             typing.Dict[str, typing.List[int]],
             LiteralType(
                 map_value_type=LiteralType(collection_type=LiteralType(simple=SimpleType.INTEGER)),
-                annotation=TypeAnnotation(
-                    {
-                        "cache-key-metadata": {
-                            "serialization-format": "msgpack",
-                        },
-                    },
-                ),
             ),
         ),
         (
@@ -2573,13 +2552,6 @@ class AnnotatedDataclassTest(DataClassJsonMixin):
                         },
                     ),
                 ),
-                annotation=TypeAnnotation(
-                    {
-                        "cache-key-metadata": {
-                            "serialization-format": "msgpack",
-                        },
-                    },
-                ),
             ),
         ),
         (
@@ -2589,20 +2561,6 @@ class AnnotatedDataclassTest(DataClassJsonMixin):
                     map_value_type=LiteralType(
                         simple=SimpleType.INTEGER,
                     ),
-                    annotation=TypeAnnotation(
-                        {
-                            "cache-key-metadata": {
-                                "serialization-format": "msgpack",
-                            },
-                        },
-                    ),
-                ),
-                annotation=TypeAnnotation(
-                    {
-                        "cache-key-metadata": {
-                            "serialization-format": "msgpack",
-                        },
-                    },
                 ),
             ),
         ),

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -486,7 +486,10 @@ def test_dict_transformer():
     )
     recursive_assert(
         d.get_literal_type(typing.Dict[str, dict]),
-        LiteralType(simple=SimpleType.STRUCT),
+        LiteralType(
+            simple=SimpleType.STRUCT,
+            annotation=TypeAnnotation({"cache-key-metadata": {"serialization-format": "msgpack"}})
+        ),
     )
     recursive_assert(
         d.get_literal_type(typing.Dict[str, typing.Dict[str, str]]),
@@ -495,7 +498,10 @@ def test_dict_transformer():
     )
     recursive_assert(
         d.get_literal_type(typing.Dict[str, typing.Dict[int, str]]),
-        LiteralType(simple=SimpleType.STRUCT),
+        LiteralType(
+            simple=SimpleType.STRUCT,
+            annotation=TypeAnnotation({"cache-key-metadata": {"serialization-format": "msgpack"}})
+        ),
         expected_depth=2,
     )
     recursive_assert(
@@ -505,12 +511,18 @@ def test_dict_transformer():
     )
     recursive_assert(
         d.get_literal_type(typing.Dict[str, typing.Dict[str, typing.Dict[str, dict]]]),
-        LiteralType(simple=SimpleType.STRUCT),
+        LiteralType(
+            simple=SimpleType.STRUCT,
+            annotation=TypeAnnotation({"cache-key-metadata": {"serialization-format": "msgpack"}})
+        ),
         expected_depth=3,
     )
     recursive_assert(
         d.get_literal_type(typing.Dict[str, typing.Dict[str, typing.Dict[int, dict]]]),
-        LiteralType(simple=SimpleType.STRUCT),
+        LiteralType(
+            simple=SimpleType.STRUCT,
+            annotation=TypeAnnotation({"cache-key-metadata": {"serialization-format": "msgpack"}})
+        ),
         expected_depth=2,
     )
 
@@ -2357,10 +2369,6 @@ def test_annotated_simple_types():
         typing_extensions.Annotated[int, FlyteAnnotation({"d": {"test": "data"}, "l": ["nested", ["list"]]})],
         {"d": {"test": "data"}, "l": ["nested", ["list"]]},
     )
-    _check_annotation(
-        typing_extensions.Annotated[int, FlyteAnnotation(InnerStruct(a=1, b="fizz", c=[1]))],
-        InnerStruct(a=1, b="fizz", c=[1]),
-    )
 
 
 def test_annotated_list():
@@ -2446,112 +2454,265 @@ class AnnotatedDataclassTest(DataClassJsonMixin):
 @pytest.mark.parametrize(
     "t,expected_type",
     [
-        (dict, LiteralType(simple=SimpleType.STRUCT)),
-        # Annotations are not being copied over to the LiteralType
         (
-                typing_extensions.Annotated[dict, "a-tag"],
-                LiteralType(simple=SimpleType.STRUCT),
-        ),
-        (typing.Dict[int, str], LiteralType(simple=SimpleType.STRUCT)),
-        (
-                typing.Dict[str, int],
-                LiteralType(map_value_type=LiteralType(simple=SimpleType.INTEGER)),
-        ),
-        (
-                typing.Dict[str, str],
-                LiteralType(map_value_type=LiteralType(simple=SimpleType.STRING)),
-        ),
-        (
-                typing.Dict[str, typing.List[int]],
-                LiteralType(map_value_type=LiteralType(collection_type=LiteralType(simple=SimpleType.INTEGER))),
-        ),
-        (typing.Dict[int, typing.List[int]], LiteralType(simple=SimpleType.STRUCT)),
-        (
-                typing.Dict[int, typing.Dict[int, int]],
-                LiteralType(simple=SimpleType.STRUCT),
-        ),
-        (
-                typing.Dict[str, typing.Dict[int, int]],
-                LiteralType(map_value_type=LiteralType(simple=SimpleType.STRUCT)),
-        ),
-        (
-                typing.Dict[str, typing.Dict[str, int]],
-                LiteralType(map_value_type=LiteralType(map_value_type=LiteralType(simple=SimpleType.INTEGER))),
-        ),
-        (
-                DataclassTest,
-                LiteralType(
-                    simple=SimpleType.STRUCT,
-                    metadata={
-                        "type": "object",
-                        "title": "DataclassTest",
-                        "properties": {
-                            "a": {"type": "integer"},
-                            "b": {"type": "string"}
+            dict,
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
                         },
-                        "additionalProperties": False,
-                        "required": ["a", "b"]
                     },
-                    structure=TypeStructure(
-                        tag="",
-                        dataclass_type={
-                            "a": LiteralType(simple=SimpleType.INTEGER),
-                            "b": LiteralType(simple=SimpleType.STRING),
+                ),
+            ),
+        ),
+        # Only the special `cache-key-metadata` TypeAnnotations is copied over to the LiteralType
+        (
+            typing_extensions.Annotated[dict, "a-tag"],
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            typing.Dict[int, str],
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+
+            ),
+        ),
+        (
+            typing.Dict[str, int],
+            LiteralType(
+                map_value_type=LiteralType(simple=SimpleType.INTEGER),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            typing.Dict[str, str],
+            LiteralType(
+                map_value_type=LiteralType(simple=SimpleType.STRING),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            typing.Dict[str, typing.List[int]],
+            LiteralType(
+                map_value_type=LiteralType(collection_type=LiteralType(simple=SimpleType.INTEGER)),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            typing.Dict[int, typing.List[int]],
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            typing.Dict[int, typing.Dict[int, int]],
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            typing.Dict[str, typing.Dict[int, int]],
+            LiteralType(
+                map_value_type=LiteralType(
+                    simple=SimpleType.STRUCT,
+                    annotation=TypeAnnotation(
+                        {
+                            "cache-key-metadata": {
+                                "serialization-format": "msgpack",
+                            },
                         },
                     ),
                 ),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            typing.Dict[str, typing.Dict[str, int]],
+            LiteralType(
+                map_value_type=LiteralType(
+                    map_value_type=LiteralType(
+                        simple=SimpleType.INTEGER,
+                    ),
+                    annotation=TypeAnnotation(
+                        {
+                            "cache-key-metadata": {
+                                "serialization-format": "msgpack",
+                            },
+                        },
+                    ),
+                ),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        (
+            DataclassTest,
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                metadata={
+                    "type": "object",
+                    "title": "DataclassTest",
+                    "properties": {
+                        "a": {"type": "integer"},
+                        "b": {"type": "string"}
+                    },
+                    "additionalProperties": False,
+                    "required": ["a", "b"]
+                },
+                structure=TypeStructure(
+                    tag="",
+                    dataclass_type={
+                        "a": LiteralType(simple=SimpleType.INTEGER),
+                        "b": LiteralType(simple=SimpleType.STRING),
+                    },
+                ),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
         ),
         #  Similar to the dict[int, str] case, the annotation is not being copied over to the LiteralType
         (
-                Annotated[DataclassTest, "another-tag"],
-                LiteralType(
-                    simple=SimpleType.STRUCT,
-                    metadata={
-                        "type": "object",
-                        "title": "DataclassTest",
-                        "properties": {
-                            "a": {"type": "integer"},
-                            "b": {"type": "string"}
-                        },
-                        "additionalProperties": False,
-                        "required": ["a", "b"]
+            Annotated[DataclassTest, "another-tag"],
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                metadata={
+                    "type": "object",
+                    "title": "DataclassTest",
+                    "properties": {
+                        "a": {"type": "integer"},
+                        "b": {"type": "string"}
                     },
-                    structure=TypeStructure(
-                        tag="",
-                        dataclass_type={
-                            "a": LiteralType(simple=SimpleType.INTEGER),
-                            "b": LiteralType(simple=SimpleType.STRING),
-                        },
-                    ),
+                    "additionalProperties": False,
+                    "required": ["a", "b"]
+                },
+                structure=TypeStructure(
+                    tag="",
+                    dataclass_type={
+                        "a": LiteralType(simple=SimpleType.INTEGER),
+                        "b": LiteralType(simple=SimpleType.STRING),
+                    },
                 ),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
         ),
         # Notice how the annotation in the field is not carried over either
         (
-                Annotated[AnnotatedDataclassTest, "another-tag"],
-                LiteralType(
-                    simple=SimpleType.STRUCT,
-                    metadata={
-                        "type": "object",
-                        "title": "AnnotatedDataclassTest",
-                        "properties": {
-                            "a": {"type": "integer"},
-                            "b": {"type": "string"},
-                        },
-                        "additionalProperties": False,
-                        "required": ["a", "b"],
+            Annotated[AnnotatedDataclassTest, "another-tag"],
+            LiteralType(
+                simple=SimpleType.STRUCT,
+                metadata={
+                    "type": "object",
+                    "title": "AnnotatedDataclassTest",
+                    "properties": {
+                        "a": {"type": "integer"},
+                        "b": {"type": "string"},
                     },
-                    structure=TypeStructure(
-                        tag="",
-                        dataclass_type={
-                            "a": LiteralType(simple=SimpleType.INTEGER),
-                            "b": LiteralType(simple=SimpleType.STRING),
-                        },
-                    ),
+                    "additionalProperties": False,
+                    "required": ["a", "b"],
+                },
+                structure=TypeStructure(
+                    tag="",
+                    dataclass_type={
+                        "a": LiteralType(simple=SimpleType.INTEGER),
+                        "b": LiteralType(simple=SimpleType.STRING),
+                    },
                 ),
+                annotation=TypeAnnotation(
+                    {
+                        "cache-key-metadata": {
+                            "serialization-format": "msgpack",
+                        },
+                    },
+                ),
+            ),
+        ),
+        # Notice how the `FlyteAnnotation` is carried over
+        (
+            Annotated[int, FlyteAnnotation({"some-annotation": "a value"})],
+            LiteralType(
+                simple=SimpleType.INTEGER,
+                annotation=TypeAnnotation(
+                    {
+                        "some-annotation": "a value",
+                    },
+                ),
+            ),
         ),
     ],
 )
-def test_annotated_dicts(t, expected_type):
+def test_annotated(t, expected_type):
     assert TypeEngine.to_literal_type(t) == expected_type
 
 

--- a/tests/flytekit/unit/extras/pydantic_transformer/test_pydantic_basemodel_transformer.py
+++ b/tests/flytekit/unit/extras/pydantic_transformer/test_pydantic_basemodel_transformer.py
@@ -10,9 +10,12 @@ from google.protobuf import struct_pb2 as _struct
 from pydantic import BaseModel, Field
 
 from flytekit import task, workflow
+from flytekit.core.constants import CACHE_KEY_METADATA, MESSAGEPACK, SERIALIZATION_FORMAT
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.type_engine import TypeEngine
+from flytekit.models.annotation import TypeAnnotation
 from flytekit.models.literals import Literal, Scalar
+from flytekit.models.types import LiteralType, SimpleType
 from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import FlyteFile
 from flytekit.types.schema import FlyteSchema
@@ -980,3 +983,12 @@ def test_union_in_basemodel_wf():
         return bm
 
     assert wf_return_bm(bm=bm(a=1, b=2)) == bm(a=1, b=2)
+
+
+def test_basemodel_literal_type_annotation():
+    class BM(BaseModel):
+        a: int = -1
+        b: float = 2.1
+        c: str = "Hello, Flyte"
+
+    assert TypeEngine.to_literal_type(BM).annotation == TypeAnnotation({CACHE_KEY_METADATA: {SERIALIZATION_FORMAT: MESSAGEPACK}})


### PR DESCRIPTION
## Tracking issue
https://linear.app/unionai/issue/DX-1202/add-cacke-key-attributes-to-typeannotation

## Why are the changes needed?
This is the flytekit PR mentioned in https://github.com/flyteorg/flyte/pull/6078.


## What changes were proposed in this pull request?
We introduce a top-level dictionary to `TypeAnnotation` under a special key called `cache-key-metadata`. 

The three transformers that produce msgpack-binary idl literals (i.e. `DictTransformer`, `DataclassTransformer`, and `PydanticTransformer`) will now emit a `TypeAnnotation` that contains that special key.


## How was this patch tested?
unit tests and sandbox.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
