### PR TITLE
Add request and limit to ray config

### DIFF
--- a/flytekit/core/resources.py
+++ b/flytekit/core/resources.py
@@ -102,7 +102,7 @@ def convert_resources_to_resource_model(
     return task_models.Resources(requests=request_entries, limits=limit_entries)
 
 
-def _pod_spec_from_resources(
+def pod_spec_from_resources(
     primary_container_name: Optional[str] = None,
     requests: Optional[Resources] = None,
     limits: Optional[Resources] = None,

--- a/flytekit/core/resources.py
+++ b/flytekit/core/resources.py
@@ -102,12 +102,12 @@ def convert_resources_to_resource_model(
     return task_models.Resources(requests=request_entries, limits=limit_entries)
 
 
-def pod_spec_from_resources(
-    k8s_pod_name: str,
+def _pod_spec_from_resources(
+    primary_container_name: Optional[str] = None,
     requests: Optional[Resources] = None,
     limits: Optional[Resources] = None,
     k8s_gpu_resource_key: str = "nvidia.com/gpu",
-) -> dict[str, Any]:
+) -> V1PodSpec:
     def _construct_k8s_pods_resources(resources: Optional[Resources], k8s_gpu_resource_key: str):
         if resources is None:
             return None
@@ -133,10 +133,10 @@ def pod_spec_from_resources(
     requests = requests or limits
     limits = limits or requests
 
-    k8s_pod = V1PodSpec(
+    pod_spec = V1PodSpec(
         containers=[
             V1Container(
-                name=k8s_pod_name,
+                name=primary_container_name,
                 resources=V1ResourceRequirements(
                     requests=requests,
                     limits=limits,
@@ -145,4 +145,4 @@ def pod_spec_from_resources(
         ]
     )
 
-    return k8s_pod.to_dict()
+    return pod_spec

--- a/flytekit/core/resources.py
+++ b/flytekit/core/resources.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, fields
-from typing import Any, List, Optional, Union
+from typing import List, Optional, Union
 
 from kubernetes.client import V1Container, V1PodSpec, V1ResourceRequirements
 from mashumaro.mixins.json import DataClassJSONMixin

--- a/plugins/flytekit-ray/flytekitplugins/ray/task.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/task.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
 
 import yaml
+
+from flytekit.core.resources import _pod_spec_from_resources
 from flytekitplugins.ray.models import (
     HeadGroupSpec,
     RayCluster,
@@ -14,7 +16,7 @@ from flytekitplugins.ray.models import (
 )
 from google.protobuf.json_format import MessageToDict
 
-from flytekit import lazy_module
+from flytekit import lazy_module, PodTemplate, Resources
 from flytekit.configuration import SerializationSettings
 from flytekit.core.context_manager import ExecutionParameters, FlyteContextManager
 from flytekit.core.python_function_task import PythonFunctionTask
@@ -27,7 +29,14 @@ ray = lazy_module("ray")
 @dataclass
 class HeadNodeConfig:
     ray_start_params: typing.Optional[typing.Dict[str, str]] = None
-    k8s_pod: typing.Optional[K8sPod] = None
+    pod_template: typing.Optional[PodTemplate] = None
+    requests: Optional[Resources] = None
+    limits: Optional[Resources] = None
+
+    def __post_init__(self):
+        if self.pod_template:
+            if self.requests and self.limits:
+                raise ValueError("Cannot specify both pod_template and requests/limits")
 
 
 @dataclass
@@ -37,7 +46,14 @@ class WorkerNodeConfig:
     min_replicas: typing.Optional[int] = None
     max_replicas: typing.Optional[int] = None
     ray_start_params: typing.Optional[typing.Dict[str, str]] = None
-    k8s_pod: typing.Optional[K8sPod] = None
+    pod_template: typing.Optional[PodTemplate] = None
+    requests: Optional[Resources] = None
+    limits: Optional[Resources] = None
+
+    def __post_init__(self):
+        if self.pod_template:
+            if self.requests and self.limits:
+                raise ValueError("Cannot specify both pod_template and requests/limits")
 
 
 @dataclass
@@ -86,22 +102,46 @@ class RayFunctionTask(PythonFunctionTask):
 
         # Deprecated: runtime_env is removed KubeRay >= 1.1.0. It is replaced by runtime_env_yaml
         runtime_env = base64.b64encode(json.dumps(cfg.runtime_env).encode()).decode() if cfg.runtime_env else None
-
         runtime_env_yaml = yaml.dump(cfg.runtime_env) if cfg.runtime_env else None
+
+        if cfg.head_node_config.requests or cfg.head_node_config.limits:
+            head_pod_template = PodTemplate(
+                pod_spec=_pod_spec_from_resources(
+                    primary_container_name="ray-head",
+                    requests=cfg.head_node_config.requests,
+                    limits=cfg.head_node_config.limits,
+                )
+            )
+        else:
+            head_pod_template = cfg.head_node_config.pod_template
+
+        worker_group_spec: typing.List[WorkerGroupSpec] = []
+        for c in cfg.worker_node_config:
+            if c.requests or c.limits:
+                worker_pod_template = PodTemplate(
+                    pod_spec=_pod_spec_from_resources(
+                        primary_container_name=f"ray-worker",
+                        requests=c.requests,
+                        limits=c.limits,
+                    )
+                )
+            else:
+                worker_pod_template = c.pod_template
+            k8s_pod = K8sPod.from_pod_template(worker_pod_template) if worker_pod_template else None
+            worker_group_spec.append(
+                WorkerGroupSpec(
+                    c.group_name, c.replicas, c.min_replicas, c.max_replicas, c.ray_start_params, k8s_pod
+                )
+            )
 
         ray_job = RayJob(
             ray_cluster=RayCluster(
                 head_group_spec=(
-                    HeadGroupSpec(cfg.head_node_config.ray_start_params, cfg.head_node_config.k8s_pod)
+                    HeadGroupSpec(cfg.head_node_config.ray_start_params, K8sPod.from_pod_template(head_pod_template) if head_pod_template else None)
                     if cfg.head_node_config
                     else None
                 ),
-                worker_group_spec=[
-                    WorkerGroupSpec(
-                        c.group_name, c.replicas, c.min_replicas, c.max_replicas, c.ray_start_params, c.k8s_pod
-                    )
-                    for c in cfg.worker_node_config
-                ],
+                worker_group_spec=worker_group_spec,
                 enable_autoscaling=(cfg.enable_autoscaling if cfg.enable_autoscaling else False),
             ),
             runtime_env=runtime_env,

--- a/plugins/flytekit-ray/setup.py
+++ b/plugins/flytekit-ray/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "ray"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["ray[default]", "flytekit>=1.3.0b2,<2.0.0", "flyteidl>=1.13.6"]
+plugin_requires = ["ray[default]", "flytekit>1.14.5", "flyteidl>=1.13.6"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-ray/tests/test_ray.py
+++ b/plugins/flytekit-ray/tests/test_ray.py
@@ -4,7 +4,7 @@ import json
 import ray
 import yaml
 
-from flytekit.core.resources import _pod_spec_from_resources
+from flytekit.core.resources import pod_spec_from_resources
 from flytekitplugins.ray import HeadNodeConfig
 from flytekitplugins.ray.models import (
     HeadGroupSpec,
@@ -65,7 +65,7 @@ def test_ray_task():
         env={},
     )
     head_pod_template = PodTemplate(
-                pod_spec=_pod_spec_from_resources(
+                pod_spec=pod_spec_from_resources(
                     primary_container_name="ray-head",
                     requests=Resources(cpu="1", mem="1Gi"),
                     limits=Resources(cpu="2", mem="2Gi"),

--- a/plugins/flytekit-ray/tests/test_ray.py
+++ b/plugins/flytekit-ray/tests/test_ray.py
@@ -3,6 +3,8 @@ import json
 
 import ray
 import yaml
+
+from flytekit.core.resources import _pod_spec_from_resources
 from flytekitplugins.ray import HeadNodeConfig
 from flytekitplugins.ray.models import (
     HeadGroupSpec,
@@ -13,9 +15,16 @@ from flytekitplugins.ray.models import (
 from flytekitplugins.ray.task import RayJobConfig, WorkerNodeConfig
 from google.protobuf.json_format import MessageToDict
 
-from flytekit import PythonFunctionTask, task
+from flytekit import PythonFunctionTask, task, PodTemplate, Resources
 from flytekit.configuration import Image, ImageConfig, SerializationSettings
 from flytekit.models.task import K8sPod
+
+
+pod_template=PodTemplate(
+        primary_container_name="primary",
+        labels={"lKeyA": "lValA"},
+        annotations={"aKeyA": "aValA"},
+    )
 
 config = RayJobConfig(
     worker_node_config=[
@@ -24,10 +33,10 @@ config = RayJobConfig(
             replicas=3,
             min_replicas=0,
             max_replicas=10,
-            k8s_pod=K8sPod(pod_spec={"str": "worker", "int": 1}),
+            pod_template=pod_template,
         )
     ],
-    head_node_config=HeadNodeConfig(k8s_pod=K8sPod(pod_spec={"str": "head", "int": 2})),
+    head_node_config=HeadNodeConfig(requests=Resources(cpu="1", mem="1Gi"), limits=Resources(cpu="2", mem="2Gi")),
     runtime_env={"pip": ["numpy"]},
     enable_autoscaling=True,
     shutdown_after_job_finishes=True,
@@ -55,6 +64,13 @@ def test_ray_task():
         image_config=ImageConfig(default_image=default_img, images=[default_img]),
         env={},
     )
+    head_pod_template = PodTemplate(
+                pod_spec=_pod_spec_from_resources(
+                    primary_container_name="ray-head",
+                    requests=Resources(cpu="1", mem="1Gi"),
+                    limits=Resources(cpu="2", mem="2Gi"),
+                )
+            )
 
     ray_job_pb = RayJob(
         ray_cluster=RayCluster(
@@ -64,10 +80,10 @@ def test_ray_task():
                     replicas=3,
                     min_replicas=0,
                     max_replicas=10,
-                    k8s_pod=K8sPod(pod_spec={"str": "worker", "int": 1}),
+                    k8s_pod=K8sPod.from_pod_template(pod_template),
                 )
             ],
-            head_group_spec=HeadGroupSpec(k8s_pod=K8sPod(pod_spec={"str": "head", "int": 2})),
+            head_group_spec=HeadGroupSpec(k8s_pod=K8sPod.from_pod_template(head_pod_template)),
             enable_autoscaling=True,
         ),
         runtime_env=base64.b64encode(json.dumps({"pip": ["numpy"]}).encode()).decode(),

--- a/tests/flytekit/unit/core/test_resources.py
+++ b/tests/flytekit/unit/core/test_resources.py
@@ -110,12 +110,12 @@ def test_resources_round_trip():
 def test_pod_spec_from_resources_requests_limits_set():
     requests = Resources(cpu="1", mem="1Gi", gpu="1", ephemeral_storage="1Gi")
     limits = Resources(cpu="4", mem="2Gi", gpu="1", ephemeral_storage="1Gi")
-    k8s_pod_name = "foo"
+    primary_container_name = "foo"
 
     expected_pod_spec = V1PodSpec(
         containers=[
             V1Container(
-                name=k8s_pod_name,
+                name=primary_container_name,
                 resources=V1ResourceRequirements(
                     requests={
                         "cpu": "1",
@@ -133,19 +133,19 @@ def test_pod_spec_from_resources_requests_limits_set():
             )
         ]
     )
-    pod_spec = pod_spec_from_resources(primary_container_name=k8s_pod_name, requests=requests, limits=limits)
+    pod_spec = pod_spec_from_resources(primary_container_name=primary_container_name, requests=requests, limits=limits)
     assert expected_pod_spec == pod_spec
 
 
 def test_pod_spec_from_resources_requests_set():
     requests = Resources(cpu="1", mem="1Gi")
     limits = None
-    k8s_pod_name = "foo"
+    primary_container_name = "foo"
 
     expected_pod_spec = V1PodSpec(
         containers=[
             V1Container(
-                name=k8s_pod_name,
+                name=primary_container_name,
                 resources=V1ResourceRequirements(
                     requests={"cpu": "1", "memory": "1Gi"},
                     limits={"cpu": "1", "memory": "1Gi"},
@@ -153,5 +153,5 @@ def test_pod_spec_from_resources_requests_set():
             )
         ]
     )
-    pod_spec = pod_spec_from_resources(primary_container_name=k8s_pod_name, requests=requests, limits=limits)
+    pod_spec = pod_spec_from_resources(primary_container_name=primary_container_name, requests=requests, limits=limits)
     assert expected_pod_spec == pod_spec

--- a/tests/flytekit/unit/core/test_resources.py
+++ b/tests/flytekit/unit/core/test_resources.py
@@ -133,8 +133,8 @@ def test_pod_spec_from_resources_requests_limits_set():
             )
         ]
     )
-    pod_spec = pod_spec_from_resources(k8s_pod_name=k8s_pod_name, requests=requests, limits=limits)
-    assert expected_pod_spec == V1PodSpec(**pod_spec)
+    pod_spec = pod_spec_from_resources(primary_container_name=k8s_pod_name, requests=requests, limits=limits)
+    assert expected_pod_spec == pod_spec
 
 
 def test_pod_spec_from_resources_requests_set():
@@ -153,5 +153,5 @@ def test_pod_spec_from_resources_requests_set():
             )
         ]
     )
-    pod_spec = pod_spec_from_resources(k8s_pod_name=k8s_pod_name, requests=requests, limits=limits)
-    assert expected_pod_spec == V1PodSpec(**pod_spec)
+    pod_spec = pod_spec_from_resources(primary_container_name=k8s_pod_name, requests=requests, limits=limits)
+    assert expected_pod_spec == pod_spec


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
- Improve the devx: people can easily override the request and limit for the head/worker node

## What changes were proposed in this pull request?
- Replace K8sPod with PodTemplate to make it consistent with the parameter in `@task`
- Add resource and limit to HeadNodeConfig and WorkerNodeConfig

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process
```python
import typing

from flytekit import ImageSpec, Resources, task, workflow
import ray
from flytekitplugins.ray import HeadNodeConfig, RayJobConfig, WorkerNodeConfig

flytekit_hash = "234603bde982c4ece390dd77c33390c6d8db93cf"
new_flytekitplugins_ray = f"git+https://github.com/flyteorg/flytekit.git@{flytekit_hash}#subdirectory=plugins/flytekit-ray"
new_flytekit = f"git+https://github.com/flyteorg/flytekit.git@{flytekit_hash}"


custom_image = ImageSpec(
    registry="pingsutw",
    packages=[new_flytekitplugins_ray, "kubernetes", new_flytekit],
    apt_packages=["wget", "git"],
)


@ray.remote
def f(x):
    return x * x


ray_config = RayJobConfig(
    head_node_config=HeadNodeConfig(ray_start_params={"log-color": "True"}, requests=Resources(cpu="1.7")),
    worker_node_config=[WorkerNodeConfig(group_name="ray-group", replicas=2, requests=Resources(cpu="1.8"))],
    runtime_env={"pip": ["numpy", "pandas"]},
    enable_autoscaling=False,
    shutdown_after_job_finishes=True,
    ttl_seconds_after_finished=3,
)


@task(
    task_config=ray_config,
    requests=Resources(mem="2Gi", cpu="2"),
    container_image=custom_image,
)
def ray_task(n: int) -> typing.List[int]:
    futures = [f.remote(i) for i in range(n)]
    return ray.get(futures)


@workflow
def ray_workflow(n: int = 3):
    for i in range(1):
        ray_task(n=n)
```

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
https://github.com/flyteorg/flytekit/pull/2943

## Docs link
NA 
 <div id='description'>
<h3>Summary by Bito</h3>
Enhanced Ray configuration system with resource requests/limits support for head and worker nodes, replacing K8sPod with PodTemplate. Updated resource configuration implementation and flytekit version requirement. Improved naming conventions, including renaming k8s_pod_name to primary_container_name for better clarity. Added CPU and memory specification options in HeadNodeConfig and WorkerNodeConfig.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>