### PR TITLE
Fixed type hint

### DIFF
--- a/flytekit/types/directory/types.py
+++ b/flytekit/types/directory/types.py
@@ -221,7 +221,7 @@ class FlyteDirectory(SerializableType, DataClassJsonMixin, os.PathLike, typing.G
         return cls(path=remote_path)
 
     @classmethod
-    def new(cls, dirname: str | os.PathLike) -> FlyteFile:
+    def new(cls, dirname: str | os.PathLike) -> FlyteDirectory:
         """
         Create a new FlyteDirectory object in current Flyte working directory.
         """


### PR DESCRIPTION
## Tracking issue
Closes flyteorg/flyte#6219

## Why are the changes needed?
Type hint wrong

## What changes were proposed in this pull request?
Changed the output type hint from FlyteDirectory.new from the incorrect FlyteFile to the correct FlyteDirectory.

## How was this patch tested?
No tests. Just types affected.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
Fixed incorrect return type hint in FlyteDirectory class's new() method, changing it from FlyteFile to FlyteDirectory. This is a straightforward type safety improvement that enhances code correctness without impacting runtime behavior.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>