### PR TITLE
fix a bug where sync_execution is not calling itself recursively

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2405,7 +2405,7 @@ class FlyteRemote(object):
         :param execution:
         :param entity_definition:
         :param sync_nodes: By default sync will fetch data on all underlying node executions (recursively,
-          so subworkflows will also get picked up). Set this to False in order to prevent that (which
+          so subworkflows and launch plans will also get picked up). Set this to False in order to prevent that (which
           will make this call faster).
         :return: Returns the same execution object, but with additional information pulled in.
         """
@@ -2542,7 +2542,7 @@ class FlyteRemote(object):
             launched_exec = self.fetch_execution(
                 project=launched_exec_id.project, domain=launched_exec_id.domain, name=launched_exec_id.name
             )
-            self.sync_execution(launched_exec)
+            self.sync_execution(launched_exec, sync_nodes=True)
             if launched_exec.is_done:
                 # The synced underlying execution should've had these populated.
                 execution._inputs = launched_exec.inputs

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -217,7 +217,7 @@ def test_monitor_workflow_execution(register):
     )
 
     poll_interval = datetime.timedelta(seconds=1)
-    time_to_give_up = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=60)
+    time_to_give_up = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=600)
 
     execution = remote.sync_execution(execution, sync_nodes=True)
     while datetime.datetime.now(datetime.timezone.utc) < time_to_give_up:

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -217,7 +217,7 @@ def test_monitor_workflow_execution(register):
     )
 
     poll_interval = datetime.timedelta(seconds=1)
-    time_to_give_up = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=600)
+    time_to_give_up = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=60)
 
     execution = remote.sync_execution(execution, sync_nodes=True)
     while datetime.datetime.now(datetime.timezone.utc) < time_to_give_up:
@@ -255,7 +255,7 @@ def test_sync_execution_sync_nodes_get_all_executions(register):
     )
 
     poll_interval = datetime.timedelta(seconds=1)
-    time_to_give_up = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=60)
+    time_to_give_up = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=600)
 
     execution = remote.sync_execution(execution, sync_nodes=True)
     while datetime.datetime.now(datetime.timezone.utc) < time_to_give_up:

--- a/tests/flytekit/integration/remote/workflows/basic/deep_child_workflow.py
+++ b/tests/flytekit/integration/remote/workflows/basic/deep_child_workflow.py
@@ -27,13 +27,13 @@ def my_childwf(a: int = 42) -> int:
     return c
 
 
-child_lp = LaunchPlan.get_or_create(my_childwf, name="my_fixed_child_lp", labels=Labels({"l1": "v1"}))
+shallow_child_lp = LaunchPlan.get_or_create(my_childwf, name="my_shallow_fixed_child_lp", labels=Labels({"l1": "v1"}))
 
 
 @workflow
 def parent_wf(a: int) -> int:
     x = double(a=a)
-    y = child_lp(a=x)
+    y = shallow_child_lp(a=x)
     z = add(a=x, b=y)
     return z
 

--- a/tests/flytekit/integration/remote/workflows/basic/deep_child_workflow.py
+++ b/tests/flytekit/integration/remote/workflows/basic/deep_child_workflow.py
@@ -1,0 +1,42 @@
+from flytekit import LaunchPlan, task, workflow
+from flytekit.models.common import Labels
+
+
+@task
+def double(a: int) -> int:
+    return a * 2
+
+
+@task
+def add(a: int, b: int) -> int:
+    return a + b
+
+
+@workflow
+def my_deep_childwf(a: int = 42) -> int:
+    b = double(a=a)
+    return b
+
+deep_child_lp = LaunchPlan.get_or_create(my_deep_childwf, name="my_fixed_deep_child_lp", labels=Labels({"l1": "v1"}))
+
+
+@workflow
+def my_childwf(a: int = 42) -> int:
+    b = deep_child_lp(a=a)
+    c = double(a=b)
+    return c
+
+
+child_lp = LaunchPlan.get_or_create(my_childwf, name="my_fixed_child_lp", labels=Labels({"l1": "v1"}))
+
+
+@workflow
+def parent_wf(a: int) -> int:
+    x = double(a=a)
+    y = child_lp(a=x)
+    z = add(a=x, b=y)
+    return z
+
+
+if __name__ == "__main__":
+    print(f"Running parent_wf(a=3) {parent_wf(a=3)}")


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->
N/A
## Why are the changes needed?
There is currently a bug where the function does not recursively fetch executions on subworkflows when the subworkflow is a reference to a launch plan. Currently, it only fetch executions on launch plan only for the first layer and not deeper layer. 

E.g.
Say if your execution reference launchPlanA. launchPlanA references launchPlanB. Currently, the `sync_nodes` only gets launchPlanA.
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Fix the bug so that the `sync_nodes` is truly recursive.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
tested locally with a deeply nested workflow to confirm reference plans are fetched.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
Implementation of recursive synchronization for launch plans in nested workflows, fixing bugs in sync_execution functionality. Added proper handling of subworkflows, launch plans synchronization, and sync_nodes parameter. Modified remote test timeouts: first reduced from 600s to 60s, and second increased from 60s to 600s to accommodate deeply nested workflow synchronization. Improved documentation clarity and variable naming for better testing comprehension.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>