### PR TITLE
Set map task metadata only for subnode

### DIFF
--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -138,6 +138,11 @@ class ArrayNodeMapTask(PythonTask):
 
     def construct_node_metadata(self) -> NodeMetadata:
         # TODO: add support for other Flyte entities
+        return NodeMetadata(
+            name=self.name,
+        )
+
+    def construct_sub_node_metadata(self) -> NodeMetadata:
         nm = super().construct_node_metadata()
         nm._name = self.name
         return nm

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -619,7 +619,7 @@ def get_serializable_array_node_map_task(
     )
     node = workflow_model.Node(
         id=entity.name,
-        metadata=entity.construct_node_metadata(),
+        metadata=entity.construct_sub_node_metadata(),
         inputs=node.bindings,
         upstream_node_ids=[],
         output_aliases=[],

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -1,4 +1,5 @@
 import functools
+from datetime import timedelta
 import os
 import tempfile
 import typing
@@ -386,7 +387,12 @@ def test_serialization_metadata2(serialization_settings):
     def t1(a: int) -> typing.Optional[int]:
         return a + 1
 
-    arraynode_maptask = map_task(t1, min_success_ratio=0.9, concurrency=10, metadata=TaskMetadata(retries=2, interruptible=True))
+    arraynode_maptask = map_task(
+        t1,
+        min_success_ratio=0.9,
+        concurrency=10,
+        metadata=TaskMetadata(retries=2, interruptible=True, timeout=timedelta(seconds=10))
+    )
     assert arraynode_maptask.metadata.interruptible
 
     @workflow
@@ -402,9 +408,7 @@ def test_serialization_metadata2(serialization_settings):
     od = OrderedDict()
     wf_spec = get_serializable(od, serialization_settings, wf)
 
-    assert arraynode_maptask.construct_node_metadata().interruptible
     array_node = wf_spec.template.nodes[0]
-    assert array_node.metadata.interruptible
     assert array_node.array_node._min_success_ratio == 0.9
     assert array_node.array_node._parallelism == 10
     assert not array_node.array_node._is_original_sub_node_interface
@@ -412,6 +416,7 @@ def test_serialization_metadata2(serialization_settings):
     task_spec = od[arraynode_maptask]
     assert task_spec.template.metadata.retries.retries == 2
     assert task_spec.template.metadata.interruptible
+    assert task_spec.template.metadata.timeout == timedelta(seconds=10)
 
     wf1_spec = get_serializable(od, serialization_settings, wf1)
     array_node = wf1_spec.template.nodes[0]

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -409,6 +409,7 @@ def test_serialization_metadata2(serialization_settings):
     wf_spec = get_serializable(od, serialization_settings, wf)
 
     array_node = wf_spec.template.nodes[0]
+    assert array_node.metadata.timeout == timedelta()
     assert array_node.array_node._min_success_ratio == 0.9
     assert array_node.array_node._parallelism == 10
     assert not array_node.array_node._is_original_sub_node_interface


### PR DESCRIPTION
## Tracking issue
fixes: https://linear.app/unionai/issue/COR-2212/[bug]-setting-task-metadata-for-the-parent-array-node-causes-incorrect

## Why are the changes needed?

Right now metadata such as task timeout is set on the ArrayNode instead of just the subnode. This causes issues as we add support for sub node timeouts as the timeout that is intended for the subnode is also applied to the parent node.

## What changes were proposed in this pull request?
Set metadata only for the subnode

## How was this patch tested?
- added unit test

### Setup process
```
@task(timeout=timedelta(seconds=30))
def do_thing(t: int) -> str:
    sleep(15)
    return str(t)


@workflow
def wf():
    map_task(do_thing, concurrency=1)(t=[1, 2, 3])
```


### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flyte/pull/6054

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
