### PR TITLE
Fix async coroutine limit not respected and add s3/gcs chunk size

### DIFF
--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -363,8 +363,6 @@ class FileAccessProvider(object):
         """
         file_system = await self.get_async_filesystem_for_path(to_path)
         from_path = self.strip_file_header(from_path)
-        import os
-
         if recursive:
             # Only check this for the local filesystem
             if file_system.protocol == "file" and not file_system.isdir(from_path):

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -52,6 +52,8 @@ _ANON = "anon"
 
 Uploadable = typing.Union[str, os.PathLike, pathlib.Path, bytes, io.BufferedReader, io.BytesIO, io.StringIO]
 
+_S3_WRITE_SIZE_CHUNK_BYTES = int(os.environ.get("FLYTE_S3_WRITE_CHUNKSIZE_BYTES", "26214400"))  # 25 * 2**20
+
 
 def s3_setup_args(s3_cfg: configuration.S3Config, anonymous: bool = False) -> Dict[str, Any]:
     kwargs: Dict[str, Any] = {
@@ -340,8 +342,8 @@ class FileAccessProvider(object):
         from_path = self.strip_file_header(from_path)
         import os
 
-        cs = os.environ.get("chunksize", "8388608")  # 8 * 2**20
-        kwargs["chunksize"] = int(cs)
+        if to_path.startswith("s3"):
+            kwargs["chunksize"] = _S3_WRITE_SIZE_CHUNK_BYTES
         if recursive:
             # Only check this for the local filesystem
             if file_system.protocol == "file" and not file_system.isdir(from_path):

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -338,7 +338,9 @@ class FileAccessProvider(object):
         """
         file_system = await self.get_async_filesystem_for_path(to_path)
         from_path = self.strip_file_header(from_path)
-        kwargs["chunksize"] = 1 * 2**20
+        import os
+        cs = os.environ.get("chunksize", "8388608")  # 8 * 2**20
+        kwargs["chunksize"] = int(cs)
         if recursive:
             # Only check this for the local filesystem
             if file_system.protocol == "file" and not file_system.isdir(from_path):

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -338,6 +338,7 @@ class FileAccessProvider(object):
         """
         file_system = await self.get_async_filesystem_for_path(to_path)
         from_path = self.strip_file_header(from_path)
+        kwargs["chunksize"] = 1 * 2**20
         if recursive:
             # Only check this for the local filesystem
             if file_system.protocol == "file" and not file_system.isdir(from_path):

--- a/flytekit/core/data_persistence.py
+++ b/flytekit/core/data_persistence.py
@@ -339,6 +339,7 @@ class FileAccessProvider(object):
         file_system = await self.get_async_filesystem_for_path(to_path)
         from_path = self.strip_file_header(from_path)
         import os
+
         cs = os.environ.get("chunksize", "8388608")  # 8 * 2**20
         kwargs["chunksize"] = int(cs)
         if recursive:

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1694,7 +1694,7 @@ class ListTransformer(AsyncTypeTransformer[T]):
         print(f"Type engine batch size: {_TYPE_ENGINE_COROS_BATCH_SIZE}")
         print(f"Number of coros {len(lit_list)}", flush=True)
 
-        lit_list = await _run_coros_in_chunks(lit_list, batch_size=1)
+        lit_list = await _run_coros_in_chunks(lit_list, batch_size=_TYPE_ENGINE_COROS_BATCH_SIZE)
 
         return Literal(collection=LiteralCollection(literals=lit_list))
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1693,6 +1693,9 @@ class ListTransformer(AsyncTypeTransformer[T]):
         lit_list = [
             asyncio.create_task(TypeEngine.async_to_literal(ctx, x, t, expected.collection_type)) for x in python_val
         ]
+        print(f"Type engine batch size: {_TYPE_ENGINE_COROS_BATCH_SIZE}")
+        print(f"Number of coros {len(lit_list)}", flush=True)
+
         lit_list = await _run_coros_in_chunks(lit_list, batch_size=_TYPE_ENGINE_COROS_BATCH_SIZE)
 
         return Literal(collection=LiteralCollection(literals=lit_list))
@@ -1715,8 +1718,6 @@ class ListTransformer(AsyncTypeTransformer[T]):
 
         st = self.get_sub_type(expected_python_type)
         result = [TypeEngine.async_to_python_value(ctx, x, st) for x in lits]
-        print(f"Type engine batch size: {_TYPE_ENGINE_COROS_BATCH_SIZE}")
-        print(f"Number of coros {len(result)}", flush=True)
         result = await _run_coros_in_chunks(result, batch_size=_TYPE_ENGINE_COROS_BATCH_SIZE)
         return result  # type: ignore  # should be a list, thinks its a tuple
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -60,7 +60,7 @@ T = typing.TypeVar("T")
 DEFINITIONS = "definitions"
 TITLE = "title"
 
-coros_env = os.environ.get("FLYTE_COROS", "5")
+coros_env = os.environ.get("FLYTE_COROS", "10")
 
 _TYPE_ENGINE_COROS_BATCH_SIZE = int(coros_env)
 
@@ -1691,8 +1691,6 @@ class ListTransformer(AsyncTypeTransformer[T]):
 
         t = self.get_sub_type(python_type)
         lit_list = [TypeEngine.async_to_literal(ctx, x, t, expected.collection_type) for x in python_val]
-        print(f"Type engine batch size: {_TYPE_ENGINE_COROS_BATCH_SIZE}")
-        print(f"Number of coros {len(lit_list)}", flush=True)
 
         lit_list = await _run_coros_in_chunks(lit_list, batch_size=_TYPE_ENGINE_COROS_BATCH_SIZE)
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1715,6 +1715,8 @@ class ListTransformer(AsyncTypeTransformer[T]):
 
         st = self.get_sub_type(expected_python_type)
         result = [TypeEngine.async_to_python_value(ctx, x, st) for x in lits]
+        print(f"Type engine batch size: {_TYPE_ENGINE_COROS_BATCH_SIZE}")
+        print(f"Number of coros {len(result)}", flush=True)
         result = await _run_coros_in_chunks(result, batch_size=_TYPE_ENGINE_COROS_BATCH_SIZE)
         return result  # type: ignore  # should be a list, thinks its a tuple
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -60,9 +60,7 @@ T = typing.TypeVar("T")
 DEFINITIONS = "definitions"
 TITLE = "title"
 
-coros_env = os.environ.get("FLYTE_COROS", "10")
-
-_TYPE_ENGINE_COROS_BATCH_SIZE = int(coros_env)
+_TYPE_ENGINE_COROS_BATCH_SIZE = int(os.environ.get("_F_TE_MAX_COROS", "10"))
 
 
 # In Mashumaro, the default encoder uses strict_map_key=False, while the default decoder uses strict_map_key=True.

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -60,7 +60,9 @@ T = typing.TypeVar("T")
 DEFINITIONS = "definitions"
 TITLE = "title"
 
-_TYPE_ENGINE_COROS_BATCH_SIZE = 30
+coros_env = os.environ.get("FLYTE_COROS", "5")
+
+_TYPE_ENGINE_COROS_BATCH_SIZE = int(coros_env)
 
 
 # In Mashumaro, the default encoder uses strict_map_key=False, while the default decoder uses strict_map_key=True.

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -514,7 +514,6 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
         python_type: typing.Type[FlyteFile],
         expected: LiteralType,
     ) -> Literal:
-        print(f"uploading file {python_val.path}", flush=True)
         remote_path = None
         should_upload = True
 

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -514,6 +514,7 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
         python_type: typing.Type[FlyteFile],
         expected: LiteralType,
     ) -> Literal:
+        print(f"uploading file {python_val.path}", flush=True)
         remote_path = None
         should_upload = True
 

--- a/tests/flytekit/unit/core/test_data_persistence.py
+++ b/tests/flytekit/unit/core/test_data_persistence.py
@@ -10,9 +10,10 @@ import fsspec
 import mock
 import pytest
 from azure.identity import ClientSecretCredential, DefaultAzureCredential
+from mock import AsyncMock
 
 from flytekit.configuration import Config
-from flytekit.core.data_persistence import FileAccessProvider
+from flytekit.core.data_persistence import FileAccessProvider, get_additional_fsspec_call_kwargs
 from flytekit.core.local_fsspec import FlyteLocalFileSystem
 
 
@@ -208,6 +209,37 @@ def test_get_file_system():
 
     fp = FileAccessProvider("/tmp", "s3://my-bucket")
     fp.get_filesystem("testgetfs", test_arg="test_arg")
+
+
+def test_get_additional_fsspec_call_kwargs():
+    with mock.patch("flytekit.core.data_persistence._WRITE_SIZE_CHUNK_BYTES", 12345):
+        kwargs = get_additional_fsspec_call_kwargs(("s3", "s3a"), "put")
+        assert kwargs == {"chunksize": 12345}
+
+        kwargs = get_additional_fsspec_call_kwargs("s3", "put")
+        assert kwargs == {"chunksize": 12345}
+
+        kwargs = get_additional_fsspec_call_kwargs("s3", "get")
+        assert kwargs == {}
+
+
+@pytest.mark.asyncio
+@mock.patch("flytekit.core.data_persistence.FileAccessProvider.get_async_filesystem_for_path", new_callable=AsyncMock)
+@mock.patch("flytekit.core.data_persistence.get_additional_fsspec_call_kwargs")
+async def test_chunk_size(mock_call_kwargs, mock_get_fs):
+    mock_call_kwargs.return_value = {"chunksize": 1234}
+    mock_fs = mock.MagicMock()
+    mock_get_fs.return_value = mock_fs
+
+    mock_fs.protocol = ("s3", "s3a")
+    fp = FileAccessProvider("/tmp", "s3://container/path/within/container")
+
+    def put(*args, **kwargs):
+        assert "chunksize" in kwargs
+
+    mock_fs.put = put
+    upload_location = await fp._put("/tmp/foo", "s3://bar")
+    assert upload_location == "s3://bar"
 
 
 @pytest.mark.sandbox_test

--- a/tests/flytekit/unit/core/test_data_persistence.py
+++ b/tests/flytekit/unit/core/test_data_persistence.py
@@ -216,7 +216,7 @@ def test_get_additional_fsspec_call_kwargs():
         kwargs = get_additional_fsspec_call_kwargs(("s3", "s3a"), "put")
         assert kwargs == {"chunksize": 12345}
 
-        kwargs = get_additional_fsspec_call_kwargs("s3", "put")
+        kwargs = get_additional_fsspec_call_kwargs("s3", "_put")
         assert kwargs == {"chunksize": 12345}
 
         kwargs = get_additional_fsspec_call_kwargs("s3", "get")

--- a/tests/flytekit/unit/core/test_list.py
+++ b/tests/flytekit/unit/core/test_list.py
@@ -1,4 +1,6 @@
 import mock
+
+import pytest
 import typing
 import asyncio
 import datetime
@@ -79,5 +81,9 @@ def test_file_formats_getting_literal_type():
 
     with mock.patch("flytekit.core.type_engine._TYPE_ENGINE_COROS_BATCH_SIZE", 2):
         TypeEngine.to_literal(ctx, python_val, typing.List[MyInt], lt)
+
+    with mock.patch("flytekit.core.type_engine._TYPE_ENGINE_COROS_BATCH_SIZE", 5):
+        with pytest.raises(Exception):
+            TypeEngine.to_literal(ctx, python_val, typing.List[MyInt], lt)
 
     del TypeEngine._REGISTRY[MyInt]

--- a/tests/flytekit/unit/core/test_list.py
+++ b/tests/flytekit/unit/core/test_list.py
@@ -16,8 +16,6 @@ from flytekit.models.literals import (
 )
 from flytekit.models.types import LiteralType, SimpleType
 
-T = typing.TypeVar("T")
-
 
 class MyInt:
     def __init__(self, x: int):

--- a/tests/flytekit/unit/core/test_list.py
+++ b/tests/flytekit/unit/core/test_list.py
@@ -1,0 +1,71 @@
+import typing
+import asyncio
+import datetime
+from flytekit.core.context_manager import FlyteContext, FlyteContextManager
+
+from flytekit.core.type_engine import (
+    AsyncTypeTransformer,
+    TypeEngine,
+)
+from flytekit.models.literals import (
+    Literal,
+    Primitive,
+    Scalar,
+)
+from flytekit.models.types import LiteralType, SimpleType
+
+T = typing.TypeVar("T")
+
+
+class MyInt:
+    def __init__(self, x: int):
+        self.val = x
+
+    def __eq__(self, other):
+        if not isinstance(other, MyInt):
+            return False
+        return other.val == self.val
+
+
+class MyIntAsyncTransformer(AsyncTypeTransformer[MyInt]):
+    def __init__(self):
+        super().__init__(name="MyAsyncInt", t=MyInt)
+
+    def assert_type(self, t, v):
+        return
+
+    def get_literal_type(self, t: typing.Type[MyInt]) -> LiteralType:
+        return LiteralType(simple=SimpleType.INTEGER)
+
+    async def async_to_literal(
+        self,
+        ctx: FlyteContext,
+        python_val: MyInt,
+        python_type: typing.Type[MyInt],
+        expected: LiteralType,
+    ) -> Literal:
+        print(f"start waiting on {python_val.val} {datetime.datetime.now()}")
+        await asyncio.sleep(1)
+        print(f"done waiting on {python_val.val} {datetime.datetime.now()}")
+        return Literal(scalar=Scalar(primitive=Primitive(integer=python_val.val)))
+
+    async def async_to_python_value(
+        self, ctx: FlyteContext, lv: Literal, expected_python_type: typing.Type[MyInt]
+    ) -> MyInt:
+        return MyInt(lv.scalar.primitive.integer)
+
+    def guess_python_type(self, literal_type: LiteralType) -> typing.Type[MyInt]:
+        return MyInt
+
+
+def test_file_formats_getting_literal_type():
+    TypeEngine.register(MyIntAsyncTransformer())
+
+    lt = LiteralType(simple=SimpleType.INTEGER)
+    python_val = [MyInt(10), MyInt(11), MyInt(12), MyInt(13), MyInt(14)]
+    ctx = FlyteContext.current_context()
+
+    xx = TypeEngine.to_literal(ctx, python_val, typing.List[MyInt], lt)
+
+    del TypeEngine._REGISTRY[MyInt]
+


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/6188

## Why are the changes needed?
Please see issue.

## What changes were proposed in this pull request?
Because flytekit loops run on a different thread, the moment the asyncio.Task is created, it starts running, rendering any batching of coroutines moot.

In testing, we also noticed that the s3fs and gcsfs default write chunk sizes were 50MB.  We felt that was a bit high and in testing noticed no performance decrease (actually saw possibly non-statistically significant increase) in performance.  We are therefore changing it by default to 25MB.  Also this setting and the number of coroutine batches the list & dict transformers run will be configurable via environment variables.

The new env vars are:
* `_F_P_WRITE_CHUNK_SIZE` - This is the number of bytes and by default is set to `"26214400"` (25 * 2^20)
* `_F_TE_MAX_COROS` - This is the number of coroutines the type engine will use for lists/dicts and is set to `"10"`.


## How was this patch tested?
Tested on our byoc clusters, and by the OSS OP.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request introduces improvements to the Flytekit library by adding configurable chunk sizes for S3 and GCS uploads and enhancing coroutine batching in the type engine. The chunk size for S3/GCS uploads is now set to 25MB by default and can be configured via an environment variable.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>