### PR TITLE
Prevent register_launch_plan from re-registering already registered workflow

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1316,7 +1316,7 @@ class FlyteRemote(object):
                 launch_plan_model, serialization_settings, version, create_default_launchplan=False
             )
             if ident is None:
-                raise ValueError("Failed to register launch plan")
+                raise ValueError("Failed to register launch plan, identifier returned was empty...")
         else:
             # Register the launch and everything under it
             ident = run_sync(

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -852,3 +852,43 @@ def test_register_task_with_node_dependency_hints(mock_client):
     registered_workflow = rr.register_workflow(workflow1, ss)
     assert isinstance(registered_workflow, FlyteWorkflow)
     assert registered_workflow.id == Identifier(ResourceType.WORKFLOW, "flytesnacks", "development", "tests.flytekit.unit.remote.test_remote.workflow1", "dummy_version")
+
+
+@mock.patch("flytekit.remote.remote.get_serializable")
+@mock.patch("flytekit.remote.remote.FlyteRemote.fetch_launch_plan")
+@mock.patch("flytekit.remote.remote.FlyteRemote.raw_register")
+@mock.patch("flytekit.remote.remote.FlyteRemote._serialize_and_register")
+@mock.patch("flytekit.remote.remote.FlyteRemote.client")
+def test_register_launch_plan(mock_client, mock_serialize_and_register, mock_raw_register,mock_fetch_launch_plan, mock_get_serializable):
+    serialization_settings = SerializationSettings(
+        image_config=ImageConfig.auto_default_image(),
+        version="dummy_version",
+    )
+
+    rr = FlyteRemote(
+        Config.for_sandbox(),
+        default_project="flytesnacks",
+        default_domain="development",
+    )
+
+    @task
+    def say_hello() -> str:
+        return "Hello, World!"
+
+    @workflow
+    def hello_world_wf() -> str:
+        res = say_hello()
+        return res
+
+    lp = LaunchPlan.get_or_create(workflow=hello_world_wf, name="additional_lp_for_hello_world", default_inputs={})
+
+    mock_get_serializable.return_value = MagicMock()
+    mock_client.get_workflow.return_value = MagicMock()
+
+    mock_remote_lp = MagicMock()
+    mock_fetch_launch_plan.return_value = mock_remote_lp
+
+    remote_lp = rr.register_launch_plan(lp, version="dummy_version", project="flytesnacks", domain="development", serialization_settings=serialization_settings)
+    assert remote_lp is mock_remote_lp
+    assert not mock_serialize_and_register.called
+    assert mock_raw_register.called


### PR DESCRIPTION
## Tracking issue
Linking this to https://github.com/flyteorg/flyte/issues/6062 which is related.

## Why are the changes needed?
Please see [comment](https://github.com/flyteorg/flyte/issues/6062) in the linked issue, copied here:

Assume in the past `my_wf` has already been registered with version `ksD2LBYDu5PrNtNnnpd95Q`

Now if you try to do:
```
from wfs import my_wf

lp = LaunchPlan.get_or_create(workflow=my_wf, name="other_lp_for_hello2", default_inputs={})
remote = FlyteRemote(...)
remote.register_launch_plan(entity=lp, version="ksD2LBYDu5PrNtNnnpd95Q")
...
```

The issue is that `register_launch_plan` will currently try to register the underlying workflow again.  This would be fine, except that the serialization settings that are used may be completely different.  Even if it's exactly the same, this is a waste of time because the best case scenario is that Admin returns already exists for the workflow and every underlying task (and subwf, etc.).

We should check first to see if the workflow already exists with that version, and only register the launch plan if the workflow already exists.

Skipping re-registration of the workflow does mean that users who were relying on this re-registration (and were somehow reconstructing serialization settings to be identical) to detect changes in workflow/task structure will no longer see errors, but that seems too far-fetched.


## What changes were proposed in this pull request?
* Check if the underlying workflow exists, and if so only register the launch plan.
* Also pass through an argument (`create_default_launchplan`) in `_serialize_and_register` which for some reason wasn't used.  Just a nit, default was always just `True`.


## How was this patch tested?
Tested with local sandbox.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR streamlines the launch plan registration process by implementing checks to prevent redundant workflow registrations. The changes optimize the registration flow by adding existence verification and proper handling of the create_default_launchplan parameter. The implementation focuses on efficiency and maintainability through improved registration logic.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>