### PR TITLE
Fix: Always propagate pytorch task worker process exception timestamp to task exception

### DIFF
--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -15,14 +15,15 @@ class FlyteUserException(_FlyteException):
 class FlyteUserRuntimeException(_FlyteException):
     _ERROR_CODE = "USER:RuntimeError"
 
-    def __init__(self, exc_value: Exception):
+    def __init__(self, exc_value: Exception, timestamp: typing.Optional[float] = None):
         """
         FlyteUserRuntimeException is thrown when a user code raises an exception.
 
         :param exc_value: The exception that was raised from user code.
+        :param timestamp: The timestamp as fractional seconds since epoch when the exception was raised.
         """
         self._exc_value = exc_value
-        super().__init__(str(exc_value))
+        super().__init__(str(exc_value), timestamp=timestamp)
 
     @property
     def value(self):

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -18,7 +18,7 @@ from flytekit.configuration import SerializationSettings
 from flytekit.core.context_manager import FlyteContextManager, OutputMetadata
 from flytekit.core.pod_template import PodTemplate
 from flytekit.core.resources import convert_resources_to_resource_model
-from flytekit.exceptions.user import FlyteRecoverableException
+from flytekit.exceptions.user import FlyteRecoverableException, FlyteUserRuntimeException
 from flytekit.extend import IgnoreOutputs, TaskPlugins
 from flytekit.loggers import logger
 
@@ -475,7 +475,7 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
                 # the automatically assigned timestamp based on exception creation time
                 raise FlyteRecoverableException(e.format_msg(), timestamp=first_failure.timestamp)
             else:
-                raise RuntimeError(e.format_msg())
+                raise FlyteUserRuntimeException(e, timestamp=first_failure.timestamp)
         except SignalException as e:
             logger.exception(f"Elastic launch agent process terminating: {e}")
             raise IgnoreOutputs()

--- a/plugins/flytekit-kf-pytorch/tests/test_elastic_task.py
+++ b/plugins/flytekit-kf-pytorch/tests/test_elastic_task.py
@@ -276,3 +276,37 @@ def test_omp_num_threads(start_method: str) -> None:
         assert os.environ["OMP_NUM_THREADS"] == "42"
 
     test_task_omp_set()
+
+
+def test_exception_timestamp() -> None:
+    """Test that the timestamp of the worker process exception is propagated to the task exception."""
+    @task(
+        task_config=Elastic(
+            nnodes=1,
+            nproc_per_node=2,
+        )
+    )
+    def test_task():
+        raise Exception("Test exception")
+
+    with pytest.raises(Exception) as e:
+        test_task()
+
+    assert e.value.timestamp is not None
+
+
+def test_recoverable_exception_timestamp() -> None:
+    """Test that the timestamp of the worker process exception is propagated to the task exception."""
+    @task(
+        task_config=Elastic(
+            nnodes=1,
+            nproc_per_node=2,
+        )
+    )
+    def test_task():
+        raise FlyteRecoverableException("Recoverable test exception")
+
+    with pytest.raises(Exception) as e:
+        test_task()
+
+    assert e.value.timestamp is not None

--- a/plugins/flytekit-kf-pytorch/tests/test_elastic_task.py
+++ b/plugins/flytekit-kf-pytorch/tests/test_elastic_task.py
@@ -17,7 +17,7 @@ import flytekit
 from flytekit import task, workflow
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager, ExecutionState, ExecutionParameters, OutputMetadataTracker
 from flytekit.configuration import SerializationSettings
-from flytekit.exceptions.user import FlyteRecoverableException
+from flytekit.exceptions.user import FlyteRecoverableException, FlyteUserRuntimeException
 
 @pytest.fixture(autouse=True, scope="function")
 def restore_env():
@@ -223,7 +223,7 @@ def test_recoverable_error(recoverable: bool, start_method: str) -> None:
         with pytest.raises(FlyteRecoverableException):
             wf(recoverable=recoverable)
     else:
-        with pytest.raises(RuntimeError):
+        with pytest.raises(FlyteUserRuntimeException):
             wf(recoverable=recoverable)
 
 


### PR DESCRIPTION
## Why are the changes needed?

Since RFC https://github.com/flyteorg/flyte/pull/5598, flytepropeller can collect error files from multiple worker pods of a distributed task in order to determine the root cause error by identifying the exception with the earliest timestamp. Before, only a single error file was used even if a task launched multiple pods that each could produce an error file.

Generally, the timestamp of the container error is measured [here](https://github.com/flyteorg/flytekit/blob/a2bcf95048962b77ba2e67052b8f4a8c956fe81f/flytekit/bin/entrypoint.py#L382) in the pod entrypoint.

In the case of the pytorch elastic plugin where each worker pod can launch multiple worker processes, [torch elastic launch determines the worker process exception with the earliest timestamp](https://github.com/flyteorg/flytekit/blob/a2bcf95048962b77ba2e67052b8f4a8c956fe81f/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py#L472). The earliest worker process timestamp determined by torch elastic launch is considered the timestamp with which the entire pytorch elastic task pod failed [here](https://github.com/flyteorg/flytekit/blob/a2bcf95048962b77ba2e67052b8f4a8c956fe81f/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py#L476).

However, we only propagate the timestamp of the worker process exception to the task exception in the case of [recoverable errors](https://github.com/flyteorg/flytekit/blob/a2bcf95048962b77ba2e67052b8f4a8c956fe81f/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py#L476). In the case of[ non-recoverable errors](https://github.com/flyteorg/flytekit/blob/a2bcf95048962b77ba2e67052b8f4a8c956fe81f/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py#L478) we don't propagate the timestamp and instead rely on a new timestamp being measured in the pod entrypoint (see above).

I observed that sometimes the timestamps measured in the pod entrypoint are roughly the same even though the timestamps in the worker processes in the different pods definitely differed. This suggests that in these cases torch distributed still manages to synchronize after one worker experienced an exception so that the pod entrypoints execute [`get_container_error_timestamp(...)`](https://github.com/flyteorg/flytekit/blob/a2bcf95048962b77ba2e67052b8f4a8c956fe81f/flytekit/bin/entrypoint.py#L363) roughly at the same time. The fix is obvious: propagate the worker process exception timestamp to the task exception also for non-recoverable errors.


Added unit tests.

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flytekit/pull/2797 
 <div id='description'>
<h3>Summary by Bito</h3>
Updates exception handling in PyTorch elastic task tests to use FlyteUserRuntimeException instead of RuntimeError. Improves worker process exception timestamp propagation for both recoverable and non-recoverable scenarios. Enhances test expectations and imports required exception classes.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>