### PR TITLE
Add GetTaskMetrics and GetTaskLogs to connector service

### DIFF
--- a/flytekit/extend/backend/base_connector.py
+++ b/flytekit/extend/backend/base_connector.py
@@ -11,7 +11,7 @@ from functools import partial
 from types import FrameType
 from typing import Any, Dict, List, Optional, Union
 
-from flyteidl.admin.agent_pb2 import Agent
+from flyteidl.admin.agent_pb2 import Agent, GetTaskLogsResponse, GetTaskMetricsResponse
 from flyteidl.admin.agent_pb2 import Resource as _Resource
 from flyteidl.admin.agent_pb2 import TaskCategory as _TaskCategory
 from flyteidl.core import literals_pb2
@@ -228,6 +228,18 @@ class AsyncConnectorBase(ConnectorBase):
     def delete(self, resource_meta: ResourceMeta, **kwargs):
         """
         Delete the task. This call should be idempotent. It should raise an error if fails to delete the task.
+        """
+        raise NotImplementedError
+
+    def get_metrics(self, resource_meta: ResourceMeta, **kwargs) -> GetTaskMetricsResponse:
+        """
+        Return the metrics for the task.
+        """
+        raise NotImplementedError
+
+    def get_logs(self, resource_meta: ResourceMeta, **kwargs) -> GetTaskLogsResponse:
+        """
+        Return the metrics for the task.
         """
         raise NotImplementedError
 

--- a/flytekit/extend/backend/connector_service.py
+++ b/flytekit/extend/backend/connector_service.py
@@ -12,6 +12,10 @@ from flyteidl.admin.agent_pb2 import (
     ExecuteTaskSyncResponseHeader,
     GetAgentRequest,
     GetAgentResponse,
+    GetTaskLogsRequest,
+    GetTaskLogsResponse,
+    GetTaskMetricsRequest,
+    GetTaskMetricsResponse,
     GetTaskRequest,
     GetTaskResponse,
     ListAgentsRequest,
@@ -150,6 +154,28 @@ class AsyncConnectorService(AsyncAgentServiceServicer):
             connector.delete, resource_meta=connector.metadata_type.decode(request.resource_meta)
         )
         return DeleteTaskResponse()
+
+    async def GetTaskMetrics(
+        self, request: GetTaskMetricsRequest, context: grpc.ServicerContext
+    ) -> GetTaskMetricsResponse:
+        if request.task_category and request.task_category.name:
+            connector = ConnectorRegistry.get_connector(request.task_category.name, request.task_category.version)
+        else:
+            connector = ConnectorRegistry.get_connector(request.task_type)
+        logger.info(f"{connector.name} start getting metrics of the job")
+        return await mirror_async_methods(
+            connector.get_metrics, resource_meta=connector.metadata_type.decode(request.resource_meta)
+        )
+
+    async def GetTaskLogs(self, request: GetTaskLogsRequest, context: grpc.ServicerContext) -> GetTaskLogsResponse:
+        if request.task_category and request.task_category.name:
+            connector = ConnectorRegistry.get_connector(request.task_category.name, request.task_category.version)
+        else:
+            connector = ConnectorRegistry.get_connector(request.task_type)
+        logger.info(f"{connector.name} start getting logs of the job")
+        return await mirror_async_methods(
+            connector.get_logs, resource_meta=connector.metadata_type.decode(request.resource_meta)
+        )
 
 
 class SyncConnectorService(SyncAgentServiceServicer):


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Allow agent to fetch the log and metrics from the external service, such as databricks and bigquery.

## What changes were proposed in this pull request?
Add GetMetric and GetLog interface to the baseAgent

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR extends the agent backend to fetch task metrics and logs from external services. It updates the base connector with new methods and enhances the connector service for asynchronous log and metrics retrieval. The changes support broader integration with services like Databricks and BigQuery.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>