### PR TITLE
Bug when calling wf in eager task with thread

### DIFF
--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1482,7 +1482,7 @@ def flyte_entity_call_handler(
         # call the blocking version of the async call handler
         # This is a recursive call, the async handler also calls this function, so this conditional must match
         # the one in the async function perfectly, otherwise you'll get infinite recursion.
-        loop_manager.run_sync(async_flyte_entity_call_handler, entity, **kwargs)
+        return loop_manager.run_sync(async_flyte_entity_call_handler, entity, **kwargs)
 
     if ctx.execution_state and (
         ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -608,7 +608,7 @@ class EagerAsyncPythonFunctionTask(AsyncPythonFunctionTask[T], metaclass=FlyteTr
                 raise FlyteNonRecoverableSystemException(base_error)
             return result
 
-    def run(self, remote: "FlyteRemote", ss: SerializationSettings, **kwargs):
+    def run(self, remote: "FlyteRemote", ss: SerializationSettings, **kwargs):  # type: ignore[name-defined]
         """
         This is a helper function to help run eager parent tasks locally, pointing to a remote cluster. This is used
         only for local testing for now.

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -609,6 +609,10 @@ class EagerAsyncPythonFunctionTask(AsyncPythonFunctionTask[T], metaclass=FlyteTr
             return result
 
     def run(self, remote: "FlyteRemote", ss: SerializationSettings, **kwargs):
+        """
+        This is a helper function to help run eager parent tasks locally, pointing to a remote cluster. This is used
+        only for local testing for now.
+        """
         ctx = FlyteContextManager.current_context()
         # tag is the current execution id
         # root tag is read from the environment variable if it exists, if not, it's the current execution id

--- a/flytekit/core/worker_queue.py
+++ b/flytekit/core/worker_queue.py
@@ -222,18 +222,24 @@ class Controller:
                 logger.warning(f"reconcile should launch for {id(item)} entity name: {item.entity.name}")
                 wf_exec = self.launch_execution(update.work_item, update.idx)
                 update.wf_exec = wf_exec
+                # Set this to running even if the launched execution was a re-run and already succeeded.
+                # This forces the bottom half of the conditional to run, properly fetching all outputs.
                 update.status = ItemStatus.RUNNING
             else:
-                if not item.wf_exec.is_done:
-                    update.status = ItemStatus.RUNNING
-                    # Technically a mutating operation, but let's pretend it's not
-                    update.wf_exec = self.remote.sync_execution(item.wf_exec)
-                    if update.wf_exec.closure.phase == WorkflowExecutionPhase.SUCCEEDED:
-                        update.status = ItemStatus.SUCCESS
-                    elif update.wf_exec.closure.phase == WorkflowExecutionPhase.FAILED:
-                        update.status = ItemStatus.FAILED
+                # Technically a mutating operation, but let's pretend it's not
+                update.wf_exec = self.remote.sync_execution(item.wf_exec)
+
+                # Fill in update status
+                if update.wf_exec.closure.phase == WorkflowExecutionPhase.SUCCEEDED:
+                    update.status = ItemStatus.SUCCESS
+                elif update.wf_exec.closure.phase == WorkflowExecutionPhase.FAILED:
+                    update.status = ItemStatus.FAILED
+                elif update.wf_exec.closure.phase == WorkflowExecutionPhase.ABORTED:
+                    update.status = ItemStatus.FAILED
+                elif update.wf_exec.closure.phase == WorkflowExecutionPhase.TIMED_OUT:
+                    update.status = ItemStatus.FAILED
                 else:
-                    developer_logger.debug(f"Execution {item.wf_exec.id.name} is done, item is {item.status}")
+                    update.status = ItemStatus.RUNNING
 
         except Exception as e:
             logger.error(
@@ -261,10 +267,12 @@ class Controller:
                     if item.uuid in update_items:
                         update = update_items[typing.cast(uuid.UUID, item.uuid)]
                         item.wf_exec = update.wf_exec
-                        assert update.status is not None
+                        if update.status is None:
+                            raise AssertionError("update.status is None")
                         item.status = update.status
                         if update.status == ItemStatus.SUCCESS:
-                            assert update.wf_exec is not None
+                            if update.wf_exec is None:
+                                raise AssertionError("update.wf_exec is None")
                             item.result = update.wf_exec.outputs.as_python_native(item.python_interface)
                         elif update.status == ItemStatus.FAILED:
                             # If update object already has an error, then use that, otherwise look for one in the
@@ -274,7 +282,8 @@ class Controller:
                             else:
                                 from flytekit.exceptions.eager import EagerException
 
-                                assert update.wf_exec is not None
+                                if update.wf_exec is None:
+                                    raise AssertionError("update.wf_exec is None")
 
                                 exc = EagerException(
                                     f"Error executing {update.work_item.entity.name} with error:"
@@ -394,7 +403,8 @@ class Controller:
             if i.status == ItemStatus.SUCCESS:
                 return i.result
             elif i.status == ItemStatus.FAILED:
-                assert i.error is not None
+                if i.error is None:
+                    raise AssertionError("Error should not be None if status is failed")
                 raise i.error
             else:
                 await asyncio.sleep(2)  # Small delay to avoid busy-waiting

--- a/flytekit/core/worker_queue.py
+++ b/flytekit/core/worker_queue.py
@@ -268,11 +268,11 @@ class Controller:
                         update = update_items[typing.cast(uuid.UUID, item.uuid)]
                         item.wf_exec = update.wf_exec
                         if update.status is None:
-                            raise AssertionError("update.status is None")
+                            raise AssertionError(f"update's status missing for {item.entity.name}")
                         item.status = update.status
                         if update.status == ItemStatus.SUCCESS:
                             if update.wf_exec is None:
-                                raise AssertionError("update.wf_exec is None")
+                                raise AssertionError(f"update's wf_exec missing for {item.entity.name}")
                             item.result = update.wf_exec.outputs.as_python_native(item.python_interface)
                         elif update.status == ItemStatus.FAILED:
                             # If update object already has an error, then use that, otherwise look for one in the
@@ -283,7 +283,9 @@ class Controller:
                                 from flytekit.exceptions.eager import EagerException
 
                                 if update.wf_exec is None:
-                                    raise AssertionError("update.wf_exec is None")
+                                    raise AssertionError(
+                                        f"update's wf_exec missing in error case for {item.entity.name}"
+                                    )
 
                                 exc = EagerException(
                                     f"Error executing {update.work_item.entity.name} with error:"
@@ -404,7 +406,7 @@ class Controller:
                 return i.result
             elif i.status == ItemStatus.FAILED:
                 if i.error is None:
-                    raise AssertionError("Error should not be None if status is failed")
+                    raise AssertionError(f"Error should not be None if status is failed for {entity.name}")
                 raise i.error
             else:
                 await asyncio.sleep(2)  # Small delay to avoid busy-waiting

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -296,7 +296,9 @@ class WorkflowBase(object):
         # Get default arguments and override with kwargs passed in
         input_kwargs = self.python_interface.default_inputs_as_kwargs
         input_kwargs.update(kwargs)
-        self.compile()
+        ctx = FlyteContext.current_context()
+        if not (ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.EAGER_EXECUTION):
+            self.compile()
         try:
             return flyte_entity_call_handler(self, *args, **input_kwargs)
         except Exception as exc:

--- a/flytekit/core/workflow.py
+++ b/flytekit/core/workflow.py
@@ -297,6 +297,7 @@ class WorkflowBase(object):
         input_kwargs = self.python_interface.default_inputs_as_kwargs
         input_kwargs.update(kwargs)
         ctx = FlyteContext.current_context()
+        # todo: remove this conditional once context manager is thread safe
         if not (ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.EAGER_EXECUTION):
             self.compile()
         try:

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -148,7 +148,7 @@ def get_flytekit_for_pypi():
     if not __version__ or "dev" in __version__:
         return "flytekit"
     else:
-        return f"flytekit"
+        return f"flytekit=={__version__}"
 
 
 _PACKAGE_NAME_RE = re.compile(r"^[\w-]+")
@@ -251,13 +251,11 @@ def prepare_python_install(image_spec: ImageSpec, tmp_dir: Path) -> str:
             requirements.extend(image_spec.packages)
 
         # Adds flytekit if it is not specified
-        # if not any(_is_flytekit(package) for package in requirements):
-        #     requirements.append(get_flytekit_for_pypi())
+        if not any(_is_flytekit(package) for package in requirements):
+            requirements.append(get_flytekit_for_pypi())
 
         requirements_uv_path = tmp_dir / "requirements_uv.txt"
         requirements_uv_path.write_text("\n".join(requirements))
-        print(requirements_uv_path)
-        breakpoint()
         pip_install_args.extend(["--requirement", "requirements_uv.txt"])
 
     pip_install_args = " ".join(pip_install_args)

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -148,7 +148,7 @@ def get_flytekit_for_pypi():
     if not __version__ or "dev" in __version__:
         return "flytekit"
     else:
-        return f"flytekit=={__version__}"
+        return f"flytekit"
 
 
 _PACKAGE_NAME_RE = re.compile(r"^[\w-]+")
@@ -251,11 +251,13 @@ def prepare_python_install(image_spec: ImageSpec, tmp_dir: Path) -> str:
             requirements.extend(image_spec.packages)
 
         # Adds flytekit if it is not specified
-        if not any(_is_flytekit(package) for package in requirements):
-            requirements.append(get_flytekit_for_pypi())
+        # if not any(_is_flytekit(package) for package in requirements):
+        #     requirements.append(get_flytekit_for_pypi())
 
         requirements_uv_path = tmp_dir / "requirements_uv.txt"
         requirements_uv_path.write_text("\n".join(requirements))
+        print(requirements_uv_path)
+        breakpoint()
         pip_install_args.extend(["--requirement", "requirements_uv.txt"])
 
     pip_install_args = " ".join(pip_install_args)

--- a/tests/flytekit/unit/core/test_worker_queue.py
+++ b/tests/flytekit/unit/core/test_worker_queue.py
@@ -280,7 +280,6 @@ def test_reconcile(phase, expected_update_status):
             phase=phase,
             started_at=datetime.datetime(year=2024, month=1, day=2, tzinfo=datetime.timezone.utc),
             duration=datetime.timedelta(seconds=10),
-            # abort_metadata=AbortMetadata(cause="cause", principal="testuser"),
         )
     )
     mock_remote.sync_execution.return_value = wf_exec

--- a/tests/flytekit/unit/core/test_worker_queue.py
+++ b/tests/flytekit/unit/core/test_worker_queue.py
@@ -4,10 +4,11 @@ import datetime
 from flytekit.core.task import task
 from flytekit.remote.remote import FlyteRemote
 from flytekit.core.worker_queue import Controller, WorkItem, ItemStatus, Update
-from flytekit.configuration import ImageConfig, LocalConfig, SerializationSettings
+from flytekit.configuration import ImageConfig, LocalConfig, SerializationSettings, Image
 from flytekit.utils.asyn import loop_manager
 from flytekit.models.execution import ExecutionSpec, ExecutionClosure, ExecutionMetadata, NotificationList, Execution, AbortMetadata
 from flytekit.models.core import identifier
+from flytekit.remote.executions import FlyteWorkflowExecution
 from flytekit.models import common as common_models
 from flytekit.models.core import execution
 from flytekit.exceptions.eager import EagerException
@@ -249,3 +250,47 @@ def test_work_item_hashing_equality():
     wi2 = WorkItem(entity=t1, wf_exec=fwex, input_kwargs={})
     wi2.uuid = wi1.uuid
     assert wi1 == wi2
+
+
+default_img = Image(name="default", fqn="test", tag="tag")
+serialization_settings = SerializationSettings(
+    project="project",
+    domain="domain",
+    version="version",
+    env=None,
+    image_config=ImageConfig(default_image=default_img, images=[default_img]),
+)
+
+
+@pytest.mark.parametrize("phase,expected_update_status", [
+    (execution.WorkflowExecutionPhase.SUCCEEDED, ItemStatus.SUCCESS),
+    (execution.WorkflowExecutionPhase.FAILED, ItemStatus.FAILED),
+    (execution.WorkflowExecutionPhase.ABORTED, ItemStatus.FAILED),
+    (execution.WorkflowExecutionPhase.TIMED_OUT, ItemStatus.FAILED),
+])
+def test_reconcile(phase, expected_update_status):
+    mock_remote = mock.MagicMock()
+    wf_exec = FlyteWorkflowExecution(
+        id=identifier.WorkflowExecutionIdentifier("project", "domain", "exec-name"),
+        spec=ExecutionSpec(
+            identifier.Identifier(identifier.ResourceType.LAUNCH_PLAN, "project", "domain", "name", "version"),
+            ExecutionMetadata(ExecutionMetadata.ExecutionMode.MANUAL, "tester", 1),
+        ),
+        closure=ExecutionClosure(
+            phase=phase,
+            started_at=datetime.datetime(year=2024, month=1, day=2, tzinfo=datetime.timezone.utc),
+            duration=datetime.timedelta(seconds=10),
+            # abort_metadata=AbortMetadata(cause="cause", principal="testuser"),
+        )
+    )
+    mock_remote.sync_execution.return_value = wf_exec
+
+    @task
+    def t1():
+        ...
+
+    wi = WorkItem(entity=t1, wf_exec=wf_exec, input_kwargs={})
+    c = Controller(mock_remote, serialization_settings, tag="exec-id", root_tag="exec-id", exec_prefix="e-unit-test")
+    u = Update(wi, 0)
+    c.reconcile_one(u)
+    assert u.status == expected_update_status


### PR DESCRIPTION
## Why are the changes needed?
Unable to run subworkflows, as part of eager workflows, via to_thread.  This PR only fixes the ability to run subworkflows on the backend.  Local execution still needs additional fixes.

## What changes were proposed in this pull request?
* A return was missing from the call handler, leading to local runs of subworkflows locally run by eager to run multiple things.
* The compile step has been taken out of the workflow call handler.
* In local testing found that the behavior of the reconcile function in the worker doesn't handle the re-run case where the execution is already found. The reconcile function now will always just sync the execution, and then handle state management appropriately.
  * Additional terminal states are mapped to failed in the update object.
  * asserts were hard to debug - these have been changed to explicit assertion errors.

The issues encountered while debugging this...
* Local execute in my test case (not included) was only succeeding maybe 1 out of every 6-7 times.
* The compile step that was moved into the conditional was causing failures all the time.

My running theory for this is because the context manager is not thread safe.  Need to investigate further how to_thread's contextvar copy works.  Context copying is needed because we need to accurately represent the state upon entering the thread, but removing the context frames seems to be polluting each other's context.

## How was this patch tested?
Tested locally and on Union internal clusters.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances subworkflow execution in eager workflows via to_thread by implementing improved error handling and state management. The changes include adding a missing return statement in async call handling, better error messaging for worker queue assertions, and proper terminal state handling. Additional improvements include fixes to flytekit version specification in image builds, enhanced thread safety in the context manager, and making workflow compilation conditional. Documentation improvements and comprehensive test additions for workflow execution phases were also made.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>