### PR TITLE
Fix error code propagation from user defined errors

### DIFF
--- a/flytekit/exceptions/user.py
+++ b/flytekit/exceptions/user.py
@@ -31,7 +31,7 @@ class FlyteUserRuntimeException(_FlyteException):
 
     @property
     def error_code(self):
-        return self._ERROR_CODE
+        return self.value.error_code if hasattr(self.value, "error_code") else self._ERROR_CODE
 
 
 class FlyteTypeException(FlyteUserException, TypeError):


### PR DESCRIPTION
## Tracking issue
Closes flyteorg/flyte#6343

## Why are the changes needed?

As detailed in the linked issue, we use custom defined `_ERROR_CODE` attributes in exceptions that are raised in tasks so that our services know how to handle certain failures. For example, if an exception is raised that defines an `_ERROR_CODE` as `"USER:NotReady"`, we treat that error code as a soft failure, and no alerting is triggered in such a case.

Currently, since [this PR](https://github.com/flyteorg/flytekit/pull/2671/files#diff-932d345851356237c198d139fa9a11d53d68257dc05387e933680ed2e764a50f), when an exception is raised that defines its own `_ERROR_CODE` from a task, that error code is ignored and instead, `"USER:RuntimeError"` is passed whatever the case. The linked issue explains why this happens in more detail. 

## What changes were proposed in this pull request?

This PR makes a change to the `FlyteUserRuntimeException` to make it consider the `error_code` attribute of the exception that it wraps, if that wrapped exception defines an error code. If this is not the case, it uses its default error code of `"USER:RuntimeError"`. 

This is so that if such a custom error code is defined in the original user-raised exception, it is propagated to the `ContainerError` which is [eventually raised in `_dispatch_execute()`](https://github.com/flyteorg/flytekit/blob/master/flytekit/bin/entrypoint.py#L254-L276).

## How was this patch tested?

Existing unit test was modified to verify the expected behaviour.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

https://github.com/flyteorg/flytekit/pull/3059

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes error code propagation in FlyteUserRuntimeException by considering wrapped exceptions' error_code attributes. The implementation updates the exception module and modifies tests to verify that user-defined error codes are properly respected, resulting in more accurate error reporting and handling.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>