### PR TITLE
Expose eager from `unsafe` sub-package

### DIFF
--- a/flytekit/unsafe/__init__.py
+++ b/flytekit/unsafe/__init__.py
@@ -1,0 +1,3 @@
+from flytekit.core.task import eager
+
+__all__ = ["eager"]

--- a/tests/flytekit/unit/unsafe/test_eager.py
+++ b/tests/flytekit/unit/unsafe/test_eager.py
@@ -1,0 +1,21 @@
+import pytest
+
+from flytekit import task
+from flytekit.unsafe import eager
+
+
+@pytest.mark.asyncio
+async def test_import_eager_from_unsafe():
+    assert eager is not None
+
+    @task
+    def add_one(x: int) -> int:
+        return x + 1
+
+    @eager
+    async def eager_addition(x: int) -> int:
+        return add_one(x)
+
+    res = await eager_addition(x=5)
+
+    assert res == 6


### PR DESCRIPTION
## Tracking issue
https://linear.app/unionai/issue/BB-4798/expose-eager-in-unsafe-module-in-flytekit

## Why are the changes needed?
We want to make sure that users understand that while the new eager mode is being developed it'll have a few rough edges, so the idea is to expose it via an `unsafe` submodule while we work through them.

## What changes were proposed in this pull request?
Create a `flytekit.unsafe` sub-package.

## How was this patch tested?
Added a unit test.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR introduces a new eager functionality through the flytekit.unsafe sub-package, providing a path for early adoption while indicating future improvements. It includes a module initializer to expose the eager function and comprehensive unit tests to verify functionality.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>