### PR TITLE
Adds python_exec into ImageSpec

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -62,6 +62,7 @@ class ImageSpec:
 
             If the option is set by the user, then that option is of course used.
         copy: List of files/directories to copy to /root. e.g. ["src/file1.txt", "src/file2.txt"]
+        python_exec: Python executable to use for install packages
     """
 
     name: str = "flytekit"
@@ -87,6 +88,7 @@ class ImageSpec:
     tag_format: Optional[str] = None
     source_copy_mode: Optional[CopyFileDetection] = None
     copy: Optional[List[str]] = None
+    python_exec: Optional[str] = None
 
     def __post_init__(self):
         self.name = self.name.lower()

--- a/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
+++ b/plugins/flytekit-envd/flytekitplugins/envd/image_builder.py
@@ -98,6 +98,9 @@ def _create_str_from_package_list(packages):
 
 
 def create_envd_config(image_spec: ImageSpec) -> str:
+    if image_spec.python_exec is not None:
+        raise ValueError("python_exec is not supported with the envd image builder")
+
     base_image = DefaultImages.default_image() if image_spec.base_image is None else image_spec.base_image
     if image_spec.cuda:
         if image_spec.python_version is None:

--- a/plugins/flytekit-envd/tests/test_image_spec.py
+++ b/plugins/flytekit-envd/tests/test_image_spec.py
@@ -131,3 +131,18 @@ def test_image_spec_extra_index_url():
     )
 
     assert contents == expected_contents
+
+
+def test_envd_failure_python_exec():
+    base_image = "ghcr.io/flyteorg/flytekit:py3.11-1.14.4"
+    python_exec = "/usr/local/bin/python"
+
+    image_spec = ImageSpec(
+        name="FLYTEKIT",
+        base_image=base_image,
+        python_exec=python_exec
+    )
+
+    msg = "python_exec is not supported with the envd image builder"
+    with pytest.raises(ValueError, match=msg):
+        EnvdImageSpecBuilder().build_image(image_spec)


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, `ImageSpec` will always create a new virtualenv to install packages. With this PR, users can specify, `python_exec` to use a Python from a `base_image`'s python to install packages into.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR:
- Moves the `micromamba` python install into it's own function and only uses it if `python_exec` is not set.
- Errors in `envd` when `python_exec` is set.
- Errors when any of the `conda_*` parameters are set and `python_exec` is set.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I ran the follow on sandbox:

```python
from flytekit import ImageSpec, task

image = ImageSpec(
    base_image="ghcr.io/flyteorg/flytekit:py3.11-1.14.4",
    name="wow",
    apt_packages=["git"],
    packages=[
        "numpy",
        "git+https://github.com/thomasjpfan/flytekit.git@176ecfbe006e00d563380d4c2638c3e550b35fbc",
    ],
    registry="localhost:30000",
    python_exec="/usr/local/bin/python",
)


@task(container_image=image)
def main() -> float:
    import numpy as np

    return np.ones(10).sum().item()
```

And confirm that the image built uses system python. 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR introduces a new ImageSpec feature allowing custom Python executable specification for package installation, replacing the default virtualenv approach. The implementation includes Micromamba installation logic refactoring, validation for conda-related parameters, and proper error handling in the envd builder. The changes are well-structured with comprehensive validation checks for python_exec paths.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>