### PR TITLE
fix: dbt-test

### DIFF
--- a/plugins/flytekit-dbt/setup.py
+++ b/plugins/flytekit-dbt/setup.py
@@ -4,11 +4,7 @@ PLUGIN_NAME = "dbt"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = [
-    "flytekit>=1.3.0b2",
-    "dbt-core>=1.6.0,<1.8.0",
-    "networkx>=2.5"
-]
+plugin_requires = ["flytekit>=1.3.0b2", "dbt-core>=1.6.0,<1.8.0", "networkx>=2.5"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-dbt/setup.py
+++ b/plugins/flytekit-dbt/setup.py
@@ -6,7 +6,8 @@ microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 plugin_requires = [
     "flytekit>=1.3.0b2",
-    "dbt-core<1.8.0",
+    "dbt-core>=1.6.0,<1.8.0",
+    "networkx>=2.5"
 ]
 
 __version__ = "0.0.0+develop"


### PR DESCRIPTION
## Why are the changes needed?

GitHub Actions with Python 3.9 will break when running dbt tests.

## What changes were proposed in this pull request?

Due to compatibility issues encountered when running dbt tests on Python 3.9, we need to adjust the version ranges of the dependent packages and add networkx.

why we need the networkx ?
Because the error in GitHub Actions indicates that when `import dbt` is executed, an ImportError occurred during the import of networkx. The specific reason is that networkx attempted to execute from fractions import gcd, which failed because fractions.gcd was removed in Python 3.9. 

```
Traceback (most recent call last):\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/bin/dbt", line 5, in <module>\n    from dbt.main import main\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/dbt/main.py", line 25, in <module>\n    import dbt.task.build as build_task\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/dbt/task/build.py", line 1, in <module>\n    from .run import RunTask, ModelRunner as run_model_runner\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/dbt/task/run.py", line 8, in <module>\n    from .compile import CompileRunner, CompileTask\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/dbt/task/compile.py", line 4, in <module>\n    from .runnable import GraphRunnableTask\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/dbt/task/runnable.py", line 17, in <module>\n    from dbt.task.base import ConfiguredTask\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/dbt/task/base.py", line 43, in <module>\n    from dbt.adapters.factory import register_adapter\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/dbt/adapters/factory.py", line 8, in <module>\n    from dbt.adapters.base.plugin import AdapterPlugin\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/dbt/adapters/base/__init__.py", line 13, in <module>\n    from dbt.adapters.base.impl import AdapterConfig, BaseAdapter, PythonJobHelper  # noqa\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/dbt/adapters/base/impl.py", line 41, in <module>\n    from dbt.adapters.protocol import (\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/dbt/adapters/protocol.py", line 24, in <module>\n    from dbt.graph import Graph\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/dbt/graph/__init__.py", line 1, in <module>\n    from .selector_spec import (  # noqa: F401\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/dbt/graph/selector_spec.py", line 8, in <module>\n    from .graph import UniqueId\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/dbt/graph/graph.py", line 3, in <module>\n    import networkx as nx  # type: ignore\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/networkx/__init__.py", line 114, in <module>\n    import networkx.generators\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/networkx/generators/__init__.py", line 14, in <module>\n    from networkx.generators.intersection import *\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/networkx/generators/intersection.py", line 13, in <module>\n    from networkx.algorithms import bipartite\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/networkx/algorithms/__init__.py", line 16, in <module>\n    from networkx.algorithms.dag import *\n  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/networkx/algorithms/dag.py", line 23, in <module>\n    from fractions import gcd\nImportError: cannot import name \'gcd\' from \'fractions\' (/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/fractions.py)
```


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
