### PR TITLE
[flyteagent] FileSensor Timeout (Remote Execution Only) Enhancement

### DIFF
--- a/flytekit/sensor/base_sensor.py
+++ b/flytekit/sensor/base_sensor.py
@@ -63,10 +63,15 @@ class BaseSensor(AsyncAgentExecutorMixin, PythonTask):
             annotation = type_hints.get(k, None)
             inputs[k] = annotation
 
-        if kwargs.get("metadata", None) and timeout:
-            raise ValueError("You cannot set timeout and metadata at the same time in the sensor")
-
-        metadata = TaskMetadata(timeout=timeout)
+        # Handle metadata and timeout logic
+        metadata = kwargs.pop("metadata", None)
+        if metadata is not None and timeout is not None:
+            if metadata.timeout is not None:
+                raise ValueError("You cannot set both timeout and metadata parameters at the same time in the sensor")
+            else:
+                metadata.timeout = timeout
+        else:
+            metadata = TaskMetadata(timeout=timeout) if timeout else TaskMetadata()
 
         super().__init__(
             task_type=task_type,

--- a/tests/flytekit/unit/sensor/test_file_sensor.py
+++ b/tests/flytekit/unit/sensor/test_file_sensor.py
@@ -79,8 +79,19 @@ def test_agent_executor_timeout_logging():
     assert sensor.metadata.timeout == datetime.timedelta(seconds=60)
 
 def test_file_sensor_set_timeout_and_metadata_at_the_same_time():
-    timeout = datetime.timedelta(seconds=60)
-    metadata = TaskMetadata(timeout=timeout)
+    """
+    The test is the combination of the following cases:
+    1. Set timeout and metadata with timeout at the same time
+    2. Set timeout and metadata without timeout
+    3. Set timeout and no metadata
+    4. Not set timeout and metadata with timeout
+    """
 
-    with pytest.raises(ValueError, match="You cannot set timeout and metadata at the same time in the sensor"):
-        FileSensor(name="test_sensor", timeout=60, metadata=metadata)
+    timeout = datetime.timedelta(seconds=60)
+
+    with pytest.raises(ValueError, match="You cannot set both timeout and metadata parameters at the same time in the sensor"):
+        FileSensor(name="test_sensor", timeout=60, metadata=TaskMetadata(timeout=timeout))
+
+    FileSensor(name="test_sensor", timeout=60, metadata=TaskMetadata())
+    FileSensor(name="test_sensor", timeout=60)
+    FileSensor(name="test_sensor", metadata=TaskMetadata(timeout=timeout))


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flyte/issues/5035

## Why are the changes needed?
Previously, setting both `timeout` and `metadata` parameters simultaneously in a sensor would raise an error, regardless of whether `metadata` already contained a timeout.
This change allows both parameters to be used together as long as there's no conflict (i.e., `metadata.timeout` is None).

## What changes were proposed in this pull request?
- Enhanced the timeout handling logic in `BaseSensor` to allow setting both `timeout` and `metadata` parameters when `metadata.timeout` is None
- Updated error message to be more specific about the conflict condition
- Added comprehensive test cases covering all timeout and metadata combinations

## How was this patch tested?
1. unit test
2. single binary


### Setup process

### Screenshots
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/1aa31add-0303-4bc9-90a8-952da6f5e7b5" />

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
