### PR TITLE
Docker Buildx support in CLI

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -7,7 +7,7 @@ import tempfile
 import warnings
 from pathlib import Path
 from string import Template
-from subprocess import run
+from subprocess import run, DEVNULL
 from typing import ClassVar, List, NamedTuple, Tuple
 
 import click
@@ -472,8 +472,16 @@ class DefaultImageBuilder(ImageSpecBuilder):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
-            create_docker_context(image_spec, tmp_path)
-            builder = "buildx" if run(["docker", "buildx", "version"]).returncode == 0 else "image"
+            create_docker_context(image_spec, tmp_path)            
+            try:
+                builder = "buildx" if run(
+                    ["docker", "buildx", "version"],
+                    stdout=DEVNULL,
+                    stderr=DEVNULL,
+                    check=True
+                ).returncode == 0 else "image"
+            except:
+                builder = "image"
 
             command = [
                 "docker",

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -7,7 +7,7 @@ import tempfile
 import warnings
 from pathlib import Path
 from string import Template
-from subprocess import run, DEVNULL
+from subprocess import run
 from typing import ClassVar, List, NamedTuple, Tuple
 
 import click
@@ -472,20 +472,10 @@ class DefaultImageBuilder(ImageSpecBuilder):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
-            create_docker_context(image_spec, tmp_path)            
-            try:
-                builder = "buildx" if run(
-                    ["docker", "buildx", "version"],
-                    stdout=DEVNULL,
-                    stderr=DEVNULL,
-                    check=True
-                ).returncode == 0 else "image"
-            except:
-                builder = "image"
+            create_docker_context(image_spec, tmp_path)
 
             command = [
                 "docker",
-                builder,
                 "build",
                 "--tag",
                 f"{image_spec.image_name()}",

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -473,10 +473,11 @@ class DefaultImageBuilder(ImageSpecBuilder):
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
             create_docker_context(image_spec, tmp_path)
+            builder = "buildx" if run(["docker", "buildx", "version"]).returncode == 0 else "image"
 
             command = [
                 "docker",
-                "image",
+                builder,
                 "build",
                 "--tag",
                 f"{image_spec.image_name()}",


### PR DESCRIPTION
## Why are the changes needed?

Pushing docker images from a local network with a bad upload speed can take forever, but buildx is capable of building docker images remotely. For a user who has buildx installed we should prefer this method rather than force them to compromise and use a different environment to use `ImageSpec`.

## What changes were proposed in this pull request?

Remove `image` from the string altogether and let docker decide for us. Users who run `docker buildx install` will automatically alias this command for them, and therefore the flyte cli.

## How was this patch tested?

I tested this patch on a system with and without buildx to verify the command's functionality persisted.

### Setup process

1. Install Docker
2. (optional) Install the buildx plugin and configure a remote driver
3. Use an existing imagespec workflow to test:
```python
from flytekit import ImageSpec

sklearn_image_spec = ImageSpec(
  packages=["scikit-learn", "tensorflow==2.5.0"],
  apt_packages=["curl", "wget"],
  registry="ghcr.io/flyteorg",
)
```

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements Docker Buildx support by updating the CLI to use remote image building capabilities. It removes the explicit 'image' flag from the default builder, allowing Docker to automatically select the appropriate builder when buildx is available. These changes improve build performance in environments with slower networks and ensure consistent behavior across different systems.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>