### PR TITLE
silence union warning

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1900,7 +1900,7 @@ class UnionTransformer(AsyncTypeTransformer[T]):
                 res_type = _add_tag_to_type(trans.get_literal_type(t), trans.name)
                 found_res = True
             except Exception as e:
-                logger.warning(
+                logger.debug(
                     f"UnionTransformer failed attempt to convert from {python_val} to {t} error: {e}",
                 )
                 continue


### PR DESCRIPTION
Silence warning.  sister of https://github.com/flyteorg/flytekit/pull/3091/files 
 <div id='description'>
<h3>Summary by Bito</h3>
Minor modification to logging levels in the type engine module, reducing verbosity by downgrading a union-related warning message to debug level. This change improves log clarity by ensuring only significant warnings are displayed at the warning level.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>