### PR TITLE
check execution phase before access outputs

### DIFF
--- a/flytekit/remote/executions.py
+++ b/flytekit/remote/executions.py
@@ -150,6 +150,13 @@ class FlyteWorkflowExecution(RemoteExecutionBase, execution_models.Execution):
         }
 
     @property
+    def is_successful(self) -> bool:
+        """
+        Whether or not the execution is successful.
+        """
+        return self.closure.phase == core_execution_models.WorkflowExecutionPhase.SUCCEEDED
+
+    @property
     def outputs(self) -> Optional[LiteralsResolver]:
         outputs = super().outputs
         if outputs and self._type_hints:

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2562,7 +2562,8 @@ class FlyteRemote(object):
             if launched_exec.is_done:
                 # The synced underlying execution should've had these populated.
                 execution._inputs = launched_exec.inputs
-                execution._outputs = launched_exec.outputs
+                if launched_exec.is_successful:
+                    execution._outputs = launched_exec.outputs
             execution._workflow_executions.append(launched_exec)
             execution._interface = launched_exec._flyte_workflow.interface
             return execution


### PR DESCRIPTION
## Why are the changes needed?
Currently if we sync an execution which contains a launch plan, the sync would fail if the execution failed. This is because we didn't check the execution phase before access the outputs.

## What changes were proposed in this pull request?
Check if the execution is successful before access the output.

## How was this patch tested?
Tested with
```python
from flytekit import workflow, task, LaunchPlan

@task()
def print_head(a: int) -> int:
    print(1 / 1)
    return a + 1


@workflow()
def easy_execution(b: int) -> int:
    return print_head(a=b)


lp = LaunchPlan.create(name="lp-easy-execution", workflow=easy_execution)


@workflow()
def master(a: int) -> int:
    return lp(b=a)
```
```python
r = FlyteRemote()
a = r.sync(exec, sync_nodes=True)
```
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes a critical bug where output access could fail for unsuccessful executions. It adds a new property to verify execution phase and updates remote logic to check execution success before accessing outputs, preventing synchronization failures from premature output access.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>