### PR TITLE
Skip base install files

### DIFF
--- a/flytekit/tools/ignore.py
+++ b/flytekit/tools/ignore.py
@@ -48,7 +48,7 @@ class GitIgnore(Ignore):
             out = subprocess.run(["git", "ls-files", "-io", "--exclude-standard"], cwd=self.root, capture_output=True)
             if out.returncode == 0:
                 return dict.fromkeys(out.stdout.decode("utf-8").split("\n")[:-1])
-            logger.warning(f"Could not determine ignored files due to:\n{out.stderr}\nNot applying any filters")
+            logger.info(f"Could not determine ignored files due to:\n{out.stderr}\nNot applying any filters")
             return {}
         logger.info("No git executable found, not applying any filters")
         return {}

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -230,6 +230,10 @@ def list_imported_modules_as_files(source_path: str, modules: List[ModuleType]) 
                 # Do not upload from the bin directory
                 continue
 
+            if os.path.commonpath([sys.base_prefix, mod_file]) == sys.base_prefix:
+                # Do not upload from the python installation directory
+                continue
+
         except ValueError:
             # ValueError is raised by windows if the paths are not from the same drive
             # If the files are not in the same drive, then mod_file is not


### PR DESCRIPTION
Edge case with finding imported module files when running a python script from home dir.

Noticed while running a simple hello world workflow while in the my home directory that it was copying in files from the base python install.  These are files that are shared across virtualenvs.  In this case the venv was managed by uv, which stored base python install files in the `~/.local` folder.

If I have the hello world file in `~/temp/` then the filter on line 245 would prevent it from being included... it'd see that these base python files (in `~/.local/...`) sat outside of the `source_path` folder (in `~/temp/...`).  But because the file was in my home dir, the commonpath was the same and they were allowed through.