### PR TITLE
Gatenode local execution, was parsing the input twice

### DIFF
--- a/flytekit/interaction/parse_stdin.py
+++ b/flytekit/interaction/parse_stdin.py
@@ -28,8 +28,6 @@ def parse_stdin_to_literal(
     )
     user_input = click.prompt(message, type=literal_converter.click_type)
     try:
-        option = click.Option(["--input"], type=literal_converter.click_type)
-        v = literal_converter.click_type.convert(user_input, option, click.Context(command=click.Command("")))
-        return TypeEngine.to_literal(FlyteContext.current_context(), v, t, lt)
+        return TypeEngine.to_literal(FlyteContext.current_context(), user_input, t, lt)
     except Exception as e:
         raise click.ClickException(f"Failed to parse input: {e}")


### PR DESCRIPTION
For example like so,

```python
import flytekit as fl
from dataclasses import dataclass
from datetime import timedelta

dt = timedelta(seconds=60)

@dataclass
class MyClass:
  x: int
  y: str


@fl.task
def my_task(c: MyClass) -> MyClass:
   return c


@fl.workflow
def my_wf():
  c = fl.wait_for_input("tst", dt, MyClass)
  my_task(c=c)
```

Local execution will result in failure

```
Failed to parse input: stat: path should be string, bytes, os.PathLike or integer, not MyClass
```

This fixes the local execution. Remote works fine! 
 <div id='description'>
<h3>Summary by Bito</h3>
Fixed a bug in local execution where input parsing was being performed twice for gatenode interactions. The change simplifies input parsing by removing redundant type conversion in parse_stdin.py, improving handling of complex types like custom dataclasses during local workflow execution while maintaining remote execution behavior.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>