### PR TITLE
Follow up to 2980 - Do not copy socket files

### DIFF
--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -5,6 +5,7 @@ import hashlib
 import os
 import shutil
 import site
+import stat
 import sys
 import tarfile
 import tempfile
@@ -172,6 +173,10 @@ def list_all_files(source_path: str, deref_symlinks, ignore_group: Optional[Igno
             if ignore_group:
                 if ignore_group.is_ignored(abspath):
                     continue
+            # Skip socket files
+            if stat.S_ISSOCK(os.stat(abspath).st_mode):
+                logger.info(f"Skip socket file {abspath}")
+                continue
 
             ff.append(abspath)
         all_files.extend(ff)

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -170,13 +170,13 @@ def list_all_files(source_path: str, deref_symlinks, ignore_group: Optional[Igno
             if not os.path.exists(abspath):
                 logger.info(f"Skipping non-existent file {abspath}")
                 continue
-            if ignore_group:
-                if ignore_group.is_ignored(abspath):
-                    continue
             # Skip socket files
             if stat.S_ISSOCK(os.stat(abspath).st_mode):
                 logger.info(f"Skip socket file {abspath}")
                 continue
+            if ignore_group:
+                if ignore_group.is_ignored(abspath):
+                    continue
 
             ff.append(abspath)
         all_files.extend(ff)


### PR DESCRIPTION
## Why are the changes needed?
Follow up to https://github.com/flyteorg/flytekit/pull/2980, but this time we not only skip socket files from the digest calculation but we also do not copy them to the tar file.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Skip Unix Domain Files
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Unit tests and local sandbox. Pass `--copy all` to `pyflyte run` and verified that it succeeds:
```
❯ pyflyte run --remote --copy all workflows/example.py wf
```


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
