### PR TITLE
[Bug] SecretsManager get function supports env_var pararmeters.

### DIFF
--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -399,6 +399,7 @@ class SecretsManager(object):
         group: Optional[str] = None,
         key: Optional[str] = None,
         group_version: Optional[str] = None,
+        env_var: Optional[str] = None,
         encode_mode: str = "r",
     ) -> str:
         """
@@ -412,11 +413,18 @@ class SecretsManager(object):
         if ctx.execution_state is None or ctx.execution_state.is_local_execution():
             env_prefixes.append("")
 
+        default_env_var = ""
         for env_prefix in env_prefixes:
-            env_var = self._get_secrets_env_var(
+            default_env_var = self._get_secrets_env_var(
                 group=group, key=key, group_version=group_version, env_prefix=env_prefix
             )
-            v = os.environ.get(env_var)
+            v = os.environ.get(default_env_var)
+            if v is not None:
+                return v.strip()
+
+        custom_env_var = env_var
+        if custom_env_var is not None:
+            v = os.environ.get(custom_env_var, None)
             if v is not None:
                 return v.strip()
 
@@ -426,7 +434,7 @@ class SecretsManager(object):
                 return f.read().strip()
         raise ValueError(
             f"Please make sure to add secret_requests=[Secret(group={group}, key={key})] in @task. Unable to find secret for key {key} in group {group} "
-            f"in Env Var:{env_var} and FilePath: {fpath}"
+            f"in Env Var:{default_env_var}{', ' + custom_env_var if custom_env_var is not None else ''} and FilePath: {fpath}"
         )
 
     def get_secrets_env_var(
@@ -443,7 +451,7 @@ class SecretsManager(object):
         key: Optional[str] = None,
         group_version: Optional[str] = None,
         env_prefix: str = "",
-    ):
+    ) -> str:
         l = [k.upper() for k in filter(None, (group, group_version, key))]
         return f"{env_prefix}{'_'.join(l)}"
 

--- a/tests/flytekit/unit/core/test_context_manager.py
+++ b/tests/flytekit/unit/core/test_context_manager.py
@@ -251,6 +251,11 @@ def test_secrets_manager_env():
     os.environ[sec.get_secrets_env_var(group="group", key="key")] = "value"
     assert sec.get(group="group", key="key") == "value"
 
+    os.environ["LOCAL_ENV_VAR"] = "value"
+    assert sec.get(group="group", key="key2", env_var="LOCAL_ENV_VAR") == "value"
+    assert sec.get(key="key", env_var="LOCAL_ENV_VAR") == "value"
+    assert sec.get(env_var="LOCAL_ENV_VAR") == "value"
+
 
 @pytest.mark.parametrize("is_local_execution, prefix", [(True, ""), (False, "_FSEC_")])
 def test_secrets_manager_execution(monkeypatch, is_local_execution, prefix):


### PR DESCRIPTION
## Tracking issue
[flyteorg/flyte#](https://github.com/flyteorg/flyte/issues/6302)

## Why are the changes needed?

In flytekit secretsManager, it will check whether  the secret exist in an env var "<group>_<key>"  or in a file "/etc/secrets/<group>/<key>".
In flytekit secret, create a env "MY_SECRET" when setting "env_var=MY_SECRET" parameters.
SecretManager won't find it with naming rule with  "<group>_<key>".

## What changes were proposed in this pull request?

Adding env_var pararmeters in secreateManager get function.
Initially, secretManager search the secret with following orders.
1. "<group>_<key>"  env
2. "/etc/secrets/<group>/<key>" file
In this PR, its order will be
1. "<group>_<key>"  env
2 . env_var
3. "/etc/secrets/<group>/<key>" file

## How was this patch tested?
make test
`
os.environ["LOCAL_ENV_VAR"] = "value"
assert sec.get(group="group", key="key2", env_var="LOCAL_ENV_VAR") == "value"
assert sec.get(key="key", env_var="LOCAL_ENV_VAR") == "value"
assert sec.get(env_var="LOCAL_ENV_VAR") == "value"
`

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes a bug in SecretsManager's get function by adding support for an optional 'env_var' parameter and updating the secret lookup order. The changes improve variable naming, add conditional logic for environment variables, update logging messages and type hints, and include new unit tests for reliability.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>