### PR TITLE
pin grpcio and grpcio-status <= 1.68.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
     "googleapis-common-protos>=1.57",
     # Skipping those versions to account for the unwanted output coming from grpcio and grpcio-status.
     # Issue being tracked in https://github.com/flyteorg/flyte/issues/6082.
-    "grpcio!=1.68.0,!=1.68.1",
-    "grpcio-status!=1.68.0,!=1.68.1",
+    "grpcio<=1.68.0",
+    "grpcio-status<=1.68.0",
     "importlib-metadata",
     "joblib",
     "jsonlines",


### PR DESCRIPTION
This prevents noisy grpcio warnings showing up when running `pyflyte run`: https://github.com/grpc/grpc/issues/38336 
 <div id='description'>
<h3>Summary by Bito</h3>
Fixed gRPC warning messages during pyflyte run execution by pinning grpcio and grpcio-status package versions to <= 1.68.0 in pyproject.toml. This change eliminates noisy warnings that were previously reported in the grpc/grpc#38336 issue.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>