### PR TITLE
wrap agent outputs in a literalmap

### DIFF
--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_agent.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_agent.py
@@ -122,20 +122,22 @@ class BotoAgent(SyncAgentBase):
                 )
             )
             with context_manager.FlyteContextManager.with_context(builder) as new_ctx:
-                outputs = {
-                    "result": TypeEngine.to_literal(
-                        new_ctx,
-                        truncated_result if truncated_result else result,
-                        Annotated[dict, kwtypes(allow_pickle=True)],
-                        TypeEngine.to_literal_type(dict),
-                    ),
-                    "idempotence_token": TypeEngine.to_literal(
-                        new_ctx,
-                        idempotence_token,
-                        str,
-                        TypeEngine.to_literal_type(str),
-                    ),
-                }
+                outputs = LiteralMap(
+                    {
+                        "result": TypeEngine.to_literal(
+                            new_ctx,
+                            truncated_result if truncated_result else result,
+                            Annotated[dict, kwtypes(allow_pickle=True)],
+                            TypeEngine.to_literal_type(dict),
+                        ),
+                        "idempotence_token": TypeEngine.to_literal(
+                            new_ctx,
+                            idempotence_token,
+                            str,
+                            TypeEngine.to_literal_type(str),
+                        ),
+                    }
+                )
 
         return Resource(phase=TaskExecution.SUCCEEDED, outputs=outputs)
 

--- a/plugins/flytekit-aws-sagemaker/tests/test_boto3_agent.py
+++ b/plugins/flytekit-aws-sagemaker/tests/test_boto3_agent.py
@@ -158,6 +158,7 @@ async def test_agent(mock_boto_call, mock_return_value):
     )
 
     assert resource.phase == TaskExecution.SUCCEEDED
+    assert isinstance(resource.outputs, literals.LiteralMap)
 
     if mock_return_value[0][0]:
         outputs = literal_map_string_repr(resource.outputs)

--- a/plugins/flytekit-aws-sagemaker/tests/test_boto3_agent.py
+++ b/plugins/flytekit-aws-sagemaker/tests/test_boto3_agent.py
@@ -68,7 +68,7 @@ idempotence_token = "74443947857331f7"
 @mock.patch(
     "flytekitplugins.awssagemaker_inference.boto3_agent.Boto3AgentMixin._call",
 )
-async def test_agent(mock_boto_call, mock_return_value):
+async def test_agent(mock_boto_call, mock_return_value, request):
     mock_boto_call.return_value = mock_return_value[0]
 
     agent = AgentRegistry.get_agent("boto")
@@ -158,7 +158,9 @@ async def test_agent(mock_boto_call, mock_return_value):
     )
 
     assert resource.phase == TaskExecution.SUCCEEDED
-    assert isinstance(resource.outputs, literals.LiteralMap)
+
+    if request.node.callspec.indices["mock_return_value"] in (0, 1):
+        assert isinstance(resource.outputs, literals.LiteralMap)
 
     if mock_return_value[0][0]:
         outputs = literal_map_string_repr(resource.outputs)

--- a/plugins/flytekit-openai/flytekitplugins/openai/batch/agent.py
+++ b/plugins/flytekit-openai/flytekitplugins/openai/batch/agent.py
@@ -105,7 +105,7 @@ class BatchEndpointAgent(AsyncAgentBase):
         result = retrieved_result.to_dict()
 
         ctx = FlyteContextManager.current_context()
-        outputs = {"result": TypeEngine.to_literal(ctx, result, Dict, TypeEngine.to_literal_type(Dict))}
+        outputs = LiteralMap({"result": TypeEngine.to_literal(ctx, result, Dict, TypeEngine.to_literal_type(Dict))})
 
         return Resource(phase=flyte_phase, outputs=outputs, message=message)
 

--- a/plugins/flytekit-openai/tests/openai_batch/test_agent.py
+++ b/plugins/flytekit-openai/tests/openai_batch/test_agent.py
@@ -1,9 +1,8 @@
+import json
 from datetime import timedelta
 from unittest import mock
 from unittest.mock import AsyncMock
-import json
-import msgpack
-import base64
+
 import pytest
 from flyteidl.core.execution_pb2 import TaskExecution
 from flytekitplugins.openai.batch.agent import BatchEndpointMetadata
@@ -157,6 +156,7 @@ async def test_openai_batch_agent(mock_retrieve, mock_create, mock_context):
     mock_retrieve.return_value = batch_retrieve_result
     resource = await agent.get(metadata)
     assert resource.phase == TaskExecution.SUCCEEDED
+    assert isinstance(resource.outputs, literals.LiteralMap)
 
     outputs = literal_map_string_repr(resource.outputs)
 


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
This is necessary because although the result is already a literal, it is being converted to a literal again. Since literal isn't a valid Python type, it ends up being pickled. This issue surfaced in Flytekit 1.15.0.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

Wrapping agent outputs in a `LiteralMap` so they don't get converted to literals again.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Tested the OpenAI plugin with the updated code.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
Fixed a bug in agent output handling where results were being converted to literals multiple times, affecting Python type validation in Flytekit 1.15.0. Implemented proper LiteralMap wrapping for agent outputs in AWS SageMaker and OpenAI plugins to prevent double literal conversion. Modified AWS SageMaker plugin test cases to enhance output type validation and added conditional checks for LiteralMap instances with improved mock return value handling.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>