### PR TITLE
Allow user-defined dataclass type transformer (again)

### DIFF
--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -30,7 +30,6 @@ from typing_extensions import Annotated, get_args, get_origin
 
 from flytekit import dynamic, kwtypes, task, workflow
 from flytekit.core.annotation import FlyteAnnotation
-from flytekit.core.base_task import Task
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.data_persistence import flyte_tmp_dir
 from flytekit.core.hash import HashMethod
@@ -3750,7 +3749,7 @@ def test_register_dataclass_override():
     Test to confirm that a dataclass transformer can be overridden by a user defined transformer
     """
 
-    # We register a
+    # We register a type transformer for the top-level user-defined dataclass
     @dataclass
     class ParentDC:
         ...
@@ -3776,3 +3775,5 @@ def test_register_dataclass_override():
 
     assert TypeEngine.get_transformer(ChildDC) != TypeEngine.get_transformer(RegularDC)
     assert TypeEngine.get_transformer(RegularDC) == TypeEngine._DATACLASS_TRANSFORMER
+
+    del TypeEngine._REGISTRY[ParentDC]

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -30,6 +30,7 @@ from typing_extensions import Annotated, get_args, get_origin
 
 from flytekit import dynamic, kwtypes, task, workflow
 from flytekit.core.annotation import FlyteAnnotation
+from flytekit.core.base_task import Task
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.data_persistence import flyte_tmp_dir
 from flytekit.core.hash import HashMethod
@@ -3742,3 +3743,36 @@ def test_structured_dataset_mismatch():
 
     with pytest.raises(TypeTransformerFailedError):
         TypeEngine.to_literal(FlyteContext.current_context(), df, StructuredDataset, TypeEngine.to_literal_type(StructuredDataset))
+
+
+def test_register_dataclass_override():
+    """
+    Test to confirm that a dataclass transformer can be overridden by a user defined transformer
+    """
+
+    # We register a
+    @dataclass
+    class ParentDC:
+        ...
+
+    @dataclass
+    class ChildDC(ParentDC):
+        ...
+
+    class ParentDCTransformer(TypeTransformer[ParentDC]):
+        def __init__(self):
+            super().__init__("ParentDC Transformer", ParentDC)
+
+    # Register a type transformer for the parent dataclass
+    TypeEngine.register(ParentDCTransformer())
+
+    # Confirm that the transformer for ChildDC is the same as the ParentDC
+    assert TypeEngine.get_transformer(ChildDC) == TypeEngine.get_transformer(ParentDC)
+
+    # Confirm that the transformer for ChildDC is not flytekit's default dataclass transformer
+    @dataclass
+    class RegularDC:
+        ...
+
+    assert TypeEngine.get_transformer(ChildDC) != TypeEngine.get_transformer(RegularDC)
+    assert TypeEngine.get_transformer(RegularDC) == TypeEngine._DATACLASS_TRANSFORMER


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/6183

## Why are the changes needed?
Users should be able to register user-defined dataclass type transformers.

## What changes were proposed in this pull request?
Fallback to flytekit's dataclass type transformer after mro evaluation.

## How was this patch tested?
Unit tests and local tests in sandbox.


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances the TypeEngine by implementing custom dataclass transformer registration functionality. The changes allow users to override default dataclass transformers with their own implementations by modifying the MRO chain evaluation order. The implementation includes support for inheritance behavior in custom dataclass transformers.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>