### PR TITLE
Use digest as file_name to get signed url

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1185,7 +1185,6 @@ class FlyteRemote(object):
         :param project: Project to upload under, if not supplied will use the remote's default
         :param domain: Domain to upload under, if not specified will use the remote's default
         :param filename_root: If provided will be used as the root of the filename. If not, Admin will use a hash
-        If not, will use the file name of the file being uploaded.
         :return: The uploaded location.
         """
         if not to_upload.is_file():

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1177,7 +1177,6 @@ class FlyteRemote(object):
         project: typing.Optional[str] = None,
         domain: typing.Optional[str] = None,
         filename_root: typing.Optional[str] = None,
-        file_name: typing.Optional[str] = None,
     ) -> typing.Tuple[bytes, str]:
         """
         Function will use remote's client to hash and then upload the file using Admin's data proxy service.
@@ -1186,21 +1185,18 @@ class FlyteRemote(object):
         :param project: Project to upload under, if not supplied will use the remote's default
         :param domain: Domain to upload under, if not specified will use the remote's default
         :param filename_root: If provided will be used as the root of the filename. If not, Admin will use a hash
-        :param file_name: If provided will be used as the filename.
         If not, will use the file name of the file being uploaded.
         :return: The uploaded location.
         """
         if not to_upload.is_file():
             raise ValueError(f"{to_upload} is not a single file, upload arg must be a single file.")
         md5_bytes, str_digest, _ = hash_file(to_upload)
-        if file_name is None:
-            file_name = to_upload.name
 
         upload_location = self.client.get_upload_signed_url(
             project=project or self.default_project,
             domain=domain or self.default_domain,
             content_md5=md5_bytes,
-            filename=file_name,
+            filename=to_upload.name,
             filename_root=filename_root,
         )
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1169,7 +1169,7 @@ class FlyteRemote(object):
         # Create a zip file containing all the entries.
         zip_file = fast_package(root, output, deref_symlinks, options)
         # Upload zip file to Admin using FlyteRemote.
-        return self.upload_file(pathlib.Path(zip_file), file_name=pathlib.Path(zip_file).name)
+        return self.upload_file(pathlib.Path(zip_file))
 
     def upload_file(
         self,
@@ -1186,13 +1186,15 @@ class FlyteRemote(object):
         :param project: Project to upload under, if not supplied will use the remote's default
         :param domain: Domain to upload under, if not specified will use the remote's default
         :param filename_root: If provided will be used as the root of the filename. If not, Admin will use a hash
+        :param file_name: If provided will be used as the filename.
+        If not, will use the file name of the file being uploaded.
         :return: The uploaded location.
         """
         if not to_upload.is_file():
             raise ValueError(f"{to_upload} is not a single file, upload arg must be a single file.")
         md5_bytes, str_digest, _ = hash_file(to_upload)
         if file_name is None:
-            file_name = str(str_digest)
+            file_name = to_upload.name
 
         upload_location = self.client.get_upload_signed_url(
             project=project or self.default_project,
@@ -1358,7 +1360,6 @@ class FlyteRemote(object):
                     archive_fname,
                     project or self.default_project,
                     domain or self.default_domain,
-                    file_name=archive_fname.name,
                 )
 
         serialization_settings = SerializationSettings(
@@ -2979,7 +2980,7 @@ class FlyteRemote(object):
                     "The size of the task to pickled exceeds the limit of 150MB. Please reduce the size of the task."
                 )
             logger.debug(f"Uploading Pickled representation of Workflow `{entity.name}` to remote storage...")
-            _, native_url = self.upload_file(dest, file_name=dest.name)
+            _, native_url = self.upload_file(dest)
 
         return FastSerializationSettings(enabled=True, distribution_location=native_url, destination_dir=".")
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1191,8 +1191,6 @@ class FlyteRemote(object):
         if not to_upload.is_file():
             raise ValueError(f"{to_upload} is not a single file, upload arg must be a single file.")
         md5_bytes, str_digest, _ = hash_file(to_upload)
-        print("md5_bytes", md5_bytes)
-        print("file_name", file_name)
         if file_name is None:
             file_name = str(str_digest)
 
@@ -1357,7 +1355,10 @@ class FlyteRemote(object):
                 archive_fname = pathlib.Path(os.path.join(tmp_dir, "script_mode.tar.gz"))
                 compress_scripts(source_path, str(archive_fname), get_all_modules(source_path, module_name))
                 md5_bytes, upload_native_url = self.upload_file(
-                    archive_fname, project or self.default_project, domain or self.default_domain, file_name=archive_fname.name
+                    archive_fname,
+                    project or self.default_project,
+                    domain or self.default_domain,
+                    file_name=archive_fname.name,
                 )
 
         serialization_settings = SerializationSettings(

--- a/flytekit/remote/remote_fs.py
+++ b/flytekit/remote/remote_fs.py
@@ -146,6 +146,8 @@ class FlyteFS(HTTPFileSystem):
         _, native_url = self._remote.upload_file(
             pathlib.Path(lpath), self._remote.default_project, self._remote.default_domain, prefix
         )
+        print("prefix", prefix)
+        print("native_url", native_url)
         return native_url
 
     @staticmethod

--- a/flytekit/remote/remote_fs.py
+++ b/flytekit/remote/remote_fs.py
@@ -143,9 +143,8 @@ class FlyteFS(HTTPFileSystem):
         Make the request and upload, but then how do we get the s3 paths back to the user?
         """
         prefix = kwargs.pop(_PREFIX_KEY)
-        _, str_digest, _ = hash_file(pathlib.Path(lpath))
         _, native_url = self._remote.upload_file(
-            pathlib.Path(lpath), self._remote.default_project, self._remote.default_domain, prefix, str_digest
+            pathlib.Path(lpath), self._remote.default_project, self._remote.default_domain, prefix
         )
         return native_url
 

--- a/flytekit/remote/remote_fs.py
+++ b/flytekit/remote/remote_fs.py
@@ -146,8 +146,6 @@ class FlyteFS(HTTPFileSystem):
         _, native_url = self._remote.upload_file(
             pathlib.Path(lpath), self._remote.default_project, self._remote.default_domain, prefix
         )
-        print("prefix", prefix)
-        print("native_url", native_url)
         return native_url
 
     @staticmethod

--- a/flytekit/remote/remote_fs.py
+++ b/flytekit/remote/remote_fs.py
@@ -143,8 +143,9 @@ class FlyteFS(HTTPFileSystem):
         Make the request and upload, but then how do we get the s3 paths back to the user?
         """
         prefix = kwargs.pop(_PREFIX_KEY)
+        _, str_digest, _ = hash_file(pathlib.Path(lpath))
         _, native_url = self._remote.upload_file(
-            pathlib.Path(lpath), self._remote.default_project, self._remote.default_domain, prefix
+            pathlib.Path(lpath), self._remote.default_project, self._remote.default_domain, prefix, str_digest
         )
         return native_url
 

--- a/flytekit/tools/script_mode.py
+++ b/flytekit/tools/script_mode.py
@@ -11,6 +11,7 @@ import tarfile
 import tempfile
 import typing
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from types import ModuleType
 from typing import List, Optional, Tuple, Union
@@ -292,6 +293,7 @@ def get_all_modules(source_path: str, module_name: Optional[str]) -> List[Module
         return sys_modules
 
 
+@lru_cache
 def hash_file(file_path: typing.Union[os.PathLike, str]) -> (bytes, str, int):
     """
     Hash a file and produce a digest to be used as a version

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -92,7 +92,6 @@ class FlytePickleTransformer(AsyncTypeTransformer[FlytePickle]):
             )
         )
         remote_path = await FlytePickle.to_pickle(ctx, python_val)
-        print(remote_path)
         return Literal(scalar=Scalar(blob=Blob(metadata=meta, uri=remote_path)))
 
     def guess_python_type(self, literal_type: LiteralType) -> typing.Type[FlytePickle[typing.Any]]:

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -42,7 +42,7 @@ class FlytePickle(typing.Generic[T]):
     @classmethod
     async def to_pickle(cls, ctx: FlyteContext, python_val: typing.Any) -> str:
         h = hashlib.md5()
-        h.update(python_val)
+        h.update(cloudpickle.dumps(python_val))
 
         uri = ctx.file_access.get_random_local_path(file_path_or_file_name=h.hexdigest())
         os.makedirs(os.path.dirname(uri), exist_ok=True)

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -47,9 +47,7 @@ class FlytePickle(typing.Generic[T]):
         with open(uri, "w+b") as outfile:
             cloudpickle.dump(python_val, outfile)
 
-        path = await ctx.file_access.async_put_raw_data(uri)
-        print("path", path)
-        return path
+        return await ctx.file_access.async_put_raw_data(uri)
 
     @classmethod
     async def from_pickle(cls, uri: str) -> typing.Any:

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import typing
 from typing import Type
@@ -40,9 +41,12 @@ class FlytePickle(typing.Generic[T]):
 
     @classmethod
     async def to_pickle(cls, ctx: FlyteContext, python_val: typing.Any) -> str:
+        h = hashlib.md5()
+        h.update(python_val)
+
         local_dir = ctx.file_access.get_random_local_directory()
         os.makedirs(local_dir, exist_ok=True)
-        local_path = ctx.file_access.get_random_local_path()
+        local_path = ctx.file_access.get_random_local_path(file_path_or_file_name=h.hexdigest())
         uri = os.path.join(local_dir, local_path)
         with open(uri, "w+b") as outfile:
             cloudpickle.dump(python_val, outfile)

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -44,10 +44,8 @@ class FlytePickle(typing.Generic[T]):
         h = hashlib.md5()
         h.update(python_val)
 
-        local_dir = ctx.file_access.get_random_local_directory()
-        os.makedirs(local_dir, exist_ok=True)
-        local_path = ctx.file_access.get_random_local_path(file_path_or_file_name=h.hexdigest())
-        uri = os.path.join(local_dir, local_path)
+        uri = ctx.file_access.get_random_local_path(file_path_or_file_name=h.hexdigest())
+        os.makedirs(os.path.dirname(uri), exist_ok=True)
         with open(uri, "w+b") as outfile:
             cloudpickle.dump(python_val, outfile)
 

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -42,12 +42,13 @@ class FlytePickle(typing.Generic[T]):
     @classmethod
     async def to_pickle(cls, ctx: FlyteContext, python_val: typing.Any) -> str:
         h = hashlib.md5()
-        h.update(cloudpickle.dumps(python_val))
+        str_bytes = cloudpickle.dumps(python_val)
+        h.update(str_bytes)
 
         uri = ctx.file_access.get_random_local_path(file_path_or_file_name=h.hexdigest())
         os.makedirs(os.path.dirname(uri), exist_ok=True)
         with open(uri, "w+b") as outfile:
-            cloudpickle.dump(python_val, outfile)
+            outfile.write(str_bytes)
 
         return await ctx.file_access.async_put_raw_data(uri)
 

--- a/flytekit/types/pickle/pickle.py
+++ b/flytekit/types/pickle/pickle.py
@@ -47,7 +47,9 @@ class FlytePickle(typing.Generic[T]):
         with open(uri, "w+b") as outfile:
             cloudpickle.dump(python_val, outfile)
 
-        return await ctx.file_access.async_put_raw_data(uri)
+        path = await ctx.file_access.async_put_raw_data(uri)
+        print("path", path)
+        return path
 
     @classmethod
     async def from_pickle(cls, uri: str) -> typing.Any:
@@ -92,6 +94,7 @@ class FlytePickleTransformer(AsyncTypeTransformer[FlytePickle]):
             )
         )
         remote_path = await FlytePickle.to_pickle(ctx, python_val)
+        print(remote_path)
         return Literal(scalar=Scalar(blob=Blob(metadata=meta, uri=remote_path)))
 
     def guess_python_type(self, literal_type: LiteralType) -> typing.Type[FlytePickle[typing.Any]]:

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -1150,7 +1150,7 @@ def test_execute_workflow_with_dataclass():
 
 
 def test_register_wf_twice(register):
-    from workflows.basic import pickle_wf
+    from tests.flytekit.integration.remote.workflows.basic import pickle_wf
 
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
     fast_version = f"{VERSION}_fast"

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -1147,3 +1147,14 @@ def test_execute_workflow_with_dataclass():
         image_config=ImageConfig.from_images(IMAGE),
     )
     assert out.outputs["o0"] == ""
+
+
+def test_register_wf_twice(register):
+    from workflows.basic import pickle_wf
+
+    remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
+    fast_version = f"{VERSION}_fast"
+    serialization_settings = SerializationSettings(image_config=ImageConfig.auto(img_name=IMAGE))
+    remote.fast_register_workflow(pickle_wf, serialization_settings, version=fast_version)
+    # Register the same workflow again should not raise an error
+    remote.fast_register_workflow(pickle_wf, serialization_settings, version=fast_version)

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -1150,7 +1150,7 @@ def test_execute_workflow_with_dataclass():
 
 
 def test_register_wf_twice(register):
-    from tests.flytekit.integration.remote.workflows.basic import pickle_wf
+    from tests.flytekit.integration.remote.workflows.basic.pickle_wf import pickle_wf
 
     remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
     fast_version = f"{VERSION}_fast"

--- a/tests/flytekit/integration/remote/test_remote.py
+++ b/tests/flytekit/integration/remote/test_remote.py
@@ -1150,11 +1150,23 @@ def test_execute_workflow_with_dataclass():
 
 
 def test_register_wf_twice(register):
-    from tests.flytekit.integration.remote.workflows.basic.pickle_wf import pickle_wf
-
-    remote = FlyteRemote(Config.auto(config_file=CONFIG), PROJECT, DOMAIN)
-    fast_version = f"{VERSION}_fast"
-    serialization_settings = SerializationSettings(image_config=ImageConfig.auto(img_name=IMAGE))
-    remote.fast_register_workflow(pickle_wf, serialization_settings, version=fast_version)
     # Register the same workflow again should not raise an error
-    remote.fast_register_workflow(pickle_wf, serialization_settings, version=fast_version)
+    out = subprocess.run(
+        [
+            "pyflyte",
+            "--verbose",
+            "-c",
+            CONFIG,
+            "register",
+            "--image",
+            IMAGE,
+            "--project",
+            PROJECT,
+            "--domain",
+            DOMAIN,
+            "--version",
+            VERSION,
+            MODULE_PATH / "pickle_wf.py",
+        ]
+    )
+    assert out.returncode == 0

--- a/tests/flytekit/integration/remote/workflows/basic/pickle_wf.py
+++ b/tests/flytekit/integration/remote/workflows/basic/pickle_wf.py
@@ -1,0 +1,14 @@
+import typing
+
+from flytekit import task, workflow
+
+
+@task
+def t1(game_id: typing.Any):
+    print(game_id)
+
+
+# test
+@workflow
+def pickle_wf():
+    t1(game_id="123456")


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
I encountered an error when attempting to run the task for the second time. Here’s the error message I received.

The issue occurs because the pickle path in the node binding changes each time a new workflow is registered

File name was a random string generated from [here](https://github.com/flyteorg/flytekit/blob/55e9f8d7f226302277c5d70abdcfd5d1ff19a789/flytekit/types/pickle/pickle.py#L45), and it causes `get_upload_signed_url` to always return a different S3 path. 

```
Request rejected by the API, due to Invalid input.
RPC Failed, with Status: StatusCode.INVALID_ARGUMENT
        Details: cus.test_workflow workflow with different structure already exists. (Please register a new version of the workflow):
/primary/connections:
        - <nil>
        + map[downstream:map[n0:map[ids:[end-node]] start-node:map[ids:[n0]]] upstream:map[end-node:map[ids:[n0]] n0:map[ids:[start-node]]]]
/primary/template/id:
        - <nil>
        + map[domain:development name:cus.test_workflow project:flytesnacks resource_type:2 version:VZzeazr6eSezJIFQpbjG5w]
/primary/template/metadata:
        - <nil>
        + map[]
/primary/template/metadata_defaults:
        - <nil>
        + map[]
/primary/template/nodes:
        - <nil>
        + [map[Target:<nil> id:start-node] map[Target:<nil> id:end-node inputs:[map[binding:map[Value:map[Scalar:map[Value:map[Primitive:map[Value:map[StringValue:Done]]]]]] var:o0]]] map[Target:map[TaskNode:map[Reference:map[ReferenceId:map[domain:development name:cus.test_task project:flytesnacks resource_type:1 version:VZzeazr6eSezJIFQpbjG5w]] overrides:map[]]] id:n0 inputs:[map[binding:map[Value:map[Scalar:map[Value:map[Blob:map[metadata:map[type:map[format:PythonPickle]] uri:s3://my-s3-bucket/flytesnacks/development/33MFF3MWMFPRKSOCGUARVNAQZE======/c9a3f0c59b8cd3b750e0a0d96e5079e7]]]]] var:game_id]] metadata:map[CacheSerializableValue:<nil> CacheVersionValue:<nil> CacheableValue:<nil> InterruptibleValue:<nil> name:test_task retries:map[]]]]
/primary/template/outputs:
        - <nil>
        + [map[binding:map[Value:map[Scalar:map[Value:map[Primitive:map[Value:map[StringValue:Done]]]]]] var:o0]]
/tasks:
        - <nil>
        + [map[template:map[Target:map[Container:map[args:[pyflyte-fast-execute --additional-distribution s3://my-s3-bucket/flytesnacks/development/5MLZDNYX3SFVNSRTVLRSUQZARI======/fast55118ecf880885b3b42868f6cf690429.tar.gz --dest-dir /root -- pyflyte-execute --inputs {{.input}} --output-prefix {{.outputPrefix}} --raw-output-data-prefix {{.rawOutputDataPrefix}} --checkpoint-path {{.checkpointOutputPrefix}} --prev-checkpoint {{.prevCheckpointPrefix}} --resolver flytekit.core.python_auto_container.default_task_resolver -- task-module cus task-name test_task] image:flytekit:f5CA7ElyTVmVZsyiBAOWxw resources:map[]]] id:map[domain:development name:cus.test_task project:flytesnacks resource_type:1 version:VZzeazr6eSezJIFQpbjG5w] interface:map[inputs:map[variables:map[game_id:map[description:game_id type:map[Type:map[Blob:map[format:PythonPickle]] metadata:map[python_class_name:<class 'uuid.UUID'>]]]]] outputs:map[variables:map[o0:map[description:o0 type:map[Type:map[Blob:map[dimensionality:1]]]]]]] metadata:map[InterruptibleValue:<nil> generates_deck:map[] retries:map[] runtime:map[flavor:python type:1 version:1.15.1.dev1+ge19fedc2b]] type:python-task]]]
```

## What changes were proposed in this pull request?
Use digest as file_name to get signed url since digest is deterministic.

## How was this patch tested?
```python
import uuid

from flytekit import task, workflow


@task
def test_task(game_id: uuid.UUID):
    print(game_id)


# test
@workflow
def test_workflow() -> str:
    test_task(game_id="123456")

    return "Done"
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances file upload functionality by implementing deterministic MD5 digest-based file naming for consistency across upload calls, resolving non-deterministic naming issues. It replaces direct API calls with pyflyte CLI subprocess commands, eliminates redundant registration calls, modifies API signatures, and refines file handling in remote modules while improving test execution consistency and reliability.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>