### PR TITLE
Make launch plan registrable by removing requirement for name

### DIFF
--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -686,6 +686,12 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
             docs=docs,
             default_options=default_options,
         )
+
+        # Set this here so that the lhs call doesn't fail at least. This is only useful in the context of the
+        # ClassStorageTaskResolver, to satisfy the understanding that my_wf.lhs should be fetch the worflow object
+        # from the module.
+        self._lhs = workflow_function.__name__
+
         self.compiled = False
 
     @property

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -688,7 +688,7 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
         )
 
         # Set this here so that the lhs call doesn't fail at least. This is only useful in the context of the
-        # ClassStorageTaskResolver, to satisfy the understanding that my_wf.lhs should be fetch the worflow object
+        # ClassStorageTaskResolver, to satisfy the understanding that my_wf.lhs should be fetch the workflow object
         # from the module.
         self._lhs = workflow_function.__name__
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1264,7 +1264,7 @@ class FlyteRemote(object):
         :return:
         """
         if serialization_settings is None:
-            _, _, _, module_file = extract_task_module(entity)
+            _, _, _, module_file = extract_task_module(entity.workflow)
             project_root = _find_project_root(module_file)
             serialization_settings = SerializationSettings(
                 image_config=ImageConfig.auto_default_image(),

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -114,6 +114,7 @@ def test_remote_eager_run():
     # child_workflow.parent_wf asynchronously register a parent wf1 with child lp from another wf2.
     run("eager_example.py", "simple_eager_workflow", "--x", "3")
 
+
 def test_pydantic_default_input_with_map_task():
     execution_id = run("pydantic_wf.py", "wf")
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
@@ -784,6 +785,20 @@ def test_execute_workflow_remote_fn_with_maptask():
         image_config=ImageConfig.from_images(IMAGE),
     )
     assert out.outputs["o0"] == [4, 5, 6]
+
+
+def test_launch_plans_registrable():
+    """Test remote execution of a @workflow-decorated python function with a map task."""
+    from workflows.basic.array_map import workflow_with_maptask
+
+    from random import choice
+    from string import ascii_letters
+
+    remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN, interactive_mode_enabled=True)
+    version = "".join(choice(ascii_letters) for _ in range(20))
+    new_lp = LaunchPlan.create(name="dynamically_created_lp", workflow=workflow_with_maptask)
+    remote.register_launch_plan(new_lp, version=version)
+
 
 def test_register_wf_fast(register):
     from workflows.basic.subworkflows import parent_wf

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -357,6 +357,10 @@ def my_wf_example(a: int) -> typing.Tuple[int, int]:
     return x, e
 
 
+def test_workflow_lhs():
+    assert my_wf_example._lhs == "my_wf_example"
+
+
 def test_all_node_types():
     assert my_wf_example(a=1) == (6, 16)
     entity_mapping = OrderedDict()


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/6062

## Why are the changes needed?
See issue please.

## What changes were proposed in this pull request?
When FlyteRemote tries to register a launch plan without serialization settings it tries to construct them.  In order to do so it backs out the module that the launch plan object is in.

* Change FlyteRemote to use the workflow that the launch plan points to instead.  This makes more sense because if the underlying workflow is missing, the serialization settings should be based on the workflow.  Registration of the launch plan itself really only needs things like project/domain/version.
* Add an `_lhs` field to workflow.  This isn't actually useful for python function workflows, but it is implied to be set correctly as part of the `ClassStorageTaskResolver` which inherits from `TrackedInstance`.  This gets triggered inside the tracker [here](https://github.com/flyteorg/flytekit/blob/f634d53cdb2be9562c86b73d032c9a27a0bdcd72/flytekit/core/tracker.py#L353) (even though the name is discarded later).

## How was this patch tested?
Local testing with sandbox.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR streamlines launch plan registration by removing the name parameter requirement and adds an _lhs field for ClassStorageTaskResolver compatibility. The changes include updates to FlyteRemote for workflow reference serialization settings and corresponding test coverage for launch plan registration and workflow field behavior.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>