### PR TITLE
Skip test_get_container_error_timestamp on windows

### DIFF
--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import os
 import re
+import sys
 import textwrap
 import time
 import typing

--- a/tests/flytekit/unit/bin/test_python_entrypoint.py
+++ b/tests/flytekit/unit/bin/test_python_entrypoint.py
@@ -519,6 +519,7 @@ def test_get_traceback_str():
     assert expected_error_re.match(traceback_str) is not None
 
 
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="granularity of timestamp is not reliable")
 def test_get_container_error_timestamp(monkeypatch) -> None:
     # Set the timezone to UTC
     monkeypatch.setenv("TZ", "UTC")


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
The test test_get_container_error_timestamp has been failing on windows since its introduction. We don't get any signal from it, mainly because no one is really going to use pytorch on windows.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Skip a particular test on windows.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
Added a Windows-specific skip condition for test_get_container_error_timestamp test to address unreliable timestamp granularity issues on Windows platforms. This change enhances test suite reliability by preventing failures caused by platform-specific limitations.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>