### PR TITLE
Do not set group or group_version when secret_requires_group=False

### DIFF
--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -405,12 +405,6 @@ class SecretsManager(object):
         Retrieves a secret using the resolution order -> Env followed by file. If not found raises a ValueError
         param encode_mode, defines the mode to open files, it can either be "r" to read file, or "rb" to read binary file
         """
-
-        from flytekit.configuration.plugin import get_plugin
-
-        if not get_plugin().secret_requires_group():
-            group, group_version = None, None
-
         env_prefixes = [self._env_prefix]
 
         # During local execution check for the key without a prefix

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -174,6 +174,19 @@ def test_secret_manager_no_group(monkeypatch):
     assert sec.get_secrets_file(key="ABC") == str(expected_path)
 
 
+def test_secret_no_group_required_with_group(monkeypatch, tmp_path):
+    plugin_mock = Mock()
+    plugin_mock.secret_requires_group.return_value = False
+    mock_global_plugin = {"plugin": plugin_mock}
+    monkeypatch.setattr(flytekit.configuration.plugin, "_GLOBAL_CONFIG", mock_global_plugin)
+
+    cfg = SecretsConfig.auto()
+    sec = SecretsManager(secrets_cfg=cfg)
+    monkeypatch.setenv(f"{cfg.env_prefix}MY-GROUP_V1_ABC", "my-super-secret")
+
+    assert sec.get(key="ABC", group="my-group", group_version="v1") == "my-super-secret"
+
+
 def test_secrets_manager_get_file():
     sec = SecretsManager()
     cfg = SecretsConfig.auto()


### PR DESCRIPTION
## Why are the changes needed?

Overriding `group` and `group_version` is a bug when trying to get the secret from `SecretManager`. We already have a check during registration time:

https://github.com/flyteorg/flytekit/blob/fc5421e1692b04bf72c69fc0f1fba319ea3428d3/flytekit/models/security.py#L54-L56

This means that during registration time, we'll check if groups are required. During runtime,  there are two cases (assuming `secret_requires_group=True`):

1. If the secret manager requires groups, then `Secret(group="...")` is configured correctly.
2. If the secret manager does not require group, then compiling passes and `group` is set to `None` already.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
3. If there is design documentation, please add the link.
-->

This PR removes the check for groups in `SecretManager`.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
A unit test was added to this PR.

On sandbox, I created a kubernetes secret:

```bash
kubectl create secret -n flytesnacks-development generic my-group --from-literal=token=abc-xyz
```

And ran:

```python
from flytekit import Secret, task, current_context, ImageSpec

new_flytekit = "git+https://github.com/thomasjpfan/flytekit.git@9d6d5481dd42a746bc0973b03c7a79414655a084"

image = ImageSpec(
    apt_packages=["git"],
    packages=["union>=0.1.155"],
    registry="localhost:30000",
    commands=[f"uv pip install {new_flytekit}"],
)


@task(secret_requests=[Secret(key="token", group="my-group")], container_image=image)
def get_secret() -> str:
    return current_context().secrets.get(key="token", group="my-group")
```

If I use the latest release of `flytekit`, then the above will fail. With this PR, it passes and returns the secret. 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes a bug in SecretManager by removing redundant group parameter validation in flytekit/core/context_manager.py, aligning with registration-time validations. A unit test was added to verify secret retrieval works correctly when the secret manager doesn't require group information.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>