### PR TITLE
remove check of settings lists in partials

### DIFF
--- a/flytekit/core/array_node_map_task.py
+++ b/flytekit/core/array_node_map_task.py
@@ -53,10 +53,6 @@ class ArrayNodeMapTask(PythonTask):
         """
         self._partial = None
         if isinstance(python_function_task, functools.partial):
-            # TODO: We should be able to support partial tasks with lists as inputs
-            for arg in python_function_task.keywords.values():
-                if isinstance(arg, list):
-                    raise ValueError("Cannot use a partial task with lists as inputs")
             self._partial = python_function_task
             actual_task = self._partial.func
         else:

--- a/tests/flytekit/unit/core/test_array_node_map_task.py
+++ b/tests/flytekit/unit/core/test_array_node_map_task.py
@@ -309,30 +309,33 @@ def test_partials_local_execute():
 
     param_a = [1, 2, 3]
     param_b = [0.1, 0.2, 0.3]
-    param_c = "c"
+    fixed_param_c = "c"
 
-    m1 = map_task(functools.partial(task1, c=param_c))(a=param_a, b=param_b)
-    m2 = map_task(functools.partial(task2, c=param_c))(a=param_a, b=param_b)
-    m3 = map_task(functools.partial(task3, c=param_c))(a=param_a, b=param_b)
+    m1 = map_task(functools.partial(task1, c=fixed_param_c))(a=param_a, b=param_b)
+    m2 = map_task(functools.partial(task2, c=fixed_param_c))(a=param_a, b=param_b)
+    m3 = map_task(functools.partial(task3, c=fixed_param_c))(a=param_a, b=param_b)
 
-    m4 = ArrayNodeMapTask(task1, bound_inputs_values={"c": param_c})(a=param_a, b=param_b)
-    m5 = ArrayNodeMapTask(task2, bound_inputs_values={"c": param_c})(a=param_a, b=param_b)
-    m6 = ArrayNodeMapTask(task3, bound_inputs_values={"c": param_c})(a=param_a, b=param_b)
+    m4 = ArrayNodeMapTask(task1, bound_inputs_values={"c": fixed_param_c})(a=param_a, b=param_b)
+    m5 = ArrayNodeMapTask(task2, bound_inputs_values={"c": fixed_param_c})(a=param_a, b=param_b)
+    m6 = ArrayNodeMapTask(task3, bound_inputs_values={"c": fixed_param_c})(a=param_a, b=param_b)
 
     assert m1 == m2 == m3 == m4 == m5 == m6 == ["1 - 0.1 - c", "2 - 0.2 - c", "3 - 0.3 - c"]
 
-    param_a = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-    param_b = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]
-    param_c = ["c", "d", "e"]
+    list_param_a = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    list_param_b = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]
+    fixed_list_param_c = ["c", "d", "e"]
 
-    m7 = map_task(functools.partial(task4, c=param_c))(a=param_a, b=param_b)
-    m8 = ArrayNodeMapTask(task4, bound_inputs_values={"c": param_c})(a=param_a, b=param_b)
+    m7 = map_task(functools.partial(task4, c=fixed_list_param_c))(a=list_param_a, b=list_param_b)
+    m8 = ArrayNodeMapTask(task4, bound_inputs_values={"c": fixed_list_param_c})(a=list_param_a, b=list_param_b)
 
     assert m7 == m8 == [
         ['1 - 0.1 - c', '2 - 0.2 - d', '3 - 0.3 - e'],
         ['4 - 0.4 - c', '5 - 0.5 - d', '6 - 0.6 - e'],
         ['7 - 0.7 - c', '8 - 0.8 - d', '9 - 0.9 - e']
     ]
+
+    with pytest.raises(ValueError):
+        map_task(functools.partial(task1, c=fixed_list_param_c))(a=param_a, b=param_b)
 
 
 def test_bounded_inputs_vars_order(serialization_settings):

--- a/tests/flytekit/unit/core/test_partials.py
+++ b/tests/flytekit/unit/core/test_partials.py
@@ -142,7 +142,6 @@ def test_map_task_types(map_task_fn):
     "map_task_fn",
     [
         legacy_map_task,
-        array_node_map_task,
     ],
 )
 def test_lists_cannot_be_used_in_partials(map_task_fn):


### PR DESCRIPTION
## Tracking issue
fixes https://linear.app/unionai/issue/BB-3499/cannot-pass-arguments-of-type-list-to-a-partial-function-that-will-be
closes: https://github.com/flyteorg/flyte/issues/4325

## Why are the changes needed?
w/ https://github.com/flyteorg/flyte/pull/6322 merged, we can now set lists for partials in map_tasks

## What changes were proposed in this pull request?
remove check for list getting set in partials

Since this is reliant on a BE change, is there something that we set for ~"min flyte version" or do we need to make this backwards compatible w/ older flyte propeller versions?

## How was this patch tested?
```
from flytekit import map_task, task, workflow

import functools
import typing


@task
def demo_task(strings: typing.List[str], num: int) -> str:
    return f"{num}".join(strings)


@workflow
def demo_wf(nums: typing.List[int] = [1, 2]) -> None:
    map_task(functools.partial(demo_task, strings=["a", "b", "c"]))(num=nums)
```
![image](https://github.com/user-attachments/assets/86c9d820-e227-4c38-966e-e87153d089af)


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR removes restrictions that previously prevented lists from being used as inputs to partial tasks in map_tasks, enhancing flexibility. The implementation removes error-raising code for list arguments and updates tests accordingly. It includes renamed test functions and variables to reflect the updated functionality, along with new test cases that verify correct handling of list inputs, aligning with backend updates that now support lists for partial functions.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>