### PR TITLE
Deprecate `increase_shared_mem` flag in flytekitplugins-kf-pytorch in favor of new native `@task` argument

### DIFF
--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/pod_template.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/pod_template.py
@@ -9,8 +9,9 @@ def add_shared_mem_volume_to_pod_template(pod_template: PodTemplate) -> None:
     """Add shared memory volume and volume mount to the pod template."""
 
     warn(
-        "Configuring shared memory via `@task(task_config=Elastic(increase_shared_mem=True))` or "
-        "`PyTorch(increase_shared_mem=True)` is deprecated. Use `@task(shared_memory=...)` instead."
+        "Configuring shared memory via `@task(task_config=Elastic(..., increase_shared_mem=True))` or "
+        "`PyTorch(..., increase_shared_mem=True)` is deprecated. Use `@task(shared_memory=True, task_config="
+        "Elastic(..., increase_shared_mem=False)` instead."
     )
 
     mount_path = "/dev/shm"

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/pod_template.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/pod_template.py
@@ -1,3 +1,5 @@
+from warnings import warn
+
 from kubernetes.client import V1Container, V1EmptyDirVolumeSource, V1PodSpec, V1Volume, V1VolumeMount
 
 from flytekit.core.pod_template import PodTemplate
@@ -5,6 +7,12 @@ from flytekit.core.pod_template import PodTemplate
 
 def add_shared_mem_volume_to_pod_template(pod_template: PodTemplate) -> None:
     """Add shared memory volume and volume mount to the pod template."""
+
+    warn(
+        "Configuring shared memory via `@task(task_config=Elastic(increase_shared_mem=True))` or "
+        "`PyTorch(increase_shared_mem=True)` is deprecated. Use `@task(shared_memory=...)` instead."
+    )
+
     mount_path = "/dev/shm"
     shm_volume = V1Volume(name="shm", empty_dir=V1EmptyDirVolumeSource(medium="Memory"))
     shm_volume_mount = V1VolumeMount(name="shm", mount_path=mount_path)

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/pod_template.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/pod_template.py
@@ -10,8 +10,7 @@ def add_shared_mem_volume_to_pod_template(pod_template: PodTemplate) -> None:
 
     warn(
         "Configuring shared memory via `@task(task_config=Elastic(..., increase_shared_mem=True))` or "
-        "`PyTorch(..., increase_shared_mem=True)` is deprecated. Use `@task(shared_memory=True, task_config="
-        "Elastic(..., increase_shared_mem=False)` instead."
+        "`PyTorch(..., increase_shared_mem=True)` is deprecated. Use `@task(shared_memory=True)` instead."
     )
 
     mount_path = "/dev/shm"

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -191,7 +191,8 @@ class PyTorchFunctionTask(PythonFunctionTask[PyTorch]):
             task_type_version=1,
             **kwargs,
         )
-        if self.task_config.increase_shared_mem:
+
+        if self.task_config.increase_shared_mem and (self.shared_memory is False or self.shared_memory is None):
             if self.pod_template is None:
                 self.pod_template = PodTemplate()
             add_shared_mem_volume_to_pod_template(self.pod_template)
@@ -338,7 +339,7 @@ class PytorchElasticFunctionTask(PythonFunctionTask[Elastic]):
         """
         self.rdzv_backend = "c10d"
 
-        if self.task_config.increase_shared_mem:
+        if self.task_config.increase_shared_mem and (self.shared_memory is False or self.shared_memory is None):
             if self.pod_template is None:
                 self.pod_template = PodTemplate()
             add_shared_mem_volume_to_pod_template(self.pod_template)

--- a/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
+++ b/plugins/flytekit-kf-pytorch/flytekitplugins/kfpytorch/task.py
@@ -106,7 +106,8 @@ class PyTorch(object):
         worker: Configuration for the worker replica group.
         run_policy: Configuration for the run policy.
         num_workers: [DEPRECATED] This argument is deprecated. Use `worker.replicas` instead.
-        increase_shared_mem (bool): PyTorch uses shared memory to share data between processes. If torch multiprocessing is used
+        increase_shared_mem (bool): [DEPRECATED] This argument is deprecated. Use `@task(shared_memory=...)` instead.
+            PyTorch uses shared memory to share data between processes. If torch multiprocessing is used
             (e.g. for multi-processed data loaders) the default shared memory segment size that the container runs with might not be enough
             and and one might have to increase the shared memory size. This option configures the task's pod template to mount
             an `emptyDir` volume with medium `Memory` to to `/dev/shm`.
@@ -146,7 +147,8 @@ class Elastic(object):
             Default timeouts are set to 15 minutes to account for the fact that some workers might start faster than others: Some pods might
             be assigned to a running node which might have the image in its cache while other workers might require a node scale up and image pull.
 
-        increase_shared_mem (bool): PyTorch uses shared memory to share data between processes. If torch multiprocessing is used
+        increase_shared_mem (bool): [DEPRECATED] This argument is deprecated. Use `@task(shared_memory=...)` instead.
+            PyTorch uses shared memory to share data between processes. If torch multiprocessing is used
             (e.g. for multi-processed data loaders) the default shared memory segment size that the container runs with might not be enough
             and and one might have to increase the shared memory size. This option configures the task's pod template to mount
             an `emptyDir` volume with medium `Memory` to to `/dev/shm`.

--- a/plugins/flytekit-kf-pytorch/tests/test_shared.py
+++ b/plugins/flytekit-kf-pytorch/tests/test_shared.py
@@ -136,3 +136,29 @@ def test_task_shared_memory(
 
             assert no_shm_volume_condition
             assert no_shm_volume_mount_condition
+
+
+def test_native_task_arg():
+    """Test that no shared memory volume mount is added if it is configured via the task decorator itself."""
+
+    @task(
+        # Has precedence ...
+        shared_memory=True,
+        # ... over this
+        task_config=Elastic(nnodes=2, increase_shared_mem=True),
+    )
+    def test_task() -> None:
+        pass
+
+    assert test_task.pod_template is None
+
+    @task(
+        # Has precedence ...
+        shared_memory=True,
+        # ... over this
+        task_config=PyTorch(num_workers=3, increase_shared_mem=True),
+    )
+    def test_task_pytorch() -> None:
+        pass
+
+    assert test_task_pytorch.pod_template is None


### PR DESCRIPTION
https://github.com/flyteorg/flytekit/pull/2543 introduced a convenience flag `increase_shared_mem` to the task configs provided by the kfpytorch plugins (`PyTorch` and `Elastic`). If specified, a shared memory volume mount is added to the pod template under the hood.

The flytekit 1.15.0 release introduced a similar flag to the `@task` decorator itself. Instead of using the pod template to configure the volume mount on the flytekit side, there is [proper support in flyteidl ](https://github.com/flyteorg/flyte/blob/b779bed928e4fbc914ab64b51940d861ffbc968d/flyteidl/protos/flyteidl/core/tasks.proto#L82) and the volume mount is added in flytepropeller.

The flag on the `@task` level also works for the distributed kfpytorch plugin task types which means there are now two ways to increase shared memory for pytorch jobs.

Let's mark the kfpytorch-plugin specific mechanism as deprecated so that users switch to the native one and we can eventually delete this code.

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR deprecates the increase_shared_mem flag in kfpytorch plugin, directing users to use the native @task(shared_memory=...) functionality instead. It updates deprecation messages, refines condition checks in pod templates and task implementations, and adds tests to verify that the shared_memory flag takes precedence correctly. Warning messages and updated docstrings have been added to alert users about this deprecation.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>