### PR TITLE
Backport to v1.14 - Unify dependencies in agent image (#3008)

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -222,6 +222,9 @@ jobs:
           file: ./Dockerfile.agent
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Confirm Agent can start
+        run: |
+          docker run --rm ghcr.io/${{ github.repository_owner }}/flyteagent:${{ github.sha }} pyflyte serve agent --port 8000 --timeout 1
       - name: Push flyteagent-all Image to GitHub Registry
         uses: docker/build-push-action@v2
         with:

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -8,13 +8,14 @@ ARG VERSION
 RUN apt-get update && apt-get install build-essential -y \
     && pip install uv
 
-RUN uv pip install --system prometheus-client grpcio-health-checking
 RUN uv pip install --system --no-cache-dir -U flytekit==$VERSION \
   flytekitplugins-airflow==$VERSION \
   flytekitplugins-bigquery==$VERSION \
   flytekitplugins-openai==$VERSION \
   flytekitplugins-snowflake==$VERSION \
   flytekitplugins-awssagemaker==$VERSION \
+  prometheus-client \
+  grpcio-health-checking \
   && apt-get clean autoclean \
   && apt-get autoremove --yes \
   && rm -rf /var/lib/{apt,dpkg,cache,log}/ \


### PR DESCRIPTION
As title says. Backport https://github.com/flyteorg/flytekit/pull/3008 to unblock the Flyte 1.14.1 release.