### PR TITLE
Bugfix Omegaconf plugin: Properly deal with NoneType values

### DIFF
--- a/plugins/flytekit-omegaconf/flytekitplugins/omegaconf/dictconfig_transformer.py
+++ b/plugins/flytekit-omegaconf/flytekitplugins/omegaconf/dictconfig_transformer.py
@@ -143,6 +143,8 @@ def parse_type_description(type_desc: str) -> Type:
             return origin[sub_types[0]]
         return origin[tuple(sub_types)]
     else:
+        if type_desc == "builtins.NoneType":
+            return NoneType
         module_name, class_name = type_desc.rsplit(".", 1)
         return importlib.import_module(module_name).__getattribute__(class_name)
 

--- a/plugins/flytekit-omegaconf/tests/test_dictconfig_transformer.py
+++ b/plugins/flytekit-omegaconf/tests/test_dictconfig_transformer.py
@@ -5,7 +5,7 @@ from flytekitplugins.omegaconf.dictconfig_transformer import (
     check_if_valid_dictconfig,
     extract_type_and_value_maps,
     is_flattenable,
-    parse_type_description,
+    parse_type_description, NoneType,
 )
 from omegaconf import DictConfig, OmegaConf
 
@@ -77,11 +77,11 @@ def test_is_flattenable(config: DictConfig, should_flatten: bool, monkeypatch: p
 def test_extract_type_and_value_maps_simple() -> None:
     """Test extraction of type and value maps from a simple DictConfig."""
     ctx = FlyteContext.current_context()
-    config: DictConfig = OmegaConf.create({"key1": "value1", "key2": 123, "key3": True})
+    config: DictConfig = OmegaConf.create({"key1": "value1", "key2": 123, "key3": True, "key4": None})
 
     type_map, value_map = extract_type_and_value_maps(ctx, config)
 
-    expected_type_map = {"key1": "builtins.str", "key2": "builtins.int", "key3": "builtins.bool"}
+    expected_type_map = {"key1": "builtins.str", "key2": "builtins.int", "key3": "builtins.bool", "key4": "builtins.NoneType"}
 
     assert type_map == expected_type_map
     assert "key1" in value_map
@@ -93,6 +93,7 @@ def test_extract_type_and_value_maps_simple() -> None:
     "type_desc, expected_type",
     [
         ("builtins.int", int),
+        ("builtins.NoneType", NoneType),
         ("typing.List[builtins.int]", t.List[int]),
         ("typing.Optional[builtins.int]", t.Optional[int]),
     ],


### PR DESCRIPTION
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

Explicit handling of `None` values within OmegaConf.DictConfig objects.
Currently, launching a flyte workflow locally with a DictConfig object as input, it fails with the following error if there is a null value in the DictConfig object:

```
  File "/venv/lib/python3.9/site-packages/flytekit/core/workflow.py", line 308, in __call__
    raise exc
  File "/venv/lib/python3.9/site-packages/flytekit/core/workflow.py", line 301, in __call__
    return flyte_entity_call_handler(self, *args, **input_kwargs)
  File "/venv/lib/python3.9/site-packages/flytekit/core/promise.py", line 1459, in flyte_entity_call_handler
    result = cast(LocallyExecutable, entity).local_execute(child_ctx, **kwargs)
  File "/venv/lib/python3.9/site-packages/flytekit/core/workflow.py", line 327, in local_execute
    function_outputs = self.execute(**kwargs_literals)
  File "/venv/lib/python3.9/site-packages/flytekit/core/workflow.py", line 844, in execute
    return self._workflow_function(**kwargs)
  File "/src/bi_ba_ml/flyte/scheduled_workflow/manual_workflow.py", line 61, in manual_scheduled_static_wf
    video_paths, vp_workflow_cfg, fe_workflow_cfg, inf_workflow_cfg = split_config(cfg=cfg)
  File "/venv/lib/python3.9/site-packages/flytekit/core/base_task.py", line 364, in __call__
    return flyte_entity_call_handler(self, *args, **kwargs)  # type: ignore
  File "/venv/lib/python3.9/site-packages/flytekit/core/promise.py", line 1451, in flyte_entity_call_handler
    return cast(LocallyExecutable, entity).local_execute(ctx, **kwargs)
  File "/venv/lib/python3.9/site-packages/flytekitplugins/pod/task.py", line 126, in local_execute
    return super().local_execute(ctx=ctx, **kwargs)
  File "/venv/lib/python3.9/site-packages/flytekit/core/base_task.py", line 341, in local_execute
    outputs_literal_map = self.sandbox_execute(ctx, input_literal_map)
  File "/venv/lib/python3.9/site-packages/flytekit/core/base_task.py", line 421, in sandbox_execute
    return self.dispatch_execute(ctx, input_literal_map)
  File "/venv/lib/python3.9/site-packages/flytekit/core/base_task.py", line 741, in dispatch_execute
    native_inputs = self._literal_map_to_python_input(input_literal_map, exec_ctx)
  File "/venv/lib/python3.9/site-packages/flytekit/core/base_task.py", line 610, in _literal_map_to_python_input
    return TypeEngine.literal_map_to_kwargs(ctx, literal_map, self.python_interface.inputs)
  File "/venv/lib/python3.9/site-packages/flytekit/core/utils.py", line 312, in wrapper
    return func(*args, **kwargs)
  File "/venv/lib/python3.9/site-packages/flytekit/core/type_engine.py", line 1479, in literal_map_to_kwargs
    return synced(ctx, lm, python_types, literal_types)
  File "/venv/lib/python3.9/site-packages/flytekit/utils/asyn.py", line 100, in wrapped
    return self.run_sync(coro_func, *args, **kwargs)
  File "/venv/lib/python3.9/site-packages/flytekit/utils/asyn.py", line 93, in run_sync
    return self._runner_map[name].run(coro)
  File "/venv/lib/python3.9/site-packages/flytekit/utils/asyn.py", line 72, in run
    res = fut.result(None)
  File "/usr/lib/python3.9/concurrent/futures/_base.py", line 446, in result
    return self.__get_result()
  File "/usr/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/venv/lib/python3.9/site-packages/flytekit/core/type_engine.py", line 1517, in _literal_map_to_kwargs
    await asyncio.gather(*kwargs.values())
  File "/venv/lib/python3.9/site-packages/flytekit/core/type_engine.py", line 1443, in async_to_python_value
    pv = transformer.to_python_value(ctx, lv, expected_python_type)
  File "/venv/lib/python3.9/site-packages/flytekitplugins/omegaconf/dictconfig_transformer.py", line 56, in to_python_value
    cfg_dict[key] = parse_node_value(ctx, key, type_desc, nested_dict)
  File "/venv/lib/python3.9/site-packages/flytekitplugins/omegaconf/dictconfig_transformer.py", line 159, in parse_node_value
    return transformer.to_python_value(ctx, value_literal, node_type)
  File "/venv/lib/python3.9/site-packages/flytekitplugins/omegaconf/dictconfig_transformer.py", line 56, in to_python_value
    cfg_dict[key] = parse_node_value(ctx, key, type_desc, nested_dict)
  File "/venv/lib/python3.9/site-packages/flytekitplugins/omegaconf/dictconfig_transformer.py", line 159, in parse_node_value
    return transformer.to_python_value(ctx, value_literal, node_type)
  File "/venv/lib/python3.9/site-packages/flytekitplugins/omegaconf/dictconfig_transformer.py", line 56, in to_python_value
    cfg_dict[key] = parse_node_value(ctx, key, type_desc, nested_dict)
  File "/venv/lib/python3.9/site-packages/flytekitplugins/omegaconf/dictconfig_transformer.py", line 159, in parse_node_value
    return transformer.to_python_value(ctx, value_literal, node_type)
  File "/venv/lib/python3.9/site-packages/flytekitplugins/omegaconf/dictconfig_transformer.py", line 56, in to_python_value
    cfg_dict[key] = parse_node_value(ctx, key, type_desc, nested_dict)
  File "/venv/lib/python3.9/site-packages/flytekitplugins/omegaconf/dictconfig_transformer.py", line 159, in parse_node_value
    return transformer.to_python_value(ctx, value_literal, node_type)
  File "/venv/lib/python3.9/site-packages/flytekitplugins/omegaconf/dictconfig_transformer.py", line 56, in to_python_value
    cfg_dict[key] = parse_node_value(ctx, key, type_desc, nested_dict)
  File "/venv/lib/python3.9/site-packages/flytekitplugins/omegaconf/dictconfig_transformer.py", line 159, in parse_node_value
    return transformer.to_python_value(ctx, value_literal, node_type)
  File "/venv/lib/python3.9/site-packages/flytekitplugins/omegaconf/dictconfig_transformer.py", line 56, in to_python_value
    cfg_dict[key] = parse_node_value(ctx, key, type_desc, nested_dict)
  File "/venv/lib/python3.9/site-packages/flytekitplugins/omegaconf/dictconfig_transformer.py", line 156, in parse_node_value
    node_type = parse_type_description(type_desc)
  File "/venv/lib/python3.9/site-packages/flytekitplugins/omegaconf/dictconfig_transformer.py", line 148, in parse_type_description
    return importlib.import_module(module_name).__getattribute__(class_name)
AttributeError: Error encountered while converting inputs of 'src.workflow.split_config':
  module 'builtins' has no attribute 'NoneType'
```

The issue is that the code currently tries to parse the type description `builtins.NoneType` and then to import the type from `builtins`.
This fails, while it works for other builtins type like `int`, which is why the current test suit didnt cover this properly yet.


<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

I have a workflow with NoneType values, and with the suggested line change this works as expected but fails otherwise.
Given the size of the change and that reading the code in `parse_type_description` it is easy to see why the current code fails, and I modified the tests to cover it. Without the change proposed in this PR, the `test_parse_type_description` test will fail.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off. 
 <div id='description'>
<h3>Summary by Bito</h3>
Fixed bug in OmegaConf plugin to properly handle NoneType values in DictConfig objects. Added explicit support for parsing 'builtins.NoneType' in type description parser to prevent AttributeError exceptions. Updated test suite with NoneType value test cases.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>