### PR TITLE
Fix lazy import

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1146,7 +1146,6 @@ class TypeEngine(typing.Generic[T]):
     _RESTRICTED_TYPES: typing.List[type] = []
     _DATACLASS_TRANSFORMER: TypeTransformer = DataclassTransformer()  # type: ignore
     _ENUM_TRANSFORMER: TypeTransformer = EnumTransformer()  # type: ignore
-    has_lazy_import = False
     lazy_import_lock = threading.Lock()
 
     @classmethod
@@ -1247,7 +1246,7 @@ class TypeEngine(typing.Generic[T]):
         return FlytePickleTransformer()
 
     @classmethod
-    def lazy_import_transformers(cls, force: bool = False):
+    def lazy_import_transformers(cls):
         """
         Only load the transformers if needed.
         If force is set to True, the transformers will be loaded regardless of whether they have been loaded before.

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1258,14 +1258,9 @@ class TypeEngine(typing.Generic[T]):
             if cls.has_lazy_import:
                 return
             cls.has_lazy_import = True
-            from flytekit.types.structured import (
-                register_arrow_handlers,
-                register_bigquery_handlers,
-                register_pandas_handlers,
-                register_snowflake_handlers,
-            )
-            from flytekit.types.structured.structured_dataset import DuplicateHandlerError
+            from flytekit.types.structured import lazy_import_structured_dataset_handler
 
+            lazy_import_structured_dataset_handler()
             if is_imported("tensorflow"):
                 from flytekit.extras import tensorflow  # noqa: F401
             if is_imported("torch"):
@@ -1279,29 +1274,10 @@ class TypeEngine(typing.Generic[T]):
                     from flytekit.types.schema.types_pandas import PandasSchemaReader, PandasSchemaWriter  # noqa: F401
                 except ValueError:
                     logger.debug("Transformer for pandas is already registered.")
-                try:
-                    register_pandas_handlers()
-                except DuplicateHandlerError:
-                    logger.debug("Transformer for pandas is already registered.")
-            if is_imported("pyarrow"):
-                try:
-                    register_arrow_handlers()
-                except DuplicateHandlerError:
-                    logger.debug("Transformer for arrow is already registered.")
-            if is_imported("google.cloud.bigquery"):
-                try:
-                    register_bigquery_handlers()
-                except DuplicateHandlerError:
-                    logger.debug("Transformer for bigquery is already registered.")
             if is_imported("numpy"):
                 from flytekit.types import numpy  # noqa: F401
             if is_imported("PIL"):
                 from flytekit.types.file import image  # noqa: F401
-            if is_imported("snowflake.connector"):
-                try:
-                    register_snowflake_handlers()
-                except DuplicateHandlerError:
-                    logger.debug("Transformer for snowflake is already registered.")
 
     @classmethod
     def to_literal_type(cls, python_type: Type[T]) -> LiteralType:

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1249,7 +1249,6 @@ class TypeEngine(typing.Generic[T]):
     def lazy_import_transformers(cls):
         """
         Only load the transformers if needed.
-        If force is set to True, the transformers will be loaded regardless of whether they have been loaded before.
         """
         with cls.lazy_import_lock:
             # Avoid a race condition where concurrent threads may exit lazy_import_transformers before the transformers

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1260,7 +1260,6 @@ class TypeEngine(typing.Generic[T]):
             cls.has_lazy_import = True
             from flytekit.types.structured import lazy_import_structured_dataset_handler
 
-            lazy_import_structured_dataset_handler()
             if is_imported("tensorflow"):
                 from flytekit.extras import tensorflow  # noqa: F401
             if is_imported("torch"):
@@ -1278,6 +1277,8 @@ class TypeEngine(typing.Generic[T]):
                 from flytekit.types import numpy  # noqa: F401
             if is_imported("PIL"):
                 from flytekit.types.file import image  # noqa: F401
+            lazy_import_structured_dataset_handler()
+
 
     @classmethod
     def to_literal_type(cls, python_type: Type[T]) -> LiteralType:

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1247,17 +1247,15 @@ class TypeEngine(typing.Generic[T]):
         return FlytePickleTransformer()
 
     @classmethod
-    def lazy_import_transformers(cls):
+    def lazy_import_transformers(cls, force: bool = False):
         """
         Only load the transformers if needed.
+        If force is set to True, the transformers will be loaded regardless of whether they have been loaded before.
         """
         with cls.lazy_import_lock:
             # Avoid a race condition where concurrent threads may exit lazy_import_transformers before the transformers
             # have been imported. This could be implemented without a lock if you assume python assignments are atomic
             # and re-registering transformers is acceptable, but I decided to play it safe.
-            if cls.has_lazy_import:
-                return
-            cls.has_lazy_import = True
             from flytekit.types.structured import lazy_import_structured_dataset_handler
 
             if is_imported("tensorflow"):
@@ -1278,7 +1276,6 @@ class TypeEngine(typing.Generic[T]):
             if is_imported("PIL"):
                 from flytekit.types.file import image  # noqa: F401
             lazy_import_structured_dataset_handler()
-
 
     @classmethod
     def to_literal_type(cls, python_type: Type[T]) -> LiteralType:

--- a/flytekit/lazy_import/lazy_module.py
+++ b/flytekit/lazy_import/lazy_module.py
@@ -4,6 +4,10 @@ import types
 
 
 class _LazyModule(types.ModuleType):
+    """
+    `lazy_module` returns an instance of this class if the module is not found in the python environment.
+    """
+
     def __init__(self, module_name: str):
         super().__init__(module_name)
         self._module_name = module_name
@@ -39,6 +43,8 @@ def lazy_module(fullname):
     if spec is None or spec.loader is None:
         # Return a lazy module if the module is not found in the python environment,
         # so that we can raise a proper error when the user tries to access an attribute in the module.
+        # The reason to do this is because importlib.util.LazyLoader still requires
+        # the module to be installed even if you don't use it.
         return _LazyModule(fullname)
     loader = importlib.util.LazyLoader(spec.loader)
     spec.loader = loader

--- a/flytekit/lazy_import/lazy_module.py
+++ b/flytekit/lazy_import/lazy_module.py
@@ -3,7 +3,7 @@ import sys
 import types
 
 
-class LazyModule(types.ModuleType):
+class _LazyModule(types.ModuleType):
     def __init__(self, module_name: str):
         super().__init__(module_name)
         self._module_name = module_name
@@ -19,7 +19,7 @@ def is_imported(module_name):
     """
     return (
         module_name in sys.modules
-        and object.__getattribute__(lazy_module(module_name), "__class__").__name__ != "LazyModule"
+        and object.__getattribute__(lazy_module(module_name), "__class__").__name__ != "_LazyModule"
     )
 
 
@@ -39,7 +39,7 @@ def lazy_module(fullname):
     if spec is None or spec.loader is None:
         # Return a lazy module if the module is not found in the python environment,
         # so that we can raise a proper error when the user tries to access an attribute in the module.
-        return LazyModule(fullname)
+        return _LazyModule(fullname)
     loader = importlib.util.LazyLoader(spec.loader)
     spec.loader = loader
     module = importlib.util.module_from_spec(spec)

--- a/flytekit/lazy_import/lazy_module.py
+++ b/flytekit/lazy_import/lazy_module.py
@@ -1,9 +1,6 @@
 import importlib.util
 import sys
 import types
-import typing
-
-LAZY_MODULES: typing.List[str] = []
 
 
 class LazyModule(types.ModuleType):
@@ -18,8 +15,17 @@ class LazyModule(types.ModuleType):
 def is_imported(module_name):
     """
     This function is used to check if a module has been imported by the regular import.
+    Return false if module is lazy imported and not used yet.
     """
-    return module_name in sys.modules and module_name not in LAZY_MODULES
+    return (
+        module_name in sys.modules
+        and object.__getattribute__(lazy_module(module_name), "__class__").__name__ != "LazyModule"
+    )
+
+
+# lazy import pandas
+# someone imports pandas
+# register sd transformer
 
 
 def lazy_module(fullname):
@@ -43,6 +49,5 @@ def lazy_module(fullname):
     spec.loader = loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[fullname] = module
-    LAZY_MODULES.append(module.__name__)
     loader.exec_module(module)
     return module

--- a/flytekit/lazy_import/lazy_module.py
+++ b/flytekit/lazy_import/lazy_module.py
@@ -23,11 +23,6 @@ def is_imported(module_name):
     )
 
 
-# lazy import pandas
-# someone imports pandas
-# register sd transformer
-
-
 def lazy_module(fullname):
     """
     This function is used to lazily import modules.  It is used in the following way:

--- a/flytekit/lazy_import/lazy_module.py
+++ b/flytekit/lazy_import/lazy_module.py
@@ -1,8 +1,9 @@
 import importlib.util
 import sys
 import types
+import typing
 
-LAZY_MODULES = []
+LAZY_MODULES: typing.List[str] = []
 
 
 class LazyModule(types.ModuleType):
@@ -42,6 +43,6 @@ def lazy_module(fullname):
     spec.loader = loader
     module = importlib.util.module_from_spec(spec)
     sys.modules[fullname] = module
-    LAZY_MODULES.append(module)
+    LAZY_MODULES.append(module.__name__)
     loader.exec_module(module)
     return module

--- a/flytekit/types/structured/__init__.py
+++ b/flytekit/types/structured/__init__.py
@@ -13,17 +13,15 @@ Flytekit StructuredDataset
 """
 
 from flytekit.deck.renderer import ArrowRenderer, TopFrameRenderer
+from flytekit.lazy_import.lazy_module import is_imported
 from flytekit.loggers import logger
 
-from ...lazy_import.lazy_module import is_imported
 from .structured_dataset import (
     DuplicateHandlerError,
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
-    StructuredDatasetMetadata,
     StructuredDatasetTransformerEngine,
-    StructuredDatasetType,
 )
 
 

--- a/flytekit/types/structured/__init__.py
+++ b/flytekit/types/structured/__init__.py
@@ -15,7 +15,9 @@ Flytekit StructuredDataset
 from flytekit.deck.renderer import ArrowRenderer, TopFrameRenderer
 from flytekit.loggers import logger
 
+from ...lazy_import.lazy_module import is_imported
 from .structured_dataset import (
+    DuplicateHandlerError,
     StructuredDataset,
     StructuredDatasetDecoder,
     StructuredDatasetEncoder,
@@ -84,3 +86,27 @@ def register_snowflake_handlers():
             "We won't register snowflake handler for structured dataset because "
             "we can't find package snowflake-connector-python"
         )
+
+
+def lazy_import_structured_dataset_handler():
+    if is_imported("pandas"):
+        try:
+            register_pandas_handlers()
+            register_csv_handlers()
+        except DuplicateHandlerError:
+            logger.debug("Transformer for pandas is already registered.")
+    if is_imported("pyarrow"):
+        try:
+            register_arrow_handlers()
+        except DuplicateHandlerError:
+            logger.debug("Transformer for arrow is already registered.")
+    if is_imported("google.cloud.bigquery"):
+        try:
+            register_bigquery_handlers()
+        except DuplicateHandlerError:
+            logger.debug("Transformer for bigquery is already registered.")
+    if is_imported("snowflake.connector"):
+        try:
+            register_snowflake_handlers()
+        except DuplicateHandlerError:
+            logger.debug("Transformer for snowflake is already registered.")

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -174,11 +174,10 @@ class StructuredDataset(SerializableType, DataClassJSONMixin):
 
         """
         Load the handler if needed. For the use case like:
-        
-            @task
-            def t1(sd: StructuredDataset):
-              import pandas as pd
-              sd.open(pd.DataFrame).all()
+        @task
+        def t1(sd: StructuredDataset):
+          import pandas as pd
+          sd.open(pd.DataFrame).all()
 
         pandas is imported inside the task, so padnas handler won't be loaded during deserialization in type engine.
         """

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -179,7 +179,7 @@ class StructuredDataset(SerializableType, DataClassJSONMixin):
           import pandas as pd
           sd.open(pd.DataFrame).all()
 
-        pandas is imported inside the task, so padnas handler won't be loaded during deserialization in type engine.
+        pandas is imported inside the task, so pandnas handler won't be loaded during deserialization in type engine.
         """
         lazy_import_structured_dataset_handler()
         self._dataframe_type = dataframe_type

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -172,6 +172,16 @@ class StructuredDataset(SerializableType, DataClassJSONMixin):
     def open(self, dataframe_type: Type[DF]):
         from flytekit.types.structured import lazy_import_structured_dataset_handler
 
+        """
+        Load the handler if needed. For the use case like:
+        
+            @task
+            def t1(sd: StructuredDataset):
+              import pandas as pd
+              sd.open(pd.DataFrame).all()
+
+        pandas is imported inside the task, so padnas handler won't be loaded during deserialization in type engine.
+        """
         lazy_import_structured_dataset_handler()
         self._dataframe_type = dataframe_type
         return self

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -170,6 +170,9 @@ class StructuredDataset(SerializableType, DataClassJSONMixin):
         return self._literal_sd
 
     def open(self, dataframe_type: Type[DF]):
+        from flytekit.types.structured import lazy_import_structured_dataset_handler
+
+        lazy_import_structured_dataset_handler()
         self._dataframe_type = dataframe_type
         return self
 

--- a/tests/flytekit/unit/core/test_generice_idl_type_engine.py
+++ b/tests/flytekit/unit/core/test_generice_idl_type_engine.py
@@ -3439,31 +3439,6 @@ def test_dataclass_none_output_input_deserialization():
     assert none_value_output is None, f"None value was {none_value_output}, not None as expected"
 
 
-@pytest.mark.serial
-def test_lazy_import_transformers_concurrently():
-    # Configure the mocks similar to https://stackoverflow.com/questions/29749193/python-unit-testing-with-two-mock-objects-how-to-verify-call-order
-    after_import_mock, mock_register = mock.Mock(), mock.Mock()
-    mock_wrapper = mock.Mock()
-    mock_wrapper.mock_register = mock_register
-    mock_wrapper.after_import_mock = after_import_mock
-
-    with mock.patch.object(StructuredDatasetTransformerEngine, "register", new=mock_register):
-        def run():
-            TypeEngine.lazy_import_transformers()
-            after_import_mock()
-
-        N = 5
-        with ThreadPoolExecutor(max_workers=N) as executor:
-            futures = [executor.submit(run) for _ in range(N)]
-            [f.result() for f in futures]
-
-        # Assert that all the register calls come before anything else.
-        assert mock_wrapper.mock_calls[-N:] == [mock.call.after_import_mock()] * N
-        expected_number_of_register_calls = len(mock_wrapper.mock_calls) - N
-        assert all([mock_call[0] == "mock_register" for mock_call in
-                    mock_wrapper.mock_calls[:expected_number_of_register_calls]])
-
-
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="PEP604 requires >=3.10, 585 requires >=3.9")
 def test_option_list_with_pipe():
     pt = list[int] | None

--- a/tests/flytekit/unit/core/test_generice_idl_type_engine.py
+++ b/tests/flytekit/unit/core/test_generice_idl_type_engine.py
@@ -3441,10 +3441,6 @@ def test_dataclass_none_output_input_deserialization():
 
 @pytest.mark.serial
 def test_lazy_import_transformers_concurrently():
-    # Ensure that next call to TypeEngine.lazy_import_transformers doesn't skip the import. Mark as serial to ensure
-    # this achieves what we expect.
-    TypeEngine.has_lazy_import = False
-
     # Configure the mocks similar to https://stackoverflow.com/questions/29749193/python-unit-testing-with-two-mock-objects-how-to-verify-call-order
     after_import_mock, mock_register = mock.Mock(), mock.Mock()
     mock_wrapper = mock.Mock()

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -3451,10 +3451,6 @@ def test_dataclass_none_output_input_deserialization():
 
 @pytest.mark.serial
 def test_lazy_import_transformers_concurrently():
-    # Ensure that next call to TypeEngine.lazy_import_transformers doesn't skip the import. Mark as serial to ensure
-    # this achieves what we expect.
-    TypeEngine.has_lazy_import = False
-
     # Configure the mocks similar to https://stackoverflow.com/questions/29749193/python-unit-testing-with-two-mock-objects-how-to-verify-call-order
     after_import_mock, mock_register = mock.Mock(), mock.Mock()
     mock_wrapper = mock.Mock()

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -3459,8 +3459,6 @@ def test_lazy_import_transformers_concurrently():
 
     with mock.patch.object(StructuredDatasetTransformerEngine, "register", new=mock_register):
         def run():
-            import pandas as pd
-            print(pd.__version__)  # This is to ensure that the import is done.
             TypeEngine.lazy_import_transformers()
             after_import_mock()
 

--- a/tests/flytekit/unit/lazy_module/test_lazy_module.py
+++ b/tests/flytekit/unit/lazy_module/test_lazy_module.py
@@ -1,12 +1,13 @@
 import pytest
 
-from flytekit.lazy_import.lazy_module import LazyModule, lazy_module
+from flytekit.lazy_import.lazy_module import LazyModule, lazy_module, is_imported
 
 
 def test_lazy_module():
     mod = lazy_module("click")
     assert mod.__name__ == "click"
     mod = lazy_module("fake_module")
+    assert not is_imported("fake_module")
     assert isinstance(mod, LazyModule)
     with pytest.raises(ImportError, match="Module fake_module is not yet installed."):
         print(mod.attr)

--- a/tests/flytekit/unit/lazy_module/test_lazy_module.py
+++ b/tests/flytekit/unit/lazy_module/test_lazy_module.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 from flytekit.lazy_import.lazy_module import LazyModule, lazy_module, is_imported
 
@@ -6,6 +7,7 @@ def test_lazy_module():
     mod = lazy_module("click")
     assert mod.__name__ == "click"
     mod = lazy_module("fake_module")
+    sys.modules["fake_module"] = mod
     assert not is_imported("fake_module")
     assert isinstance(mod, LazyModule)
     with pytest.raises(ImportError, match="Module fake_module is not yet installed."):

--- a/tests/flytekit/unit/lazy_module/test_lazy_module.py
+++ b/tests/flytekit/unit/lazy_module/test_lazy_module.py
@@ -1,6 +1,6 @@
 import sys
 import pytest
-from flytekit.lazy_import.lazy_module import LazyModule, lazy_module, is_imported
+from flytekit.lazy_import.lazy_module import _LazyModule, lazy_module, is_imported
 
 
 def test_lazy_module():
@@ -9,6 +9,6 @@ def test_lazy_module():
     mod = lazy_module("fake_module")
     sys.modules["fake_module"] = mod
     assert not is_imported("fake_module")
-    assert isinstance(mod, LazyModule)
+    assert isinstance(mod, _LazyModule)
     with pytest.raises(ImportError, match="Module fake_module is not yet installed."):
         print(mod.attr)

--- a/tests/flytekit/unit/lazy_module/test_lazy_module.py
+++ b/tests/flytekit/unit/lazy_module/test_lazy_module.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 from flytekit.lazy_import.lazy_module import _LazyModule, lazy_module, is_imported
+import dataclasses
 
 
 def test_lazy_module():
@@ -20,3 +21,5 @@ def test_lazy_module():
     non_lazy_module.__name__ = 'NonLazyModule'
     sys.modules["fake_module"] = non_lazy_module
     assert is_imported("fake_module")
+
+    assert is_imported("dataclasses")

--- a/tests/flytekit/unit/lazy_module/test_lazy_module.py
+++ b/tests/flytekit/unit/lazy_module/test_lazy_module.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 from flytekit.lazy_import.lazy_module import LazyModule, lazy_module, is_imported
 
@@ -8,7 +6,6 @@ def test_lazy_module():
     mod = lazy_module("click")
     assert mod.__name__ == "click"
     mod = lazy_module("fake_module")
-    sys.modules["fake_module"] = mod
     assert not is_imported("fake_module")
     assert isinstance(mod, LazyModule)
     with pytest.raises(ImportError, match="Module fake_module is not yet installed."):

--- a/tests/flytekit/unit/lazy_module/test_lazy_module.py
+++ b/tests/flytekit/unit/lazy_module/test_lazy_module.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock
 
 import pytest
 from flytekit.lazy_import.lazy_module import _LazyModule, lazy_module, is_imported
-import dataclasses
 
 
 def test_lazy_module():

--- a/tests/flytekit/unit/lazy_module/test_lazy_module.py
+++ b/tests/flytekit/unit/lazy_module/test_lazy_module.py
@@ -1,5 +1,6 @@
-import pytest
+import sys
 
+import pytest
 from flytekit.lazy_import.lazy_module import LazyModule, lazy_module, is_imported
 
 
@@ -7,6 +8,7 @@ def test_lazy_module():
     mod = lazy_module("click")
     assert mod.__name__ == "click"
     mod = lazy_module("fake_module")
+    sys.modules["fake_module"] = mod
     assert not is_imported("fake_module")
     assert isinstance(mod, LazyModule)
     with pytest.raises(ImportError, match="Module fake_module is not yet installed."):

--- a/tests/flytekit/unit/lazy_module/test_lazy_module.py
+++ b/tests/flytekit/unit/lazy_module/test_lazy_module.py
@@ -1,4 +1,6 @@
 import sys
+from unittest.mock import Mock
+
 import pytest
 from flytekit.lazy_import.lazy_module import _LazyModule, lazy_module, is_imported
 
@@ -7,8 +9,14 @@ def test_lazy_module():
     mod = lazy_module("click")
     assert mod.__name__ == "click"
     mod = lazy_module("fake_module")
+
     sys.modules["fake_module"] = mod
     assert not is_imported("fake_module")
     assert isinstance(mod, _LazyModule)
     with pytest.raises(ImportError, match="Module fake_module is not yet installed."):
         print(mod.attr)
+
+    non_lazy_module = Mock()
+    non_lazy_module.__name__ = 'NonLazyModule'
+    sys.modules["fake_module"] = non_lazy_module
+    assert is_imported("fake_module")

--- a/tests/flytekit/unit/types/structured_dataset/test_structured_dataset.py
+++ b/tests/flytekit/unit/types/structured_dataset/test_structured_dataset.py
@@ -22,7 +22,6 @@ from flytekit.models import literals
 from flytekit.models.literals import StructuredDatasetMetadata
 from flytekit.models.types import LiteralType, SchemaType, SimpleType, StructuredDatasetType
 from flytekit.tools.translator import get_serializable
-from flytekit.types.file import FlyteFile
 from flytekit.types.structured.structured_dataset import (
     PARQUET,
     StructuredDataset,


### PR DESCRIPTION
## Tracking issue
closed https://github.com/flyteorg/flyte/issues/6046

## Why are the changes needed?
We always import pandas by default if it's installed.

## What changes were proposed in this pull request?
Fix the is_imported function to return False if the module is lazily imported

## How was this patch tested?
```
pyflyte run --remote flyte-example/lazy_import_wf.py wf
```

### Setup process
```python
from flytekit import task, workflow, ImageSpec
from flytekit.lazy_import.lazy_module import is_imported
from flytekit import lazy_module

old_image_spec = ImageSpec(registry="ghcr.io/flyteorg", packages=["pyarrow", "pandas", "scikit-learn", "torch"], apt_packages=["git"])

new_flytekit = "git+https://github.com/flyteorg/flytekit.git@6874a02bd1be5359079c443992ca1202ead98d16"
new_image_spec = ImageSpec(registry="ghcr.io/flyteorg", packages=["pyarrow", "pandas", "scikit-learn", "torch", new_flytekit], apt_packages=["git"])


@task(container_image=old_image_spec, retries=5, enable_deck=True)
def bad_flytekit() -> str:
    lazy_module("sklearn")
    lazy_module("pandas")
    lazy_module("torch")
    lazy_module("pyarrow")
    print("sklearn", is_imported("sklearn"))  # True
    print("pandas", is_imported("pandas")) # True
    print("torch", is_imported("torch")) # True
    print("pyarrow", is_imported("pyarrow")) # True
    return "Hello, World!"


@task(container_image=new_image_spec, retries=5, enable_deck=True)
def good_flytekit() -> str:
    lazy_module("sklearn")
    lazy_module("pandas")
    lazy_module("torch")
    lazy_module("pyarrow")
    print("sklearn", is_imported("sklearn")) # False
    print("pandas", is_imported("pandas")) # False
    print("torch", is_imported("torch")) # False
    print("pyarrow", is_imported("pyarrow")) # False
    return "Hello, World!"


@workflow
def wf():
    bad_flytekit()
    good_flytekit()

```

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

