### PR TITLE
[WIP][need discussion] Pydantic Transformer guess python type

### DIFF
--- a/flytekit/extras/pydantic_transformer/transformer.py
+++ b/flytekit/extras/pydantic_transformer/transformer.py
@@ -1,11 +1,11 @@
 import json
 import os
-from typing import Type
+from typing import Any, List, Optional, Type
 
 import msgpack
 from google.protobuf import json_format as _json_format
 from google.protobuf import struct_pb2 as _struct
-from pydantic import BaseModel
+from pydantic import BaseModel, create_model
 
 from flytekit import FlyteContext
 from flytekit.core.constants import CACHE_KEY_METADATA, FLYTE_USE_OLD_DC_FORMAT, MESSAGEPACK, SERIALIZATION_FORMAT
@@ -102,6 +102,91 @@ class PydanticTransformer(TypeTransformer[BaseModel]):
         json_str = _json_format.MessageToJson(lv.scalar.generic)
         python_val = expected_python_type.model_validate_json(json_str, strict=False, context={"deserialize": True})
         return python_val
+
+    def guess_python_type(self, literal_type: LiteralType) -> Type[BaseModel]:
+        """
+        Reconstructs the Pydantic BaseModel subclass from the JSON schema stored in LiteralType metadata.
+        """
+
+        schema = literal_type.metadata
+        model_name = schema.get("title", "DynamicModel")
+
+        properties = schema.get("properties", {})
+        required_fields = schema.get("required", [])
+
+        annotations = {}
+        field_definitions = {}
+
+        for field_name, field_info in properties.items():
+            field_type = self._map_json_type_to_python(field_info)
+            annotations[field_name] = Optional[field_type] if field_name not in required_fields else field_type
+            field_definitions[field_name] = (field_type, ... if field_name in required_fields else None)
+
+        try:
+            DynamicModel = create_model(model_name, **field_definitions)
+            return DynamicModel
+        except Exception as e:
+            raise TypeTransformerFailedError(f"Failed to create Pydantic model from schema: {e}")
+
+    def _map_json_type_to_python(self, field_info: dict) -> Any:
+        """
+        Maps JSON schema types to Python types for Pydantic model fields.
+        """
+        json_type = field_info.get("type")
+        if isinstance(json_type, list):
+            # Handle Union types like ["string", "null"]
+            json_type = [t for t in json_type if t != "null"]
+            if len(json_type) == 1:
+                json_type = json_type[0]
+            else:
+                # More complex unions can be handled here if needed
+                json_type = "string"  # default fallback
+
+        type_mapping = {
+            "string": str,
+            "integer": int,
+            "number": float,
+            "boolean": bool,
+            "object": dict,
+            "array": list,
+        }
+
+        python_type = type_mapping.get(json_type, Any)
+
+        # Handle nested objects
+        if python_type == dict and "properties" in field_info:
+            # Recursively create a nested Pydantic model
+            nested_model = self._create_nested_model(field_info)
+            return nested_model
+
+        # Handle arrays with specified items
+        if python_type == list and "items" in field_info:
+            item_type = self._map_json_type_to_python(field_info["items"])
+            return List[item_type]
+
+        return python_type
+
+    def _create_nested_model(self, field_info: dict) -> Type[BaseModel]:
+        """
+        Recursively creates nested Pydantic models for objects within the schema.
+        """
+        properties = field_info.get("properties", {})
+        required_fields = field_info.get("required", [])
+
+        model_name = field_info.get("title", "NestedModel")
+        annotations = {}
+        field_definitions = {}
+
+        for field_name, sub_field_info in properties.items():
+            sub_field_type = self._map_json_type_to_python(sub_field_info)
+            annotations[field_name] = Optional[sub_field_type] if field_name not in required_fields else sub_field_type
+            field_definitions[field_name] = (sub_field_type, ... if field_name in required_fields else None)
+
+        try:
+            NestedModel = create_model(model_name, **field_definitions)
+            return NestedModel
+        except Exception as e:
+            raise TypeTransformerFailedError(f"Failed to create nested Pydantic model: {e}")
 
 
 TypeEngine.register(PydanticTransformer())


### PR DESCRIPTION
## Need Discussion
[need discussion]
I found a problem when supporting guess python type for pydantic basemodel.
json schema -> python class
Since the JSON schema can be converted into either a dataclass or a Pydantic BaseModel, we need to include additional metadata in the literal type’s metadata.
This ensures we know whether to generate a Pydantic BaseModel or a dataclass from the JSON schema.
## Tracking issue
https://github.com/flyteorg/flyte/issues/5318

## Related issue
https://github.com/pydantic/pydantic/issues/643
https://github.com/flyteorg/flyte/issues/6081

## Why are the changes needed?
People want to use remote api to execute workflow with pydantic basemodel input.
This work in single binary and Union Cluster.

```python
from enum import Enum
from typing import Optional
from pydantic import BaseModel
from flytekit import task, workflow, ImageSpec

image = ImageSpec(
    name="glossai-flyte-example",
    packages=["pydantic > 2"],
    registry="localhost:30000",
)

# Define the Enum
class ContributionScoreType(Enum):
    DISABLED = "disabled"
    ENABLED = "enabled"
    PARTIAL = "partial"

# Define the nested Pydantic models
class EnrichmentData(BaseModel):
    title: str
    score: float
    is_valid: bool
    count: int
    metadata: dict = {}

class TransporterInput(BaseModel):
    source: str
    destination: str
    batch_size: int = 100
    retry_count: int = 3
    timeout: float = 30.0
    enabled: bool = True

# Define the main input model
class EnrichmentWorkflowInput(BaseModel):
    post_id: str = "123"
    job_id: str = "456"
    enrichment: EnrichmentData = EnrichmentData(
        title="Test Title",
        score=0.9,
        is_valid=True,
        count=100,
        metadata={"key": "value"}
    )
    transporter: Optional[TransporterInput] = None
    contribution_score_type: ContributionScoreType = ContributionScoreType.DISABLED

# ==================

from flytekit.remote.remote import FlyteRemote
from flytekit.configuration import Config



remote = FlyteRemote(
    Config.for_endpoint("localhost:30080", True),
)
# i = remote.get("flyte://v1/flytesnacks/development/ab5nmkg6fhxjvmprs9gv/n0/i")

previous_execution = remote.fetch_execution(
    project="flytesnacks",
    domain="development",
    name="ab5nmkg6fhxjvmprs9gv")
input_data = previous_execution.inputs
print("previous_execution:", previous_execution)

workflow = remote.fetch_workflow(
    project="flytesnacks",
    domain="development",
    name="flyte_example.enrichment_workflow",  
    version="oSqsuSJKfiZuSRduQ7ODGw",
)

# # Execute the workflow with the same inputs
new_execution = remote.execute(
    workflow,
    inputs={"input_data": EnrichmentWorkflowInput()},
    project="flytesnacks",  # Use the same project as the original execution
    domain="development",   # Use the same domain as the original execution
    name="new_execution",
    version="oSqsuSJKfiZuSRduQ7ODGw",
    wait=True  # Set to True if you want to wait for execution to complete
)

print(f"New execution launched: {new_execution.id.name}")
```

## What changes were proposed in this pull request?
Implement a non-perfect `guess_python_type` in pydantic basemodel transformer.

## How was this patch tested?
integration test and remote execution.
It's hard to test in unit test because we make lots of type `Any`.

### Setup process

### Screenshots
#### single binary
<img width="920" alt="image" src="https://github.com/user-attachments/assets/6d8ba421-9a08-4d8f-a5e2-8386b62bd221" />
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/0e33a7ea-f0db-4db6-b2d8-2b80984f700c" />


#### Union cluster
<img width="1148" alt="image" src="https://github.com/user-attachments/assets/a944e043-49a8-41cb-aee0-0aad08ee55d2" />
<img width="1259" alt="image" src="https://github.com/user-attachments/assets/df0517ca-e204-41f8-bb5f-5880841d1732" />


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
