### PR TITLE
Remove open_async usage in put raw data

### DIFF
--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -199,8 +199,7 @@ class FileAccessProvider(object):
         elif protocol == "s3":
             s3kwargs = s3_setup_args(self._data_config.s3, anonymous=anonymous)
             s3kwargs.update(kwargs)
-            fs = fsspec.filesystem(protocol, **s3kwargs)  # type: ignore
-            return fs
+            return fsspec.filesystem(protocol, **s3kwargs)  # type: ignore
         elif protocol == "gs":
             if anonymous:
                 kwargs["token"] = _ANON
@@ -221,8 +220,7 @@ class FileAccessProvider(object):
     ) -> Union[AsyncFileSystem, fsspec.AbstractFileSystem]:
         protocol = get_protocol(path)
         loop = asyncio.get_running_loop()
-        fs = self.get_filesystem(protocol, anonymous=anonymous, path=path, asynchronous=True, loop=loop, **kwargs)
-        return fs
+        return self.get_filesystem(protocol, anonymous=anonymous, path=path, asynchronous=True, loop=loop, **kwargs)
 
     def get_filesystem_for_path(self, path: str = "", anonymous: bool = False, **kwargs) -> fsspec.AbstractFileSystem:
         protocol = get_protocol(path)

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -220,6 +220,7 @@ class FileAccessProvider(object):
     ) -> Union[AsyncFileSystem, fsspec.AbstractFileSystem]:
         protocol = get_protocol(path)
         loop = asyncio.get_running_loop()
+
         return self.get_filesystem(protocol, anonymous=anonymous, path=path, asynchronous=True, loop=loop, **kwargs)
 
     def get_filesystem_for_path(self, path: str = "", anonymous: bool = False, **kwargs) -> fsspec.AbstractFileSystem:
@@ -422,6 +423,8 @@ class FileAccessProvider(object):
                 r = await self._put(from_path, to_path, **kwargs)
             return r or to_path
 
+        # See https://github.com/fsspec/s3fs/issues/871 for more background and pending work on the fsspec side to
+        # support effectively async open(). For now these use-cases below will revert to sync calls.
         # raw bytes
         if isinstance(lpath, bytes):
             fs = self.get_filesystem_for_path(to_path)

--- a/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
+++ b/plugins/flytekit-polars/flytekitplugins/polars/sd_transformers.py
@@ -69,9 +69,10 @@ class PolarsDataFrameToParquetEncodingHandler(StructuredDatasetEncoder):
             df.to_parquet(output_bytes)
 
         if structured_dataset.uri is not None:
+            output_bytes.seek(0)
             fs = ctx.file_access.get_filesystem_for_path(path=structured_dataset.uri)
             with fs.open(structured_dataset.uri, "wb") as s:
-                s.write(output_bytes)
+                s.write(output_bytes.read())
             output_uri = structured_dataset.uri
         else:
             remote_fn = "00000"  # 00000 is our default unnamed parquet filename

--- a/tests/flytekit/unit/core/test_data_persistence.py
+++ b/tests/flytekit/unit/core/test_data_persistence.py
@@ -210,7 +210,7 @@ def test_get_file_system():
     fp.get_filesystem("testgetfs", test_arg="test_arg")
 
 
-@pytest.mark.sandbox_text
+@pytest.mark.sandbox_test
 def test_put_raw_data_bytes():
     dc = Config.for_sandbox().data_config
     raw_output = f"s3://my-s3-bucket/"


### PR DESCRIPTION
## Why are the changes needed?
Syntax was always wrong.  This is not how open_async is used.

See https://github.com/fsspec/s3fs/issues/871, which may be resolved [here](https://github.com/fsspec/s3fs/pull/885).

### Polars
This also affected polars.  In testing, noticed part of the logic was incorrect - updated and added a test to exercise.

## What changes were proposed in this pull request?
Replace with a normal call - this means that writes for bytes and bytes-like objects will be blocking.  Given this seems to be fundamentally missing from fsspec at this time I think it's okay.

## How was this patch tested?
Unit tested and local sandbox.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
