### PR TITLE
Exclude the builder from image tag calculation

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -160,7 +160,7 @@ class ImageSpec:
 
         :return: a unique identifier of the ImageSpec
         """
-        parameters_to_exclude = ["pip_secret_mounts"]
+        parameters_to_exclude = ["pip_secret_mounts", "builder"]
         # Only get the non-None values in the ImageSpec to ensure the hash is consistent across different Flytekit versions.
         image_spec_dict = asdict(
             self, dict_factory=lambda x: {k: v for (k, v) in x if v is not None and k not in parameters_to_exclude}

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -63,7 +63,7 @@ def test_image_spec(mock_image_spec_builder, monkeypatch):
     assert image_spec.entrypoint == ["/bin/bash"]
     assert image_spec.copy == ["/src/file1.txt", "/src", "/src/file2.txt"]
 
-    assert image_spec.image_name() == f"localhost:30001/flytekit:AjLtng9gJfYzLnjbNy70gA"
+    assert image_spec.image_name() == f"localhost:30001/flytekit:{image_spec.tag}"
     ctx = context_manager.FlyteContext.current_context()
     with context_manager.FlyteContextManager.with_context(
         ctx.with_execution_state(ctx.execution_state.with_params(mode=ExecutionState.Mode.TASK_EXECUTION))

--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -294,3 +294,10 @@ def test_image_spec_same_id_and_tag_with_pip_secret_mounts():
     image_spec_with_pip_secret_mounts = ImageSpec(name="my_image", pip_secret_mounts=[("src", "dst")])
     assert image_spec.id == image_spec_with_pip_secret_mounts.id
     assert image_spec.tag == image_spec_with_pip_secret_mounts.tag
+
+
+def test_image_spec_same_id_and_tag_with_builder():
+    image_spec = ImageSpec(name="my_image")
+    image_spec_with_builder = ImageSpec(name="my_image", builder="envd")
+    assert image_spec.id == image_spec_with_builder.id
+    assert image_spec.tag == image_spec_with_builder.tag


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
The image tag is different when specifying the builder 

## What changes were proposed in this pull request?
Exclude the builder from image tag calculation.

## How was this patch tested?
unit test

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes an issue where the 'builder' parameter was incorrectly affecting image tag calculation. The update to image_spec.py ensures builder is excluded from tag computation parameters. The unit test has been updated to validate that tags are computed using dynamic values from image_spec.tag instead of hard-coded strings, improving test accuracy and preventing potential build issues.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>