### PR TITLE
Add unit test for ray with an existing cluster and fix nil pointer

### DIFF
--- a/plugins/flytekit-ray/flytekitplugins/ray/task.py
+++ b/plugins/flytekit-ray/flytekitplugins/ray/task.py
@@ -104,16 +104,23 @@ class RayFunctionTask(PythonFunctionTask):
         runtime_env = base64.b64encode(json.dumps(cfg.runtime_env).encode()).decode() if cfg.runtime_env else None
         runtime_env_yaml = yaml.dump(cfg.runtime_env) if cfg.runtime_env else None
 
-        if cfg.head_node_config.requests or cfg.head_node_config.limits:
-            head_pod_template = PodTemplate(
-                pod_spec=pod_spec_from_resources(
-                    primary_container_name=_RAY_HEAD_CONTAINER_NAME,
-                    requests=cfg.head_node_config.requests,
-                    limits=cfg.head_node_config.limits,
+        head_group_spec = None
+        if cfg.head_node_config:
+            if cfg.head_node_config.requests or cfg.head_node_config.limits:
+                head_pod_template = PodTemplate(
+                    pod_spec=pod_spec_from_resources(
+                        primary_container_name=_RAY_HEAD_CONTAINER_NAME,
+                        requests=cfg.head_node_config.requests,
+                        limits=cfg.head_node_config.limits,
+                    )
                 )
+            else:
+                head_pod_template = cfg.head_node_config.pod_template
+
+            head_group_spec = HeadGroupSpec(
+                cfg.head_node_config.ray_start_params,
+                K8sPod.from_pod_template(head_pod_template) if head_pod_template else None,
             )
-        else:
-            head_pod_template = cfg.head_node_config.pod_template
 
         worker_group_spec: typing.List[WorkerGroupSpec] = []
         for c in cfg.worker_node_config:
@@ -134,14 +141,7 @@ class RayFunctionTask(PythonFunctionTask):
 
         ray_job = RayJob(
             ray_cluster=RayCluster(
-                head_group_spec=(
-                    HeadGroupSpec(
-                        cfg.head_node_config.ray_start_params,
-                        K8sPod.from_pod_template(head_pod_template) if head_pod_template else None,
-                    )
-                    if cfg.head_node_config
-                    else None
-                ),
+                head_group_spec=head_group_spec,
                 worker_group_spec=worker_group_spec,
                 enable_autoscaling=(cfg.enable_autoscaling if cfg.enable_autoscaling else False),
             ),

--- a/plugins/flytekit-ray/tests/test_ray.py
+++ b/plugins/flytekit-ray/tests/test_ray.py
@@ -43,6 +43,15 @@ config = RayJobConfig(
     ttl_seconds_after_finished=20,
 )
 
+default_img = Image(name="default", fqn="test", tag="tag")
+settings = SerializationSettings(
+    project="proj",
+    domain="dom",
+    version="123",
+    image_config=ImageConfig(default_image=default_img, images=[default_img]),
+    env={},
+)
+
 
 def test_ray_task():
     @task(task_config=config)
@@ -56,14 +65,6 @@ def test_ray_task():
     assert t1.task_type == "ray"
     assert isinstance(t1, PythonFunctionTask)
 
-    default_img = Image(name="default", fqn="test", tag="tag")
-    settings = SerializationSettings(
-        project="proj",
-        domain="dom",
-        version="123",
-        image_config=ImageConfig(default_image=default_img, images=[default_img]),
-        env={},
-    )
     head_pod_template = PodTemplate(
                 pod_spec=pod_spec_from_resources(
                     primary_container_name="ray-head",
@@ -117,3 +118,52 @@ def test_ray_task():
 
     assert t1(a=3) == "5"
     assert ray.is_initialized()
+
+existing_cluster_config = RayJobConfig(
+    worker_node_config=[],
+    runtime_env={"pip": ["numpy"]},
+    address="localhost:8265",
+)
+
+def test_ray_task_existing_cluster():
+    @task(task_config=existing_cluster_config)
+    def t1(a: int) -> str:
+        assert ray.is_initialized()
+        inc = a + 2
+        return str(inc)
+
+    assert t1.task_config is not None
+    assert t1.task_config == existing_cluster_config
+    assert t1.task_type == "ray"
+    assert isinstance(t1, PythonFunctionTask)
+
+    ray_job_pb = RayJob(
+        ray_cluster=RayCluster(worker_group_spec=[]),
+        runtime_env=base64.b64encode(json.dumps({"pip": ["numpy"]}).encode()).decode(),
+        runtime_env_yaml=yaml.dump({"pip": ["numpy"]}),
+    ).to_flyte_idl()
+
+    assert t1.get_custom(settings) == MessageToDict(ray_job_pb)
+
+    assert t1.get_command(settings) == [
+        "pyflyte-execute",
+        "--inputs",
+        "{{.input}}",
+        "--output-prefix",
+        "{{.outputPrefix}}",
+        "--raw-output-data-prefix",
+        "{{.rawOutputDataPrefix}}",
+        "--checkpoint-path",
+        "{{.checkpointOutputPrefix}}",
+        "--prev-checkpoint",
+        "{{.prevCheckpointPrefix}}",
+        "--resolver",
+        "flytekit.core.python_auto_container.default_task_resolver",
+        "--",
+        "task-module",
+        "tests.test_ray",
+        "task-name",
+        "t1",
+    ]
+
+    # cannot execute this as it will try to hit a non-existent cluster


### PR DESCRIPTION
## Tracking issue
Relayed to https://github.com/flyteorg/flyte/issues/5877

In a follow up pull request I'd like to make the `worker_node_config` optional.

## Why are the changes needed?
When submitting a job to an existing ray cluster you shouldn't need to configure details for an ephemeral cluster you will never use. 

## What changes were proposed in this pull request?
Adds a unit test and just handles a nil pointer case since head node specs can be `None`

## How was this patch tested?
Unit tests

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements fixes for a nil pointer issue in the Ray plugin's head node configuration and enhances test coverage for existing cluster scenarios. The changes include adding null checks for head_node_config and restructuring head group spec initialization. The PR also adds comprehensive unit testing for Ray task execution with existing cluster configurations.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>