### PR TITLE
Install the dependencies in the default venv in the spark base image

### DIFF
--- a/flytekit/image_spec/__init__.py
+++ b/flytekit/image_spec/__init__.py
@@ -19,4 +19,4 @@ from .default_builder import DefaultImageBuilder
 from .image_spec import ImageBuildEngine, ImageSpec
 
 # Set this to a lower priority compared to `envd` to maintain backward compatibility
-ImageBuildEngine.register("default", DefaultImageBuilder(), priority=1)
+ImageBuildEngine.register(DefaultImageBuilder.builder_type, DefaultImageBuilder(), priority=1)

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -425,6 +425,8 @@ def create_docker_context(image_spec: ImageSpec, tmp_dir: Path):
 class DefaultImageBuilder(ImageSpecBuilder):
     """Image builder using Docker and buildkit."""
 
+    builder_type = "default"
+
     _SUPPORTED_IMAGE_SPEC_PARAMETERS: ClassVar[set] = {
         "id",
         "name",

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -116,6 +116,7 @@ class ImageSpec:
 
         builder_registry = ImageBuildEngine.get_registry()
         if self.builder is None and builder_registry:
+            # Use the builder with the highest priority by default
             self.builder = max(builder_registry, key=lambda name: builder_registry[name][1])
 
         parameters_str_list = [

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -114,6 +114,10 @@ class ImageSpec:
         if self.source_root is not None:
             self.source_copy_mode = self.source_copy_mode or CopyFileDetection.LOADED_MODULES
 
+        builder_registry = ImageBuildEngine.get_registry()
+        if self.builder is None and builder_registry:
+            self.builder = max(builder_registry, key=lambda name: builder_registry[name][1])
+
         parameters_str_list = [
             "packages",
             "conda_channels",
@@ -440,6 +444,10 @@ class ImageBuildEngine:
         cls._REGISTRY[builder_type] = (image_spec_builder, priority)
 
     @classmethod
+    def get_registry(cls) -> Dict[str, Tuple[ImageSpecBuilder, int]]:
+        return cls._REGISTRY
+
+    @classmethod
     @lru_cache
     def build(cls, image_spec: ImageSpec):
         from flytekit.core.context_manager import FlyteContextManager
@@ -455,13 +463,8 @@ class ImageBuildEngine:
             cls.build(spec.base_image)
             spec.base_image = spec.base_image.image_name()
 
-        if spec.builder is None and cls._REGISTRY:
-            builder = max(cls._REGISTRY, key=lambda name: cls._REGISTRY[name][1])
-        else:
-            builder = spec.builder
-
         img_name = spec.image_name()
-        img_builder = cls._get_builder(builder)
+        img_builder = cls._get_builder(spec.builder)
         if img_builder.should_build(spec):
             fully_qualified_image_name = img_builder.build_image(spec)
             if fully_qualified_image_name is not None:

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -13,7 +13,6 @@ from flytekit.core.context_manager import ExecutionParameters
 from flytekit.extend import ExecutionState, TaskPlugins
 from flytekit.extend.backend.base_agent import AsyncAgentExecutorMixin
 from flytekit.image_spec import ImageSpec
-from flytekit.image_spec.image_spec import ImageBuildEngine
 
 from .models import SparkJob, SparkType
 
@@ -142,8 +141,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
             if container_image.base_image is None:
                 img = f"cr.flyte.org/flyteorg/flytekit:spark-{DefaultImages.get_version_suffix()}"
                 self._container_image = dataclasses.replace(container_image, base_image=img)
-                builder = ImageBuildEngine._get_builder(container_image.builder)
-                if builder == "default":
+                if container_image.builder == "default":
                     # Install the dependencies in the default venv in the spark base image
                     self._container_image = dataclasses.replace(container_image, python_exec="/usr/bin/python3")
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -13,6 +13,7 @@ from flytekit.core.context_manager import ExecutionParameters
 from flytekit.extend import ExecutionState, TaskPlugins
 from flytekit.extend.backend.base_agent import AsyncAgentExecutorMixin
 from flytekit.image_spec import ImageSpec
+from flytekit.image_spec.image_spec import ImageBuildEngine
 
 from .models import SparkJob, SparkType
 
@@ -141,6 +142,11 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
             if container_image.base_image is None:
                 img = f"cr.flyte.org/flyteorg/flytekit:spark-{DefaultImages.get_version_suffix()}"
                 self._container_image = dataclasses.replace(container_image, base_image=img)
+                builder = ImageBuildEngine._get_builder(container_image.builder)
+                if builder == "default":
+                    # Install the dependencies in the default venv in the spark base image
+                    self._container_image = dataclasses.replace(container_image, python_exec="/usr/bin/python3")
+
                 # default executor path and applications path in apache/spark-py:3.3.1
                 self._default_executor_path = self._default_executor_path or "/usr/bin/python3"
                 self._default_applications_path = (

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -12,7 +12,7 @@ from flytekit.configuration import DefaultImages, SerializationSettings
 from flytekit.core.context_manager import ExecutionParameters
 from flytekit.extend import ExecutionState, TaskPlugins
 from flytekit.extend.backend.base_agent import AsyncAgentExecutorMixin
-from flytekit.image_spec import ImageSpec
+from flytekit.image_spec import DefaultImageBuilder, ImageSpec
 
 from .models import SparkJob, SparkType
 
@@ -141,7 +141,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
             if container_image.base_image is None:
                 img = f"cr.flyte.org/flyteorg/flytekit:spark-{DefaultImages.get_version_suffix()}"
                 self._container_image = dataclasses.replace(container_image, base_image=img)
-                if container_image.builder == "default":
+                if container_image.builder == DefaultImageBuilder.builder_type:
                     # Install the dependencies in the default venv in the spark base image
                     self._container_image = dataclasses.replace(container_image, python_exec="/usr/bin/python3")
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -56,7 +56,7 @@ class Databricks(Spark):
     databricks_instance: Optional[str] = None
 
     def __post_init__(self):
-        logger.warn(
+        logger.warning(
             "Databricks is deprecated. Use 'from flytekitplugins.spark import Databricks' instead,"
             "and make sure to upgrade the version of flyteagent deployment to >v1.13.0.",
         )
@@ -143,7 +143,7 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
                 self._container_image = dataclasses.replace(container_image, base_image=img)
                 if container_image.builder == DefaultImageBuilder.builder_type:
                     # Install the dependencies in the default venv in the spark base image
-                    self._container_image = dataclasses.replace(container_image, python_exec="/usr/bin/python3")
+                    self._container_image = dataclasses.replace(self._container_image, python_exec="/usr/bin/python3")
 
                 # default executor path and applications path in apache/spark-py:3.3.1
                 self._default_executor_path = self._default_executor_path or "/usr/bin/python3"

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -91,10 +91,7 @@ def test_image_spec(mock_image_spec_builder, monkeypatch):
 
 
 def test_image_spec_engine_priority():
-    image_spec = ImageSpec(name="FLYTEKIT")
-    image_name = image_spec.image_name()
-
-    new_image_name = f"fqn.xyz/{image_name}"
+    new_image_name = "fqn.xyz/flytekit"
     mock_image_builder_10 = Mock()
     mock_image_builder_10.build_image.return_value = new_image_name
     mock_image_builder_default = Mock()
@@ -102,6 +99,8 @@ def test_image_spec_engine_priority():
 
     ImageBuildEngine.register("build_10", mock_image_builder_10, priority=10)
     ImageBuildEngine.register("build_default", mock_image_builder_default)
+
+    image_spec = ImageSpec(name="FLYTEKIT")
 
     ImageBuildEngine.build(image_spec)
     mock_image_builder_10.build_image.assert_called_once_with(image_spec)


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
The default builder creates another Python venv in the image. The driver is using the venv (python3.11) that was created from the default builder, and the worker is using the default venv (python3.9) in the base image

## What changes were proposed in this pull request?
Always install the dependencies in the default venv in the spark base image.

## How was this patch tested?
```python
from operator import add

import flytekit
from flytekit import ImageSpec, Resources, task, workflow, dynamic
from flytekitplugins.spark import Spark
from utils import f

container_image = ImageSpec(
    # name="inrix_onboarding",
    registry="pingsutw",
    packages=["flytekitplugins-spark==1.15.1b0", "numpy"],
    builder="default",
)


@task(
    task_config=Spark(
        # This configuration is applied to the Spark cluster
        spark_conf={
            "spark.driver.memory": "1000M",
            "spark.executor.memory": "2000M",
            "spark.executor.cores": "1",
            "spark.executor.instances": "5",
            "spark.driver.cores": "2",
        },
        executor_path="/usr/bin/python3",
        applications_path="local:///usr/local/bin/entrypoint.py",
    ),
    # requests=Resources(cpu="2", mem="3000Mi"),
    # limits=Resources(cpu="3", mem="5000Mi"),
    container_image=container_image,
)
def hello_spark(partitions: int) -> float:
    print("Starting Spark with Partitions:! {}".format(partitions))

    n = 1 * partitions
    sess = flytekit.current_context().spark_session
    count = (
        sess.sparkContext.parallelize(range(1, n + 1), partitions).map(f).reduce(add)
    )
    print("Im done")
    pi_val = 4.0 * count / n
    return pi_val


@task(container_image=container_image)
def print_every_time(value_to_print: float):
    print("My printed value: {}".format(value_to_print))


@workflow
def wf(partitions: int = 10000) -> float:
    pi = hello_spark(partitions=partitions)
    print_every_time(value_to_print=pi)
    return pi
``` 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR refactors the image builder implementation across the codebase, introducing a builder_type attribute and registry method. It updates the Spark task module by fixing deprecated logging methods and ensuring proper container image references. The test suite was updated to reflect a new image naming approach and validate image spec engine priority, aligning dependency installation with the default virtual environment.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>