### PR TITLE
Faster GitIgnore directory check

### DIFF
--- a/flytekit/tools/ignore.py
+++ b/flytekit/tools/ignore.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from fnmatch import fnmatch
 from pathlib import Path
 from shutil import which
-from typing import Dict, List, Optional, Type
+from typing import List, Optional, Type
 
 from docker.utils.build import PatternMatcher
 
@@ -41,28 +41,45 @@ class GitIgnore(Ignore):
     def __init__(self, root: Path):
         super().__init__(root)
         self.has_git = which("git") is not None
-        self.ignored = self._list_ignored()
+        self.ignored_files = self._list_ignored_files()
+        self.ignored_dirs = self._list_ignored_dirs()
 
-    def _list_ignored(self) -> Dict:
+    def _list_ignored_files(self) -> set[str]:
         if self.has_git:
-            out = subprocess.run(["git", "ls-files", "-io", "--exclude-standard"], cwd=self.root, capture_output=True)
+            out = subprocess.run(
+                ["git", "ls-files", "-io", "--exclude-standard"],
+                cwd=self.root,
+                capture_output=True,
+            )
             if out.returncode == 0:
-                return dict.fromkeys(out.stdout.decode("utf-8").split("\n")[:-1])
+                return set(out.stdout.decode("utf-8").split("\n")[:-1])
             logger.info(f"Could not determine ignored files due to:\n{out.stderr}\nNot applying any filters")
-            return {}
+            return set()
         logger.info("No git executable found, not applying any filters")
-        return {}
+        return set()
+
+    def _list_ignored_dirs(self) -> set[str]:
+        if self.has_git:
+            out = subprocess.run(
+                ["git", "ls-files", "-io", "--exclude-standard", "--directory"],
+                cwd=self.root,
+                capture_output=True,
+            )
+            if out.returncode == 0:
+                return set(out.stdout.decode("utf-8").split("\n")[:-1])
+            logger.info(f"Could not determine ignored files due to:\n{out.stderr}\nNot applying any filters")
+            return set()
+        logger.info("No git executable found, not applying any filters")
+        return set()
 
     def _is_ignored(self, path: str) -> bool:
-        if self.ignored:
+        if self.ignored_files:
             # git-ls-files uses POSIX paths
-            if Path(path).as_posix() in self.ignored:
+            if Path(path).as_posix() in self.ignored_files:
                 return True
             # Ignore empty directories
-            if os.path.isdir(os.path.join(self.root, path)) and all(
-                [self.is_ignored(os.path.join(path, f)) for f in os.listdir(os.path.join(self.root, path))]
-            ):
-                return True
+            if os.path.isdir(os.path.join(self.root, path)) and self.ignored_dirs:
+                return Path(path).as_posix() + "/" in self.ignored_dirs
         return False
 
 


### PR DESCRIPTION
## Why are the changes needed?

flytekit's `GitIgnore` performs a recursive file check to detect empty / ignored folders instead of checking the folder status directly. For folders with a lot of files (e.g. a python `.venv`), this can be unnecessarily slow.

An extreme example with 1M files in an ignored folder:

```sh
Old ignore folder: 5.39s
New ignore folder: 0.000158s
```

<details>

<summary>Code</summary>

The measurements were created using this script

```py
import subprocess
import shutil
from pathlib import Path
import os
import logging

from flytekit.tools.ignore import (
    GitIgnore as GitIgnoreOld,
    Ignore,
)

class GitIgnoreNew(Ignore):
  # The implementation ftom this PR
  ...

import time

start = time.perf_counter()
newIgnore = GitIgnoreNew(Path.cwd())
print(f"New ignore setup: {time.perf_counter() - start}")

start = time.perf_counter()
oldIgnore = GitIgnoreOld(Path.cwd())
print(f"Old ignore setup: {time.perf_counter() - start}")

start = time.perf_counter()
assert newIgnore.is_ignored("large-file-collection")
print(f"New ignore folder: {time.perf_counter() - start}")

start = time.perf_counter()
assert newIgnore.is_ignored("large-file-collection/1.txt")
print(f"New ignore file: {time.perf_counter() - start}")

start = time.perf_counter()
assert oldIgnore.is_ignored("large-file-collection")
print(f"Old ignore folder: {time.perf_counter() - start}")


start = time.perf_counter()
assert oldIgnore.is_ignored("large-file-collection/1.txt")
print(f"Old ignore file: {time.perf_counter() - start}")
```

</details>

## What changes were proposed in this pull request?

1.  Use `git ls-files` to also check against the list of ignored directories

## How was this patch tested?

Existing unit tests seem to already cover the changed code, performance benchmarks done manually as explained above.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
