### PR TITLE
Backport to v1.14 - Use correct name in flyteagent test

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -224,7 +224,7 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Confirm Agent can start
         run: |
-          docker run --rm ghcr.io/${{ github.repository_owner }}/flyteagent:${{ github.sha }} pyflyte serve agent --port 8000 --timeout 1
+          docker run --rm ghcr.io/${{ github.repository_owner }}/flyteagent-slim:${{ github.sha }} pyflyte serve agent --port 8000 --timeout 1
       - name: Push flyteagent-all Image to GitHub Registry
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
As title says. Backport https://github.com/flyteorg/flytekit/pull/3011.