### PR TITLE
[WIP] Rename Slurm task and sbatch config for improved UX

### DIFF
--- a/plugins/flytekit-slurm/flytekitplugins/slurm/__init__.py
+++ b/plugins/flytekit-slurm/flytekitplugins/slurm/__init__.py
@@ -1,4 +1,4 @@
 from .function.agent import SlurmFunctionAgent
-from .function.task import SlurmFunction, SlurmFunctionTask
+from .function.task import SlurmFunctionConfig, SlurmFunctionTask
 from .script.agent import SlurmScriptAgent
-from .script.task import Slurm, SlurmRemoteScript, SlurmShellTask, SlurmTask
+from .script.task import SlurmConfig, SlurmScriptConfig, SlurmShellTask, SlurmTask

--- a/plugins/flytekit-slurm/flytekitplugins/slurm/function/agent.py
+++ b/plugins/flytekit-slurm/flytekitplugins/slurm/function/agent.py
@@ -61,12 +61,12 @@ class SlurmFunctionAgent(AsyncAgentBase):
 
         # Retrieve task config
         ssh_config = task_template.custom["ssh_config"]
-        sbatch_conf = task_template.custom["sbatch_conf"]
+        sbatch_config = task_template.custom["sbatch_config"]
         script = task_template.custom["script"]
 
         # Construct command for Slurm cluster
         cmd, script = _get_sbatch_cmd_and_script(
-            sbatch_conf=sbatch_conf,
+            sbatch_config=sbatch_config,
             entrypoint=" ".join(task_template.container.args),
             script=script,
             batch_script_path=unique_script_name,
@@ -143,7 +143,7 @@ class SlurmFunctionAgent(AsyncAgentBase):
 
 
 def _get_sbatch_cmd_and_script(
-    sbatch_conf: Dict[str, str],
+    sbatch_config: Dict[str, str],
     entrypoint: str,
     script: Optional[str] = None,
     batch_script_path: str = "/tmp/task.slurm",
@@ -153,7 +153,7 @@ def _get_sbatch_cmd_and_script(
     Flyte entrypoint, pyflyte-execute, is run within a bash shell process.
 
     Args:
-        sbatch_conf (Dict[str, str]): Options of sbatch command.
+        sbatch_config (Dict[str, str]): Options of sbatch command.
         entrypoint (str): Flyte entrypoint.
         script (Optional[str], optional): User-defined script where "{task.fn}" serves as a placeholder for the
             task function execution. Users should insert "{task.fn}" at the desired
@@ -169,7 +169,7 @@ def _get_sbatch_cmd_and_script(
     """
     # Setup sbatch options
     cmd = ["sbatch"]
-    for opt, val in sbatch_conf.items():
+    for opt, val in sbatch_config.items():
         cmd.extend([f"--{opt}", str(val)])
 
     # Assign the batch script to run

--- a/plugins/flytekit-slurm/flytekitplugins/slurm/function/task.py
+++ b/plugins/flytekit-slurm/flytekitplugins/slurm/function/task.py
@@ -9,13 +9,13 @@ from flytekit.image_spec import ImageSpec
 
 
 @dataclass
-class SlurmFunction(object):
+class SlurmFunctionConfig(object):
     """Configure Slurm settings. Note that we focus on sbatch command now.
 
     Args:
         ssh_config: Options of SSH client connection. For available options, please refer to
             <newly-added-ssh-utils-file>
-        sbatch_conf: Options of sbatch command. If not provided, defaults to an empty dict.
+        sbatch_config: Options of sbatch command. If not provided, defaults to an empty dict.
         script: User-defined script where "{task.fn}" serves as a placeholder for the
             task function execution. Users should insert "{task.fn}" at the desired
             execution point within the script. If the script is not provided, the task
@@ -23,21 +23,21 @@ class SlurmFunction(object):
 
     Attributes:
         ssh_config (Dict[str, Union[str, List[str], Tuple[str, ...]]]): SSH client configuration options.
-        sbatch_conf (Optional[Dict[str, str]]): Slurm sbatch command options.
+        sbatch_config (Optional[Dict[str, str]]): Slurm sbatch command options.
         script (Optional[str]): Custom script template for task execution.
     """
 
     ssh_config: Dict[str, Union[str, List[str], Tuple[str, ...]]]
-    sbatch_conf: Optional[Dict[str, str]] = None
+    sbatch_config: Optional[Dict[str, str]] = None
     script: Optional[str] = None
 
     def __post_init__(self):
         assert self.ssh_config["host"] is not None, "'host' must be specified in ssh_config."
-        if self.sbatch_conf is None:
-            self.sbatch_conf = {}
+        if self.sbatch_config is None:
+            self.sbatch_config = {}
 
 
-class SlurmFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[SlurmFunction]):
+class SlurmFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[SlurmFunctionConfig]):
     """
     Actual Plugin that transforms the local python code for execution within a slurm context...
     """
@@ -46,7 +46,7 @@ class SlurmFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[SlurmFunctio
 
     def __init__(
         self,
-        task_config: SlurmFunction,
+        task_config: SlurmFunctionConfig,
         task_function: Callable,
         container_image: Optional[Union[str, ImageSpec]] = None,
         **kwargs,
@@ -62,7 +62,7 @@ class SlurmFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[SlurmFunctio
     def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
         return {
             "ssh_config": self.task_config.ssh_config,
-            "sbatch_conf": self.task_config.sbatch_conf,
+            "sbatch_config": self.task_config.sbatch_config,
             "script": self.task_config.script,
         }
 
@@ -76,4 +76,4 @@ class SlurmFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[SlurmFunctio
             return PythonFunctionTask.execute(self, **kwargs)
 
 
-TaskPlugins.register_pythontask_plugin(SlurmFunction, SlurmFunctionTask)
+TaskPlugins.register_pythontask_plugin(SlurmFunctionConfig, SlurmFunctionTask)

--- a/plugins/flytekit-slurm/flytekitplugins/slurm/script/agent.py
+++ b/plugins/flytekit-slurm/flytekitplugins/slurm/script/agent.py
@@ -56,7 +56,7 @@ class SlurmScriptAgent(AsyncAgentBase):
         # Retrieve task config
         ssh_config = task_template.custom["ssh_config"]
         batch_script_args = task_template.custom["batch_script_args"]
-        sbatch_conf = task_template.custom["sbatch_conf"]
+        sbatch_config = task_template.custom["sbatch_config"]
 
         # Construct sbatch command for Slurm cluster
         upload_script = False
@@ -76,7 +76,7 @@ class SlurmScriptAgent(AsyncAgentBase):
             # Assume the batch script is already on Slurm
             batch_script_path = task_template.custom["batch_script_path"]
         cmd = _get_sbatch_cmd(
-            sbatch_conf=sbatch_conf, batch_script_path=batch_script_path, batch_script_args=batch_script_args
+            sbatch_config=sbatch_config, batch_script_path=batch_script_path, batch_script_args=batch_script_args
         )
 
         # Run Slurm job
@@ -160,12 +160,12 @@ class SlurmScriptAgent(AsyncAgentBase):
         return script, outputs
 
 
-def _get_sbatch_cmd(sbatch_conf: Dict[str, str], batch_script_path: str, batch_script_args: List[str] = None) -> str:
+def _get_sbatch_cmd(sbatch_config: Dict[str, str], batch_script_path: str, batch_script_args: List[str] = None) -> str:
     """
     Construct the Slurm sbatch command.
 
     Args:
-        sbatch_conf (Dict[str, str]): Slurm sbatch configuration options (e.g., partition, job-name, etc.).
+        sbatch_config (Dict[str, str]): Slurm sbatch configuration options (e.g., partition, job-name, etc.).
         batch_script_path (str): Absolute path on the Slurm cluster of the script to run.
         batch_script_args (List[str], optional): Additional arguments to pass to the batch script.
 
@@ -173,7 +173,7 @@ def _get_sbatch_cmd(sbatch_conf: Dict[str, str], batch_script_path: str, batch_s
         str: The sbatch command string that can be executed on the Slurm cluster.
     """
     cmd = ["sbatch"]
-    for opt, val in sbatch_conf.items():
+    for opt, val in sbatch_config.items():
         cmd.extend([f"--{opt}", str(val)])
 
     # Assign the batch script to run

--- a/plugins/flytekit-slurm/flytekitplugins/slurm/script/task.py
+++ b/plugins/flytekit-slurm/flytekitplugins/slurm/script/task.py
@@ -12,7 +12,7 @@ from flytekit.types.file import FlyteFile
 
 
 @dataclass
-class Slurm(object):
+class SlurmConfig(object):
     """
     Configure Slurm settings. Note that we focus on sbatch command now.
 
@@ -22,22 +22,22 @@ class Slurm(object):
     Attributes:
         ssh_config (Dict[str, Any]): Options of SSH client connection. For available options, please refer to
             <newly-added-ssh-utils-file>.
-        sbatch_conf (Optional[Dict[str, str]]): Options of sbatch command. For available options, please refer to
+        sbatch_config (Optional[Dict[str, str]]): Options of sbatch command. For available options, please refer to
             https://slurm.schedmd.com/sbatch.html.
         batch_script_args (Optional[List[str]]): Additional args for the batch script on Slurm cluster.
     """
 
     ssh_config: Dict[str, Any]
-    sbatch_conf: Optional[Dict[str, str]] = None
+    sbatch_config: Optional[Dict[str, str]] = None
     batch_script_args: Optional[List[str]] = None
 
     def __post_init__(self):
-        if self.sbatch_conf is None:
-            self.sbatch_conf = {}
+        if self.sbatch_config is None:
+            self.sbatch_config = {}
 
 
 @dataclass
-class SlurmRemoteScript(Slurm):
+class SlurmScriptConfig(SlurmConfig):
     """Encounter collision if Slurm is shared btw SlurmTask and SlurmShellTask."""
 
     batch_script_path: str = field(default=None)
@@ -48,13 +48,13 @@ class SlurmRemoteScript(Slurm):
             raise ValueError("batch_script_path must be provided")
 
 
-class SlurmTask(AsyncAgentExecutorMixin, PythonTask[SlurmRemoteScript]):
+class SlurmTask(AsyncAgentExecutorMixin, PythonTask[SlurmScriptConfig]):
     _TASK_TYPE = "slurm"
 
     def __init__(
         self,
         name: str,
-        task_config: SlurmRemoteScript,
+        task_config: SlurmScriptConfig,
         **kwargs,
     ):
         super(SlurmTask, self).__init__(
@@ -71,17 +71,17 @@ class SlurmTask(AsyncAgentExecutorMixin, PythonTask[SlurmRemoteScript]):
             "ssh_config": self.task_config.ssh_config,
             "batch_script_path": self.task_config.batch_script_path,
             "batch_script_args": self.task_config.batch_script_args,
-            "sbatch_conf": self.task_config.sbatch_conf,
+            "sbatch_config": self.task_config.sbatch_config,
         }
 
 
-class SlurmShellTask(AsyncAgentExecutorMixin, PythonTask[Slurm]):
+class SlurmShellTask(AsyncAgentExecutorMixin, PythonTask[SlurmConfig]):
     _TASK_TYPE = "slurm"
 
     def __init__(
         self,
         name: str,
-        task_config: Slurm,
+        task_config: SlurmConfig,
         script: str,
         inputs: Optional[Dict[str, Type]] = None,
         output_locs: Optional[List[OutputLocation]] = None,
@@ -121,7 +121,7 @@ class SlurmShellTask(AsyncAgentExecutorMixin, PythonTask[Slurm]):
         return {
             "ssh_config": self.task_config.ssh_config,
             "batch_script_args": self.task_config.batch_script_args,
-            "sbatch_conf": self.task_config.sbatch_conf,
+            "sbatch_config": self.task_config.sbatch_config,
             "script": self._script,
             "python_input_types": self._inputs,
             "output_locs": self._output_locs,
@@ -132,5 +132,5 @@ class SlurmShellTask(AsyncAgentExecutorMixin, PythonTask[Slurm]):
         return self._script
 
 
-TaskPlugins.register_pythontask_plugin(SlurmRemoteScript, SlurmTask)
-TaskPlugins.register_pythontask_plugin(Slurm, SlurmShellTask)
+TaskPlugins.register_pythontask_plugin(SlurmScriptConfig, SlurmTask)
+TaskPlugins.register_pythontask_plugin(SlurmConfig, SlurmShellTask)


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?
The original task config naming for `SlurmTask`, `SlurmShellTask`, and `SlurmFunctionTask` is not intuitive. Additionally, `sbatch_conf` is inconsistent with the naming convention used for other options, such as `ssh_config`.

## What changes were proposed in this pull request?
1. Rename `Slurm` to `SlurmConfig`
2. Rename `SlurmRemoteScript` to `SlurmScriptConfig`
3. Rename `SlurmFunction` to `SlurmFunctionConfig`
4. Rename `sbatch_conf` to `sbatch_config`

## How was this patch tested?

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs
* https://github.com/flyteorg/flytekit/pull/3150
* https://github.com/flyteorg/flytekit/pull/3159

## Docs link
N/A
