### PR TITLE
Adds @task(resources)

### DIFF
--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -97,7 +97,10 @@ class ContainerTask(PythonTask):
                 raise ValueError(msg)
             self._resources = ResourceSpec.from_multiple_resource(resources)
         else:
-            self._resources = ResourceSpec.from_single_resources(requests=requests, limits=limits)
+            self._resources = ResourceSpec(
+                requests=Resources() if requests is None else requests,
+                limits=Resources() if limits is None else limits,
+            )
         self.pod_template = pod_template
         self.local_logs = local_logs
 
@@ -317,18 +320,11 @@ class ContainerTask(PythonTask):
         env = {**env, **self.environment} if self.environment else env
         return _get_container_definition(
             image=self._get_image(settings),
+            resource_spec=self.resources,
             command=self._cmd,
             args=self._args,
             data_loading_config=self._get_data_loading_config(),
             environment=env,
-            ephemeral_storage_request=self.resources.requests.ephemeral_storage,
-            cpu_request=self.resources.requests.cpu,
-            gpu_request=self.resources.requests.gpu,
-            memory_request=self.resources.requests.mem,
-            ephemeral_storage_limit=self.resources.limits.ephemeral_storage,
-            cpu_limit=self.resources.limits.cpu,
-            gpu_limit=self.resources.limits.gpu,
-            memory_limit=self.resources.limits.mem,
         )
 
     def get_k8s_pod(self, settings: SerializationSettings) -> _task_model.K8sPod:

--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -60,6 +60,7 @@ class ContainerTask(PythonTask):
         pod_template: Optional["PodTemplate"] = None,
         pod_template_name: Optional[str] = None,
         local_logs: bool = False,
+        resources: Optional[Resources] = None,
         **kwargs,
     ):
         sec_ctx = None
@@ -90,9 +91,13 @@ class ContainerTask(PythonTask):
         self._outputs = outputs
         self._md_format = metadata_format
         self._io_strategy = io_strategy
-        self._resources = ResourceSpec(
-            requests=requests if requests else Resources(), limits=limits if limits else Resources()
-        )
+        if resources is not None:
+            if limits is not None or requests is not None:
+                msg = "`resource` can not be used together with the `limits` or `requests`. Please only set `resource`."
+                raise ValueError(msg)
+            self._resources = ResourceSpec.from_multiple_resource(resources)
+        else:
+            self._resources = ResourceSpec.from_single_resources(requests=requests, limits=limits)
         self.pod_template = pod_template
         self.local_logs = local_logs
 

--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -10,7 +10,7 @@ from flyteidl.core import tasks_pb2
 from flytekit.core.pod_template import PodTemplate
 from flytekit.core.resources import (
     Resources,
-    _to_resource_spec,
+    ResourceSpec,
     construct_extended_resources,
     convert_resources_to_resource_model,
 )
@@ -226,7 +226,7 @@ class Node(object):
             if limits is not None or requests is not None:
                 msg = "`resource` can not be used together with the `limits` or `requests`. Please only set `resource`."
                 raise ValueError(msg)
-            resource_spec = _to_resource_spec(resources)
+            resource_spec = ResourceSpec.from_multiple_resource(resources)
             requests = resource_spec.requests
             limits = resource_spec.limits
 

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -14,7 +14,7 @@ from flytekit.constants import CopyFileDetection
 from flytekit.core.base_task import PythonTask, TaskMetadata, TaskResolverMixin
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.pod_template import PodTemplate
-from flytekit.core.resources import Resources, ResourceSpec, _to_resource_spec, construct_extended_resources
+from flytekit.core.resources import Resources, ResourceSpec, construct_extended_resources
 from flytekit.core.tracked_abc import FlyteTrackedABC
 from flytekit.core.tracker import TrackedInstance, extract_task_module
 from flytekit.core.utils import _get_container_definition, _serialize_pod_spec, timeit
@@ -106,11 +106,9 @@ class PythonAutoContainerTask(PythonTask[T], ABC, metaclass=FlyteTrackedABC):
             if limits is not None or requests is not None:
                 msg = "`resource` can not be used together with the `limits` or `requests`. Please only set `resource`."
                 raise ValueError(msg)
-            self._resources = _to_resource_spec(resources)
+            self._resources = ResourceSpec.from_multiple_resource(resources)
         else:
-            self._resources = ResourceSpec(
-                requests=requests if requests else Resources(), limits=limits if limits else Resources()
-            )
+            self._resources = ResourceSpec.from_single_resources(requests=requests, limits=limits)
 
         # The serialization of the other tasks (Task -> protobuf), as well as the initialization of the current task, may occur simultaneously.
         # We should make sure super().__init__ is being called after setting _container_image because PythonAutoContainerTask

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -85,8 +85,8 @@ class PythonAutoContainerTask(PythonTask[T], ABC, metaclass=FlyteTrackedABC):
             to the allocated memory. If str, then the shared memory is set to that size.
         :param resources: Specify both the request and the limit. When the value is set to a tuple or list, the
             first value is the request and the second value is the limit. If the value is a single value, then both the
-            requests and limit is set to that value. For example, the `Resource(cpu=("1", "2"), mem=1024)` will set
-            the cpu request to 1, cpu limit to 2, mem limit and request to 1024.
+            requests and limit is set to that value. For example, the `Resource(cpu=("1", "2"), mem="1Gi")` will set
+            the cpu request to 1, cpu limit to 2, and mem request to 1Gi.
         """
         sec_ctx = None
         if secret_requests:

--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -14,7 +14,7 @@ from flytekit.constants import CopyFileDetection
 from flytekit.core.base_task import PythonTask, TaskMetadata, TaskResolverMixin
 from flytekit.core.context_manager import FlyteContextManager
 from flytekit.core.pod_template import PodTemplate
-from flytekit.core.resources import Resources, ResourceSpec, construct_extended_resources
+from flytekit.core.resources import Resources, ResourceSpec, _to_resource_spec, construct_extended_resources
 from flytekit.core.tracked_abc import FlyteTrackedABC
 from flytekit.core.tracker import TrackedInstance, extract_task_module
 from flytekit.core.utils import _get_container_definition, _serialize_pod_spec, timeit
@@ -53,6 +53,7 @@ class PythonAutoContainerTask(PythonTask[T], ABC, metaclass=FlyteTrackedABC):
         pod_template_name: Optional[str] = None,
         accelerator: Optional[BaseAccelerator] = None,
         shared_memory: Optional[Union[L[True], str]] = None,
+        resources: Optional[Resources] = None,
         **kwargs,
     ):
         """
@@ -82,6 +83,10 @@ class PythonAutoContainerTask(PythonTask[T], ABC, metaclass=FlyteTrackedABC):
         :param accelerator: The accelerator to use for this task.
         :param shared_memory: If True, then shared memory will be attached to the container where the size is equal
             to the allocated memory. If str, then the shared memory is set to that size.
+        :param resources: Specify both the request and the limit. When the value is set to a tuple or list, the
+            first value is the request and the second value is the limit. If the value is a single value, then both the
+            requests and limit is set to that value. For example, the `Resource(cpu=("1", "2"), mem=1024)` will set
+            the cpu request to 1, cpu limit to 2, mem limit and request to 1024.
         """
         sec_ctx = None
         if secret_requests:
@@ -96,9 +101,16 @@ class PythonAutoContainerTask(PythonTask[T], ABC, metaclass=FlyteTrackedABC):
 
         self._container_image = container_image
         # TODO(katrogan): Implement resource overrides
-        self._resources = ResourceSpec(
-            requests=requests if requests else Resources(), limits=limits if limits else Resources()
-        )
+
+        if resources is not None:
+            if limits is not None or requests is not None:
+                msg = "`resource` can not be used together with the `limits` or `requests`. Please only set `resource`."
+                raise ValueError(msg)
+            self._resources = _to_resource_spec(resources)
+        else:
+            self._resources = ResourceSpec(
+                requests=requests if requests else Resources(), limits=limits if limits else Resources()
+            )
 
         # The serialization of the other tasks (Task -> protobuf), as well as the initialization of the current task, may occur simultaneously.
         # We should make sure super().__init__ is being called after setting _container_image because PythonAutoContainerTask

--- a/flytekit/core/python_customized_container_task.py
+++ b/flytekit/core/python_customized_container_task.py
@@ -104,9 +104,7 @@ class PythonCustomizedContainerTask(ExecutableTemplateShimTask, PythonTask[TC]):
             security_ctx=sec_ctx,
             **kwargs,
         )
-        self._resources = ResourceSpec(
-            requests=requests if requests else Resources(), limits=limits if limits else Resources()
-        )
+        self._resources = ResourceSpec.from_single_resources(requests=requests, limits=limits)
         self._environment = environment or {}
         self._container_image = container_image
         self._task_resolver = task_resolver or default_task_template_resolver

--- a/flytekit/core/python_customized_container_task.py
+++ b/flytekit/core/python_customized_container_task.py
@@ -105,8 +105,7 @@ class PythonCustomizedContainerTask(ExecutableTemplateShimTask, PythonTask[TC]):
             **kwargs,
         )
         self._resources = ResourceSpec(
-            requests=Resources() if requests is None else requests,
-            limits=Resources() if limits is None else limits,
+            requests=requests if requests else Resources(), limits=limits if limits else Resources()
         )
         self._environment = environment or {}
         self._container_image = container_image

--- a/flytekit/core/python_customized_container_task.py
+++ b/flytekit/core/python_customized_container_task.py
@@ -104,7 +104,10 @@ class PythonCustomizedContainerTask(ExecutableTemplateShimTask, PythonTask[TC]):
             security_ctx=sec_ctx,
             **kwargs,
         )
-        self._resources = ResourceSpec.from_single_resources(requests=requests, limits=limits)
+        self._resources = ResourceSpec(
+            requests=Resources() if requests is None else requests,
+            limits=Resources() if limits is None else limits,
+        )
         self._environment = environment or {}
         self._container_image = container_image
         self._task_resolver = task_resolver or default_task_template_resolver
@@ -168,18 +171,11 @@ class PythonCustomizedContainerTask(ExecutableTemplateShimTask, PythonTask[TC]):
         env = {**settings.env, **self.environment} if self.environment else settings.env
         return _get_container_definition(
             image=self.get_image(settings),
+            resource_spec=self.resources,
             command=[],
             args=self.get_command(settings=settings),
             data_loading_config=None,
             environment=env,
-            ephemeral_storage_request=self.resources.requests.ephemeral_storage,
-            cpu_request=self.resources.requests.cpu,
-            gpu_request=self.resources.requests.gpu,
-            memory_request=self.resources.requests.mem,
-            ephemeral_storage_limit=self.resources.limits.ephemeral_storage,
-            cpu_limit=self.resources.limits.cpu,
-            gpu_limit=self.resources.limits.gpu,
-            memory_limit=self.resources.limits.mem,
         )
 
     def serialize_to_model(self, settings: SerializationSettings) -> _task_model.TaskTemplate:

--- a/flytekit/core/resources.py
+++ b/flytekit/core/resources.py
@@ -100,7 +100,7 @@ def _check_resource_is_singular(resource: Resources):
     for field in fields(resource):
         value = getattr(resource, field.name)
         if isinstance(value, (tuple, list)):
-            raise ValueError(f"{value} can not be a list or a tuple")
+            raise ValueError(f"{value} can not be a list or tuple")
 
 
 _ResourceName = task_models.Resources.ResourceName

--- a/flytekit/core/resources.py
+++ b/flytekit/core/resources.py
@@ -86,7 +86,8 @@ class ResourceSpec(DataClassJSONMixin):
                 if isinstance(value, (list, tuple)):
                     requests[attr], limits[attr] = value
                 else:
-                    requests[attr], limits[attr] = value, value
+                    # With a single value, only set the requests
+                    requests[attr] = value
 
         return ResourceSpec(requests=Resources(**requests), limits=Resources(**limits))
 

--- a/flytekit/core/resources.py
+++ b/flytekit/core/resources.py
@@ -109,7 +109,8 @@ class ResourceSpec(DataClassJSONMixin):
         requests = {}
         limits = {}
 
-        def _set_value(attr):
+        for field in fields(resource):
+            attr = field.name
             value = getattr(resource, attr)
             if value is not None:
                 if isinstance(value, (list, tuple)):
@@ -117,10 +118,10 @@ class ResourceSpec(DataClassJSONMixin):
                 else:
                     requests[attr], limits[attr] = value, value
 
-        for field in fields(resource):
-            _set_value(field.name)
-
-        return ResourceSpec(requests=SimpleResource(**requests), limits=SimpleResource(**limits))
+        return ResourceSpec(
+            requests=SimpleResource.from_resources(Resources(**requests)),
+            limits=SimpleResource.from_resources(Resources(**limits)),
+        )
 
 
 def _check_resource_is_singular(resource: Resources):

--- a/flytekit/core/task.py
+++ b/flytekit/core/task.py
@@ -128,6 +128,7 @@ def task(
     accelerator: Optional[BaseAccelerator] = ...,
     pickle_untyped: bool = ...,
     shared_memory: Optional[Union[L[True], str]] = None,
+    resources: Optional[Resources] = ...,
     **kwargs,
 ) -> Callable[[Callable[..., FuncOut]], PythonFunctionTask[T]]: ...
 
@@ -166,6 +167,7 @@ def task(
     accelerator: Optional[BaseAccelerator] = ...,
     pickle_untyped: bool = ...,
     shared_memory: Optional[Union[L[True], str]] = ...,
+    resources: Optional[Resources] = ...,
     **kwargs,
 ) -> Union[Callable[P, FuncOut], PythonFunctionTask[T]]: ...
 
@@ -209,6 +211,7 @@ def task(
     accelerator: Optional[BaseAccelerator] = None,
     pickle_untyped: bool = False,
     shared_memory: Optional[Union[L[True], str]] = None,
+    resources: Optional[Resources] = None,
     **kwargs,
 ) -> Union[
     Callable[P, FuncOut],
@@ -344,6 +347,10 @@ def task(
     :param pickle_untyped: Boolean that indicates if the task allows unspecified data types.
     :param shared_memory: If True, then shared memory will be attached to the container where the size is equal
         to the allocated memory. If int, then the shared memory is set to that size.
+    :param resources: Specify both the request and the limit. When the value is set to a tuple or list, the
+        first value is the request and the second value is the limit. If the value is a single value, then both the
+        requests and limit is set to that value. For example, the `Resource(cpu=("1", "2"), mem=1024)` will set the cpu
+        request to 1, cpu limit to 2, mem limit and request to 1024.
     """
     # Maintain backwards compatibility with the old cache parameters, while cleaning up the task function definition.
     cache_serialize = kwargs.get("cache_serialize")
@@ -435,6 +442,7 @@ def task(
             accelerator=accelerator,
             pickle_untyped=pickle_untyped,
             shared_memory=shared_memory,
+            resources=resources,
         )
         update_wrapper(task_instance, decorated_fn)
         return task_instance

--- a/flytekit/core/task.py
+++ b/flytekit/core/task.py
@@ -349,8 +349,8 @@ def task(
         to the allocated memory. If int, then the shared memory is set to that size.
     :param resources: Specify both the request and the limit. When the value is set to a tuple or list, the
         first value is the request and the second value is the limit. If the value is a single value, then both the
-        requests and limit is set to that value. For example, the `Resource(cpu=("1", "2"), mem=1024)` will set the cpu
-        request to 1, cpu limit to 2, mem limit and request to 1024.
+        requests and limit is set to that value. For example, the `Resource(cpu=("1", "2"), mem="1Gi")` will set the cpu
+        request to 1, cpu limit to 2, and mem request to 1Gi.
     """
     # Maintain backwards compatibility with the old cache parameters, while cleaning up the task function definition.
     cache_serialize = kwargs.get("cache_serialize")

--- a/flytekit/core/utils.py
+++ b/flytekit/core/utils.py
@@ -10,12 +10,13 @@ from abc import ABC, abstractmethod
 from functools import wraps
 from hashlib import sha224 as _sha224
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, cast
 
 from flyteidl.core import tasks_pb2 as _core_task
 
 from flytekit.configuration import SerializationSettings
 from flytekit.core.pod_template import PodTemplate
+from flytekit.core.resources import ResourceSpec, _check_resource_is_singular
 from flytekit.loggers import logger
 
 if TYPE_CHECKING:
@@ -62,27 +63,23 @@ def _dnsify(value: str) -> str:
 
 def _get_container_definition(
     image: str,
+    resource_spec: ResourceSpec,
     command: List[str],
     args: Optional[List[str]] = None,
     data_loading_config: Optional["task_models.DataLoadingConfig"] = None,
-    ephemeral_storage_request: Optional[Union[str, int]] = None,
-    cpu_request: Optional[Union[str, int, float]] = None,
-    gpu_request: Optional[Union[str, int]] = None,
-    memory_request: Optional[Union[str, int]] = None,
-    ephemeral_storage_limit: Optional[Union[str, int]] = None,
-    cpu_limit: Optional[Union[str, int, float]] = None,
-    gpu_limit: Optional[Union[str, int]] = None,
-    memory_limit: Optional[Union[str, int]] = None,
     environment: Optional[Dict[str, str]] = None,
 ) -> "task_models.Container":
-    ephemeral_storage_limit = ephemeral_storage_limit
-    ephemeral_storage_request = ephemeral_storage_request
-    cpu_limit = cpu_limit
-    cpu_request = cpu_request
-    gpu_limit = gpu_limit
-    gpu_request = gpu_request
-    memory_limit = memory_limit
-    memory_request = memory_request
+    limits = _check_resource_is_singular(resource_spec.limits)
+    requests = _check_resource_is_singular(resource_spec.requests)
+
+    ephemeral_storage_limit = limits.ephemeral_storage
+    ephemeral_storage_request = requests.ephemeral_storage
+    cpu_limit = limits.cpu
+    cpu_request = requests.cpu
+    gpu_limit = limits.gpu
+    gpu_request = requests.gpu
+    memory_limit = limits.mem
+    memory_request = requests.mem
 
     from flytekit.models import task as task_models
 

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -187,9 +187,8 @@ class FlyteFile(SerializableType, os.PathLike, typing.Generic[T], DataClassJSONM
                             )
                         ),
                         uri=self.path,
-                    ),
-                ),
-                metadata=self._metadata,
+                    )
+                )
             ),
             type(self),
         )
@@ -282,7 +281,6 @@ class FlyteFile(SerializableType, os.PathLike, typing.Generic[T], DataClassJSONM
         path: typing.Union[str, os.PathLike],
         downloader: typing.Callable = noop,
         remote_path: typing.Optional[typing.Union[os.PathLike, str, bool]] = None,
-        metadata: typing.Optional[typing.Dict[str, str]] = None,
     ):
         """
         FlyteFile's init method.
@@ -301,7 +299,6 @@ class FlyteFile(SerializableType, os.PathLike, typing.Generic[T], DataClassJSONM
         self._downloaded = False
         self._remote_path = remote_path
         self._remote_source: typing.Optional[typing.Union[str, os.PathLike]] = None
-        self._metadata = metadata
 
         # Setup local path and downloader for delayed downloading
         # We introduce another attribute self._local_path to avoid overriding user-defined self.path

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -187,8 +187,9 @@ class FlyteFile(SerializableType, os.PathLike, typing.Generic[T], DataClassJSONM
                             )
                         ),
                         uri=self.path,
-                    )
-                )
+                    ),
+                ),
+                metadata=self._metadata,
             ),
             type(self),
         )
@@ -281,6 +282,7 @@ class FlyteFile(SerializableType, os.PathLike, typing.Generic[T], DataClassJSONM
         path: typing.Union[str, os.PathLike],
         downloader: typing.Callable = noop,
         remote_path: typing.Optional[typing.Union[os.PathLike, str, bool]] = None,
+        metadata: typing.Optional[typing.Dict[str, str]] = None,
     ):
         """
         FlyteFile's init method.
@@ -299,6 +301,7 @@ class FlyteFile(SerializableType, os.PathLike, typing.Generic[T], DataClassJSONM
         self._downloaded = False
         self._remote_path = remote_path
         self._remote_source: typing.Optional[typing.Union[str, os.PathLike]] = None
+        self._metadata = metadata
 
         # Setup local path and downloader for delayed downloading
         # We introduce another attribute self._local_path to avoid overriding user-defined self.path

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -323,11 +323,11 @@ def test_input_output_dir_manipulation():
     "kwargs, expected_resource", [
         (
             {"limits": Resources(cpu=1), "requests": Resources(mem="1Gi")},
-            ResourceSpec.from_single_resources(limits=Resources(cpu=1), requests=Resources(mem="1Gi"))
+            ResourceSpec(limits=Resources(cpu=1), requests=Resources(mem="1Gi"))
         ),
         (
             {"resources": Resources(cpu=(1, 2), mem="1Gi")},
-            ResourceSpec.from_multiple_resource(Resources(cpu=(1, 2), mem="1Gi"))
+            ResourceSpec(limits=Resources(cpu=1, mem="1Gi"), requests=Resources(cpu=2, mem="1Gi"))
         )
     ]
 )

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -327,7 +327,7 @@ def test_input_output_dir_manipulation():
         ),
         (
             {"resources": Resources(cpu=(1, 2), mem="1Gi")},
-            ResourceSpec(limits=Resources(cpu=1, mem="1Gi"), requests=Resources(cpu=2, mem="1Gi"))
+            ResourceSpec(requests=Resources(cpu=1, mem="1Gi"), limits=Resources(cpu=2, mem="1Gi"))
         )
     ]
 )

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -8,7 +8,8 @@ import docker
 import pytest
 
 import flytekit
-from flytekit import ContainerTask, kwtypes, task, workflow
+from flytekit import ContainerTask, kwtypes, task, workflow, Resources
+from flytekit.core.resources import ResourceSpec
 from flytekit.types.directory import FlyteDirectory
 from flytekit.types.file import FlyteFile
 
@@ -316,3 +317,48 @@ def test_input_output_dir_manipulation():
     assert d == "hello"
     assert e == now
     assert f == datetime.timedelta(days=1, hours=3, minutes=2, seconds=3, microseconds=5)
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_resource", [
+        (
+            {"limits": Resources(cpu=1), "requests": Resources(mem="1Gi")},
+            ResourceSpec.from_single_resources(limits=Resources(cpu=1), requests=Resources(mem="1Gi"))
+        ),
+        (
+            {"resources": Resources(cpu=(1, 2), mem="1Gi")},
+            ResourceSpec.from_multiple_resource(Resources(cpu=(1, 2), mem="1Gi"))
+        )
+    ]
+)
+def test_container_task_resources(kwargs, expected_resource):
+    square = ContainerTask(
+        name="square",
+        input_data_dir="/var/inputs",
+        output_data_dir="/var/outputs",
+        inputs=kwtypes(val=int),
+        outputs=kwtypes(out=int),
+        image="alpine",
+        environment={"a": "b"},
+        command=["sh", "-c", "echo $(( {{.Inputs.val}} * {{.Inputs.val}} )) | tee /var/outputs/out"],
+        **kwargs
+    )
+
+    assert square.resources == expected_resource
+
+
+def test_container_task_resources_error():
+    msg = "`resource` can not be used together with"
+    with pytest.raises(ValueError, match=msg):
+        ContainerTask(
+            name="square",
+            input_data_dir="/var/inputs",
+            output_data_dir="/var/outputs",
+            inputs=kwtypes(val=int),
+            outputs=kwtypes(out=int),
+            image="alpine",
+            environment={"a": "b"},
+            command=["sh", "-c", "echo $(( {{.Inputs.val}} * {{.Inputs.val}} )) | tee /var/outputs/out"],
+            resources=Resources(cpu=("1", "2"), mem=(1024, 2048), gpu=1),
+            limits=Resources(cpu=1)
+        )

--- a/tests/flytekit/unit/core/test_local_raw_container.py
+++ b/tests/flytekit/unit/core/test_local_raw_container.py
@@ -327,7 +327,7 @@ def test_input_output_dir_manipulation():
         ),
         (
             {"resources": Resources(cpu=(1, 2), mem="1Gi")},
-            ResourceSpec(requests=Resources(cpu=1, mem="1Gi"), limits=Resources(cpu=2, mem="1Gi"))
+            ResourceSpec(requests=Resources(cpu=1, mem="1Gi"), limits=Resources(cpu=2))
         )
     ]
 )

--- a/tests/flytekit/unit/core/test_node_creation.py
+++ b/tests/flytekit/unit/core/test_node_creation.py
@@ -334,7 +334,6 @@ def test_map_task_resources_override_directly():
 
     assert wf_spec.template.nodes[0].array_node.node.task_node.overrides.resources.limits == [
         _resources_models.ResourceEntry(_resources_models.ResourceName.CPU, "2"),
-        _resources_models.ResourceEntry(_resources_models.ResourceName.MEMORY, "100"),
         _resources_models.ResourceEntry(_resources_models.ResourceName.EPHEMERAL_STORAGE, "1Gi"),
     ]
 
@@ -500,7 +499,6 @@ def test_void_promise_override_resource_directly():
     ]
     assert wf_spec.template.nodes[0].task_node.overrides.resources.limits == [
         _resources_models.ResourceEntry(_resources_models.ResourceName.CPU, "2"),
-        _resources_models.ResourceEntry(_resources_models.ResourceName.MEMORY, "100"),
     ]
 
 

--- a/tests/flytekit/unit/core/test_resources.py
+++ b/tests/flytekit/unit/core/test_resources.py
@@ -23,6 +23,16 @@ def test_convert_no_requests_no_limits():
     assert resource_model.limits == []
 
 
+@pytest.mark.parametrize("kwargs", [
+    {"requests": Resources(cpu=[1, 2])},
+    {"limits": Resources(mem=[1, 2])}
+])
+def test_convert_tuple_request(kwargs):
+    msg = "can not be a list or tuple"
+    with pytest.raises(ValueError, match=msg):
+        convert_resources_to_resource_model(**kwargs)
+
+
 @pytest.mark.parametrize(
     argnames=("resource_dict", "expected_resource_name"),
     argvalues=(
@@ -212,3 +222,13 @@ def test_construct_extended_resources_shared_memory_none(shared_memory):
 def test_construct_extended_resources_shared_memory(shared_memory, expected_size_limit):
     resources = construct_extended_resources(shared_memory=shared_memory)
     assert resources.shared_memory.size_limit == expected_size_limit
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"requests": Resources(cpu=[1, 2])},
+    {"limits": Resources(mem=[1, 2])}
+])
+def test_pod_spec_from_resources_error(kwargs):
+    msg = "can not be a list or tuple"
+    with pytest.raises(ValueError, match=msg):
+        pod_spec_from_resources(primary_container_name="primary", **kwargs)

--- a/tests/flytekit/unit/core/test_resources.py
+++ b/tests/flytekit/unit/core/test_resources.py
@@ -10,6 +10,7 @@ from flytekit.core.resources import (
     pod_spec_from_resources,
     convert_resources_to_resource_model,
     construct_extended_resources,
+    _to_resource_spec,
 )
 from flytekit.extras.accelerators import T4
 
@@ -130,7 +131,7 @@ def test_incorrect_type_resources():
     ]
 )
 def test_to_resource_spec(resource, expected_spec):
-    assert resource.to_resource_spec() == expected_spec
+    assert _to_resource_spec(resource) == expected_spec
 
 
 def test_resources_serialization():

--- a/tests/flytekit/unit/core/test_resources.py
+++ b/tests/flytekit/unit/core/test_resources.py
@@ -10,7 +10,6 @@ from flytekit.core.resources import (
     pod_spec_from_resources,
     convert_resources_to_resource_model,
     construct_extended_resources,
-    _to_resource_spec,
 )
 from flytekit.extras.accelerators import T4
 
@@ -101,37 +100,37 @@ def test_incorrect_type_resources():
 
 @pytest.mark.parametrize(
     "resource, expected_spec", [
-        (Resources(cpu=[1, 2]), ResourceSpec(requests=Resources(cpu=1), limits=Resources(cpu=2))),
+        (Resources(cpu=[1, 2]), ResourceSpec.from_single_resources(requests=Resources(cpu=1), limits=Resources(cpu=2))),
         (
             Resources(mem=["1Gi", "4Gi"]),
-            ResourceSpec(requests=Resources(mem="1Gi"), limits=Resources(mem="4Gi"))
+            ResourceSpec.from_single_resources(requests=Resources(mem="1Gi"), limits=Resources(mem="4Gi"))
         ),
-        (Resources(gpu=[1, 2]), ResourceSpec(requests=Resources(gpu=1), limits=Resources(gpu=2))),
+        (Resources(gpu=[1, 2]), ResourceSpec.from_single_resources(requests=Resources(gpu=1), limits=Resources(gpu=2))),
         (
             Resources(cpu="1", mem=[1024, 2058], ephemeral_storage="2Gi"),
-            ResourceSpec(
+            ResourceSpec.from_single_resources(
                 requests=Resources(cpu="1", mem=1024, ephemeral_storage="2Gi"),
                 limits=Resources(cpu="1", mem=2058, ephemeral_storage="2Gi")
             )
         ),
         (
             Resources(cpu="10", mem=1024, ephemeral_storage="2Gi", gpu=1),
-            ResourceSpec(
+            ResourceSpec.from_single_resources(
                 requests=Resources(cpu="10", mem=1024, ephemeral_storage="2Gi", gpu=1),
                 limits=Resources(cpu="10", mem=1024, ephemeral_storage="2Gi", gpu=1)
             )
         ),
         (
             Resources(ephemeral_storage="2Gi"),
-            ResourceSpec(
+            ResourceSpec.from_single_resources(
                 requests=Resources(ephemeral_storage="2Gi"),
                 limits=Resources(ephemeral_storage="2Gi")
             )
          ),
     ]
 )
-def test_to_resource_spec(resource, expected_spec):
-    assert _to_resource_spec(resource) == expected_spec
+def test_to_resource_spec(resource: Resources, expected_spec: ResourceSpec):
+    assert ResourceSpec.from_multiple_resource(resource) == expected_spec
 
 
 def test_resources_serialization():

--- a/tests/flytekit/unit/core/test_resources.py
+++ b/tests/flytekit/unit/core/test_resources.py
@@ -110,21 +110,21 @@ def test_incorrect_type_resources():
             Resources(cpu="1", mem=[1024, 2058], ephemeral_storage="2Gi"),
             ResourceSpec(
                 requests=Resources(cpu="1", mem=1024, ephemeral_storage="2Gi"),
-                limits=Resources(cpu="1", mem=2058, ephemeral_storage="2Gi")
+                limits=Resources(mem=2058)
             )
         ),
         (
             Resources(cpu="10", mem=1024, ephemeral_storage="2Gi", gpu=1),
             ResourceSpec(
                 requests=Resources(cpu="10", mem=1024, ephemeral_storage="2Gi", gpu=1),
-                limits=Resources(cpu="10", mem=1024, ephemeral_storage="2Gi", gpu=1)
+                limits=Resources()
             )
         ),
         (
             Resources(ephemeral_storage="2Gi"),
             ResourceSpec(
                 requests=Resources(ephemeral_storage="2Gi"),
-                limits=Resources(ephemeral_storage="2Gi")
+                limits=Resources()
             )
          ),
     ]

--- a/tests/flytekit/unit/core/test_resources.py
+++ b/tests/flytekit/unit/core/test_resources.py
@@ -100,29 +100,29 @@ def test_incorrect_type_resources():
 
 @pytest.mark.parametrize(
     "resource, expected_spec", [
-        (Resources(cpu=[1, 2]), ResourceSpec.from_single_resources(requests=Resources(cpu=1), limits=Resources(cpu=2))),
+        (Resources(cpu=[1, 2]), ResourceSpec(requests=Resources(cpu=1), limits=Resources(cpu=2))),
         (
             Resources(mem=["1Gi", "4Gi"]),
-            ResourceSpec.from_single_resources(requests=Resources(mem="1Gi"), limits=Resources(mem="4Gi"))
+            ResourceSpec(requests=Resources(mem="1Gi"), limits=Resources(mem="4Gi"))
         ),
-        (Resources(gpu=[1, 2]), ResourceSpec.from_single_resources(requests=Resources(gpu=1), limits=Resources(gpu=2))),
+        (Resources(gpu=[1, 2]), ResourceSpec(requests=Resources(gpu=1), limits=Resources(gpu=2))),
         (
             Resources(cpu="1", mem=[1024, 2058], ephemeral_storage="2Gi"),
-            ResourceSpec.from_single_resources(
+            ResourceSpec(
                 requests=Resources(cpu="1", mem=1024, ephemeral_storage="2Gi"),
                 limits=Resources(cpu="1", mem=2058, ephemeral_storage="2Gi")
             )
         ),
         (
             Resources(cpu="10", mem=1024, ephemeral_storage="2Gi", gpu=1),
-            ResourceSpec.from_single_resources(
+            ResourceSpec(
                 requests=Resources(cpu="10", mem=1024, ephemeral_storage="2Gi", gpu=1),
                 limits=Resources(cpu="10", mem=1024, ephemeral_storage="2Gi", gpu=1)
             )
         ),
         (
             Resources(ephemeral_storage="2Gi"),
-            ResourceSpec.from_single_resources(
+            ResourceSpec(
                 requests=Resources(ephemeral_storage="2Gi"),
                 limits=Resources(ephemeral_storage="2Gi")
             )

--- a/tests/flytekit/unit/core/test_task.py
+++ b/tests/flytekit/unit/core/test_task.py
@@ -22,8 +22,12 @@ def test_task_resources():
     def my_task():
         pass
 
-    assert my_task.resources.requests == Resources(cpu="1", mem=1024, gpu=1)
-    assert my_task.resources.limits == Resources(cpu="2", mem=2048, gpu=1)
+    assert my_task.resources.requests.cpu == "1"
+    assert my_task.resources.requests.mem == 1024
+    assert my_task.resources.requests.gpu == 1
+    assert my_task.resources.limits.cpu == "2"
+    assert my_task.resources.limits.mem == 2048
+    assert my_task.resources.limits.gpu == 1
 
 
 def test_task_resources_error():

--- a/tests/flytekit/unit/core/test_task.py
+++ b/tests/flytekit/unit/core/test_task.py
@@ -1,5 +1,6 @@
 import pytest
 
+from flytekit import task, Resources
 from flytekit.core.task import decorate_function
 from flytekit.core.utils import str2bool
 from flytekit.interactive import vscode
@@ -13,3 +14,21 @@ def test_decorate_python_task(monkeypatch: pytest.MonkeyPatch):
     assert decorate_function(t1) is t1
     monkeypatch.setenv(FLYTE_ENABLE_VSCODE_KEY, str2bool("True"))
     assert isinstance(decorate_function(t1), vscode)
+
+
+def test_task_resources():
+
+    @task(resources=Resources(cpu=("1", "2"), mem=(1024, 2048), gpu=1))
+    def my_task():
+        pass
+
+    assert my_task.resources.requests == Resources(cpu="1", mem=1024, gpu=1)
+    assert my_task.resources.limits == Resources(cpu="2", mem=2048, gpu=1)
+
+
+def test_task_resources_error():
+    msg = "`resource` can not be used together with"
+    with pytest.raises(ValueError, match=msg):
+        @task(resources=Resources(cpu=("1", "2"), mem=(1024, 2048)), gpu=1, limits=Resources(cpu=1))
+        def my_task():
+            pass

--- a/tests/flytekit/unit/core/test_task.py
+++ b/tests/flytekit/unit/core/test_task.py
@@ -22,12 +22,8 @@ def test_task_resources():
     def my_task():
         pass
 
-    assert my_task.resources.requests.cpu == "1"
-    assert my_task.resources.requests.mem == 1024
-    assert my_task.resources.requests.gpu == 1
-    assert my_task.resources.limits.cpu == "2"
-    assert my_task.resources.limits.mem == 2048
-    assert my_task.resources.limits.gpu == 1
+    assert my_task.resources.requests == Resources(cpu="1", mem=1024, gpu=1)
+    assert my_task.resources.limits == Resources(cpu="2", mem=2048)
 
 
 def test_task_resources_error():

--- a/tests/flytekit/unit/core/test_type_hints.py
+++ b/tests/flytekit/unit/core/test_type_hints.py
@@ -2201,6 +2201,20 @@ def test_promise_illegal_resources():
         my_wf(a=1)
 
 
+def test_promise_illegal_resource_combination():
+
+    @task
+    def t1(a: int) -> int:
+        return a + 1
+
+    @workflow
+    def my_wf(a: int) -> int:
+        return t1(a=a).with_overrides(requests=Resources(cpu=1), resources=Resources(cpu=[1, 2]))
+
+    with pytest.raises(ValueError):
+        my_wf(a=1)
+
+
 def test_promise_illegal_retries():
     @task
     def t1(a: int) -> int:


### PR DESCRIPTION
## Tracking issue
Related to https://github.com/flyteorg/flyte/issues/6142

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
Setting request and limits is directly is very verbose. With this PR we can do this:

```python
@task(resources=Resources(cpu=(1, 2), mem="1Gi"))
def my_task():
    ...
```

The above will set the cpu request to 1, cpu limit to 2 and the memory request to 1Gi.

Note this has basically the same API as modal: https://modal.com/docs/guide/resources

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
This PR adds support for tuples and list and `Resources`. Which means `Resources` is extended to define both the request and limits. This PR also adds checks to make sure functions that expected resources to be singular raise an error.

Also, we also raise an error if `limits` or `requests` is used together with `resources` in `@task`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit tests were added to this PR. 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances Flyte's resource management by adding support for tuple/list specifications and refactoring the resource specification API for more intuitive usage. It updates resource configuration examples across Flytekit components to consistently use '1Gi' format for memory specifications instead of integers. The changes enforce stricter validation, streamline assertions, and ensure proper parameter usage for better API usability.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 3
</div>