### PR TITLE
Add pip_extra_args

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -216,6 +216,9 @@ def prepare_python_install(image_spec: ImageSpec, tmp_dir: Path) -> str:
         extra_urls = [f"--extra-index-url {url}" for url in image_spec.pip_extra_index_url]
         pip_install_args.extend(extra_urls)
 
+    if image_spec.pip_extra_args:
+        pip_install_args.append(image_spec.pip_extra_args)
+
     requirements = []
     if image_spec.requirements:
         requirement_basename = os.path.basename(image_spec.requirements)

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -48,6 +48,7 @@ class ImageSpec:
         platform: Specify the target platforms for the build output (for example, windows/amd64 or linux/amd64,darwin/arm64
         pip_index: Specify the custom pip index url
         pip_extra_index_url: Specify one or more pip index urls as a list
+        pip_extra_args: Specify one or more extra pip install arguments as a space-delimited string
         registry_config: Specify the path to a JSON registry config file
         entrypoint: List of strings to overwrite the entrypoint of the base image with, set to [] to remove the entrypoint.
         commands: Command to run during the building process
@@ -82,6 +83,7 @@ class ImageSpec:
     platform: str = "linux/amd64"
     pip_index: Optional[str] = None
     pip_extra_index_url: Optional[List[str]] = None
+    pip_extra_args: Optional[str] = None
     registry_config: Optional[str] = None
     entrypoint: Optional[List[str]] = None
     commands: Optional[List[str]] = None

--- a/tests/flytekit/unit/core/image_spec/test_default_builder.py
+++ b/tests/flytekit/unit/core/image_spec/test_default_builder.py
@@ -235,6 +235,7 @@ def test_create_docker_context_uv_lock(tmp_path):
         requirements=os.fspath(uv_lock_file),
         pip_index="https://url.com",
         pip_extra_index_url=["https://extra-url.com"],
+        pip_extra_args="--no-install-package library-to-skip",
     )
 
     warning_msg = "uv.lock support is experimental"
@@ -247,7 +248,8 @@ def test_create_docker_context_uv_lock(tmp_path):
 
     assert (
         "uv sync --index-url https://url.com --extra-index-url "
-        "https://extra-url.com --locked --no-dev --no-install-project"
+        "https://extra-url.com --no-install-package library-to-skip "
+        "--locked --no-dev --no-install-project"
     ) in dockerfile_content
 
 
@@ -309,6 +311,7 @@ def test_create_poetry_lock(tmp_path):
         name="FLYTEKIT",
         python_version="3.12",
         requirements=os.fspath(poetry_lock),
+        pip_extra_args="--no-directory",
     )
 
     create_docker_context(image_spec, docker_context_path)
@@ -317,7 +320,7 @@ def test_create_poetry_lock(tmp_path):
     assert dockerfile_path.exists()
     dockerfile_content = dockerfile_path.read_text()
 
-    assert "poetry install --no-root" in dockerfile_content
+    assert "poetry install --no-directory --no-root" in dockerfile_content
 
 
 def test_python_exec(tmp_path):


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->
Related to https://github.com/flyteorg/flyte/issues/6119

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
We have a few path dependencies in `pyproject.toml` and `poetry.lock`, and only want to install packages from external sources, which requires adding `--no-directory` to `poetry install`. This is a standard practice when installing dependencies without code.
See
https://python-poetry.org/docs/faq/#poetry-busts-my-docker-cache-because-it-requires-me-to-copy-my-source-files-in-before-installing-3rd-party-dependencies

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
`pip_extra_args` is a specifiable parameter for `ImageSpec`, and appended when running `poetry install`, `uv sync` and `pip install`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I tested locally with a poetry project with internal path dependency by running `pyflyte build`. Planning to add unit tests once the implementation get LGTM.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->
https://github.com/flyteorg/flytekit/pull/3025


## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
Added new pip_extra_args parameter to ImageSpec class for enhanced package installation flexibility, enabling custom pip installation arguments for path dependencies in poetry projects. Enhanced test suite implementation to validate pip_extra_args parameter, including test cases for --no-install-package flag and path dependency handling with --no-directory option. Tests ensure proper integration with both poetry and pip installation workflows.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>