### PR TITLE
Added msgpack support for `pyflyte fetch`, storing as JSON

### DIFF
--- a/flytekit/interaction/string_literals.py
+++ b/flytekit/interaction/string_literals.py
@@ -1,6 +1,8 @@
 import base64
+import json
 import typing
 
+import msgpack
 from google.protobuf.json_format import MessageToDict
 
 from flytekit.models.literals import Literal, LiteralMap, Primitive, Scalar
@@ -42,6 +44,8 @@ def scalar_to_string(scalar: Scalar) -> typing.Any:
     if scalar.blob:
         return scalar.blob.uri
     if scalar.binary:
+        if scalar.binary.tag == "msgpack":
+            return json.dumps(msgpack.unpackb(scalar.binary.value))
         return base64.b64encode(scalar.binary.value)
     if scalar.generic:
         return MessageToDict(scalar.generic)

--- a/flytekit/remote/data.py
+++ b/flytekit/remote/data.py
@@ -1,7 +1,9 @@
+import json
 import os
 import pathlib
 import typing
 
+import msgpack
 from google.protobuf.json_format import MessageToJson
 from rich import print
 
@@ -39,6 +41,9 @@ def download_literal(
         elif data.scalar.generic is not None:
             with open(download_to / f"{var}.json", "w") as f:
                 f.write(MessageToJson(data.scalar.generic))
+        elif data.scalar.binary is not None and data.scalar.binary.tag == "msgpack":
+            with open(download_to / f"{var}.json", "w") as f:
+                json.dump(msgpack.unpackb(data.scalar.binary.value), f)
         else:
             print(
                 f"[dim]Skipping {var} val {literal_string_repr(data)} as it is not a blob, structured dataset,"

--- a/plugins/flytekit-aws-sagemaker/tests/test_boto3_agent.py
+++ b/plugins/flytekit-aws-sagemaker/tests/test_boto3_agent.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from unittest import mock
 import msgpack
 import base64
+import json
 
 import pytest
 from flyteidl.core.execution_pb2 import TaskExecution
@@ -163,7 +164,9 @@ async def test_agent(mock_boto_call, mock_return_value):
         if "pickle_check" in mock_return_value[0][0]:
             assert "pickle_file" in outputs["result"]
         else:
-            outputs["result"] = msgpack.loads(base64.b64decode(outputs["result"]))
+            raw_result = outputs["result"]
+            parsed_result = json.loads(raw_result)
+            outputs["result"] = parsed_result
             assert (
                 outputs["result"]["EndpointConfigArn"]
                 == "arn:aws:sagemaker:us-east-2:000000000:endpoint-config/sagemaker-xgboost-endpoint-config"

--- a/plugins/flytekit-openai/tests/openai_batch/test_agent.py
+++ b/plugins/flytekit-openai/tests/openai_batch/test_agent.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from unittest import mock
 from unittest.mock import AsyncMock
+import json
 import msgpack
 import base64
 import pytest
@@ -158,9 +159,10 @@ async def test_openai_batch_agent(mock_retrieve, mock_create, mock_context):
     assert resource.phase == TaskExecution.SUCCEEDED
 
     outputs = literal_map_string_repr(resource.outputs)
-    result = outputs["result"]
 
-    assert msgpack.loads(base64.b64decode(result)) == batch_retrieve_result.to_dict()
+    raw_result = outputs["result"]
+    parsed_result = json.loads(raw_result)
+    assert parsed_result == batch_retrieve_result.to_dict()
 
     # Status: Failed
     mock_retrieve.return_value = batch_retrieve_result_failure

--- a/tests/flytekit/unit/interaction/test_string_literals.py
+++ b/tests/flytekit/unit/interaction/test_string_literals.py
@@ -86,6 +86,9 @@ def test_scalar_to_string():
     )
     assert scalar_to_string(scalar) == 1
 
+    scalar = Scalar(binary=Binary(b'\x82\xa7compact\xc3\xa6schema\x00', "msgpack"))
+    assert scalar_to_string(scalar) == '{"compact": true, "schema": 0}'
+
 
 def test_literal_string_repr():
     lit = Literal(scalar=Scalar(primitive=Primitive(integer=1)))


### PR DESCRIPTION
## Tracking issue
Closes flyteorg/flyte#6242

## Why are the changes needed?
So that `pyflyte fetch` can process msgpack literals. Outputs JSON file.

## What changes were proposed in this pull request?
- In the handling of `pyflyte fetch` make a special case for a binary scalar with msgpack tag.
- Added msgpack binary handling to `scalar_to_string`. Return json.


## How was this patch tested?
- Added test for `scalar_to_string`
- Didn't add tests for the download code, because a test is missing for the entire function. Manually ran successfully.


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [X] All commits are signed-off.

 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements msgpack-encoded binary data support in Flyte's data fetching functionality, enabling conversion of msgpack literals to JSON format in the 'pyflyte fetch' command. The implementation handles binary scalars with msgpack tags in both string conversion and download functionalities.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>