### PR TITLE
Adds validation to Secrets.env_var

### DIFF
--- a/flytekit/models/security.py
+++ b/flytekit/models/security.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional
@@ -53,6 +54,11 @@ class Secret(_common.FlyteIdlEntity):
         in_registration_context = execution.mode is None
         if in_registration_context and get_plugin().secret_requires_group() and self.group is None:
             raise ValueError("Group is a required parameter")
+
+        if self.env_var is not None:
+            pattern = r"^[A-Z_][A-Z0-9_]*$"
+            if not re.match(pattern, self.env_var):
+                raise ValueError(f"Invalid environment variable name: {self.env_var}")
 
     def to_flyte_idl(self) -> _sec.Secret:
         return _sec.Secret(

--- a/tests/flytekit/unit/models/core/test_security.py
+++ b/tests/flytekit/unit/models/core/test_security.py
@@ -1,4 +1,5 @@
 from unittest.mock import Mock
+import re
 
 import pytest
 
@@ -51,3 +52,10 @@ def test_security_execution_context(monkeypatch, execution_mode, tmpdir):
     monkeypatch.setattr(flytekit.core.context_manager, "FlyteContextManager", context_manager)
     s = Secret(key="key")
     assert s.group is None
+
+
+@pytest.mark.parametrize("env_var", ["abc-xyz", "", "$dfadsf"])
+def test_secret_validate_env_var(env_var):
+    msg = f"Invalid environment variable name: {env_var}"
+    with pytest.raises(ValueError, match=re.escape(msg)):
+        Secret(key="abc", group="group", env_var=env_var)


### PR DESCRIPTION
## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
This PR adds validation for `Secret.env_var`, so we fail fast when the `env_var` is not a valid environment variable.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
Adds validation to `Secret.env_var`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added a unit test for the change. 
 <div id='description'>
<h3>Summary by Bito</h3>
Implementation of environment variable name validation for Secret.env_var using regex pattern validation. The validation ensures names follow the format of uppercase letters, numbers, and underscores, with proper starting character requirements. Test cases were added to verify validation behavior.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>