### PR TITLE
Eager deck name

### DIFF
--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -601,7 +601,7 @@ class EagerAsyncPythonFunctionTask(AsyncPythonFunctionTask[T], metaclass=FlyteTr
                 base_error = ee
 
             html = cast(Controller, ctx.worker_queue).render_html()
-            Deck("eager workflow", html)
+            Deck("Eager Executions", html)
 
             if base_error:
                 # now have to fail this eager task, because we don't want it to show up as succeeded.


### PR DESCRIPTION
Just a nit on the eager deck name. 
 <div id='description'>
<h3>Summary by Bito</h3>
UI enhancement that updates the deck title from 'eager workflow' to 'Eager Executions' to improve clarity and maintain consistency in the interface presentation.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>