### PR TITLE
Add python interpreter into vscode settings

### DIFF
--- a/flytekit/interactive/vscode_lib/decorator.py
+++ b/flytekit/interactive/vscode_lib/decorator.py
@@ -302,7 +302,7 @@ if __name__ == "__main__":
 
 def prepare_launch_json():
     """
-    Generate the launch.json for users to easily launch interactive debugging and task resumption.
+    Generate the launch.json and settings.json for users to easily launch interactive debugging and task resumption.
     """
 
     task_function_source_dir = os.path.dirname(
@@ -336,6 +336,10 @@ def prepare_launch_json():
 
     with open(os.path.join(vscode_directory, "launch.json"), "w") as file:
         json.dump(launch_json, file, indent=4)
+
+    settings_json = {"python.defaultInterpreterPath": sys.executable}
+    with open(os.path.join(vscode_directory, "settings.json"), "w") as file:
+        json.dump(settings_json, file, indent=4)
 
 
 VSCODE_TYPE_VALUE = "vscode"


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
This PR configures VSCode to use the Python that launched flyte.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR adds a `settings.json` file to the vscode configuration.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

I ran `pyflyte run --remote main.py wf`

```python
from flytekit import ImageSpec, task, workflow

new_flytekit = "git+https://github.com/thomasjpfan/flytekit@6a9506bd6fc6ee0590211c720f4e4a64ddbd2e8f"
image_spec = ImageSpec(registry="ghcr.io/thomasjpfan", packages=[new_flytekit], apt_packages=["git"])


@task(container_image=image_spec)
def train():
    print("forward")
    print("backwardd")
    raise RuntimeError("fail")


@workflow
def wf():
    train()
```

### Screenshots

When launching debug I get:

<img width="1497" alt="SCR-20241219-kzqt" src="https://github.com/user-attachments/assets/dd90a94b-6ea2-4c1f-b926-94953417b151" />
