### PR TITLE
Backport 3043 (remote register launch plan name) to v1.14 + 3024

### DIFF
--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -686,6 +686,12 @@ class PythonFunctionWorkflow(WorkflowBase, ClassStorageTaskResolver):
             docs=docs,
             default_options=default_options,
         )
+
+        # Set this here so that the lhs call doesn't fail at least. This is only useful in the context of the
+        # ClassStorageTaskResolver, to satisfy the understanding that my_wf.lhs should be fetch the workflow object
+        # from the module.
+        self._lhs = workflow_function.__name__
+
         self.compiled = False
 
     @property

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1264,7 +1264,7 @@ class FlyteRemote(object):
         :return:
         """
         if serialization_settings is None:
-            _, _, _, module_file = extract_task_module(entity)
+            _, _, _, module_file = extract_task_module(entity.workflow)
             project_root = _find_project_root(module_file)
             serialization_settings = SerializationSettings(
                 image_config=ImageConfig.auto_default_image(),

--- a/plugins/flytekit-airflow/setup.py
+++ b/plugins/flytekit-airflow/setup.py
@@ -6,6 +6,7 @@ microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 plugin_requires = [
     "apache-airflow",
+    "apache-airflow-providers-google<12.0.0",
     "flytekit>1.10.7",
     "flyteidl>1.10.7",
 ]

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -107,15 +107,6 @@ def test_remote_run():
     run("default_lp.py", "my_wf")
 
 
-def test_pydantic_default_input_with_map_task():
-    execution_id = run("pydantic_wf.py", "wf")
-    remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
-    execution = remote.fetch_execution(name=execution_id)
-    execution = remote.wait(execution=execution, timeout=datetime.timedelta(minutes=5))
-    print("Execution Error:", execution.error)
-    assert execution.closure.phase == WorkflowExecutionPhase.SUCCEEDED, f"Execution failed with phase: {execution.closure.phase}"
-
-
 def test_generic_idl_flytetypes():
     os.environ["FLYTE_USE_OLD_DC_FORMAT"] = "true"
     # default inputs for flyte types in dataclass

--- a/tests/flytekit/unit/core/test_workflows.py
+++ b/tests/flytekit/unit/core/test_workflows.py
@@ -357,6 +357,10 @@ def my_wf_example(a: int) -> typing.Tuple[int, int]:
     return x, e
 
 
+def test_workflow_lhs():
+    assert my_wf_example._lhs == "my_wf_example"
+
+
 def test_all_node_types():
     assert my_wf_example(a=1) == (6, 16)
     entity_mapping = OrderedDict()


### PR DESCRIPTION
Cherry-pick [a06c4dae7](https://github.com/flyteorg/flytekit/pull/3043) 

also https://github.com/flyteorg/flytekit/pull/3024/files 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR backports changes from PR #3043 to version 1.14, enhancing workflow handling and remote execution capabilities. It implements proper _lhs attribute initialization in PythonFunctionWorkflow and improves remote launch plan registration. Additionally, it adds version constraint to apache-airflow-providers-google package in flytekit-airflow plugin, limiting it to versions below 12.0.0.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>