### PR TITLE
Eager run

### DIFF
--- a/flytekit/core/worker_queue.py
+++ b/flytekit/core/worker_queue.py
@@ -398,6 +398,7 @@ class Controller:
                 image_config=self.ss.image_config,
                 options=options,
                 envs=e,
+                serialization_settings=self.ss,
             )
             return wf_exec
         else:

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2179,9 +2179,6 @@ class FlyteRemote(object):
             if self.interactive_mode_enabled:
                 ss.fast_serialization_settings = self._pickle_and_upload_entity(entity, pickled_target_dict)
 
-            # TODO: If this is being registered from eager, it will not reflect the full serialization settings
-            #   object (look into the function, the passed in ss is basically ignored). How should it be piped in?
-            #   https://github.com/flyteorg/flyte/issues/6070
             flyte_task: FlyteTask = self.register_task(entity, ss, version)
 
         return self.execute(

--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -143,9 +143,9 @@ def get_serializable_task(
                 if isinstance(e.container_image, ImageSpec):
                     if settings.image_config.images is None:
                         settings.image_config = ImageConfig.create_from(settings.image_config.default_image)
-                    settings.image_config.images.append(
-                        Image.look_up_image_info(e.container_image.id, e.get_image(settings))
-                    )
+                    img = Image.look_up_image_info(e.container_image.id, e.get_image(settings))
+                    if img not in settings.image_config.images:
+                        settings.image_config.images.append(img)
 
         # In case of Dynamic tasks, we want to pass the serialization context, so that they can reconstruct the state
         # from the serialization context. This is passed through an environment variable, that is read from

--- a/tests/flytekit/unit/core/test_worker_queue.py
+++ b/tests/flytekit/unit/core/test_worker_queue.py
@@ -64,11 +64,12 @@ def test_controller_launch(mock_thread_target):
             image_config,
             options,
             envs,
+            serialization_settings,
     ):
         assert entity is t2
         assert execution_name.startswith("e-unit-test-t2-")
         assert envs == {'_F_EE_ROOT': 'exec-id'}
-        print(entity, execution_name, inputs, version, image_config, options, envs)
+        assert serialization_settings == ss
         return wf_exec
 
     remote = mock.MagicMock()


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/6070

## Why are the changes needed?
This is a bit of a stop-gap change to allow users to call `pyflyte run` on an eager task.  Eager tasks are still tasks, which means their contents (i.e. what other flyte entities they call) are not known at compile time.  This means that those tasks are not registered, and are registered instead at run-time, by the eager task itself.  However FlyteRemote did not allow the eager controller to properly pass in the stored serialization settings.

Why the stop-gap qualification?  This change is required regardless, but we should additionally change `pyflyte run` to detect an eager task target, _not_ run the requested eager task, and instead run the corresponding workflow replete with the failure node/failure handler task. 

## What changes were proposed in this pull request?
* Add a `serialization_settings` field to the remote.execute function and pass it downstream where appropriate (local entities)


## How was this patch tested?
Tested on sandbox and Union internal clusters.


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances serialization settings handling for eager tasks by adding an optional serialization_settings parameter across FlyteRemote and related modules. It includes improved documentation, code refactoring for default settings application, and test adjustments to address configuration propagation issues identified in #6070.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>