### PR TITLE
remove master idl

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,5 +1,4 @@
 -e file:.
-flyteidl @ git+https://github.com/flyteorg/flyte.git@master#subdirectory=flyteidl
 
 coverage[toml]
 hypothesis


### PR DESCRIPTION
Removing master idl install - contributors can install this if they so choose but I've found it causes conflicts sometimes.