### PR TITLE
Fix unit tests in airflow plugin

### DIFF
--- a/plugins/flytekit-airflow/setup.py
+++ b/plugins/flytekit-airflow/setup.py
@@ -6,7 +6,7 @@ microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 plugin_requires = [
     "apache-airflow",
-    "apache-airflow-providers-google<12.0.0"
+    "apache-airflow-providers-google<12.0.0",
     "flytekit>1.10.7",
     "flyteidl>1.10.7",
 ]

--- a/plugins/flytekit-airflow/setup.py
+++ b/plugins/flytekit-airflow/setup.py
@@ -6,6 +6,7 @@ microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 plugin_requires = [
     "apache-airflow",
+    "apache-airflow-providers-google<12.0.0"
     "flytekit>1.10.7",
     "flyteidl>1.10.7",
 ]


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
`apache-airflow-providers-google` has a new release [12.0.0](https://pypi.org/project/apache-airflow-providers-google/#history), `apache-airflow` is not compatible with it

## What changes were proposed in this pull request?
set uppoer-bound in the setup.py

## How was this patch tested?
unit tests

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off. 
 <div id='description'>
<h3>Summary by Bito</h3>
Added version constraint in setup.py to resolve compatibility issues between apache-airflow and apache-airflow-providers-google package. The change prevents usage of apache-airflow-providers-google versions 12.0.0 and above to maintain system stability and prevent potential runtime issues due to incompatible package versions.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>