### PR TITLE
Reuse get SSH connection method in Slurm function agent

### DIFF
--- a/plugins/flytekit-slurm/flytekitplugins/slurm/function/agent.py
+++ b/plugins/flytekit-slurm/flytekitplugins/slurm/function/agent.py
@@ -5,13 +5,12 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from asyncssh import SSHClientConnection
 
-from flytekit import logger
 from flytekit.extend.backend.base_agent import AgentRegistry, AsyncAgentBase, Resource, ResourceMeta
 from flytekit.extend.backend.utils import convert_to_flyte_phase
 from flytekit.models.literals import LiteralMap
 from flytekit.models.task import TaskTemplate
 
-from ..ssh_utils import ssh_connect
+from ..ssh_utils import SlurmCluster, get_ssh_conn
 
 
 @dataclass
@@ -33,20 +32,11 @@ class SlurmJobMetadata(ResourceMeta):
     ssh_config: Dict[str, Union[str, List[str], Tuple[str, ...]]]
 
 
-@dataclass
-class SlurmCluster:
-    host: str
-    username: Optional[str] = None
-
-    def __hash__(self):
-        return hash((self.host, self.username))
-
-
 class SlurmFunctionAgent(AsyncAgentBase):
     name = "Slurm Function Agent"
 
     # SSH connection pool for multi-host environment
-    ssh_config_to_ssh_conn: Dict[SlurmCluster, SSHClientConnection] = {}
+    slurm_cluster_to_ssh_conn: Dict[SlurmCluster, SSHClientConnection] = {}
 
     def __init__(self) -> None:
         super(SlurmFunctionAgent, self).__init__(task_type_name="slurm_fn", metadata_type=SlurmJobMetadata)
@@ -73,7 +63,7 @@ class SlurmFunctionAgent(AsyncAgentBase):
         )
 
         # Run Slurm job
-        conn = await self._get_or_create_ssh_connection(ssh_config)
+        conn = await get_ssh_conn(ssh_config=ssh_config, slurm_cluster_to_ssh_conn=self.slurm_cluster_to_ssh_conn)
         with tempfile.NamedTemporaryFile("w") as f:
             f.write(script)
             f.flush()
@@ -87,8 +77,9 @@ class SlurmFunctionAgent(AsyncAgentBase):
         return SlurmJobMetadata(job_id=job_id, ssh_config=ssh_config)
 
     async def get(self, resource_meta: SlurmJobMetadata, **kwargs) -> Resource:
-        ssh_config = resource_meta.ssh_config
-        conn = await self._get_or_create_ssh_connection(ssh_config)
+        conn = await get_ssh_conn(
+            ssh_config=resource_meta.ssh_config, slurm_cluster_to_ssh_conn=self.slurm_cluster_to_ssh_conn
+        )
         job_res = await conn.run(f"scontrol show job {resource_meta.job_id}", check=True)
 
         # Determine the current flyte phase from Slurm job state
@@ -107,39 +98,10 @@ class SlurmFunctionAgent(AsyncAgentBase):
         return Resource(phase=cur_phase, message=msg)
 
     async def delete(self, resource_meta: SlurmJobMetadata, **kwargs) -> None:
-        conn = await self._get_or_create_ssh_connection(resource_meta.ssh_config)
+        conn = await get_ssh_conn(
+            ssh_config=resource_meta.ssh_config, slurm_cluster_to_ssh_conn=self.slurm_cluster_to_ssh_conn
+        )
         _ = await conn.run(f"scancel {resource_meta.job_id}", check=True)
-
-    async def _get_or_create_ssh_connection(
-        self, ssh_config: Dict[str, Union[str, List[str], Tuple[str, ...]]]
-    ) -> SSHClientConnection:
-        """Get an existing SSH connection or create a new one if needed.
-
-        Args:
-            ssh_config (Dict[str, Union[str, List[str], Tuple[str, ...]]]): SSH configuration dictionary.
-
-        Returns:
-            SSHClientConnection: An active SSH connection, either pre-existing or newly established.
-        """
-        host = ssh_config.get("host")
-        username = ssh_config.get("username")
-
-        ssh_cluster_config = SlurmCluster(host=host, username=username)
-        if self.ssh_config_to_ssh_conn.get(ssh_cluster_config) is None:
-            logger.info("ssh connection key not found, creating new connection")
-            conn = await ssh_connect(ssh_config=ssh_config)
-            self.ssh_config_to_ssh_conn[ssh_cluster_config] = conn
-        else:
-            conn = self.ssh_config_to_ssh_conn[ssh_cluster_config]
-            try:
-                await conn.run("echo [TEST] SSH connection", check=True)
-                logger.info("re-using new connection")
-            except Exception as e:
-                logger.info(f"Re-establishing SSH connection due to error: {e}")
-                conn = await ssh_connect(ssh_config=ssh_config)
-                self.ssh_config_to_ssh_conn[ssh_cluster_config] = conn
-
-        return conn
 
 
 def _get_sbatch_cmd_and_script(


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?
Reusing a shared method for obtaining an SSH connection object prevents code duplication and ensures consistency between `SlurmShellAgent` and `SlurmFunctionAgent`.

## What changes were proposed in this pull request?
Reuse `get_ssh_conn` method in `SlurmFunctionAgent`.

## How was this patch tested?
This patch is tested by running the following example:
```python
import os

from flytekit import task, workflow
from flytekitplugins.slurm import SlurmFunction 


@task(
    task_config=SlurmFunction(
        ssh_config={
            "host": "aws2",
            "username": "ubuntu",
        },
        sbatch_conf={
            "partition": "debug",
            "job-name": "job3",
            "output": "/home/ubuntu/fn_task.log"
        },
        script="""#!/bin/bash -i

echo [TEST SLURM FN TASK 1] Run the first user-defined task function...

# Setup env vars
export MY_ENV_VAR=123

# Source the virtual env
. /home/ubuntu/.cache/pypoetry/virtualenvs/demo-4A8TrTN7-py3.12/bin/activate 

# Run the user-defined task function
{task.fn}
"""
    )
)
def plus_one(x: int) -> int: 
    print(os.getenv("MY_ENV_VAR"))
    return x + 1


@task(
    task_config=SlurmFunction(
        ssh_config={
            "host": "aws2",
            "username": "ubuntu",
        },
        script="""#!/bin/bash -i

echo [TEST SLURM FN TASK 2] Run the second user-defined task function...

. /home/ubuntu/.cache/pypoetry/virtualenvs/demo-4A8TrTN7-py3.12/bin/activate 
{task.fn}
"""
    )
)
def greet(year: int) -> str:
    return f"Hello {year}!!!"


@workflow
def wf(x: int) -> str:
    x = plus_one(x=x)
    msg = greet(year=x)
    return msg


if __name__ == "__main__":
    from flytekit.clis.sdk_in_container import pyflyte
    from click.testing import CliRunner

    runner = CliRunner()
    path = os.path.realpath(__file__)

    print(f">>> LOCAL EXEC <<<")
    result = runner.invoke(pyflyte.main, ["run", "--raw-output-data-prefix", "s3://my-flyte-slurm-agent", path, "wf", "--x", 2024])
    print(result.output)
```

### Setup process
For agent local test, the setup process is summarized as follows:
```
git clone https://github.com/flyteorg/flytekit.git
gh pr checkout 
make setup && pip install -e .
cd plugins/flytekit-slurm && pip install -e .
```

### Screenshots
* Local machine (Flyte client)
![Screenshot 2025-03-13 at 9 37 36 PM](https://github.com/user-attachments/assets/ccd86e19-adab-4460-a3d3-6f6e2ecebaec)

* The first task on the Slurm cluster
![Screenshot 2025-03-13 at 9 38 16 PM](https://github.com/user-attachments/assets/34c98013-ccd4-436c-a77d-a14a2ab727bc)

* The second task on the Slurm cluster
![Screenshot 2025-03-13 at 9 39 23 PM](https://github.com/user-attachments/assets/43ac8253-d176-4dfb-8707-c10cebaceb52)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
* https://github.com/flyteorg/flytekit/pull/3150
* https://github.com/flyteorg/flytekit/pull/3159

## Docs link
N/A
