### PR TITLE
Fix dict annotations

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -947,7 +947,7 @@ async def binding_data_from_python_std(
             if transformer_override and hasattr(transformer_override, "extract_types_or_metadata"):
                 _, v_type = transformer_override.extract_types_or_metadata(t_value_type)  # type: ignore
             else:
-                _, v_type = DictTransformer.extract_types(t_value_type)  # type: ignore
+                _, v_type = DictTransformer.extract_types(cast(typing.Type[dict], t_value_type))
             m = _literals_models.BindingDataMap(
                 bindings={
                     k: await binding_data_from_python_std(

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -947,7 +947,7 @@ async def binding_data_from_python_std(
             if transformer_override and hasattr(transformer_override, "extract_types_or_metadata"):
                 _, v_type = transformer_override.extract_types_or_metadata(t_value_type)  # type: ignore
             else:
-                _, v_type = DictTransformer.extract_types_or_metadata(t_value_type)  # type: ignore
+                _, v_type = DictTransformer.extract_types(t_value_type)  # type: ignore
             m = _literals_models.BindingDataMap(
                 bindings={
                     k: await binding_data_from_python_std(

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -2105,7 +2105,7 @@ class DictTransformer(AsyncTypeTransformer[dict]):
     @staticmethod
     def is_pickle(python_type: Type[dict]) -> bool:
         _origin = get_origin(python_type)
-        metadata = []
+        metadata: typing.Tuple = ()
         if _origin is Annotated:
             metadata = get_args(python_type)[1:]
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -2031,8 +2031,12 @@ class DictTransformer(AsyncTypeTransformer[dict]):
                         raise ValueError(
                             f"Flytekit does not currently have support for FlyteAnnotations applied to dicts. {t} cannot be parsed."
                         )
-            if _origin in [dict, Annotated] and _args is not None:
+            if _origin is dict and _args is not None:
                 return _args  # type: ignore
+            elif _origin is Annotated:
+                return DictTransformer.extract_types_or_metadata(_args[0])
+            else:
+                raise ValueError(f"Trying to extract dictionary type information from a non-dict type {t}")
         return None, None
 
     @staticmethod
@@ -2099,31 +2103,24 @@ class DictTransformer(AsyncTypeTransformer[dict]):
             raise TypeTransformerFailedError(f"Cannot convert `{v}` to Flyte Literal.\n" f"Error Message: {e}")
 
     @staticmethod
-    def is_pickle(python_type: Type[dict]) -> typing.Tuple[bool, Type]:
-        base_type, *metadata = DictTransformer.extract_types_or_metadata(python_type)
+    def is_pickle(python_type: Type[dict]) -> bool:
+        _origin = get_origin(python_type)
+        metadata = []
+        if _origin is Annotated:
+            metadata = get_args(python_type)[1:]
 
         for each_metadata in metadata:
             if isinstance(each_metadata, OrderedDict):
                 allow_pickle = each_metadata.get("allow_pickle", False)
-                return allow_pickle, base_type
+                return allow_pickle
 
-        return False, base_type
-
-    @staticmethod
-    def dict_types(python_type: Type) -> typing.Tuple[typing.Any, ...]:
-        if get_origin(python_type) is Annotated:
-            base_type, *_ = DictTransformer.extract_types_or_metadata(python_type)
-            tp = get_args(base_type)
-        else:
-            tp = DictTransformer.extract_types_or_metadata(python_type)
-
-        return tp
+        return False
 
     def get_literal_type(self, t: Type[dict]) -> LiteralType:
         """
         Transforms a native python dictionary to a flyte-specific ``LiteralType``
         """
-        tp = self.dict_types(t)
+        tp = DictTransformer.extract_types_or_metadata(t)
 
         if tp:
             if tp[0] == str:
@@ -2144,10 +2141,9 @@ class DictTransformer(AsyncTypeTransformer[dict]):
             raise TypeTransformerFailedError("Expected a dict")
 
         allow_pickle = False
-        base_type = None
 
         if get_origin(python_type) is Annotated:
-            allow_pickle, base_type = DictTransformer.is_pickle(python_type)
+            allow_pickle = DictTransformer.is_pickle(python_type)
 
         if expected and expected.simple and expected.simple == SimpleType.STRUCT:
             if str2bool(os.getenv(FLYTE_USE_OLD_DC_FORMAT)):
@@ -2160,11 +2156,7 @@ class DictTransformer(AsyncTypeTransformer[dict]):
                 raise ValueError("Flyte MapType expects all keys to be strings")
             # TODO: log a warning for Annotated objects that contain HashMethod
 
-            if base_type:
-                _, v_type = get_args(base_type)
-            else:
-                _, v_type = self.extract_types_or_metadata(python_type)
-
+            _, v_type = self.extract_types_or_metadata(python_type)
             lit_map[k] = TypeEngine.async_to_literal(ctx, v, cast(type, v_type), expected.map_value_type)
         vals = await _run_coros_in_chunks([c for c in lit_map.values()], batch_size=_TYPE_ENGINE_COROS_BATCH_SIZE)
         for idx, k in zip(range(len(vals)), lit_map.keys()):
@@ -2177,9 +2169,9 @@ class DictTransformer(AsyncTypeTransformer[dict]):
             return self.from_binary_idl(lv.scalar.binary, expected_python_type)  # type: ignore
 
         if lv and lv.map and lv.map.literals is not None:
-            tp = self.dict_types(expected_python_type)
+            tp = DictTransformer.extract_types_or_metadata(expected_python_type)
 
-            if tp is None or tp[0] is None:
+            if tp is None or len(tp) == 0 or tp[0] is None:
                 raise TypeError(
                     "TypeMismatch: Cannot convert to python dictionary from Flyte Literal Dictionary as the given "
                     "dictionary does not have sub-type hints or they do not match with the originating dictionary "

--- a/tests/flytekit/unit/core/test_annotated_bindings.py
+++ b/tests/flytekit/unit/core/test_annotated_bindings.py
@@ -1,6 +1,7 @@
 import asyncio
+from flytekit.core.artifact import Artifact
 from dataclasses import dataclass
-from typing import List, Optional, TypeVar, Type, Tuple
+from typing import List, Optional, TypeVar, Type, Tuple, Union
 
 from pydantic import BaseModel
 from typing_extensions import Annotated
@@ -379,12 +380,14 @@ def test_annotated_dynamic():
 
         return final_model
 
+    a = Artifact(name="my_model")
+
     @dynamic
-    def dt1() -> Annotated[dict[str, Config | dict[str, Prophet]], "my tag"]:
+    def dt1() -> Annotated[dict[str, Union[Config, dict[str, Prophet]]], a]:
         return dt_function()
 
     @dynamic
-    def dt_plain() -> dict[str, Config | dict[str, Prophet]]:
+    def dt_plain() -> dict[str, Union[Config, dict[str, Prophet]]]:
         return dt_function()
 
     ss = SerializationSettings(

--- a/tests/flytekit/unit/core/test_generice_idl_type_engine.py
+++ b/tests/flytekit/unit/core/test_generice_idl_type_engine.py
@@ -2872,7 +2872,7 @@ def test_get_underlying_type(t, expected):
     ],
 )
 def test_dict_get(t, expected):
-    assert DictTransformer.extract_types_or_metadata(t) == expected
+    assert DictTransformer.extract_types(t) == expected
 
 
 def test_DataclassTransformer_get_literal_type():

--- a/tests/flytekit/unit/core/test_generice_idl_type_engine.py
+++ b/tests/flytekit/unit/core/test_generice_idl_type_engine.py
@@ -2858,23 +2858,6 @@ def test_get_underlying_type(t, expected):
     assert get_underlying_type(t) == expected
 
 
-@pytest.mark.parametrize(
-    "t,expected",
-    [
-        (None, (None, None)),
-        (typing.Dict, ()),
-        (typing.Dict[str, str], (str, str)),
-        (
-                Annotated[typing.Dict[str, str], kwtypes(allow_pickle=True)],
-                (str, str),
-        ),
-        (typing.Dict[Annotated[str, "a-tag"], int], (Annotated[str, "a-tag"], int)),
-    ],
-)
-def test_dict_get(t, expected):
-    assert DictTransformer.extract_types(t) == expected
-
-
 def test_DataclassTransformer_get_literal_type():
     @dataclass
     class MyDataClassMashumaro(DataClassJsonMixin):

--- a/tests/flytekit/unit/core/test_generice_idl_type_engine.py
+++ b/tests/flytekit/unit/core/test_generice_idl_type_engine.py
@@ -2866,7 +2866,7 @@ def test_get_underlying_type(t, expected):
         (typing.Dict[str, str], (str, str)),
         (
                 Annotated[typing.Dict[str, str], kwtypes(allow_pickle=True)],
-                (typing.Dict[str, str], kwtypes(allow_pickle=True)),
+                (str, str),
         ),
         (typing.Dict[Annotated[str, "a-tag"], int], (Annotated[str, "a-tag"], int)),
     ],

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -2863,23 +2863,6 @@ def test_get_underlying_type(t, expected):
     assert get_underlying_type(t) == expected
 
 
-@pytest.mark.parametrize(
-    "t,expected",
-    [
-        (None, (None, None)),
-        (typing.Dict, ()),
-        (typing.Dict[str, str], (str, str)),
-        (
-                Annotated[typing.Dict[str, str], kwtypes(allow_pickle=True)],
-                (typing.Dict[str, str], kwtypes(allow_pickle=True)),
-        ),
-        (typing.Dict[Annotated[str, "a-tag"], int], (Annotated[str, "a-tag"], int)),
-    ],
-)
-def test_dict_get(t, expected):
-    assert DictTransformer.extract_types_or_metadata(t) == expected
-
-
 def test_DataclassTransformer_get_literal_type():
     @dataclass
     class MyDataClassMashumaro(DataClassJsonMixin):

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -2863,6 +2863,23 @@ def test_get_underlying_type(t, expected):
     assert get_underlying_type(t) == expected
 
 
+@pytest.mark.parametrize(
+    "t,expected",
+    [
+        (None, (None, None)),
+        (typing.Dict, ()),
+        (typing.Dict[str, str], (str, str)),
+        (
+                Annotated[typing.Dict[str, str], kwtypes(allow_pickle=True)],
+                (str, str),
+        ),
+        (typing.Dict[Annotated[str, "a-tag"], int], (Annotated[str, "a-tag"], int)),
+    ],
+)
+def test_dict_get(t, expected):
+    assert DictTransformer.extract_types(t) == expected
+
+
 def test_DataclassTransformer_get_literal_type():
     @dataclass
     class MyDataClassMashumaro(DataClassJsonMixin):


### PR DESCRIPTION
## Tracking issue
Internal ticket only.

## Why are the changes needed?
Customer reported issue with internal model registry.  The issue though is that annotations don't work well with dictionary return types.

## What changes were proposed in this pull request?
Most of the changes here are in the dict transformer.
* The `extract_types_or_metadata` function is inconsistent, returning different things in different scenarios - sometimes it would return annotations, sometimes it would return the key/value type of a dictionary.  This has been changed to always return the latter, or an empty tuple `()` in the case of an untyped dictionary.  In all cases now, the caller interprets the result as a tuple of key type,value type.  Renaming function to just `extract_types`.
* the `is_pickle` function returned both a boolean, as well as types, but the latter isn't really necessary.  Changing this to just return the pickle bool.
* `dict_types` is a function that was almost the same as `extract_types_or_metadata`, removing in favor of that one and manually extracting the annotation args where needed.
* Remove a duplicate test

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances dictionary type handling in the type system by refactoring the DictTransformer class and simplifying type extraction functionality. The extract_types_or_metadata function has been renamed to extract_types, and the is_pickle function has been streamlined. The changes improve consistency in dictionary type handling and include removal of redundant functionality.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>