### PR TITLE
Worker queue to publish deck

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -173,6 +173,11 @@ def _dispatch_execute(
         input_proto = utils.load_proto_from_file(_literals_pb2.LiteralMap, local_inputs_file)
         idl_input_literals = _literal_models.LiteralMap.from_flyte_idl(input_proto)
 
+        if task_def.enable_deck:
+            new_params = ctx.user_space_params.with_enable_deck(enable_deck=True).build()
+            new_es = ctx.execution_state.with_params(user_space_params=new_params)
+            ctx = ctx.new_builder().with_execution_state(new_es).build()
+
         # Step2
         # Invoke task - dispatch_execute
         outputs = task_def.dispatch_execute(ctx, idl_input_literals)

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -176,15 +176,6 @@ def _dispatch_execute(
         # Step2
         # Invoke task - dispatch_execute
         outputs = task_def.dispatch_execute(ctx, idl_input_literals)
-        # if task_def.enable_deck:
-        #     new_params = ctx.user_space_params.with_enable_deck(enable_deck=True).build()
-        #     new_es = ctx.execution_state.with_params(user_space_params=new_params)
-        #     logger.debug(f"Enabling deck in context for execution of {task_def.name}")
-        #     cb = ctx.new_builder().with_execution_state(new_es)
-        #     with FlyteContextManager.with_context(cb) as ctx:
-        #         outputs = task_def.dispatch_execute(ctx, idl_input_literals)
-        # else:
-        #     outputs = task_def.dispatch_execute(ctx, idl_input_literals)
 
         # Step3a
         if isinstance(outputs, VoidPromise):

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -173,11 +173,11 @@ def _dispatch_execute(
         input_proto = utils.load_proto_from_file(_literals_pb2.LiteralMap, local_inputs_file)
         idl_input_literals = _literal_models.LiteralMap.from_flyte_idl(input_proto)
 
-        if task_def.enable_deck:
-            new_params = ctx.user_space_params.with_enable_deck(enable_deck=True).build()
-            new_es = ctx.execution_state.with_params(user_space_params=new_params)
-            print(f"Deck enabled for task {task_def.name}")
-            ctx = ctx.new_builder().with_execution_state(new_es).build()
+        # if task_def.enable_deck:
+        #     new_params = ctx.user_space_params.with_enable_deck(enable_deck=True).build()
+        #     new_es = ctx.execution_state.with_params(user_space_params=new_params)
+        #     print(f"Deck enabled for task {task_def.name}")
+        #     ctx = ctx.new_builder().with_execution_state(new_es).build()
 
         print(f"val {ctx.execution_state.user_space_params.enable_deck}", flush=True)
 

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -175,15 +175,16 @@ def _dispatch_execute(
 
         # Step2
         # Invoke task - dispatch_execute
-        if task_def.enable_deck:
-            new_params = ctx.user_space_params.with_enable_deck(enable_deck=True).build()
-            new_es = ctx.execution_state.with_params(user_space_params=new_params)
-            logger.debug(f"Enabling deck in context for execution of {task_def.name}")
-            cb = ctx.new_builder().with_execution_state(new_es)
-            with FlyteContextManager.with_context(cb) as ctx:
-                outputs = task_def.dispatch_execute(ctx, idl_input_literals)
-        else:
-            outputs = task_def.dispatch_execute(ctx, idl_input_literals)
+        outputs = task_def.dispatch_execute(ctx, idl_input_literals)
+        # if task_def.enable_deck:
+        #     new_params = ctx.user_space_params.with_enable_deck(enable_deck=True).build()
+        #     new_es = ctx.execution_state.with_params(user_space_params=new_params)
+        #     logger.debug(f"Enabling deck in context for execution of {task_def.name}")
+        #     cb = ctx.new_builder().with_execution_state(new_es)
+        #     with FlyteContextManager.with_context(cb) as ctx:
+        #         outputs = task_def.dispatch_execute(ctx, idl_input_literals)
+        # else:
+        #     outputs = task_def.dispatch_execute(ctx, idl_input_literals)
 
         # Step3a
         if isinstance(outputs, VoidPromise):

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -176,7 +176,14 @@ def _dispatch_execute(
         if task_def.enable_deck:
             new_params = ctx.user_space_params.with_enable_deck(enable_deck=True).build()
             new_es = ctx.execution_state.with_params(user_space_params=new_params)
+            print(f"Deck enabled for task {task_def.name}")
             ctx = ctx.new_builder().with_execution_state(new_es).build()
+
+        print(f"val {ctx.execution_state.user_space_params.enable_deck}", flush=True)
+
+        if not ctx.execution_state.user_space_params.enable_deck:
+            print("force true", flush=True)
+            ctx.execution_state.user_space_params._enable_deck = True
 
         # Step2
         # Invoke task - dispatch_execute

--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -173,21 +173,17 @@ def _dispatch_execute(
         input_proto = utils.load_proto_from_file(_literals_pb2.LiteralMap, local_inputs_file)
         idl_input_literals = _literal_models.LiteralMap.from_flyte_idl(input_proto)
 
-        # if task_def.enable_deck:
-        #     new_params = ctx.user_space_params.with_enable_deck(enable_deck=True).build()
-        #     new_es = ctx.execution_state.with_params(user_space_params=new_params)
-        #     print(f"Deck enabled for task {task_def.name}")
-        #     ctx = ctx.new_builder().with_execution_state(new_es).build()
-
-        print(f"val {ctx.execution_state.user_space_params.enable_deck}", flush=True)
-
-        if not ctx.execution_state.user_space_params.enable_deck:
-            print("force true", flush=True)
-            ctx.execution_state.user_space_params._enable_deck = True
-
         # Step2
         # Invoke task - dispatch_execute
-        outputs = task_def.dispatch_execute(ctx, idl_input_literals)
+        if task_def.enable_deck:
+            new_params = ctx.user_space_params.with_enable_deck(enable_deck=True).build()
+            new_es = ctx.execution_state.with_params(user_space_params=new_params)
+            logger.debug(f"Enabling deck in context for execution of {task_def.name}")
+            cb = ctx.new_builder().with_execution_state(new_es)
+            with FlyteContextManager.with_context(cb) as ctx:
+                outputs = task_def.dispatch_execute(ctx, idl_input_literals)
+        else:
+            outputs = task_def.dispatch_execute(ctx, idl_input_literals)
 
         # Step3a
         if isinstance(outputs, VoidPromise):

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -158,6 +158,21 @@ class ExecutionParameters(object):
     def builder(self) -> Builder:
         return ExecutionParameters.Builder(current=self)
 
+    def __repr__(self):
+        cp = f" checkpoint={self.checkpoint}," if self._checkpoint else ""
+        return (
+            f"ExecutionParameters(execution_date={self.execution_date},"
+            f" stats={self.stats},"
+            f" tmp_dir={self.working_directory},"
+            f" execution_id={self.execution_id},"
+            f" {cp},"
+            f" decks={self.decks},"
+            f" raw_output_prefix={self.raw_output_prefix},"
+            f" task_id={self.task_id},"
+            f" output_metadata_prefix={self.output_metadata_prefix},"
+            f" enable_deck={self.enable_deck})"
+        )
+
     def __init__(
         self,
         execution_date,

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -578,7 +578,7 @@ class EagerAsyncPythonFunctionTask(AsyncPythonFunctionTask[T], metaclass=FlyteTr
                 # Note: The construction of this object is in this function because this function should be on the
                 # main thread of pyflyte-execute. It needs to be on the main thread because signal handlers can only
                 # be installed on the main thread.
-                c = Controller(remote=remote, ss=ss, tag=tag, root_tag=root_tag, exec_prefix=prefix)
+                c = Controller(remote=remote, ss=ss, tag=tag, root_tag=root_tag, exec_prefix=prefix, task_ctx=ctx)
                 handler = c.get_signal_handler()
                 signal.signal(signal.SIGINT, handler)
                 signal.signal(signal.SIGTERM, handler)

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -578,7 +578,7 @@ class EagerAsyncPythonFunctionTask(AsyncPythonFunctionTask[T], metaclass=FlyteTr
                 # Note: The construction of this object is in this function because this function should be on the
                 # main thread of pyflyte-execute. It needs to be on the main thread because signal handlers can only
                 # be installed on the main thread.
-                c = Controller(remote=remote, ss=ss, tag=tag, root_tag=root_tag, exec_prefix=prefix, task_ctx=ctx)
+                c = Controller(remote=remote, ss=ss, tag=tag, root_tag=root_tag, exec_prefix=prefix)
                 handler = c.get_signal_handler()
                 signal.signal(signal.SIGINT, handler)
                 signal.signal(signal.SIGTERM, handler)

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -456,6 +456,7 @@ class EagerAsyncPythonFunctionTask(AsyncPythonFunctionTask[T], metaclass=FlyteTr
         node_dependency_hints: Optional[
             Iterable[Union["PythonFunctionTask", "_annotated_launch_plan.LaunchPlan", WorkflowBase]]
         ] = None,
+        enable_deck: bool = True,
         **kwargs,
     ):
         # delete execution mode from kwargs
@@ -475,6 +476,7 @@ class EagerAsyncPythonFunctionTask(AsyncPythonFunctionTask[T], metaclass=FlyteTr
             PythonFunctionTask.ExecutionBehavior.EAGER,
             task_resolver,
             node_dependency_hints,
+            enable_deck=enable_deck,
             **kwargs,
         )
 

--- a/flytekit/core/worker_queue.py
+++ b/flytekit/core/worker_queue.py
@@ -318,7 +318,9 @@ class Controller:
             if len(self.entries) > 0:
                 with self.entries_lock:
                     html = self.render_html()
+                    print("Current entries: ", html, flush=True)
                     Deck("Eager Executions", html).publish()
+            print(f"published {len(self.entries)}", flush=True)
 
             # This is a blocking call so we don't hit the API too much.
             time.sleep(2)

--- a/flytekit/core/worker_queue.py
+++ b/flytekit/core/worker_queue.py
@@ -456,20 +456,19 @@ class Controller:
 
         for entity_name, items_list in self.entries.items():
             for item in items_list:
-                if not item.is_in_terminal_state:
-                    logger.warning(
-                        f"Item for {item.entity.name} with inputs {item.input_kwargs}"
-                        f" isn't ready, skipping for deck rendering..."
-                    )
-                    continue
+                exec_output = ""
+                if item.is_in_terminal_state:
+                    exec_output = item.result if item.result else item.error
+
                 kind = _entity_type(item.entity)
+
                 output = f"{output}\n" + NODE_HTML_TEMPLATE.format(
                     entity_type=kind,
                     entity_name=item.entity.name,
                     execution_name=item.wf_exec.id.name,  # type: ignore[union-attr]
                     url=self.remote.generate_console_url(item.wf_exec),
                     inputs=item.input_kwargs,
-                    outputs=item.result if item.result else item.error,
+                    outputs=exec_output,
                 )
 
         return output

--- a/flytekit/core/worker_queue.py
+++ b/flytekit/core/worker_queue.py
@@ -19,6 +19,7 @@ from flytekit.core.options import Options
 from flytekit.core.reference_entity import ReferenceEntity
 from flytekit.core.utils import _dnsify
 from flytekit.core.workflow import WorkflowBase
+from flytekit.deck.deck import Deck
 from flytekit.exceptions.system import FlyteSystemException
 from flytekit.loggers import developer_logger, logger
 from flytekit.models.common import Labels
@@ -313,6 +314,11 @@ class Controller:
 
             # Take the lock again and apply all the updates
             self._apply_updates(update_items)
+
+            if len(self.entries) > 0:
+                with self.entries_lock:
+                    html = self.render_html()
+                    Deck("Eager Executions", html)
 
             # This is a blocking call so we don't hit the API too much.
             time.sleep(2)

--- a/flytekit/core/worker_queue.py
+++ b/flytekit/core/worker_queue.py
@@ -318,7 +318,7 @@ class Controller:
             if len(self.entries) > 0:
                 with self.entries_lock:
                     html = self.render_html()
-                    Deck("Eager Executions", html)
+                    Deck("Eager Executions", html).publish()
 
             # This is a blocking call so we don't hit the API too much.
             time.sleep(2)

--- a/flytekit/core/worker_queue.py
+++ b/flytekit/core/worker_queue.py
@@ -329,8 +329,8 @@ class Controller:
                 with self.entries_lock:
                     html = self.render_html()
                     print("Current entries: ", html, flush=True)
-                    with FlyteContextManager.with_context(self.task_ctx):
-                        Deck("Eager Executions", html).publish()
+                    # FlyteContextManager.push_context(self.task_ctx)
+                    Deck("Eager Executions", html).publish()
             print(f"published {len(self.entries)}", flush=True)
 
             # This is a blocking call so we don't hit the API too much.
@@ -338,6 +338,7 @@ class Controller:
 
     def _execute(self) -> None:
         try:
+            FlyteContextManager.push_context(self.task_ctx)
             self._poll()
         except Exception as e:
             logger.error(f"Error in eager execution processor: {e}")

--- a/tests/flytekit/unit/core/test_async.py
+++ b/tests/flytekit/unit/core/test_async.py
@@ -58,3 +58,4 @@ def test_serialization():
     se_spec = get_serializable(OrderedDict(), serialization_settings, simple_eager_workflow)
     assert se_spec.template.metadata.is_eager
     assert len(se_spec.template.container.env) == 2
+    assert se_spec.template.metadata.generates_deck

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -325,3 +325,5 @@ def test_exec_params():
     )
 
     assert ep.task_id.name == "local"
+    ep_str = str(ep)
+    assert ep_str.startswith("ExecutionParameters(")


### PR DESCRIPTION
## Why are the changes needed?
To enable users to see the deck listing launched executions for eager workflows before completion.

## What changes were proposed in this pull request?
* Added and set enable_deck to eager tasks
* Added a repr to ExecutionParameters for debugging
* Updated the html generation to not skip incomplete executions
* Use the context within the FlyteRemote object for publishing the deck, since `publish()` effectively does a check on the context to make sure the task has generates_deck set to true.

## How was this patch tested?
Unit tested, with sandbox, and Union servers.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR introduces deck publishing for eager workflows with an enable_deck parameter and improved context management for HTML deck rendering. It enhances worker queue processing to publish deck information without skipping incomplete executions and adds debugging capabilities through an ExecutionParameters __repr__ method.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>