### PR TITLE
Skip socket files during fast registration

### DIFF
--- a/flytekit/tools/fast_registration.py
+++ b/flytekit/tools/fast_registration.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import posixpath
 import shutil
+import stat
 import subprocess
 import tarfile
 import tempfile
@@ -188,6 +189,11 @@ def compute_digest(source: Union[os.PathLike, List[os.PathLike]], filter: Option
         # Only consider files that exist (e.g. disregard symlinks that point to non-existent files)
         if not os.path.exists(path):
             logger.info(f"Skipping non-existent file {path}")
+            return
+
+        # Skip socket files
+        if stat.S_ISSOCK(os.stat(path).st_mode):
+            logger.info(f"Skip socket file {path}")
             return
 
         if filter:

--- a/tests/flytekit/unit/tools/test_fast_registration.py
+++ b/tests/flytekit/unit/tools/test_fast_registration.py
@@ -1,6 +1,8 @@
 import os
+import socket
 import subprocess
 import tarfile
+import tempfile
 import time
 from hashlib import md5
 from pathlib import Path
@@ -46,6 +48,29 @@ def flyte_project(tmp_path):
     os.symlink(str(tmp_path) + "/utils/util.py", str(tmp_path) + "/src/util")
     subprocess.run(["git", "init", str(tmp_path)])
     return tmp_path
+
+
+def test_skip_socket_file():
+    tmp_dir = tempfile.mkdtemp()
+
+    tree = {
+        "data": {"large.file": "", "more.files": ""},
+        "src": {
+            "workflows": {
+                "hello_world.py": "print('Hello World!')",
+            },
+        },
+    }
+
+    # Add a socket file
+    socket_path = tmp_dir + "/test.sock"
+    server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server_socket.bind(socket_path)
+
+    subprocess.run(["git", "init", str(tmp_dir)])
+
+    # Assert that this runs successfully 
+    compute_digest(str(tmp_dir))
 
 
 def test_package(flyte_project, tmp_path):

--- a/tests/flytekit/unit/tools/test_fast_registration.py
+++ b/tests/flytekit/unit/tools/test_fast_registration.py
@@ -50,6 +50,10 @@ def flyte_project(tmp_path):
     return tmp_path
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Skip if running on windows since Unix Domain Sockets do not exist in that OS",
+)
 def test_skip_socket_file():
     tmp_dir = tempfile.mkdtemp()
 
@@ -69,7 +73,7 @@ def test_skip_socket_file():
 
     subprocess.run(["git", "init", str(tmp_dir)])
 
-    # Assert that this runs successfully 
+    # Assert that this runs successfully
     compute_digest(str(tmp_dir))
 
 

--- a/tests/flytekit/unit/tools/test_fast_registration.py
+++ b/tests/flytekit/unit/tools/test_fast_registration.py
@@ -1,6 +1,7 @@
 import os
 import socket
 import subprocess
+import sys
 import tarfile
 import tempfile
 import time


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?
Unix Domain Sockets are not copyable

## What changes were proposed in this pull request?
Skip socket files during fast registration.

## How was this patch tested?
Unit tests and local sandbox.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
