### PR TITLE
publish pandera deck

### DIFF
--- a/plugins/flytekit-pandera/flytekitplugins/pandera/pandas_transformer.py
+++ b/plugins/flytekit-pandera/flytekitplugins/pandera/pandas_transformer.py
@@ -91,7 +91,6 @@ class PanderaPandasTransformer(TypeTransformer[pandera.typing.DataFrame]):
             html = renderer.to_html(python_val, schema, exc)
             val = python_val
             if config.on_error == "raise":
-                # render the deck before raising the error
                 raise exc
             elif config.on_error == "warn":
                 logger.warning(str(exc))
@@ -100,7 +99,7 @@ class PanderaPandasTransformer(TypeTransformer[pandera.typing.DataFrame]):
         else:
             html = renderer.to_html(val, schema)
         finally:
-            Deck(renderer._title, html)
+            Deck(renderer._title, html).publish()
 
         lv = self._sd_transformer.to_literal(ctx, val, pandas.DataFrame, expected)
 

--- a/plugins/flytekit-pandera/flytekitplugins/pandera/pandas_transformer.py
+++ b/plugins/flytekit-pandera/flytekitplugins/pandera/pandas_transformer.py
@@ -137,7 +137,7 @@ class PanderaPandasTransformer(TypeTransformer[pandera.typing.DataFrame]):
         else:
             html = renderer.to_html(val, schema)
         finally:
-            Deck(renderer._title, html)
+            Deck(renderer._title, html).publish()
 
         return val
 

--- a/plugins/flytekit-pandera/flytekitplugins/pandera/pandas_transformer.py
+++ b/plugins/flytekit-pandera/flytekitplugins/pandera/pandas_transformer.py
@@ -91,6 +91,7 @@ class PanderaPandasTransformer(TypeTransformer[pandera.typing.DataFrame]):
             html = renderer.to_html(python_val, schema, exc)
             val = python_val
             if config.on_error == "raise":
+                Deck(renderer._title, html).publish()
                 raise exc
             elif config.on_error == "warn":
                 logger.warning(str(exc))

--- a/plugins/flytekit-pandera/flytekitplugins/pandera/pandas_transformer.py
+++ b/plugins/flytekit-pandera/flytekitplugins/pandera/pandas_transformer.py
@@ -91,7 +91,6 @@ class PanderaPandasTransformer(TypeTransformer[pandera.typing.DataFrame]):
             html = renderer.to_html(python_val, schema, exc)
             val = python_val
             if config.on_error == "raise":
-                Deck(renderer._title, html).publish()
                 raise exc
             elif config.on_error == "warn":
                 logger.warning(str(exc))

--- a/plugins/flytekit-pandera/setup.py
+++ b/plugins/flytekit-pandera/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "pandera"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.3.0b2,<2.0.0", "pandera>=0.7.1", "pandas", "great_tables"]
+plugin_requires = ["flytekit>=1.15.0b2,<2.0.0", "pandera>=0.7.1", "pandas", "great_tables"]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
## Tracking issue

https://linear.app/unionai/issue/DX-1315/update-pandera-flytekit-plugin-to-use-streaming-decks

## Why are the changes needed?

Changes support publishing the pandera deck even when a validation error is raised

## What changes were proposed in this pull request?

Call `Deck.publish` in the pandera type transformer.

## How was this patch tested?

Created local flyte cluster with

- `make -C docker/sandbox-bundled build` on flyte master branch
- `flytectl demo start --image flyte-sandbox:latest`

Then ran the following script `foo.py`:

```python
import typing
from typing import Annotated

import json
import pandas as pd
import pandera as pa
from flytekit import ImageSpec, task, workflow
from flytekitplugins.pandera import ValidationConfig
from pandera.typing import DataFrame, Series


custom_image = ImageSpec(
    apt_packages=["git"],
    packages=[
        "git+https://github.com/flyteorg/flytekit@9ebc57e27#subdirectory=plugins/flytekit-pandera",
        "scikit-learn",
        "pyarrow",
    ],
    registry="localhost:30000",
)


class InSchema(pa.DataFrameModel):
    hourly_pay: float = pa.Field(ge=7)
    hours_worked: float = pa.Field(ge=10)
    number: int
    another_number: int

    @pa.check("hourly_pay", "hours_worked")
    def check_numbers_are_positive(cls, series: Series) -> Series[bool]:
        """Defines a column-level custom check."""
        return series > 0

    class Config:
        coerce = True


class IntermediateSchema(InSchema):
    total_pay: float

    @pa.dataframe_check
    def check_total_pay(cls, df: DataFrame) -> Series[bool]:
        """Defines a dataframe-level custom check."""
        return df["total_pay"] == df["hourly_pay"] * df["hours_worked"]


class OutSchema(IntermediateSchema):
    worker_id: Series[str] = pa.Field()


config = ValidationConfig(on_error="error")

def fn(df: DataFrame[InSchema]):
    ...


@task(container_image=custom_image, enable_deck=True, deck_fields=[])
def json_to_dataframe(data: str) -> Annotated[DataFrame[InSchema], config]:
    """Helper task to convert a dictionary input to a dataframe."""
    data = json.loads(data)
    return pd.DataFrame(data)


@task(container_image=custom_image, enable_deck=True, deck_fields=[])
def total_pay(df: Annotated[DataFrame[InSchema], config]) -> Annotated[DataFrame[IntermediateSchema], config]:  # noqa : F811
    return df.assign(total_pay=df.hourly_pay * df.hours_worked)


@task(container_image=custom_image, enable_deck=True, deck_fields=[])
def add_ids(
    df: Annotated[DataFrame[IntermediateSchema], config],
    worker_ids: typing.List[str],
) -> Annotated[DataFrame[OutSchema], config]:
    return df
    # return df.assign(worker_id=worker_ids)


@workflow
def process_data(  # noqa : F811
    data: str = '{"hourly_pay": [1, 8, 9], "hours_worked": [30.5, 40.0, -1.0], "number": ["a", "b", "c"], "another_number": ["d", "e", "f"]}',
    worker_ids: typing.List[str] = ["a", "b", "c"],
) -> Annotated[DataFrame[OutSchema], config]:
    return add_ids(df=total_pay(df=json_to_dataframe(data=data)), worker_ids=worker_ids)
```

Run with
```bash
pyflyte run --remote foo.py process_data
```

### Screenshots

![image](https://github.com/user-attachments/assets/22db59e1-9e83-47cc-bec4-2919c486a988)


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
Enhancement to Pandera plugin implementing automatic real-time deck publication. The update removes redundant documentation and modifies deck creation logic to include immediate publication functionality, resulting in a more streamlined visualization workflow.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>