### PR TITLE
Fixed inputs map lp

### DIFF
--- a/flytekit/core/array_node.py
+++ b/flytekit/core/array_node.py
@@ -79,16 +79,21 @@ class ArrayNode:
 
         # TODO - bound inputs are not supported at the moment
         self._bound_inputs: Set[str] = set()
+        self._excluded_inputs: Set[str] = set()
+        if isinstance(target, (LaunchPlan, FlyteLaunchPlan)):
+            self._excluded_inputs = target.fixed_inputs.literals.keys()
 
         output_as_list_of_optionals = min_success_ratio is not None and min_success_ratio != 1 and n_outputs == 1
 
         self._remote_interface = None
         if self.target.python_interface:
             self._python_interface = transform_interface_to_list_interface(
-                self.target.python_interface, self._bound_inputs, output_as_list_of_optionals
+                self.target.python_interface, self._bound_inputs, self._excluded_inputs, output_as_list_of_optionals
             )
         elif self.target.interface:
-            self._remote_interface = self.target.interface.transform_interface_to_list(set())
+            self._remote_interface = self.target.interface.transform_interface_to_list(
+                self._bound_inputs, self._excluded_inputs
+            )
         else:
             raise ValueError("No interface found for the target entity.")
 

--- a/flytekit/core/array_node.py
+++ b/flytekit/core/array_node.py
@@ -80,10 +80,9 @@ class ArrayNode:
         # TODO - bound inputs are not supported at the moment
         self._bound_inputs: Set[str] = set()
         self._excluded_inputs: Set[str] = set()
-        if isinstance(target, (LaunchPlan, FlyteLaunchPlan)):
-            # rely on user defined workflow interface since we don't fetch reference launch plans from admin
-            if not isinstance(target, ReferenceLaunchPlan):
-                self._excluded_inputs = target.fixed_inputs.literals.keys()
+        # rely on user defined workflow interface since we don't fetch reference launch plans from admin
+        if isinstance(target, (LaunchPlan, FlyteLaunchPlan)) and not isinstance(target, ReferenceLaunchPlan):
+            self._excluded_inputs = set(target.fixed_inputs.literals)
 
         output_as_list_of_optionals = min_success_ratio is not None and min_success_ratio != 1 and n_outputs == 1
 

--- a/flytekit/core/array_node.py
+++ b/flytekit/core/array_node.py
@@ -9,7 +9,7 @@ from flytekit.core.interface import (
     transform_interface_to_list_interface,
     transform_interface_to_typed_interface,
 )
-from flytekit.core.launch_plan import LaunchPlan
+from flytekit.core.launch_plan import LaunchPlan, ReferenceLaunchPlan
 from flytekit.core.node import Node
 from flytekit.core.promise import (
     Promise,
@@ -81,7 +81,9 @@ class ArrayNode:
         self._bound_inputs: Set[str] = set()
         self._excluded_inputs: Set[str] = set()
         if isinstance(target, (LaunchPlan, FlyteLaunchPlan)):
-            self._excluded_inputs = target.fixed_inputs.literals.keys()
+            # rely on user defined workflow interface since we don't fetch reference launch plans from admin
+            if not isinstance(target, ReferenceLaunchPlan):
+                self._excluded_inputs = target.fixed_inputs.literals.keys()
 
         output_as_list_of_optionals = min_success_ratio is not None and min_success_ratio != 1 and n_outputs == 1
 

--- a/flytekit/core/array_node.py
+++ b/flytekit/core/array_node.py
@@ -88,7 +88,7 @@ class ArrayNode:
                 self.target.python_interface, self._bound_inputs, output_as_list_of_optionals
             )
         elif self.target.interface:
-            self._remote_interface = self.target.interface.transform_interface_to_list()
+            self._remote_interface = self.target.interface.transform_interface_to_list(set())
         else:
             raise ValueError("No interface found for the target entity.")
 

--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -85,7 +85,7 @@ class ArrayNodeMapTask(PythonTask):
         # Transform the interface to List[Optional[T]] in case `min_success_ratio` is set
         output_as_list_of_optionals = min_success_ratio is not None and min_success_ratio != 1 and n_outputs == 1
         collection_interface = transform_interface_to_list_interface(
-            actual_task.python_interface, self._bound_inputs, output_as_list_of_optionals
+            actual_task.python_interface, self._bound_inputs, set(), output_as_list_of_optionals
         )
 
         self._run_task: Union[PythonFunctionTask, PythonInstanceTask] = actual_task  # type: ignore

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -366,15 +366,20 @@ def transform_types_to_list_of_type(
 
 
 def transform_interface_to_list_interface(
-    interface: Interface, bound_inputs: typing.Set[str], optional_outputs: bool = False
+    interface: Interface,
+    bound_inputs: typing.Set[str],
+    excluded_inputs: typing.Set[str],
+    optional_outputs: bool = False,
 ) -> Interface:
     """
     Takes a single task interface and interpolates it to an array interface - to allow performing distributed python map
     like functions
     :param interface: Interface to be upgraded to a list interface
     :param bound_inputs: fixed inputs that should not be updated to a list and will be maintained as is
+    :param excluded_inputs: inputs that should be excluded from the interface such as fixed_inputs in a launch_plan
     """
-    map_inputs = transform_types_to_list_of_type(interface.inputs, bound_inputs)
+    filtered_inputs = {k: v for k, v in interface.inputs.items() if k not in excluded_inputs}
+    map_inputs = transform_types_to_list_of_type(filtered_inputs, bound_inputs)
     map_outputs = transform_types_to_list_of_type(interface.outputs, set(), optional_outputs)
 
     return Interface(inputs=map_inputs, outputs=map_outputs)

--- a/flytekit/core/interface.py
+++ b/flytekit/core/interface.py
@@ -372,7 +372,7 @@ def transform_interface_to_list_interface(
     Takes a single task interface and interpolates it to an array interface - to allow performing distributed python map
     like functions
     :param interface: Interface to be upgraded to a list interface
-    :param bound_inputs: fixed inputs that should not upgraded to a list and will be maintained as scalars.
+    :param bound_inputs: fixed inputs that should not be updated to a list and will be maintained as is
     """
     map_inputs = transform_types_to_list_of_type(interface.inputs, bound_inputs)
     map_outputs = transform_types_to_list_of_type(interface.outputs, set(), optional_outputs)

--- a/flytekit/core/legacy_map_task.py
+++ b/flytekit/core/legacy_map_task.py
@@ -83,7 +83,7 @@ class MapPythonTask(PythonTask):
         # Transform the interface to List[Optional[T]] in case `min_success_ratio` is set
         output_as_list_of_optionals = min_success_ratio is not None and min_success_ratio != 1 and n_outputs == 1
         collection_interface = transform_interface_to_list_interface(
-            actual_task.python_interface, self._bound_inputs, output_as_list_of_optionals
+            actual_task.python_interface, self._bound_inputs, set(), output_as_list_of_optionals
         )
 
         self._run_task: typing.Union[PythonFunctionTask, PythonInstanceTask] = actual_task  # type: ignore

--- a/flytekit/models/interface.py
+++ b/flytekit/models/interface.py
@@ -158,13 +158,19 @@ class TypedInterface(_common.FlyteIdlEntity):
             outputs={k: Variable.from_flyte_idl(v) for k, v in proto.outputs.variables.items()},
         )
 
-    def transform_interface_to_list(self) -> "TypedInterface":
+    def transform_interface_to_list(self, bound_inputs: typing.Set[str]) -> "TypedInterface":
         """
         Takes a single task interface and interpolates it to an array interface - to allow performing distributed
         python map like functions
+        :param bound_inputs: fixed inputs that should not be updated to a list and will be maintained as is
         """
         list_interface = _interface_pb2.TypedInterface(
-            inputs=_interface_pb2.VariableMap(variables={k: v.to_flyte_idl_list() for k, v in self.inputs.items()}),
+            inputs=_interface_pb2.VariableMap(
+                variables={
+                    k: (v.to_flyte_idl_list() if k not in bound_inputs else v.to_flyte_idl())
+                    for k, v in self.inputs.items()
+                }
+            ),
             outputs=_interface_pb2.VariableMap(variables={k: v.to_flyte_idl_list() for k, v in self.outputs.items()}),
         )
         return self.from_flyte_idl(list_interface)

--- a/flytekit/models/interface.py
+++ b/flytekit/models/interface.py
@@ -158,17 +158,23 @@ class TypedInterface(_common.FlyteIdlEntity):
             outputs={k: Variable.from_flyte_idl(v) for k, v in proto.outputs.variables.items()},
         )
 
-    def transform_interface_to_list(self, bound_inputs: typing.Set[str]) -> "TypedInterface":
+    def transform_interface_to_list(
+        self,
+        bound_inputs: typing.Set[str],
+        excluded_inputs: typing.Set[str],
+    ) -> "TypedInterface":
         """
         Takes a single task interface and interpolates it to an array interface - to allow performing distributed
         python map like functions
         :param bound_inputs: fixed inputs that should not be updated to a list and will be maintained as is
+        :param excluded_inputs: inputs that should be excluded from the new interface
         """
         list_interface = _interface_pb2.TypedInterface(
             inputs=_interface_pb2.VariableMap(
                 variables={
                     k: (v.to_flyte_idl_list() if k not in bound_inputs else v.to_flyte_idl())
                     for k, v in self.inputs.items()
+                    if k not in excluded_inputs
                 }
             ),
             outputs=_interface_pb2.VariableMap(variables={k: v.to_flyte_idl_list() for k, v in self.outputs.items()}),

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2639,7 +2639,7 @@ class FlyteRemote(object):
                 launch_plan = self.fetch_launch_plan(
                     launch_plan_id.project, launch_plan_id.domain, launch_plan_id.name, launch_plan_id.version
                 )
-                task_execution_interface = launch_plan.interface.transform_interface_to_list()
+                task_execution_interface = launch_plan.interface.transform_interface_to_list(bound_inputs=set())
                 execution._task_executions = [
                     self.sync_task_execution(
                         FlyteTaskExecution.promote_from_model(task_execution), task_execution_interface

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2639,7 +2639,9 @@ class FlyteRemote(object):
                 launch_plan = self.fetch_launch_plan(
                     launch_plan_id.project, launch_plan_id.domain, launch_plan_id.name, launch_plan_id.version
                 )
-                task_execution_interface = launch_plan.interface.transform_interface_to_list(bound_inputs=set())
+                task_execution_interface = launch_plan.interface.transform_interface_to_list(
+                    bound_inputs=set(), excluded_inputs=set()
+                )
                 execution._task_executions = [
                     self.sync_task_execution(
                         FlyteTaskExecution.promote_from_model(task_execution), task_execution_interface

--- a/tests/flytekit/unit/core/test_array_node.py
+++ b/tests/flytekit/unit/core/test_array_node.py
@@ -4,12 +4,15 @@ from collections import OrderedDict
 import pytest
 from flyteidl.core import workflow_pb2 as _core_workflow
 
-from flytekit import LaunchPlan, task, workflow
+from flytekit import task, workflow
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.configuration import Image, ImageConfig, SerializationSettings
 from flytekit.core.array_node import array_node
 from flytekit.core.array_node_map_task import map_task
+from flytekit.core.launch_plan import LaunchPlan, reference_launch_plan
+from flytekit.models import types
 from flytekit.models.core import identifier as identifier_models
+from flytekit.models.literals import BindingData, Literal, LiteralMap, Primitive, Scalar, Union
 from flytekit.remote import FlyteLaunchPlan
 from flytekit.remote.interface import TypedInterface
 from flytekit.tools.translator import gather_dependent_entities, get_serializable
@@ -28,6 +31,16 @@ def serialization_settings():
 
 
 @task
+def return_one() -> int:
+    return 1
+
+
+@task
+def return_two() -> int:
+    return 2
+
+
+@task
 def multiply(val: int, val1: typing.Union[int, str], val2: int) -> int:
     if type(val1) is str:
         return val * val2
@@ -41,12 +54,58 @@ def parent_wf(a: int, b: typing.Union[int, str], c: int = 2) -> int:
 
 ctx = FlyteContextManager.current_context()
 lp = LaunchPlan.get_default_launch_plan(ctx, parent_wf)
+lp_fixed_inputs = LaunchPlan.get_or_create(
+    name="parent_wf_lp_fixed_inputs", workflow=parent_wf, fixed_inputs={"a": 1}
+)
+
+
+@reference_launch_plan(project="project", domain="domain", name="tests.flytekit.unit.core.test_array_node.parent_wf", version="version")
+def ref_lp(a: int, b: typing.Union[int, str], c: int = 2) -> int:
+    ...
+
+
+@reference_launch_plan(project="project", domain="domain", name="parent_wf_lp_fixed_inputs", version="version")
+def ref_lp_fixed_inputs(b: typing.Union[int, str], c: int = 2) -> int:
+    ...
 
 
 def get_grandparent_wf(serialization_settings):
     @workflow
     def grandparent_wf() -> typing.List[int]:
-        return array_node(lp, concurrency=10, min_success_ratio=0.9)(a=[1, 3, 5], b=["two", 4, "six"], c=[7, 8, 9])
+        return map_task(lp, concurrency=10, min_success_ratio=0.9)(a=[1, 3, 5], b=["two", 4, "six"], c=[7, 8, 9])
+
+    return grandparent_wf
+
+
+def get_grandparent_wf_ref_lp(serialization_settings):
+    @workflow
+    def grandparent_wf_ref_lp() -> typing.List[int]:
+        return map_task(ref_lp, concurrency=10, min_success_ratio=0.9)(a=[1, 3, 5], b=["two", 4, "six"], c=[7, 8, 9])
+
+    return grandparent_wf_ref_lp
+
+
+def get_grandparent_wf_ref_lp_fixed_inputs(serialization_settings):
+    @workflow
+    def grandparent_wf_ref_lp_fixed_inputs() -> typing.List[int]:
+        return map_task(ref_lp_fixed_inputs, concurrency=10, min_success_ratio=0.9)(b=["two", 4, "six"], c=[7, 8, 9])
+
+    return grandparent_wf_ref_lp_fixed_inputs
+
+
+def get_grandparent_wf_fixed_inputs(serialization_settings):
+    @workflow
+    def grandparent_wf_fixed_inputs() -> typing.List[int]:
+        return map_task(lp_fixed_inputs, concurrency=10, min_success_ratio=0.9)(b=["two", 4, "six"], c=[7, 8, 9])
+
+    return grandparent_wf_fixed_inputs
+
+
+def get_grandparent_wf_upstream_input(serialization_settings):
+    @workflow
+    def grandparent_wf() -> typing.List[int]:
+        one = return_one()
+        return map_task(lp, concurrency=10, min_success_ratio=0.9)(a=[one, 3, 5], b=["two", 4, "six"], c=[7, 8, 9])
 
     return grandparent_wf
 
@@ -54,9 +113,9 @@ def get_grandparent_wf(serialization_settings):
 def get_grandparent_wf_with_overrides(serialization_settings):
     @workflow
     def grandparent_wf_with_overrides() -> typing.List[int]:
-        return array_node(
-            lp, concurrency=10, min_success_ratio=0.9
-        )(a=[1, 3, 5], b=["two", 4, "six"], c=[7, 8, 9]).with_overrides(cache=True, cache_version="1.0")
+        return map_task(lp, concurrency=10, min_success_ratio=0.9)(
+            a=[1, 3, 5], b=["two", 4, "six"], c=[7, 8, 9]
+        ).with_overrides(cache=True, cache_version="1.0")
 
     return grandparent_wf_with_overrides
 
@@ -76,60 +135,192 @@ def get_grandparent_remote_wf(serialization_settings):
 
     @workflow
     def grandparent_remote_wf() -> typing.List[int]:
-        return array_node(
-            remote_lp, concurrency=10, min_success_ratio=0.9
-        )(a=[1, 3, 5], b=["two", 4, "six"], c=[7, 8, 9])
+        return map_task(remote_lp, concurrency=10, min_success_ratio=0.9)(a=[1, 3, 5], b=["two", 4, "six"], c=[7, 8, 9])
 
     return grandparent_remote_wf
 
 
+def get_grandparent_remote_wf_fixed_inputs(serialization_settings):
+    serialized = OrderedDict()
+    lp_model = get_serializable(serialized, serialization_settings, lp)
+
+    task_templates, wf_specs, lp_specs = gather_dependent_entities(serialized)
+    for wf_id, spec in wf_specs.items():
+        break
+
+    remote_lp = FlyteLaunchPlan.promote_from_model(lp_model.id, lp_model.spec)
+    # To pretend that we've fetched this launch plan from Admin, also fill in the Flyte interface, which isn't
+    # part of the IDL object but is something FlyteRemote does
+    remote_lp._interface = TypedInterface.promote_from_model(spec.template.interface)
+    remote_lp._fixed_inputs = LiteralMap(
+        {"a": Literal(scalar=Scalar(primitive=Primitive(integer=1)))}
+    )
+
+    @workflow
+    def grandparent_remote_wf_fixed_inputs() -> typing.List[int]:
+        return map_task(remote_lp, concurrency=10, min_success_ratio=0.9)(b=["two", 4, "six"], c=[7, 8, 9])
+
+    return grandparent_remote_wf_fixed_inputs
+
+
+def get_int_binding(value):
+    return BindingData(scalar=Scalar(primitive=Primitive(integer=value)))
+
+
+def get_str_binding(value):
+    return BindingData(scalar=Scalar(primitive=Primitive(string_value=value)))
+
+
+def get_union_int_binding(value):
+    return BindingData(
+        scalar=Scalar(
+            union=Union(
+                value=Literal(scalar=Scalar(primitive=Primitive(integer=value))),
+                stored_type=types.LiteralType(
+                    simple=types.SimpleType.INTEGER, structure=types.TypeStructure(tag="int")
+                ),
+            )
+        )
+    )
+
+
+def get_union_str_binding(value):
+    return BindingData(
+        scalar=Scalar(
+            union=Union(
+                value=Literal(scalar=Scalar(primitive=Primitive(string_value=value))),
+                stored_type=types.LiteralType(simple=types.SimpleType.STRING, structure=types.TypeStructure(tag="str")),
+            )
+        )
+    )
+
+
+def promise_binding(node_id, var):
+    return BindingData(promise=types.OutputReference(node_id=node_id, var=var))
+
+
+A_BINDINGS_LIST = [get_int_binding(1), get_int_binding(3), get_int_binding(5)]
+C_BINDINGS_LIST = [get_int_binding(7), get_int_binding(8), get_int_binding(9)]
+B_BINDINGS_UNION = [get_union_str_binding("two"), get_union_int_binding(4), get_union_str_binding("six")]
+B_BINDINGS_PLAIN = [get_str_binding("two"), get_int_binding(4), get_str_binding("six")]
+
+
 @pytest.mark.parametrize(
-    ("target", "overrides_metadata"),
+    ("target", "overrides_metadata", "upstream_nodes", "expected_inputs", "lp_name"),
     [
-        (get_grandparent_wf, False),
-        (get_grandparent_remote_wf, False),
-        (get_grandparent_wf_with_overrides, True),
+        (
+            get_grandparent_wf,
+            False,
+            [],
+            {
+                "a": A_BINDINGS_LIST,
+                "b": B_BINDINGS_UNION,
+                "c": C_BINDINGS_LIST,
+            },
+            "tests.flytekit.unit.core.test_array_node.parent_wf",
+        ),
+        (
+            get_grandparent_wf_ref_lp,
+            False,
+            [],
+            {
+                "a": A_BINDINGS_LIST,
+                "b": B_BINDINGS_UNION,
+                "c": C_BINDINGS_LIST,
+            },
+            "tests.flytekit.unit.core.test_array_node.parent_wf",
+        ),
+        (
+            get_grandparent_wf_ref_lp_fixed_inputs,
+            False,
+            [],
+            {
+                "b": B_BINDINGS_UNION,
+                "c": C_BINDINGS_LIST,
+            },
+            "parent_wf_lp_fixed_inputs",
+        ),
+        (
+            get_grandparent_wf_fixed_inputs,
+            False,
+            [],
+            {
+                "b": B_BINDINGS_UNION,
+                "c": C_BINDINGS_LIST,
+            },
+            "parent_wf_lp_fixed_inputs",
+        ),
+        (
+            get_grandparent_remote_wf,
+            False,
+            [],
+            {
+                "a": A_BINDINGS_LIST,
+                "b": B_BINDINGS_PLAIN,
+                "c": C_BINDINGS_LIST,
+            },
+            "tests.flytekit.unit.core.test_array_node.parent_wf",
+        ),
+        (
+            get_grandparent_wf_with_overrides,
+            True,
+            [],
+            {
+                "a": A_BINDINGS_LIST,
+                "b": B_BINDINGS_UNION,
+                "c": C_BINDINGS_LIST,
+            },
+            "tests.flytekit.unit.core.test_array_node.parent_wf",
+        ),
+        (
+            get_grandparent_remote_wf_fixed_inputs,
+            False,
+            [],
+            {
+                "b": B_BINDINGS_PLAIN,
+                "c": C_BINDINGS_LIST,
+            },
+            "tests.flytekit.unit.core.test_array_node.parent_wf",
+        ),
     ],
 )
-def test_lp_serialization(target, overrides_metadata, serialization_settings):
+def test_lp_serialization(target, overrides_metadata, upstream_nodes, expected_inputs, lp_name, serialization_settings):
     wf_spec = get_serializable(OrderedDict(), serialization_settings, target(serialization_settings))
-    assert len(wf_spec.template.nodes) == 1
+    assert len(wf_spec.template.nodes) == len(upstream_nodes) + 1
 
-    parent_node = wf_spec.template.nodes[0]
-    assert parent_node.inputs[0].var == "a"
+    parent_node = wf_spec.template.nodes[len(upstream_nodes)]
     assert parent_node.array_node._min_success_ratio == 0.9
     assert parent_node.array_node._parallelism == 10
     assert parent_node.array_node._is_original_sub_node_interface
     assert parent_node.array_node._execution_mode == _core_workflow.ArrayNode.FULL_STATE
-    assert len(parent_node.inputs[0].binding.collection.bindings) == 3
-    for binding in parent_node.inputs[0].binding.collection.bindings:
-        assert binding.scalar.primitive.integer is not None
-    assert parent_node.inputs[1].var == "b"
-    for binding in parent_node.inputs[1].binding.collection.bindings:
-        assert (binding.scalar.union is not None or
-                binding.scalar.primitive.integer is not None or
-                binding.scalar.primitive.string_value is not None)
-    assert len(parent_node.inputs[1].binding.collection.bindings) == 3
-    assert parent_node.inputs[2].var == "c"
-    assert len(parent_node.inputs[2].binding.collection.bindings) == 3
-    for binding in parent_node.inputs[2].binding.collection.bindings:
-        assert binding.scalar.primitive.integer is not None
+
+    assert set(parent_node.upstream_node_ids) == set(upstream_nodes)
+
+    assert len(parent_node.inputs) == len(expected_inputs)
+    inputs_map = {x.var: x for x in parent_node.inputs}
+
+    for param, expected_input in expected_inputs.items():
+        node_input = inputs_map[param]
+        assert node_input
+        if isinstance(expected_input, list):
+            bindings = node_input.binding.collection.bindings
+            assert len(bindings) == len(expected_inputs[param])
+            for i, binding in enumerate(bindings):
+                assert binding == expected_input[i]
+        else:
+            binding = node_input.binding
+            assert binding == expected_input
 
     serialized_array_node = parent_node.array_node
     assert (
-            serialized_array_node.node.workflow_node.launchplan_ref.resource_type
-            == identifier_models.ResourceType.LAUNCH_PLAN
+        serialized_array_node.node.workflow_node.launchplan_ref.resource_type
+        == identifier_models.ResourceType.LAUNCH_PLAN
     )
-    assert (
-            serialized_array_node.node.workflow_node.launchplan_ref.name
-            == "tests.flytekit.unit.core.test_array_node.parent_wf"
-    )
+    assert serialized_array_node.node.workflow_node.launchplan_ref.name == lp_name
     assert serialized_array_node._min_success_ratio == 0.9
     assert serialized_array_node._parallelism == 10
 
     subnode = serialized_array_node.node
-    assert subnode.inputs == parent_node.inputs
-
     if overrides_metadata:
         assert parent_node.metadata.cacheable
         assert parent_node.metadata.cache_version == "1.0"
@@ -140,7 +331,6 @@ def test_lp_serialization(target, overrides_metadata, serialization_settings):
         assert not parent_node.metadata.cache_version
         assert not subnode.metadata.cacheable
         assert not subnode.metadata.cache_version
-
 
 @pytest.mark.parametrize(
     "min_successes, min_success_ratio, should_raise_error",

--- a/tests/flytekit/unit/core/test_interface.py
+++ b/tests/flytekit/unit/core/test_interface.py
@@ -386,7 +386,7 @@ def test_transform_interface_to_list_interface(optional_outputs, expected_type):
     def t() -> int:
         return 123
 
-    list_interface = transform_interface_to_list_interface(t.python_interface, set(), optional_outputs=optional_outputs)
+    list_interface = transform_interface_to_list_interface(t.python_interface, set(), set(), optional_outputs=optional_outputs)
     assert list_interface.outputs["o0"] == typing.List[expected_type]
 
 

--- a/tests/flytekit/unit/models/test_interface.py
+++ b/tests/flytekit/unit/models/test_interface.py
@@ -51,8 +51,18 @@ def test_typed_interface(literal_type):
     assert len(deserialized_typed_interface.inputs) == 1
     assert len(deserialized_typed_interface.outputs) == 2
 
-    deserialized_typed_interface_list = typed_interface.transform_interface_to_list()
+    deserialized_typed_interface_list = typed_interface.transform_interface_to_list(set())
     assert deserialized_typed_interface_list.inputs["a"].type == types.LiteralType(collection_type=literal_type)
+    assert deserialized_typed_interface_list.outputs["b"].type == types.LiteralType(collection_type=literal_type)
+    assert deserialized_typed_interface_list.outputs["c"].type == types.LiteralType(collection_type=literal_type)
+    assert deserialized_typed_interface_list.inputs["a"].description == "description1"
+    assert deserialized_typed_interface_list.outputs["b"].description == "description2"
+    assert deserialized_typed_interface_list.outputs["c"].description == "description3"
+    assert len(deserialized_typed_interface_list.inputs) == 1
+    assert len(deserialized_typed_interface_list.outputs) == 2
+
+    deserialized_typed_interface_list = typed_interface.transform_interface_to_list({"a"})
+    assert deserialized_typed_interface_list.inputs["a"].type == literal_type
     assert deserialized_typed_interface_list.outputs["b"].type == types.LiteralType(collection_type=literal_type)
     assert deserialized_typed_interface_list.outputs["c"].type == types.LiteralType(collection_type=literal_type)
     assert deserialized_typed_interface_list.inputs["a"].description == "description1"

--- a/tests/flytekit/unit/models/test_interface.py
+++ b/tests/flytekit/unit/models/test_interface.py
@@ -51,24 +51,53 @@ def test_typed_interface(literal_type):
     assert len(deserialized_typed_interface.inputs) == 1
     assert len(deserialized_typed_interface.outputs) == 2
 
-    deserialized_typed_interface_list = typed_interface.transform_interface_to_list(set())
-    assert deserialized_typed_interface_list.inputs["a"].type == types.LiteralType(collection_type=literal_type)
-    assert deserialized_typed_interface_list.outputs["b"].type == types.LiteralType(collection_type=literal_type)
-    assert deserialized_typed_interface_list.outputs["c"].type == types.LiteralType(collection_type=literal_type)
-    assert deserialized_typed_interface_list.inputs["a"].description == "description1"
-    assert deserialized_typed_interface_list.outputs["b"].description == "description2"
-    assert deserialized_typed_interface_list.outputs["c"].description == "description3"
-    assert len(deserialized_typed_interface_list.inputs) == 1
-    assert len(deserialized_typed_interface_list.outputs) == 2
 
-    deserialized_typed_interface_list = typed_interface.transform_interface_to_list({"a"})
-    assert deserialized_typed_interface_list.inputs["a"].type == literal_type
-    assert deserialized_typed_interface_list.outputs["b"].type == types.LiteralType(collection_type=literal_type)
-    assert deserialized_typed_interface_list.outputs["c"].type == types.LiteralType(collection_type=literal_type)
-    assert deserialized_typed_interface_list.inputs["a"].description == "description1"
-    assert deserialized_typed_interface_list.outputs["b"].description == "description2"
-    assert deserialized_typed_interface_list.outputs["c"].description == "description3"
-    assert len(deserialized_typed_interface_list.inputs) == 1
+@pytest.mark.parametrize("literal_type", LIST_OF_ALL_LITERAL_TYPES)
+@pytest.mark.parametrize(
+    "bound_inputs, excluded_inputs",
+    [
+        (set(), set()),
+        ({"a"}, set()),
+        (set(), {"b"}),
+        ({"a"}, {"b"}),
+        ({"a", "b"}, set()),
+        (set(), {"a", "b"}),
+    ])
+def test_transform_interface_to_list(literal_type, bound_inputs, excluded_inputs):
+    typed_interface = interface.TypedInterface(
+        {
+            "a": interface.Variable(literal_type, "description1"),
+            "b": interface.Variable(literal_type, "description2")
+        },
+        {
+            "c": interface.Variable(literal_type, "description3"),
+            "d": interface.Variable(literal_type, "description4")
+        },
+    )
+
+    deserialized_typed_interface_list = typed_interface.transform_interface_to_list(
+        bound_inputs=bound_inputs,
+        excluded_inputs=excluded_inputs
+    )
+
+    for param in typed_interface.inputs:
+        if param in excluded_inputs:
+            assert param not in deserialized_typed_interface_list.inputs
+        elif param in bound_inputs:
+            assert deserialized_typed_interface_list.inputs[param].type == literal_type
+        else:
+            assert deserialized_typed_interface_list.inputs[param].type == types.LiteralType(
+                collection_type=literal_type
+            )
+
+    for param in typed_interface.outputs:
+        assert deserialized_typed_interface_list.outputs[param].type == types.LiteralType(
+            collection_type=literal_type
+        )
+        assert (deserialized_typed_interface_list.outputs[param].description ==
+                typed_interface.outputs[param].description)
+
+    assert len(deserialized_typed_interface_list.inputs) == 2 - len(excluded_inputs)
     assert len(deserialized_typed_interface_list.outputs) == 2
 
 


### PR DESCRIPTION
fixes: https://linear.app/unionai/issue/BB-2860/utilize-fixed-inputs-set-for-a-launch-plan-when-mapping-over-launch

## Why are the changes needed?
Getting this change in here since this is a bug instead of an add on. Will add to union sdk as well.

## What changes were proposed in this pull request?
When mapping over a launch plan with fixed inputs, don't set the fixed_inputs as part of the array node's interface

## How was this patch tested?
- updated unit tests
- tested [launch plans](https://dogfood.cloud-staging.union.ai/console/projects/flytesnacks/domains/development/executions/ap5tstv4mrdqzfr2kn66), [reference launch plans](https://dogfood.cloud-staging.union.ai/console/projects/flytesnacks/domains/development/executions/a46ltcwc7587v5wwtwrt), and [remote launch plans](https://dogfood.cloud-staging.union.ai/console/projects/flytesnacks/domains/development/executions/axtvglqjplggb5rj8mpm) in dogfood


```
simple_wf_lp_fixed_inputs = LaunchPlan.get_or_create(
    name="simple_wf_lp_fixed_inputs", workflow=simple_wf, fixed_inputs={"x": [-3, 0, 3]}
)


@workflow
def test_map_task() -> list[float]:
    x = [[1, 2, 3], [1, 2, 3]]
    y = [[5, 6, 7], [5, 6, 7]]
    return map_task(simple_wf_lp_fixed_inputs)(y=y)
```

```
@reference_launch_plan(
    project="flytesnacks",
    domain="development",
    name="simple_wf_lp_fixed_inputs",
    version="o89vSTZ0r8ZY-6z_9OoUCA",
)
def simple_wf(
    y: list[int]
) -> float:
    return 1.0


@workflow
def map_over_ref_launch_plan():
    return map_task(simple_wf)(y=[[1, 2, 3]])
```

```
remote = FlyteRemote(config=Config.auto(), default_project="flytesnacks", default_domain="development")
lp1 = remote.fetch_launch_plan(name="simple_wf_lp_fixed_inputs",
                               version="o89vSTZ0r8ZY-6z_9OoUCA")

@workflow
def map_over_remote_lp():
    return map_task(lp1)(y=[[1, 2, 3]])
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes a critical bug related to improper inclusion of fixed inputs when mapping over launch plans by introducing an excluded_inputs parameter and modifying the array node interface for proper literal-to-set conversion. The changes affect multiple core components including array nodes and task mapping functions, improving execution reliability while maintaining compatibility with existing tests.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>