### PR TITLE
Add helper method to traverse node executions

### DIFF
--- a/flytekit/core/utils.py
+++ b/flytekit/core/utils.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, ca
 from flyteidl.core import tasks_pb2 as _core_task
 
 from flytekit.configuration import SerializationSettings
+from flytekit.core import constants
 from flytekit.core.pod_template import PodTemplate
 from flytekit.loggers import logger
 
@@ -408,3 +409,15 @@ def str2bool(value: typing.Optional[str]) -> bool:
     if value is None:
         return False
     return value.lower() in ("true", "t", "1")
+
+
+def is_start_node(name: str) -> bool:
+    return constants.START_NODE_ID in name
+
+
+def is_end_node(name: str) -> bool:
+    return constants.END_NODE_ID in name
+
+
+def is_start_or_end_node(name: str) -> bool:
+    return is_start_node(name) or is_end_node(name)

--- a/flytekit/remote/executions.py
+++ b/flytekit/remote/executions.py
@@ -112,7 +112,7 @@ class FlyteWorkflowExecution(RemoteExecutionBase, execution_models.Execution):
         self._type_hints = type_hints
 
     def traverse_node_executions(self, exclude_start_end_nodes=True):
-        for root_node in self.node_executions_list:
+        for root_node in self.node_executions.values():
             for node in root_node.traverse(exclude_start_end_nodes):
                 yield node
 
@@ -124,18 +124,6 @@ class FlyteWorkflowExecution(RemoteExecutionBase, execution_models.Execution):
     def node_executions(self) -> Dict[str, FlyteNodeExecution]:
         """Get a dictionary of node executions that are a part of this workflow execution."""
         return self._node_executions or {}
-
-    @property
-    def node_executions_list(self, contains_start_and_end_node=False) -> List[FlyteNodeExecution]:
-        if self._node_executions is None:
-            return []
-        node_executions_list = (
-            self._node_executions.values()
-            if contains_start_and_end_node
-            else list(filter(lambda x: not utils.is_start_or_end_node(x.id.node_id), self._node_executions.values()))
-        )
-        node_executions_list.sort(key=lambda x: x.id.node_id)
-        return node_executions_list
 
     @property
     def error(self) -> core_execution_models.ExecutionError:


### PR DESCRIPTION
## Why are the changes needed?
Currently it's hard for users to traverse all node executions under a workflowExecution/nodeExecution.

## What changes were proposed in this pull request?
Added helper method for workflowExecution and nodeExecution.

## How was this patch tested?
You can easily traverse nodes like
```python
r = FlyteRemote()
execs = r.recent_executions(project=project, domain=domain, limit=limit)
a = r.sync(execs[0], sync_nodes=True)
for node in a.traverse_node_executions():
    print(node.id.node_id)
```
Example output:
```
n0
n0-0-n0
n0-0-n1
n0-0-n2
n0-0-n3
n0-0-n3-0-dn0
n1
n2
n3
```

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
