### PR TITLE
Format imports better

### DIFF
--- a/tests/flytekit/unit/core/test_dataclass.py
+++ b/tests/flytekit/unit/core/test_dataclass.py
@@ -1,11 +1,12 @@
 import pytest
-from enum import Enum
 import mock
-from pathlib import Path
-from mashumaro.mixins.json import DataClassJSONMixin
 import os
 import sys
 import tempfile
+from enum import Enum
+from pathlib import Path
+from dataclasses_json import DataClassJsonMixin
+from mashumaro.mixins.json import DataClassJSONMixin
 from dataclasses import dataclass, fields, field
 from typing import List, Dict, Optional, Union, Any
 from typing_extensions import Annotated


### PR DESCRIPTION
An import was accidentally removed (because it was a duplicate in the commit that was cherry-picked).  Adding it back and formatting better. 
 <div id='description'>
<h3>Summary by Bito</h3>
Import statements in test_dataclass.py have been reorganized for better code organization. The changes include removing duplicate imports, restoring a previously removed DataClassJsonMixin import, and grouping related imports together in a more structured manner.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>