### PR TITLE
Use the same source of time in flaky test

### DIFF
--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -526,17 +526,20 @@ def test_get_container_error_timestamp(monkeypatch) -> None:
 
     assert get_container_error_timestamp(FlyteException("foo", timestamp=10.5)) == Timestamp(seconds=10, nanos=500000000)
 
-    current_dtime = datetime.fromtimestamp(time.time())
+    current_timestamp = Timestamp()
+    current_timestamp.GetCurrentTime()
     error_timestamp = get_container_error_timestamp(RuntimeError("foo"))
-    assert error_timestamp.ToDatetime() >= current_dtime
+    assert error_timestamp.ToDatetime() >= current_timestamp.ToDatetime()
 
-    current_dtime = datetime.fromtimestamp(time.time())
+    current_timestamp = Timestamp()
+    current_timestamp.GetCurrentTime()
     error_timestamp = get_container_error_timestamp(FlyteException("foo"))
-    assert error_timestamp.ToDatetime() >= current_dtime
+    assert error_timestamp.ToDatetime() >= current_timestamp.ToDatetime()
 
-    current_dtime = datetime.fromtimestamp(time.time())
+    current_timestamp = Timestamp()
+    current_timestamp.GetCurrentTime()
     error_timestamp = get_container_error_timestamp(None)
-    assert error_timestamp.ToDatetime() >= current_dtime
+    assert error_timestamp.ToDatetime() >= current_timestamp.ToDatetime()
 
 
 def get_flyte_context(tmp_path_factory, outputs_path):

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -526,15 +526,15 @@ def test_get_container_error_timestamp(monkeypatch) -> None:
 
     assert get_container_error_timestamp(FlyteException("foo", timestamp=10.5)) == Timestamp(seconds=10, nanos=500000000)
 
-    current_dtime = datetime.now()
+    current_dtime = datetime.fromtimestamp(time.time())
     error_timestamp = get_container_error_timestamp(RuntimeError("foo"))
     assert error_timestamp.ToDatetime() >= current_dtime
 
-    current_dtime = datetime.now()
+    current_dtime = datetime.fromtimestamp(time.time())
     error_timestamp = get_container_error_timestamp(FlyteException("foo"))
     assert error_timestamp.ToDatetime() >= current_dtime
 
-    current_dtime = datetime.now()
+    current_dtime = datetime.fromtimestamp(time.time())
     error_timestamp = get_container_error_timestamp(None)
     assert error_timestamp.ToDatetime() >= current_dtime
 


### PR DESCRIPTION
## Why are the changes needed?
`test_get_container_error_timestamp` has been failing semi-consistently only on Windows. We all hate flaky tests.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
The test relies on the function `get_container_error_timestamp` which returns a protobuf Timestamp object, which uses `time.time` to collect the current time. However, the granularity of `time.time` and `datetime.now` are different (the latter being more precise as per https://docs.python.org/3/library/datetime.html#datetime.datetime.now).


## How was this patch tested?
I don't have a Windows machine, but tests run fine locally. Will kick off a few runs in CI just to confirm.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
