### PR TITLE
GH-5989: Fix task registration with `node_dependency_hints`

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -869,7 +869,9 @@ class FlyteRemote(object):
             tasks.append(
                 loop.run_in_executor(
                     None,
-                    functools.partial(self.raw_register, cp_entity, serialization_settings, version, og_entity=task_entity),
+                    functools.partial(
+                        self.raw_register, cp_entity, serialization_settings, version, og_entity=task_entity
+                    ),
                 )
             )
             if task_entity == entity:

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -524,7 +524,9 @@ class FlyteRemote(object):
 
                 if node.branch_node:
                     get_launch_plan_from_branch(node.branch_node, node_launch_plans)
-        return FlyteWorkflow.promote_from_closure(compiled_wf, node_launch_plans)
+        flyte_workflow = FlyteWorkflow.promote_from_closure(compiled_wf, node_launch_plans)
+        flyte_workflow.template._id = workflow_id
+        return flyte_workflow
 
     def _upgrade_launchplan(self, lp: launch_plan_models.LaunchPlan) -> FlyteLaunchPlan:
         """

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -844,7 +844,12 @@ def test_register_task_with_node_dependency_hints(mock_client):
 
     registered_task = rr.register_task(dynamic0, ss)
     assert isinstance(registered_task, FlyteTask)
-    assert registered_task.id == Identifier(ResourceType.TASK, "flytesnacks", "development", "tests.flytekit.unit.remote.test_remote.dynamic0", "dummy_version")
+    assert registered_task.id.resource_type == ResourceType.TASK
+    assert registered_task.id.project == "flytesnacks"
+    assert registered_task.id.domain == "development"
+    # When running via `make unit_test` there is a `__-channelexec__` prefix added to the name.
+    assert registered_task.id.name.endswith("tests.flytekit.unit.remote.test_remote.dynamic0")
+    assert registered_task.id.version == "dummy_version"
 
     registered_workflow = rr.register_workflow(workflow1, ss)
     assert isinstance(registered_workflow, FlyteWorkflow)

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -845,3 +845,7 @@ def test_register_task_with_node_dependency_hints(mock_client):
     registered_task = rr.register_task(dynamic0, ss)
     assert isinstance(registered_task, FlyteTask)
     assert registered_task.id == Identifier(ResourceType.TASK, "flytesnacks", "development", "tests.flytekit.unit.remote.test_remote.dynamic0", "dummy_version")
+
+    registered_workflow = rr.register_workflow(workflow1, ss)
+    assert isinstance(registered_workflow, FlyteWorkflow)
+    assert registered_workflow.id == Identifier(ResourceType.WORKFLOW, "flytesnacks", "development", "tests.flytekit.unit.remote.test_remote.workflow1", "dummy_version")

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -35,7 +35,7 @@ from flytekit.models.core.compiler import CompiledWorkflowClosure
 from flytekit.models.core.identifier import Identifier, ResourceType, WorkflowExecutionIdentifier
 from flytekit.models.execution import Execution
 from flytekit.models.task import Task
-from flytekit.remote import FlyteTask
+from flytekit.remote import FlyteTask, FlyteWorkflow
 from flytekit.remote.lazy_entity import LazyEntity
 from flytekit.remote.remote import FlyteRemote, _get_git_repo_url, _get_pickled_target_dict
 from flytekit.tools.translator import Options, get_serializable, get_serializable_launch_plan


### PR DESCRIPTION
## Tracking issue
Closes flyteorg/flyte#5989

## Why are the changes needed?
To fix directly registering tasks that use `node_dependency_hints` pointing to a workflow. 

## What changes were proposed in this pull request?
Make `FlyteRemote._serialize_and_register` always return the remote version of the provided `entity` regardless of whether it happens to be the last entity to be registered.  

## How was this patch tested?
Wrote a new unittest

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
`node_dependency_hints` were introduced by https://github.com/flyteorg/flytekit/pull/2015

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
