### PR TITLE
Make FlyteFile and FlyteDirectory pickleable

### DIFF
--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -22,8 +22,8 @@ from mashumaro.types import SerializableType
 
 from flytekit.core.constants import MESSAGEPACK
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
-from flytekit.core.type_engine import AsyncTypeTransformer, TypeEngine, TypeTransformerFailedError, get_batch_size
 from flytekit.core.data_persistence import FileAccessProvider
+from flytekit.core.type_engine import AsyncTypeTransformer, TypeEngine, TypeTransformerFailedError, get_batch_size
 from flytekit.exceptions.user import FlyteAssertion
 from flytekit.extras.pydantic_transformer.decorator import model_serializer, model_validator
 from flytekit.models import types as _type_models

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -22,7 +22,6 @@ from mashumaro.types import SerializableType
 
 from flytekit.core.constants import MESSAGEPACK
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
-from flytekit.core.data_persistence import FileAccessProvider
 from flytekit.core.type_engine import AsyncTypeTransformer, TypeEngine, TypeTransformerFailedError, get_batch_size
 from flytekit.exceptions.user import FlyteAssertion
 from flytekit.extras.pydantic_transformer.decorator import model_serializer, model_validator
@@ -679,10 +678,6 @@ class FlyteDirToMultipartBlobTransformer(AsyncTypeTransformer[FlyteDirectory]):
         ):
             return FlyteDirectory.__class_getitem__(literal_type.blob.format)
         raise ValueError(f"Transformer {self} cannot reverse {literal_type}")
-
-
-def _flyte_directory_downloader(file_access_provider: FileAccessProvider, uri: str, local_folder: str, batch_size: int):
-    return file_access_provider.get_data(uri, local_folder, is_multipart=True, batch_size=batch_size)
 
 
 TypeEngine.register(FlyteDirToMultipartBlobTransformer())

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -667,7 +667,7 @@ class FlyteDirToMultipartBlobTransformer(AsyncTypeTransformer[FlyteDirectory]):
 
         batch_size = get_batch_size(expected_python_type)
 
-        _downloader = partial(_flyte_directory_downloader, ctx.file_access, uri, local_folder, batch_size)
+        _downloader = partial(ctx.file_access.get_data, uri, local_folder, is_multipart=True, batch_size=batch_size)
 
         expected_format = self.get_format(expected_python_type)
 

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -376,23 +376,20 @@ class FlyteDirectory(SerializableType, DataClassJsonMixin, os.PathLike, typing.G
                     paths.append(FlyteDirectory(joined_path))
             return paths
 
-        def create_downloader(_remote_path: str, _local_path: str, is_multipart: bool):
-            return lambda: file_access.get_data(_remote_path, _local_path, is_multipart=is_multipart)
-
         fs = file_access.get_filesystem_for_path(final_path)
         for key in fs.listdir(final_path):
             remote_path = os.path.join(final_path, key["name"].split(os.sep)[-1])
             if key["type"] == "file":
                 local_path = file_access.get_random_local_path()
                 os.makedirs(pathlib.Path(local_path).parent, exist_ok=True)
-                downloader = create_downloader(remote_path, local_path, is_multipart=False)
+                downloader = partial(file_access.get_data, remote_path, local_path, is_multipart=False)
 
                 flyte_file: FlyteFile = FlyteFile(local_path, downloader=downloader)
                 flyte_file._remote_source = remote_path
                 paths.append(flyte_file)
             else:
                 local_folder = file_access.get_random_local_directory()
-                downloader = create_downloader(remote_path, local_folder, is_multipart=True)
+                downloader = partial(file_access.get_data, remote_path, local_folder, is_multipart=True)
 
                 flyte_directory: FlyteDirectory = FlyteDirectory(path=local_folder, downloader=downloader)
                 flyte_directory._remote_source = remote_path

--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -23,6 +23,7 @@ from mashumaro.types import SerializableType
 from flytekit.core.constants import MESSAGEPACK
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.type_engine import AsyncTypeTransformer, TypeEngine, TypeTransformerFailedError, get_batch_size
+from flytekit.core.data_persistence import FileAccessProvider
 from flytekit.exceptions.user import FlyteAssertion
 from flytekit.extras.pydantic_transformer.decorator import model_serializer, model_validator
 from flytekit.models import types as _type_models
@@ -666,7 +667,7 @@ class FlyteDirToMultipartBlobTransformer(AsyncTypeTransformer[FlyteDirectory]):
 
         batch_size = get_batch_size(expected_python_type)
 
-        _downloader = partial(_flyte_directory_downloader, ctx, uri, local_folder, batch_size)
+        _downloader = partial(_flyte_directory_downloader, ctx.file_access, uri, local_folder, batch_size)
 
         expected_format = self.get_format(expected_python_type)
 
@@ -683,8 +684,8 @@ class FlyteDirToMultipartBlobTransformer(AsyncTypeTransformer[FlyteDirectory]):
         raise ValueError(f"Transformer {self} cannot reverse {literal_type}")
 
 
-def _flyte_directory_downloader(ctx: FlyteContext, uri: str, local_folder: str, batch_size: int):
-    return ctx.file_access.get_data(uri, local_folder, is_multipart=True, batch_size=batch_size)
+def _flyte_directory_downloader(file_access_provider: FileAccessProvider, uri: str, local_folder: str, batch_size: int):
+    return file_access_provider.get_data(uri, local_folder, is_multipart=True, batch_size=batch_size)
 
 
 TypeEngine.register(FlyteDirToMultipartBlobTransformer())

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -21,7 +21,6 @@ from mashumaro.types import SerializableType
 
 from flytekit.core.constants import MESSAGEPACK
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
-from flytekit.core.data_persistence import FileAccessProvider
 from flytekit.core.type_engine import (
     AsyncTypeTransformer,
     TypeEngine,

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -737,7 +737,8 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
 
         expected_format = FlyteFilePathTransformer.get_format(expected_python_type)
         ff = FlyteFile.__class_getitem__(expected_format)(
-            path=local_path, downloader=partial(self.downloader, ctx=ctx, remote_path=uri, local_path=local_path),
+            path=local_path,
+            downloader=partial(self.downloader, ctx=ctx, remote_path=uri, local_path=local_path),
         )
         ff._remote_source = uri
         return ff

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -21,7 +21,6 @@ from mashumaro.types import SerializableType
 
 from flytekit.core.constants import MESSAGEPACK
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
-from flytekit.core.data_persistence import FileAccessProvider
 from flytekit.core.type_engine import (
     AsyncTypeTransformer,
     TypeEngine,
@@ -736,7 +735,7 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
         local_path = ctx.file_access.get_random_local_path(uri)
 
         _downloader = partial(ctx.file_access.get_data, uri, local_path, is_multipart=False)
-  
+
         expected_format = FlyteFilePathTransformer.get_format(expected_python_type)
         ff = FlyteFile.__class_getitem__(expected_format)(
             path=local_path, downloader=lambda: self.downloader(ctx=ctx, remote_path=uri, local_path=local_path)

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -696,7 +696,7 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
         # For the remote case, return an FlyteFile object that can download
         local_path = ctx.file_access.get_random_local_path(uri)
 
-        _downloader = partial(_flyte_file_downloader, ctx.file_access, uri, local_path)
+        _downloader = partial(ctx.file_access.get_data, uri, local_path, is_multipart=False)
 
         expected_format = FlyteFilePathTransformer.get_format(expected_python_type)
         ff = FlyteFile.__class_getitem__(expected_format)(local_path, _downloader)
@@ -712,10 +712,6 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
             return FlyteFile.__class_getitem__(literal_type.blob.format)
 
         raise ValueError(f"Transformer {self} cannot reverse {literal_type}")
-
-
-def _flyte_file_downloader(file_access_provider: FileAccessProvider, uri: str, local_path: str):
-    return file_access_provider.get_data(uri, local_path, is_multipart=False)
 
 
 TypeEngine.register(FlyteFilePathTransformer(), additional_types=[os.PathLike])


### PR DESCRIPTION
## Tracking issue

https://github.com/flyteorg/flyte/issues/6144

## Why are the changes needed?

Because doing distributed training with the `Elastic` plugin fails when trying to run a task with FlyteDirectory or FlyteFile inputs.

## What changes were proposed in this pull request?

- pulls out the `_downloader` as a module-level function that's made into a partial when converting FlyteFile/Directory literals into python values.

## How was this patch tested?

Unit tests were updated to test for round-trip pickling.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- ~~[ ] I updated the documentation accordingly.~~
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
Implementation of pickleable downloaders for FlyteFile and FlyteDirectory by replacing lambda functions with functools.partial. This critical fix addresses distributed training issues with the Elastic plugin by ensuring proper serialization of file handling objects. Changes include restructuring downloader implementation, moving FileAccessProvider import, and refactoring downloader function signature for proper serialization in distributed environments.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>