### PR TITLE
[BUG] Map task logging level fixed at 30 for default logger

### DIFF
--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -470,6 +470,7 @@ class ArrayNodeMapTaskResolver(tracker.TrackedInstance, TaskResolverMixin):
         vars "var1,var2,.." resolver "resolver" [resolver_args]
         """
         _, bound_vars, _, resolver, *resolver_args = loader_args
+        logger.info(f"MapTask found task resolver {resolver} and arguments {resolver_args}")
         resolver_obj = load_object_from_module(resolver)
         # Use the resolver to load the actual task object
         _task_def = resolver_obj.load_task(loader_args=resolver_args)

--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -1,7 +1,6 @@
 # TODO: has to support the SupportsNodeCreation protocol
 import functools
 import hashlib
-import logging
 import math
 import os  # TODO: use flytekit logger
 from contextlib import contextmanager
@@ -471,7 +470,6 @@ class ArrayNodeMapTaskResolver(tracker.TrackedInstance, TaskResolverMixin):
         vars "var1,var2,.." resolver "resolver" [resolver_args]
         """
         _, bound_vars, _, resolver, *resolver_args = loader_args
-        logging.info(f"MapTask found task resolver {resolver} and arguments {resolver_args}")
         resolver_obj = load_object_from_module(resolver)
         # Use the resolver to load the actual task object
         _task_def = resolver_obj.load_task(loader_args=resolver_args)


### PR DESCRIPTION
## Tracking issue
closes https://github.com/flyteorg/flyte/issues/5961
fixes: https://linear.app/unionai/issue/DX-1155/investigate-logging-level-behavior-in-map-tasks

## Why are the changes needed?
Logging for map tasks always defaults to default since logging library is re-imported in array node map task after being initialized in the wf code's files

## What changes were proposed in this pull request?

remove logging import and utilize flytekit logger instead

## How was this patch tested?
built an image w/ the changes and ran:

```
import logging

from flytekit import task, workflow, map_task

level = logging.INFO
logging.basicConfig(level=level)

@task
def my_task(s: str) -> str:
    logger = logging.getLogger()
    print(f"Effective logging level: {logger.getEffectiveLevel()}")

    # Log something
    logging.info("This is an info log message")
    logging.error("This is an error log message")
    return s


@workflow
def wf():
    my_task(s='hello world')
    strings = ['hello', 'world']
    return map_task(my_task)(s=strings)
```

### Setup process

```
(venv) ➜  flytesnacks git:(master) ✗ k logs -n flytesnacks-development   arvs4wm4hb2j28mxk4w8-n0-0 

INFO:root:This is an info log message
ERROR:root:This is an error log message
Effective logging level: 20
(venv) ➜  flytesnacks git:(master) ✗ k logs -n flytesnacks-development   arvs4wm4hb2j28mxk4w8-n1-0-n1-0
INFO:root:This is an info log message
ERROR:root:This is an error log message
Effective logging level: 20

```

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
