### PR TITLE
Make FlyteUserRuntimeException to return error_code in Container Error

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -266,7 +266,7 @@ def _dispatch_execute(
         exc_str = get_traceback_str(e)
         output_file_dict[error_file_name] = _error_models.ErrorDocument(
             _error_models.ContainerError(
-                code="USER",
+                code=e.error_code,
                 message=exc_str,
                 kind=kind,
                 origin=_execution_models.ExecutionError.ErrorKind.USER,

--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -28,6 +28,10 @@ class FlyteUserRuntimeException(_FlyteException):
     def value(self):
         return self._exc_value
 
+    @property
+    def error_code(self):
+        return self._ERROR_CODE
+
 
 class FlyteTypeException(FlyteUserException, TypeError):
     _ERROR_CODE = "USER:TypeError"

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -169,6 +169,7 @@ def test_dispatch_execute_exception_with_multi_error_files(mock_write_to_file, m
             assert error_filename_base.startswith("error-")
             uuid.UUID(hex=error_filename_base[6:], version=4)
             assert error_filename_ext == ".pb"
+            assert container_error.code == "USER:RuntimeError"
 
         mock_write_to_file.side_effect = verify_output
         _dispatch_execute(ctx, lambda: python_task, "inputs path", "outputs prefix")
@@ -991,3 +992,35 @@ def test_dispatch_execute_offloaded_nested_lists_of_literals_offloading_disabled
                     assert lit.literals["o0"].HasField("offloaded_metadata") == False
                 else:
                     assert False, f"Unexpected file {ff}"
+
+
+@mock.patch("flytekit.core.utils.load_proto_from_file")
+@mock.patch("flytekit.core.data_persistence.FileAccessProvider.get_data")
+@mock.patch("flytekit.core.data_persistence.FileAccessProvider.put_data")
+@mock.patch("flytekit.core.utils.write_proto_to_file")
+def test_dispatch_execute_custom_error_code_with_flyte_user_runtime_exception(mock_write_to_file, mock_upload_dir, mock_get_data, mock_load_proto):
+    class CustomException(FlyteUserRuntimeException):
+        _ERROR_CODE = "CUSTOM_ERROR_CODE"
+
+    mock_get_data.return_value = True
+    mock_upload_dir.return_value = True
+
+    ctx = context_manager.FlyteContext.current_context()
+    with context_manager.FlyteContextManager.with_context(
+        ctx.with_execution_state(
+            ctx.execution_state.with_params(mode=context_manager.ExecutionState.Mode.TASK_EXECUTION)
+        )
+    ) as ctx:
+        python_task = mock.MagicMock()
+        python_task.dispatch_execute.side_effect = CustomException("custom error")
+
+        empty_literal_map = _literal_models.LiteralMap({}).to_flyte_idl()
+        mock_load_proto.return_value = empty_literal_map
+
+        def verify_output(*args, **kwargs):
+            assert isinstance(args[0], ErrorDocument)
+            assert args[0].error.code == "CUSTOM_ERROR_CODE"
+
+        mock_write_to_file.side_effect = verify_output
+        _dispatch_execute(ctx, lambda: python_task, "inputs path", "outputs prefix")
+        assert mock_write_to_file.call_count == 1

--- a/tests/flytekit/unit/exceptions/test_user.py
+++ b/tests/flytekit/unit/exceptions/test_user.py
@@ -11,6 +11,16 @@ def test_flyte_user_exception():
         assert type(e).error_code == "USER:Unknown"
         assert isinstance(e, base.FlyteException)
 
+def test_flyte_user_runtime_exception():
+    try:
+        base_exn = Exception("everywhere is bad")
+        raise user.FlyteUserRuntimeException("bad") from base_exn
+    except Exception as e:
+        assert str(e) == "USER:RuntimeError: error=bad, cause=everywhere is bad"
+        assert isinstance(type(e), base._FlyteCodedExceptionMetaclass)
+        assert type(e).error_code == "USER:RuntimeError"
+        assert isinstance(e, base.FlyteException)
+        assert isinstance(e, user.FlyteUserRuntimeException)
 
 def test_flyte_type_exception():
     try:


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/6170

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

Makes `FlyteUserRuntimeException` to return a custom `_ERROR_CODE` if defined by fytekit users


## What changes were proposed in this pull request?

Add the `error_code` property in `FlyteUserException` and use it when a `FlyteUserRuntimeException` is thrown


<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Unit tests added

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements custom error codes in FlyteKit's FlyteUserRuntimeException, adding an error_code property and updating the entrypoint for enhanced error handling. The changes improve exception management and provide more structured error reporting capabilities. The implementation includes comprehensive test coverage for both main functionality and edge cases.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>