### PR TITLE
Improve Flyte Literal Converter logic

### DIFF
--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -526,12 +526,12 @@ class FlyteLiteralConverter(object):
             # If the input matches the default value in the launch plan, serialization can be skipped.
             if param and value == param.default:
                 return None
-            lit = TypeEngine.to_literal(self._flyte_ctx, value, self._python_type, self._literal_type)
 
+            # If this is used for remote execution then we need to convert it back to a python native type
             if not self._is_remote:
-                # If this is used for remote execution then we need to convert it back to a python native type
-                # for FlyteRemote to use it. This maybe a double conversion penalty!
-                return TypeEngine.to_python_value(self._flyte_ctx, lit, self._python_type)
+                return value
+
+            lit = TypeEngine.to_literal(self._flyte_ctx, value, self._python_type, self._literal_type)
             return lit
         except click.BadParameter:
             raise

--- a/tests/flytekit/unit/interaction/test_click_types.py
+++ b/tests/flytekit/unit/interaction/test_click_types.py
@@ -6,6 +6,7 @@ import tempfile
 import typing
 from datetime import datetime, timedelta
 from enum import Enum
+from typing import Optional
 
 import click
 import mock
@@ -367,9 +368,9 @@ def test_dataclass_with_default_none():
     @dataclass
     class Datum:
         x: int
-        y: str = None
-        z: typing.Dict[int, str] = None
-        w: typing.List[int] = None
+        y: Optional[str] = None
+        z: Optional[typing.Dict[int, str]] = None
+        w: Optional[typing.List[int]] = None
 
     t = JsonParamType(Datum)
     value = '{ "x": 1 }'


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?
Make the code run faster and reduce redundant logic.

## What changes were proposed in this pull request?
return python value before calling `to_literal` func here.
https://github.com/flyteorg/flytekit/pull/3134/files#diff-cc3172a3cdf60bb2ffb23b81cb5b92d6c4a89063d691e86932b312e1df09f292R530-R534

## How was this patch tested?
unit test

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances the Flyte Literal Converter by optimizing type conversion flow in click_types.py and improving type handling. The changes eliminate redundant type conversions in remote execution scenarios and enhance type hinting for nullable fields in dataclass test cases. The modifications streamline the conversion process by ensuring proper ordering of literal conversions and explicitly marking fields with None default values as Optional, improving type system accuracy and maintainability.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>