### PR TITLE
Eager failure task to share image with parent

### DIFF
--- a/tests/flytekit/unit/core/test_eager_cleanup.py
+++ b/tests/flytekit/unit/core/test_eager_cleanup.py
@@ -1,5 +1,8 @@
-from collections import OrderedDict
+import pytest
 
+from collections import OrderedDict
+from flytekit.image_spec.image_spec import ImageSpec
+from flytekit.core.task import task, eager
 import flytekit.configuration
 from flytekit.configuration import Image, ImageConfig
 from flytekit.core.python_function_task import EagerFailureHandlerTask
@@ -13,6 +16,8 @@ serialization_settings = flytekit.configuration.SerializationSettings(
     env=None,
     image_config=ImageConfig(default_image=default_img, images=[default_img]),
 )
+
+eager_image = "ghcr.io/testorg/testimage:v12"
 
 
 def test_failure():
@@ -31,3 +36,28 @@ def test_loading():
     print(resolver)
     t = resolver.load_task([])
     assert isinstance(t, EagerFailureHandlerTask)
+
+
+@task
+def add_one(x: int) -> int:
+    return x + 1
+
+
+@eager(container_image=eager_image)
+async def simple_eager_workflow(x: int) -> int:
+    # This is the normal way of calling tasks. Call normal tasks in an effectively async way by hanging and waiting for
+    # the result.
+    out = add_one(x=x)
+    return out
+
+
+def test_as_wf():
+    imperative_wf = simple_eager_workflow.get_as_workflow()
+    assert imperative_wf.failure_node.flyte_entity.container_image == simple_eager_workflow.container_image
+
+    entities = OrderedDict()
+    get_serializable(entities, serialization_settings, imperative_wf)
+
+    for key, entity in entities.items():
+        if isinstance(key, EagerFailureHandlerTask):
+            assert entity.template.container.image == "ghcr.io/testorg/testimage:v12"


### PR DESCRIPTION
## Why are the changes needed?
Kind of a follow-up item to https://github.com/flyteorg/flytekit/pull/3148 which added a cleanup task in a failure node.  
This PR just updates that task to use the same image for the failure task as the parent eager task.

## What changes were proposed in this pull request?
Technically we don't need to do this, but it's helpful especially when the eager functionality itself is changing.

## How was this patch tested?
Tested end to end on sandbox and Union clusters.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances EagerFailureHandlerTask to use the same container image as its parent eager task. Core module changes update task initialization to incorporate the container_image parameter. Tests have been refactored and expanded to verify this behavior, improving image sharing between tasks and test robustness.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>