### PR TITLE
Structured datasets in containers (dc/pydantic)

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1361,7 +1361,7 @@ class TypeEngine(typing.Generic[T]):
     ) -> Literal:
         """
         The current dance is because we are allowing users to call from an async function, this synchronous
-        to_literal function, and allowing this to_literal function, to then invoke yet another async functionl,
+        to_literal function, and allowing this to_literal function, to then invoke yet another async function,
         namely an async transformer.
         """
         from flytekit.core.promise import Promise

--- a/flytekit/remote/remote_fs.py
+++ b/flytekit/remote/remote_fs.py
@@ -65,6 +65,8 @@ class HttpFileWriter(fsspec.spec.AbstractBufferedFile):
         """Only uploads the file at once from the buffer.
         Not suitable for large files as the buffer will blow the memory for very large files.
         Suitable for default values or local dataframes being uploaded all at once.
+        1. why is md5 none?
+        2. how is this a chunk?
         """
         if final is False:
             return False
@@ -80,6 +82,7 @@ class HttpFileWriter(fsspec.spec.AbstractBufferedFile):
                 filename_root=self._filename,
             )
             FlytePathResolver.add_mapping(self.path, res.native_url)
+            breakpoint()
             resp = requests.put(res.signed_url, data=data)
             if not resp.ok:
                 raise AssertionError(f"Failed to upload file {self._filename} to {res.signed_url} reason {resp.reason}")

--- a/flytekit/remote/remote_fs.py
+++ b/flytekit/remote/remote_fs.py
@@ -82,7 +82,6 @@ class HttpFileWriter(fsspec.spec.AbstractBufferedFile):
                 filename_root=self._filename,
             )
             FlytePathResolver.add_mapping(self.path, res.native_url)
-            breakpoint()
             resp = requests.put(res.signed_url, data=data)
             if not resp.ok:
                 raise AssertionError(f"Failed to upload file {self._filename} to {res.signed_url} reason {resp.reason}")

--- a/flytekit/remote/remote_fs.py
+++ b/flytekit/remote/remote_fs.py
@@ -65,8 +65,8 @@ class HttpFileWriter(fsspec.spec.AbstractBufferedFile):
         """Only uploads the file at once from the buffer.
         Not suitable for large files as the buffer will blow the memory for very large files.
         Suitable for default values or local dataframes being uploaded all at once.
-        1. why is md5 none?
-        2. how is this a chunk?
+
+        This function is called by fsspec.flush(). This will create a new file upload location.
         """
         if final is False:
             return False
@@ -74,6 +74,10 @@ class HttpFileWriter(fsspec.spec.AbstractBufferedFile):
         data = self.buffer.read()
 
         try:
+            # The inputs here are flipped a bit, it should be the filename is set to the filename and the filename root
+            # is something deterministic, like a hash. But since this is supposed to mimic open(), we can't hash.
+            # With the args currently below, the backend will create a random suffix for the filename.
+            # Since no hash is set on it, we will not be able to write to it again (which is totally fine).
             res = self._remote.client.get_upload_signed_url(
                 self._remote.default_project,
                 self._remote.default_domain,

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -86,7 +86,7 @@ class StructuredDataset(SerializableType, DataClassJSONMixin):
             FlyteContextManager.current_context(),
             Literal(
                 scalar=Scalar(
-                    structured_dataset=StructuredDataset(
+                    structured_dataset=literals.StructuredDataset(
                         metadata=StructuredDatasetMetadata(
                             structured_dataset_type=StructuredDatasetType(format=file_format)
                         ),
@@ -119,7 +119,7 @@ class StructuredDataset(SerializableType, DataClassJSONMixin):
             FlyteContextManager.current_context(),
             Literal(
                 scalar=Scalar(
-                    structured_dataset=StructuredDataset(
+                    structured_dataset=literals.StructuredDataset(
                         metadata=StructuredDatasetMetadata(
                             structured_dataset_type=StructuredDatasetType(format=self.file_format)
                         ),

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -23,6 +23,7 @@ from flytekit import lazy_module
 from flytekit.core.constants import MESSAGEPACK
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.type_engine import AsyncTypeTransformer, TypeEngine, TypeTransformerFailedError
+from flytekit.core.type_engine import modify_literal_uris
 from flytekit.deck.renderer import Renderable
 from flytekit.extras.pydantic_transformer.decorator import model_serializer, model_validator
 from flytekit.loggers import developer_logger, logger
@@ -63,6 +64,7 @@ class StructuredDataset(SerializableType, DataClassJSONMixin):
     file_format: typing.Optional[str] = field(default=GENERIC_FORMAT, metadata=config(mm_field=fields.String()))
 
     def _serialize(self) -> Dict[str, Optional[str]]:
+        # dataclass case
         lv = StructuredDatasetTransformerEngine().to_literal(
             FlyteContextManager.current_context(), self, type(self), None
         )
@@ -98,6 +100,7 @@ class StructuredDataset(SerializableType, DataClassJSONMixin):
 
     @model_serializer
     def serialize_structured_dataset(self) -> Dict[str, Optional[str]]:
+        # pydantic case
         lv = StructuredDatasetTransformerEngine().to_literal(
             FlyteContextManager.current_context(), self, type(self), None
         )
@@ -807,6 +810,10 @@ class StructuredDatasetTransformerEngine(AsyncTypeTransformer[StructuredDataset]
         # with a format of "" is used.
         sd_model.metadata._structured_dataset_type.format = handler.supported_format
         lit = Literal(scalar=Scalar(structured_dataset=sd_model))
+
+        # Because the handler.encode may have uploaded something, and because the sd may end up living inside a
+        # dataclass, we need to modify any uploaded flyte:// urls here.
+        modify_literal_uris(lit)
         sd._literal_sd = sd_model
         sd._already_uploaded = True
         return lit

--- a/flytekit/types/structured/structured_dataset.py
+++ b/flytekit/types/structured/structured_dataset.py
@@ -22,8 +22,7 @@ from typing_extensions import Annotated, TypeAlias, get_args, get_origin
 from flytekit import lazy_module
 from flytekit.core.constants import MESSAGEPACK
 from flytekit.core.context_manager import FlyteContext, FlyteContextManager
-from flytekit.core.type_engine import AsyncTypeTransformer, TypeEngine, TypeTransformerFailedError
-from flytekit.core.type_engine import modify_literal_uris
+from flytekit.core.type_engine import AsyncTypeTransformer, TypeEngine, TypeTransformerFailedError, modify_literal_uris
 from flytekit.deck.renderer import Renderable
 from flytekit.extras.pydantic_transformer.decorator import model_serializer, model_validator
 from flytekit.loggers import developer_logger, logger

--- a/tests/flytekit/unit/core/test_dataclass.py
+++ b/tests/flytekit/unit/core/test_dataclass.py
@@ -1207,4 +1207,3 @@ def test_modify_literal_uris_call(mock_resolver):
 
     bm_revived = TypeEngine.to_python_value(ctx, lit, DC1)
     assert bm_revived.s.literal.uri == "/my/replaced/val"
-

--- a/tests/flytekit/unit/core/test_dataclass.py
+++ b/tests/flytekit/unit/core/test_dataclass.py
@@ -1,6 +1,7 @@
 import pytest
 from enum import Enum
-from dataclasses_json import DataClassJsonMixin
+import mock
+from pathlib import Path
 from mashumaro.mixins.json import DataClassJSONMixin
 import os
 import sys
@@ -17,6 +18,8 @@ from flytekit import task, workflow
 from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import FlyteFile
 from flytekit.types.structured import StructuredDataset
+
+pd = pytest.importorskip("pandas")
 
 
 @pytest.fixture
@@ -1175,3 +1178,33 @@ def test_dataclass_serialize_with_multiple_dataclass_union():
     res = DataclassTransformer()._make_dataclass_serializable(b, Union[None, A, B])
 
     assert res.x.path == "s3://my-bucket/my-file"
+
+
+@mock.patch("flytekit.remote.remote_fs.FlytePathResolver")
+def test_modify_literal_uris_call(mock_resolver):
+    ctx = FlyteContextManager.current_context()
+
+    sd = StructuredDataset(dataframe=pd.DataFrame(
+        {"a": [1, 2], "b": [3, 4]}))
+
+    @dataclass
+    class DC1:
+        s: StructuredDataset
+
+    bm = DC1(s=sd)
+
+    def mock_resolve_remote_path(flyte_uri: str):
+        p = Path(flyte_uri)
+        if p.exists():
+            return "/my/replaced/val"
+        return ""
+
+    mock_resolver.resolve_remote_path.side_effect = mock_resolve_remote_path
+    mock_resolver.protocol = "/"
+
+    lt = TypeEngine.to_literal_type(DC1)
+    lit = TypeEngine.to_literal(ctx, bm, DC1, lt)
+
+    bm_revived = TypeEngine.to_python_value(ctx, lit, DC1)
+    assert bm_revived.s.literal.uri == "/my/replaced/val"
+

--- a/tests/flytekit/unit/extras/pydantic_transformer/test_pydantic_basemodel_transformer.py
+++ b/tests/flytekit/unit/extras/pydantic_transformer/test_pydantic_basemodel_transformer.py
@@ -1,9 +1,10 @@
 import os
 import tempfile
 from enum import Enum
+from pathlib import Path
 from typing import Dict, List, Optional, Union
 from unittest.mock import patch
-
+import mock
 import pytest
 from google.protobuf import json_format as _json_format
 from google.protobuf import struct_pb2 as _struct
@@ -15,11 +16,12 @@ from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.type_engine import TypeEngine
 from flytekit.models.annotation import TypeAnnotation
 from flytekit.models.literals import Literal, Scalar
-from flytekit.models.types import LiteralType, SimpleType
 from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import FlyteFile
 from flytekit.types.schema import FlyteSchema
 from flytekit.types.structured import StructuredDataset
+
+pd = pytest.importorskip("pandas")
 
 
 class Status(Enum):
@@ -992,3 +994,32 @@ def test_basemodel_literal_type_annotation():
         c: str = "Hello, Flyte"
 
     assert TypeEngine.to_literal_type(BM).annotation == TypeAnnotation({CACHE_KEY_METADATA: {SERIALIZATION_FORMAT: MESSAGEPACK}})
+
+
+@mock.patch("flytekit.remote.remote_fs.FlytePathResolver")
+def test_modify_literal_uris_call(mock_resolver):
+    ctx = FlyteContextManager.current_context()
+
+    sd = StructuredDataset(dataframe=pd.DataFrame(
+        {"a": [1, 2], "b": [3, 4]}))
+
+    class BM(BaseModel):
+        s: StructuredDataset
+
+    bm = BM(s=sd)
+
+    def mock_resolve_remote_path(flyte_uri: str):
+        p = Path(flyte_uri)
+        if p.exists():
+            return "/my/replaced/val"
+        return ""
+
+    mock_resolver.resolve_remote_path.side_effect = mock_resolve_remote_path
+    mock_resolver.protocol = "/"
+
+    lt = TypeEngine.to_literal_type(BM)
+    lit = TypeEngine.to_literal(ctx, bm, BM, lt)
+
+    bm_revived = TypeEngine.to_python_value(ctx, lit, BM)
+    assert bm_revived.s.literal.uri == "/my/replaced/val"
+

--- a/tests/flytekit/unit/extras/pydantic_transformer/test_pydantic_basemodel_transformer.py
+++ b/tests/flytekit/unit/extras/pydantic_transformer/test_pydantic_basemodel_transformer.py
@@ -1022,4 +1022,3 @@ def test_modify_literal_uris_call(mock_resolver):
 
     bm_revived = TypeEngine.to_python_value(ctx, lit, BM)
     assert bm_revived.s.literal.uri == "/my/replaced/val"
-

--- a/tests/flytekit/unit/types/structured_dataset/test_structured_dataset.py
+++ b/tests/flytekit/unit/types/structured_dataset/test_structured_dataset.py
@@ -3,7 +3,7 @@ import tempfile
 import typing
 from collections import OrderedDict
 from pathlib import Path
-
+import mock
 import google.cloud.bigquery
 import pytest
 from fsspec.utils import get_protocol
@@ -661,7 +661,6 @@ def test_default_args_task():
     pd.testing.assert_frame_equal(wf_with_input(), input_val)
 
 
-
 def test_read_sd_from_local_uri(local_tmp_pqt_file):
 
     @task
@@ -677,9 +676,40 @@ def test_read_sd_from_local_uri(local_tmp_pqt_file):
 
         return df
 
-
     df = generate_pandas()
 
     # Read sd from local uri
     df_local = read_sd_from_local_uri(uri=local_tmp_pqt_file)
     pd.testing.assert_frame_equal(df, df_local)
+
+
+@mock.patch("flytekit.remote.remote_fs.FlytePathResolver")
+@mock.patch("flytekit.types.structured.structured_dataset.StructuredDatasetTransformerEngine.get_encoder")
+def test_modify_literal_uris_call(mock_get_encoder, mock_resolver):
+
+    ctx = FlyteContextManager.current_context()
+
+    sd = StructuredDataset(dataframe=pd.DataFrame(
+        {"a": [1, 2], "b": [3, 4]}), uri="bq://blah", file_format="bq")
+
+    def mock_resolve_remote_path(flyte_uri: str) -> typing.Optional[str]:
+        if flyte_uri == "bq://blah":
+            return "bq://blah/blah/blah"
+        return ""
+
+    mock_resolver.resolve_remote_path.side_effect = mock_resolve_remote_path
+    mock_resolver.protocol = "bq"
+
+    dummy_encoder = mock.MagicMock()
+    sd_model = literals.StructuredDataset(uri="bq://blah", metadata=StructuredDatasetMetadata(StructuredDatasetType(format="parquet")))
+    dummy_encoder.encode.return_value = sd_model
+
+    mock_get_encoder.return_value = dummy_encoder
+
+    sdte = StructuredDatasetTransformerEngine()
+    lt = LiteralType(
+        structured_dataset_type=StructuredDatasetType()
+    )
+
+    lit = sdte.encode(ctx, sd, df_type=pd.DataFrame, protocol="bq", format="parquet", structured_literal_type=lt)
+    assert lit.scalar.structured_dataset.uri == "bq://blah/blah/blah"


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/6189

## What changes were proposed in this pull request?
Call the modify literals uris.

## How was this patch tested?
on dogfood.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
Implementation of URI modification functionality for structured datasets, focusing on handling uploaded files within dataclasses and Pydantic models. Enhanced handling of flyte:// URLs and improved type imports for StructuredDataset. Added support for modifying literal URIs in StructuredDatasetTransformerEngine with comprehensive test coverage. Includes documentation fixes in HttpFileWriter and proper handling of URI transformations in container environments.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>