### PR TITLE
add project & domain endpoint for FlyteRemote

### DIFF
--- a/flytekit/clients/friendly.py
+++ b/flytekit/clients/friendly.py
@@ -21,6 +21,7 @@ from google.protobuf.duration_pb2 import Duration
 
 from flytekit.clients.raw import RawSynchronousFlyteClient as _RawSynchronousFlyteClient
 from flytekit.models import common as _common
+from flytekit.models import domain as _domain
 from flytekit.models import execution as _execution
 from flytekit.models import filters as _filters
 from flytekit.models import launch_plan as _launch_plan
@@ -895,6 +896,21 @@ class SynchronousFlyteClient(_RawSynchronousFlyteClient):
             [_project.Project.from_flyte_idl(pb) for pb in projects.projects],
             str(projects.token),
         )
+
+    ####################################################################################################################
+    #
+    #  Domain Endpoints
+    #
+    ####################################################################################################################
+
+    def get_domains(self):
+        """
+        This returns a list of domains.
+
+        :rtype: list[flytekit.models.Domain]
+        """
+        domains = super(SynchronousFlyteClient, self).get_domains()
+        return [_domain.Domain.from_flyte_idl(domain) for domain in domains.domains]
 
     ####################################################################################################################
     #

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 
 import grpc
-from flyteidl.admin.project_pb2 import ProjectListRequest
+from flyteidl.admin.project_pb2 import GetDomainRequest, ProjectListRequest
 from flyteidl.admin.signal_pb2 import SignalList, SignalListRequest, SignalSetRequest, SignalSetResponse
 from flyteidl.service import admin_pb2_grpc as _admin_service
 from flyteidl.service import dataproxy_pb2 as _dataproxy_pb2
@@ -519,6 +519,21 @@ class RawSynchronousFlyteClient(object):
         :rtype: flyteidl.admin.project_pb2.ProjectUpdateResponse
         """
         return self._stub.UpdateProject(project, metadata=self._metadata)
+
+    ####################################################################################################################
+    #
+    #  Domain Endpoints
+    #
+    ####################################################################################################################
+
+    def get_domains(self):
+        """
+        This will return a list of domains registered with the Flyte Admin Service
+        :param flyteidl.admin.project_pb2.GetDomainRequest get_domain_request:
+        :rtype: flyteidl.admin.project_pb2.GetDomainsResponse
+        """
+        get_domain_request = GetDomainRequest()
+        return self._stub.GetDomains(get_domain_request, metadata=self._metadata)
 
     ####################################################################################################################
     #

--- a/flytekit/models/domain.py
+++ b/flytekit/models/domain.py
@@ -4,13 +4,14 @@ from flytekit.models import common as _common
 
 
 class Domain(_common.FlyteIdlEntity):
-    def __init__(self, id, name):
-        """
-        Domains are fixed and unique at the global level, and provide an abstraction to isolate resources and feature configuration for different deployment environments
+    """
+    Domains are fixed and unique at the global level, and provide an abstraction to isolate resources and feature configuration for different deployment environments.
 
-        :param Text id: A globally unique identifier associated with this domain.
-        :param Text name: A human-readable name for this domain.
-        """
+    :param Text id: A globally unique identifier associated with this domain.
+    :param Text name: A human-readable name for this domain.
+    """
+
+    def __init__(self, id, name):
         self._id = id
         self._name = name
 
@@ -34,7 +35,7 @@ class Domain(_common.FlyteIdlEntity):
         """
         :rtype: flyteidl.admin.project_pb2.Domain
         """
-        return _project_pb2.Domain(id=self.id,name=self.name)
+        return _project_pb2.Domain(id=self.id, name=self.name)
 
     @classmethod
     def from_flyte_idl(cls, pb2_object):

--- a/flytekit/models/domain.py
+++ b/flytekit/models/domain.py
@@ -1,0 +1,45 @@
+from flyteidl.admin import project_pb2 as _project_pb2
+
+from flytekit.models import common as _common
+
+
+class Domain(_common.FlyteIdlEntity):
+    def __init__(self, id, name):
+        """
+        Domains are fixed and unique at the global level, and provide an abstraction to isolate resources and feature configuration for different deployment environments
+
+        :param Text id: A globally unique identifier associated with this domain.
+        :param Text name: A human-readable name for this domain.
+        """
+        self._id = id
+        self._name = name
+
+    @property
+    def id(self):
+        """
+        A globally unique identifier associated with this domain.
+        :rtype: Text
+        """
+        return self._id
+
+    @property
+    def name(self):
+        """
+        A human-readable name for this domain.
+        :rtype: Text
+        """
+        return self._name
+
+    def to_flyte_idl(self):
+        """
+        :rtype: flyteidl.admin.project_pb2.Domain
+        """
+        return _project_pb2.Domain(id=self.id,name=self.name)
+
+    @classmethod
+    def from_flyte_idl(cls, pb2_object):
+        """
+        :param flyteidl.admin.project_pb2.Domain pb2_object:
+        :rtype: Domain
+        """
+        return cls(id=pb2_object.id, name=pb2_object.name)

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2601,40 +2601,22 @@ class FlyteRemote(object):
     # Projects #
     ############
 
-    def list_projects_paginated(
+    def list_projects(
         self,
         limit: typing.Optional[int] = 100,
-        max_iters: typing.Optional[int] = 1000,
-        token: typing.Optional[str] = None,
         filters: typing.Optional[typing.List[filter_models.Filter]] = None,
         sort_by: typing.Optional[admin_common_models.Sort] = None,
     ) -> typing.List[Project]:
         """Lists registered projects from flyte admin.
 
-        .. note ::
-
-            This is a paginated API. The input variables limit, max_iters & token are optional and set to sane defaults.
-
-        :param limit: [Optional[int]] The maximum number of entries to return per page.
-        :param max_iters [Optional[int]]: The maximum number of pages to go through.
-        :param token [Optional[str]]: Token used to navigate through pages.
+        :param limit: [Optional[int]] The maximum number of entries to return.
         :param filters Optional[typing.List[filter_models.Filter]]: If specified, the filters will be applied to
             the query. If the filter is not supported, an exception will be raised.
         :param sort_by Optional[admin_common_models.Sort]: If provided, the results will be sorted.
         :raises grpc.RpcError:
         :returns: typing.List[flytekit.models.project.Project]
         """
-        projects = []
-        while max_iters > 0:
-            _projects, token = self.client.list_projects_paginated(
-                limit=limit, token=token, filters=filters, sort_by=sort_by
-            )
-            projects.extend(_projects)
-
-            if token == "":
-                return projects
-
-            max_iters = max_iters - 1
+        return self.client.list_projects_paginated(limit=limit, filters=filters, sort_by=sort_by)[0]
 
     ############
     # Domains #

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2633,7 +2633,8 @@ class FlyteRemote(object):
 
             if token == "":
                 return projects
-        max_iters = max_iters - 1
+
+            max_iters = max_iters - 1
 
     ############
     # Domains #


### PR DESCRIPTION
## Why are the changes needed?
- Today there is no way of querying flyte projects and domains using FlyteRemote

## What changes were proposed in this pull request?
- Adds endpoint to FlyteRemote to query registered projects paginated
- Adds endpoint to FlyteRemote to query configured domains
## How was this patch tested?
- Installing this branch locally
- running this
``` python

from flytekit.remote import FlyteRemote
from flytekit.configuration import Config

r = FlyteRemote(config=Config.for_endpoint(endpoint="demo.hosted.unionai.cloud"))
print("#" * 20)
projects = r.list_projects()
print(f"length of projects {len(projects)}")
print(f"project #0: {projects[1]}")
print(f"project type #0: {type(projects[1])}")
print(f"project #0 id : {projects[1].id}")

print("#" * 20)
projects = r.list_projects(limit=2)
print(f"length of projects {len(projects)}")
print(f"project #0: {projects[1]}")
print(f"project #0 id : {projects[1].id}")
print("#" * 20)
domains = r.get_domains()
print(f"length of domains {len(domains)}")
print(f"domain #0: {domains[0]}")
print(f"domain type #0: {type(domains[0])}")
print("#" * 20)
```
- Result
``` 
####################
length of projects 36
project #0: Flyte Serialized object (Project):
  id: cloud-partners
  name: cloud-partners
project type #0: <class 'flytekit.models.project.Project'>
project #0 id : cloud-partners
####################
length of projects 2
project #0: Flyte Serialized object (Project):
  id: cloud-partners
  name: cloud-partners
project #0 id : cloud-partners
####################
length of domains 3
domain #0: Flyte Serialized object (Domain):
  id: development
  name: development
domain type #0: <class 'flytekit.models.domain.Domain'>
####################
```
### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off. 
 <div id='description'>
<h3>Summary by Bito</h3>
Enhanced FlyteRemote class with streamlined project and domain management capabilities. Simplified the API interface by renaming 'list_projects_paginated' to 'list_projects' with improved internal pagination handling. Added domain configuration retrieval endpoints and programmatic access to projects and domains. Includes minor code improvements for better maintainability.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>