### PR TITLE
Only copy over cat-certificates.crt if it does not exist in base image 

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -87,7 +87,9 @@ FROM $BASE_IMAGE
 
 USER root
 $APT_INSTALL_COMMAND
-COPY --from=micromamba /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+RUN --mount=from=micromamba,source=/etc/ssl/certs/ca-certificates.crt,target=/tmp/ca-certificates.crt \
+    [ ! -f /etc/ssl/certs/ca-certificates.crt ] && \
+    mkdir -p /etc/ssl/certs/ && cp /tmp/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 RUN id -u flytekit || useradd --create-home --shell /bin/bash flytekit
 RUN chown -R flytekit /root && chown -R flytekit /home

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -88,7 +88,7 @@ FROM $BASE_IMAGE
 USER root
 $APT_INSTALL_COMMAND
 RUN --mount=from=micromamba,source=/etc/ssl/certs/ca-certificates.crt,target=/tmp/ca-certificates.crt \
-    [ ! -f /etc/ssl/certs/ca-certificates.crt ] && \
+    [ -f /etc/ssl/certs/ca-certificates.crt ] || \
     mkdir -p /etc/ssl/certs/ && cp /tmp/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 RUN id -u flytekit || useradd --create-home --shell /bin/bash flytekit


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
Base images could have ca-certificates installed already. This PR makes it so that we only copy over the certificates if it does not already exist.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
Only if `ca-certificates` is not available does the certificates gets copied over.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I built at image with `ca-certificate` installed:
```python
FROM debian:bookworm-slim

RUN apt update && apt install -y ca-certificates && update-ca-certificates
```

and verified that the RUN command does not copy the ca-cerfiticate over. Also I ran the image builder without a `base_image` and the ca-certificate still existed:

```python
from flytekit import ImageSpec, task, workflow
import os.path

image = ImageSpec(
    name="flyte_playground",
    builder="default",
    registry="localhost:30000",
    env={"A": "c"},
)


@task(container_image=image)
def wow() -> bool:
    return os.path.exists("/etc/ssl/certs/ca-certificates.crt")


@workflow
def main():
    wow()
``` 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR optimizes Docker image builds by improving CA certificate handling, replacing a conditional installation approach with a simpler COPY command. The change streamlines the certificate management process while maintaining functionality.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>