### PR TITLE
Exclude python_history from the Ray runtime environment.

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -274,6 +274,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: miniostorage
         run: |
           make ${{ matrix.makefile-cmd }}
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 60
       - name: Codecov
         uses: codecov/codecov-action@v3.1.0
         with:

--- a/plugins/flytekit-ray/flytekitplugins/ray/task.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/task.py
@@ -92,7 +92,7 @@ class RayFunctionTask(PythonFunctionTask):
             working_dir = os.getcwd()
             init_params["runtime_env"] = {
                 "working_dir": working_dir,
-                "excludes": ["script_mode.tar.gz", "fast*.tar.gz"],
+                "excludes": ["script_mode.tar.gz", "fast*.tar.gz", ".python_history"],
             }
 
         ray.init(**init_params)


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Failed to run the ray task with error: 
```python
      File "/usr/local/lib/python3.11/site-packages/flytekit/bin/entrypoint.py", line 178, in _dispatch_execute
        outputs = task_def.dispatch_execute(ctx, idl_input_literals)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.11/site-packages/flytekit/core/base_task.py", line 726, in dispatch_execute
        new_user_params = self.pre_execute(ctx.user_space_params)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.11/site-packages/flytekitplugins/ray/task.py", line 81, in pre_execute
        ray.init(**init_params)
      File "/usr/local/lib/python3.11/site-packages/ray/_private/client_mode_hook.py", line 103, in wrapper
        return func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.11/site-packages/ray/_private/worker.py", line 1823, in init
        connect(
      File "/usr/local/lib/python3.11/site-packages/ray/_private/worker.py", line 2401, in connect
        runtime_env = upload_working_dir_if_needed(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/local/lib/python3.11/site-packages/ray/_private/runtime_env/working_dir.py", line 94, in upload_working_dir_if_needed
        raise RuntimeEnvSetupError(
    ray.exceptions.RuntimeEnvSetupError: Failed to set up runtime environment.
    Failed to upload working_dir /root to the Ray cluster: [Errno 13] Permission denied: '/root/.python_history'
```

## What changes were proposed in this pull request?
exclude `.python_history` from the Ray runtime environment.

## How was this patch tested?
```python

import typing

from flytekit import ImageSpec, Resources, task, workflow


ray_plugins = f"git+https://github.com/flyteorg/flytekit.git@c6e6051e8a3b76c854921d73d52a030f367b5923#subdirectory=plugins/flytekit-ray"

custom_image = ImageSpec(
    registry="ghcr.io/flyteorg",
    packages=[ray_plugins, "mypy"],
    # kuberay operator needs wget for readiness probe.
    apt_packages=["wget", "git"],
)

import ray
from flytekitplugins.ray import HeadNodeConfig, RayJobConfig, WorkerNodeConfig

@ray.remote
def f(x):
    return x * x

ray_config = RayJobConfig(
    head_node_config=HeadNodeConfig(ray_start_params={"log-color": "True"}),
    worker_node_config=[WorkerNodeConfig(group_name="ray-group", replicas=1)],
    runtime_env={"pip": ["numpy", "pandas"]},  # or runtime_env="./requirements.txt"
    enable_autoscaling=True,
    shutdown_after_job_finishes=True,
    ttl_seconds_after_finished=3600,
)

@task(
    task_config=ray_config,
    requests=Resources(mem="2Gi", cpu="2"),
    container_image=custom_image,
)
def ray_task(n: int) -> typing.List[int]:
    futures = [f.remote(i) for i in range(n)]
    return ray.get(futures)


@workflow
def ray_workflow(n: int) -> typing.List[int]:
    return ray_task(n=n)

```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs
NA

## Docs link
NA
 
 <div id='description'>
<h3>Summary by Bito</h3>
Fixed a critical bug in Ray plugin for Flytekit where tasks were failing due to permission issues with .python_history file. The fix involves adding .python_history to the excluded files list in Ray runtime environment configuration, preventing RuntimeEnvSetupError during cluster uploads.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>