### PR TITLE
fix: keyring refresh twice

### DIFF
--- a/flytekit/clients/grpc_utils/auth_interceptor.py
+++ b/flytekit/clients/grpc_utils/auth_interceptor.py
@@ -71,7 +71,6 @@ class AuthUnaryInterceptor(grpc.UnaryUnaryClientInterceptor, grpc.UnaryStreamCli
             if not hasattr(e, "code"):
                 raise e
             if e.code() == grpc.StatusCode.UNAUTHENTICATED or e.code() == grpc.StatusCode.UNKNOWN:
-                self._authenticator.refresh_credentials()
                 self.authenticator.refresh_credentials()
                 updated_call_details = self._call_details_with_auth_metadata(client_call_details)
                 return continuation(updated_call_details, request)
@@ -84,7 +83,6 @@ class AuthUnaryInterceptor(grpc.UnaryUnaryClientInterceptor, grpc.UnaryStreamCli
         updated_call_details = self._call_details_with_auth_metadata(client_call_details)
         c: grpc.Call = continuation(updated_call_details, request)
         if c.code() == grpc.StatusCode.UNAUTHENTICATED:
-            self._authenticator.refresh_credentials()
             self.authenticator.refresh_credentials()
             updated_call_details = self._call_details_with_auth_metadata(client_call_details)
             return continuation(updated_call_details, request)


### PR DESCRIPTION
## Tracking issue
Relates to  [PR](https://github.com/flyteorg/flytekit/pull/2962)
<!-- Remove this section if not applicable -->

## Why are the changes needed?


## What changes were proposed in this pull request?


## How was this patch tested?
All unit tests passed

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
PR optimizes authentication flow by removing redundant credential refresh calls in auth_interceptor.py. The changes eliminate duplicate refresh_credentials() invocations, improving performance and reducing unnecessary overhead in the authentication process.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>