### PR TITLE
fix: Fix resource meta typos for async agent

### DIFF
--- a/flytekit/extend/backend/agent_service.py
+++ b/flytekit/extend/backend/agent_service.py
@@ -117,14 +117,14 @@ class AsyncAgentService(AsyncAgentServiceServicer):
         task_execution_metadata = TaskExecutionMetadata.from_flyte_idl(request.task_execution_metadata)
 
         logger.info(f"{agent.name} start creating the job")
-        resource_mata = await mirror_async_methods(
+        resource_meta = await mirror_async_methods(
             agent.create,
             task_template=template,
             inputs=inputs,
             output_prefix=request.output_prefix,
             task_execution_metadata=task_execution_metadata,
         )
-        return CreateTaskResponse(resource_meta=resource_mata.encode())
+        return CreateTaskResponse(resource_meta=resource_meta.encode())
 
     @record_agent_metrics
     async def GetTask(self, request: GetTaskRequest, context: grpc.ServicerContext) -> GetTaskResponse:

--- a/flytekit/extend/backend/base_agent.py
+++ b/flytekit/extend/backend/base_agent.py
@@ -335,10 +335,10 @@ class AsyncAgentExecutorMixin:
         task_template = get_serializable(OrderedDict(), ss, self).template
         self._agent = AgentRegistry.get_agent(task_template.type, task_template.task_type_version)
 
-        resource_mata = asyncio.run(
+        resource_meta = asyncio.run(
             self._create(task_template=task_template, output_prefix=output_prefix, inputs=kwargs)
         )
-        resource = asyncio.run(self._get(resource_meta=resource_mata))
+        resource = asyncio.run(self._get(resource_meta=resource_meta))
 
         if resource.phase != TaskExecution.SUCCEEDED:
             raise FlyteUserException(f"Failed to run the task {self.name} with error: {resource.message}")


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
`resource_meta` is misspelled as `resource_mata`.

## What changes were proposed in this pull request?
Correct `resource_meta` spelling for async agent.

## How was this patch tested?
NA

### Setup process
```
git clone https://github.com/flyteorg/flytekit.git
gh pr checkout 3023
make setup && pip install -e .
```

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
