### PR TITLE
Run command in pyflyte-fast-execute in the same process

### DIFF
--- a/flytekit/core/constants.py
+++ b/flytekit/core/constants.py
@@ -23,6 +23,9 @@ FLYTE_USE_OLD_DC_FORMAT = "FLYTE_USE_OLD_DC_FORMAT"
 # Set this environment variable to true to force the task to return non-zero exit code on failure.
 FLYTE_FAIL_ON_ERROR = "FLYTE_FAIL_ON_ERROR"
 
+# Set this environment variable to true to force pyflyte-fast-execute to run task-execute-cmd in a separate process
+FLYTE_FAST_EXECUTE_CMD_IN_NEW_PROCESS = "FLYTE_FAST_EXECUTE_CMD_IN_NEW_PROCESS"
+
 # Executions launched by the current eager task will be tagged with this key:current_eager_exec_name
 EAGER_TAG_KEY = "eager-exec"
 


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
With this PR, `pyflyte-fast-execute` does not run the command in another process, which saves ~7 seconds.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
With this PR, `pyflyte-fast-execute` will run `pyflyte-map-execute` and `pyflyte-execute` in the same process, which improves startup time. There is a `FLYTE_FAST_EXECUTE_CMD_IN_NEW_PROCESS` env var that triggers the previous behavior.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I ran:

```python
from flytekit import task


@task(container_image="localhost:30000/flytekit:0.1.3")
def hello(name: str) -> str:
    return f"Hello! {name}"
```

With `pyflyte run --remote wf.py hello --name flyte`, it took 8s:

<img width="1092" alt="SCR-20250103-nocr" src="https://github.com/user-attachments/assets/c05debfa-8cb5-4c0d-b681-24e16f351eeb" />


With `pyflyte run --remote --env FLYTE_FAST_EXECUTE_CMD_IN_NEW_PROCESS=1 wf.py hello --name flyte`, which took 15 s:

<img width="1144" alt="SCR-20250103-noxh" src="https://github.com/user-attachments/assets/6441268e-91e1-437a-a5ca-5a678e2a25e8" />
