### PR TITLE
[WIP] Rename container_image to image for improved UX

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -380,7 +380,7 @@ class SimpleTransformer(TypeTransformer[T]):
                     a: Union[int, bool, str, float]
                     b: Union[int, bool, str, float]
 
-                @task(container_image=custom_image)
+                @task(image=custom_image)
                 def add(a: Union[int, bool, str, float], b: Union[int, bool, str, float]) -> Union[int, bool, str, float]:
                     return a + b
 


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/6140

## Why are the changes needed?
To enhance the user experience, the concept of `container` should be abstracted from flytekit users. 

## What changes were proposed in this pull request?
At this early stage, we propose to focus on the user-facing codebase and support both `image` and `container_image` for backward compatibility. There exist three cases:
1. Both `image` and `container_image` are specified: Raise an error
2. `container_image` is used: Warn users about the future deprecation
3. `image` is used: Use `image` directly

## How was this patch tested? 

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

## Docs link
