### PR TITLE
Place venv in /root when using uv.lock as well

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -23,15 +23,17 @@ from flytekit.tools.script_mode import ls_files
 
 UV_LOCK_INSTALL_TEMPLATE = Template(
     """\
+WORKDIR /root
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
     --mount=from=uv,source=/uv,target=/usr/bin/uv \
     --mount=type=bind,target=uv.lock,src=uv.lock \
     --mount=type=bind,target=pyproject.toml,src=pyproject.toml \
     uv sync $PIP_INSTALL_ARGS
+WORKDIR /
 
 # Update PATH and UV_PYTHON to point to the venv created by uv sync
-ENV PATH="/.venv/bin:$$PATH" \
-    UV_PYTHON=/.venv/bin/python
+ENV PATH="/root/.venv/bin:$$PATH" \
+    UV_PYTHON=/root/.venv/bin/python
 """
 )
 
@@ -407,7 +409,7 @@ class DefaultImageBuilder(ImageSpecBuilder):
             if value is not None and name not in self._SUPPORTED_IMAGE_SPEC_PARAMETERS and not name.startswith("_")
         ]
         if unsupported_parameters:
-            msg = f"The following parameters are unsupported and ignored: " f"{unsupported_parameters}"
+            msg = f"The following parameters are unsupported and ignored: {unsupported_parameters}"
             warnings.warn(msg, UserWarning, stacklevel=2)
 
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->
Follow up to https://github.com/flyteorg/flytekit/pull/2929

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->


## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

With the poetry environment in `/root/.venv`, I think it'll be good to be consistent and have the `uv.lock` environment be there too.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
```bash
mkdir uv-check
cd uv-check
uv init
uv add flytekit numpy

# activate python environment with this PR
pyflyte run --remote main.py my_task
```

where `main.py` is:

```python
from flytekit import task, ImageSpec

image_spec = ImageSpec(
    name="uv-wow",
    requirements="uv.lock",
    registry="localhost:30000",
    env={"abc": "xyz125"},
)


@task(container_image=image_spec)
def my_task() -> int:
    import numpy as np

    return np.asarray([1, 2, 3]).sum().item()
``` 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements standardization of virtual environment paths by relocating the uv.lock environment to /root/.venv to align with poetry environment location. The update includes modifications to WORKDIR commands and environment variables for consistent path references, along with minor improvements to error message formatting.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>