### PR TITLE
Fix array node empty task executions when using remote

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2552,7 +2552,7 @@ class FlyteRemote(object):
             return execution
 
         # If a node ran a static subworkflow or a dynamic subworkflow then the parent flag will be set.
-        if execution.metadata.is_parent_node or execution.metadata.is_array:
+        if execution.metadata.is_parent_node:
             # We'll need to query child node executions regardless since this is a parent node
             child_node_executions = iterate_node_executions(
                 self.client,
@@ -2606,22 +2606,30 @@ class FlyteRemote(object):
                     "not have inputs and outputs filled in"
                 )
                 return execution
-            elif execution._node.array_node is not None:
-                # if there's a task node underneath the array node, let's fetch the interface for it
-                if execution._node.array_node.node.task_node is not None:
-                    tid = execution._node.array_node.node.task_node.reference_id
-                    t = self.fetch_task(tid.project, tid.domain, tid.name, tid.version)
-                    if t.interface:
-                        execution._interface = t.interface
-                    else:
-                        logger.error(f"Fetched map task does not have an interface, skipping i/o {t}")
-                        return execution
-                else:
-                    logger.error(f"Array node not over task, skipping i/o {t}")
-                    return execution
             else:
                 logger.error(f"NE {execution} undeterminable, {type(execution._node)}, {execution._node}")
                 raise ValueError(f"Node execution undeterminable, entity has type {type(execution._node)}")
+
+        # Handle the case for array nodes
+        elif execution.metadata.is_array and execution._node.array_node is not None:
+            # if there's a task node underneath the array node, let's fetch the interface for it
+            if execution._node.array_node.node.task_node is not None:
+                tid = execution._node.array_node.node.task_node.reference_id
+                t = self.fetch_task(tid.project, tid.domain, tid.name, tid.version)
+                execution._task_executions = [
+                    self.sync_task_execution(
+                        FlyteTaskExecution.promote_from_model(task_execution), t
+                    )
+                    for task_execution in iterate_task_executions(self.client, execution.id)
+                ]
+                if t.interface:
+                    execution._interface = t.interface
+                else:
+                    logger.error(f"Fetched map task does not have an interface, skipping i/o {t}")
+                    return execution
+            else:
+                logger.error(f"Array node not over task, skipping i/o")
+                return execution
 
         # Handle the case for gate nodes
         elif execution._node.gate_node is not None:

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2617,9 +2617,7 @@ class FlyteRemote(object):
                 tid = execution._node.array_node.node.task_node.reference_id
                 t = self.fetch_task(tid.project, tid.domain, tid.name, tid.version)
                 execution._task_executions = [
-                    self.sync_task_execution(
-                        FlyteTaskExecution.promote_from_model(task_execution), t
-                    )
+                    self.sync_task_execution(FlyteTaskExecution.promote_from_model(task_execution), t)
                     for task_execution in iterate_task_executions(self.client, execution.id)
                 ]
                 if t.interface:
@@ -2628,7 +2626,7 @@ class FlyteRemote(object):
                     logger.error(f"Fetched map task does not have an interface, skipping i/o {t}")
                     return execution
             else:
-                logger.error(f"Array node not over task, skipping i/o")
+                logger.error("Array node not over task, skipping i/o")
                 return execution
 
         # Handle the case for gate nodes

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2611,7 +2611,10 @@ class FlyteRemote(object):
                 raise ValueError(f"Node execution undeterminable, entity has type {type(execution._node)}")
 
         # Handle the case for array nodes
-        elif execution.metadata.is_array and execution._node.array_node is not None:
+        elif execution.metadata.is_array:
+            if execution._node.array_node is None:
+                logger.error("Array node not found")
+                return execution
             # if there's a task node underneath the array node, let's fetch the interface for it
             if execution._node.array_node.node.task_node is not None:
                 tid = execution._node.array_node.node.task_node.reference_id

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -614,6 +614,7 @@ def test_execute_workflow_with_maptask(register):
         wait=True,
     )
     assert execution.outputs["o0"] == [4, 5, 6]
+    assert len(execution.node_executions["n0"].task_executions) == 1
 
 def test_executes_nested_workflow_dictating_interruptible(register):
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)


### PR DESCRIPTION
## Why are the changes needed?
Currently when we run
```python
r = FlyteRemote(config=Config.for_endpoint(endpoint=endpoint))

execs = r.recent_executions(project=project, domain=domain, limit=limit)
a = r.sync(execs[0], sync_nodes=True)
print("task execution", a.node_executions["n0"].task_executions)
```
if node n0 is array node, then task_executions would be an empty list.

## What changes were proposed in this pull request?
for array node type node executions, sync task executions and store them.

## How was this patch tested?
- Tested locally by running
```python
r = FlyteRemote(config=Config.for_endpoint(endpoint=endpoint))

execs = r.recent_executions(project=project, domain=domain, limit=limit)
a = r.sync(execs[0], sync_nodes=True)
print("task execution", a.node_executions["n0"].task_executions)
```
and can see the correct task executions

- added integration tests.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off. 
 <div id='description'>
<h3>Summary by Bito</h3>
Fixed synchronization bug in FlyteRemote class affecting array node task executions. Implemented proper fetching and storage of task executions during node execution syncing. Enhanced error handling and logging for array node scenarios. Added test coverage to validate the fix.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>