### PR TITLE
fix: remove duplication log when execute

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -544,8 +544,9 @@ def run_remote(
     if run_level_params.wait_execution:
         msg += " Waiting to complete..."
     p = Progress(TimeElapsedColumn(), TextColumn(msg), transient=True)
-    t = p.add_task("exec")
+    t = p.add_task("exec", visible=False)
     with p:
+        p.update(t, visible=True)
         p.start_task(t)
         execution = remote.execute(
             entity,


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

Executing either task or workflow with `--remote` will log duplicate msg "Running Execution on Remote".

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

Remove duplications.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

`pyflyte run --remote example.py wf --name "Ada"`
`pyflyte run --remote --wait example.py wf --name "Ada"`

```python
@task()
def say_hello(name: str) -> str:
    return f"Hello, {name}!"

@workflow
def wf(name: str = "world") -> str:
    return say_hello(name=name)
```


### Screenshots

#### Before
<img width="787" alt="Screenshot 2025-01-12 at 10 24 22 PM" src="https://github.com/user-attachments/assets/c8746536-c856-4995-806d-968f8835c711" />

#### After
<img width="787" alt="Screenshot 2025-01-12 at 10 25 48 PM" src="https://github.com/user-attachments/assets/239e507e-e4c3-456a-9da4-bc1db5ab580b" />

---
`--wait`
#### Before
<img width="787" alt="Screenshot 2025-01-12 at 10 24 47 PM" src="https://github.com/user-attachments/assets/1aabe0b5-f82a-40de-9165-6be8d7316c19" />

#### After
<img width="787" alt="Screenshot 2025-01-12 at 10 25 27 PM" src="https://github.com/user-attachments/assets/19ad48fa-a4ad-4b48-93e2-d61327da4c18" />


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
Fixed duplicate 'Running Execution on Remote' message display issue in CLI execution with --remote flag. Modified task visibility settings to ensure single message display during task/workflow execution. Changes focused on SDK container run functionality and task execution process.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>