### PR TITLE
Add LOCAL_DYNAMIC_TASK_EXECUTION mode

### DIFF
--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -561,6 +561,8 @@ class ExecutionState(object):
 
         EAGER_LOCAL_EXECUTION = 6
 
+        LOCAL_DYNAMIC_TASK_EXECUTION = 7
+
     mode: Optional[ExecutionState.Mode]
     working_dir: Union[os.PathLike, str]
     engine_dir: Optional[Union[os.PathLike, str]]
@@ -622,6 +624,7 @@ class ExecutionState(object):
             self.mode == ExecutionState.Mode.LOCAL_TASK_EXECUTION
             or self.mode == ExecutionState.Mode.LOCAL_WORKFLOW_EXECUTION
             or self.mode == ExecutionState.Mode.EAGER_LOCAL_EXECUTION
+            or self.mode == ExecutionState.Mode.LOCAL_DYNAMIC_TASK_EXECUTION
         )
 
 

--- a/flytekit/core/node_creation.py
+++ b/flytekit/core/node_creation.py
@@ -138,7 +138,7 @@ def create_node(
     # https://github.com/flyteorg/flytekit/blob/0815345faf0fae5dc26746a43d4bda4cc2cdf830/flytekit/core/python_function_task.py#L262
     elif ctx.execution_state and (
         ctx.execution_state.is_local_execution()
-        or ctx.execution_state.mode == ExecutionState.Mode.DYNAMIC_TASK_EXECUTION
+        or ctx.execution_state.mode == ExecutionState.Mode.LOCAL_DYNAMIC_TASK_EXECUTION
     ):
         if isinstance(entity, RemoteEntity):
             raise AssertionError(f"Remote entities are not yet runnable locally {entity.name}")

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1539,7 +1539,7 @@ def flyte_entity_call_handler(
             else:
                 raise ValueError(f"Received an output when workflow local execution expected None. Received: {result}")
 
-        if ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.DYNAMIC_TASK_EXECUTION:
+        if ctx.execution_state and ctx.execution_state.mode == ExecutionState.Mode.LOCAL_DYNAMIC_TASK_EXECUTION:
             return result
 
         if (1 < expected_outputs == len(cast(Tuple[Promise], result))) or (

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1535,7 +1535,7 @@ def flyte_entity_call_handler(
         expected_outputs = len(entity.python_interface.outputs)
         if expected_outputs == 0:
             if result is None or isinstance(result, VoidPromise):
-                return None
+                return VoidPromise(entity.name)
             else:
                 raise ValueError(f"Received an output when workflow local execution expected None. Received: {result}")
 

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -1535,7 +1535,7 @@ def flyte_entity_call_handler(
         expected_outputs = len(entity.python_interface.outputs)
         if expected_outputs == 0:
             if result is None or isinstance(result, VoidPromise):
-                return VoidPromise(entity.name)
+                return None
             else:
                 raise ValueError(f"Received an output when workflow local execution expected None. Received: {result}")
 

--- a/flytekit/core/python_function_task.py
+++ b/flytekit/core/python_function_task.py
@@ -343,7 +343,7 @@ class PythonFunctionTask(PythonAutoContainerTask[T]):  # type: ignore
             logger.debug(f"Executing Dynamic workflow, using raw inputs {kwargs}")
             self._create_and_cache_dynamic_workflow()
             if self.execution_mode == self.ExecutionBehavior.DYNAMIC:
-                es = ctx.new_execution_state().with_params(mode=ExecutionState.Mode.DYNAMIC_TASK_EXECUTION)
+                es = ctx.new_execution_state().with_params(mode=ExecutionState.Mode.LOCAL_DYNAMIC_TASK_EXECUTION)
             else:
                 es = cast(ExecutionState, ctx.execution_state)
             with FlyteContextManager.with_context(ctx.with_execution_state(es)):

--- a/tests/flytekit/unit/core/test_dataclass_dynamic.py
+++ b/tests/flytekit/unit/core/test_dataclass_dynamic.py
@@ -20,8 +20,6 @@ from mashumaro.config import BaseConfig
 
 
 class SimpleObjectOriginal:
-    # Of course we COULD make this a dataclass; this is overly simple for repro purposes,
-    # and in reality this class is a lot more complex!
     def __init__(self, a: Optional[str] = None, b: Optional[int] = None):
         self.a = a
         self.b = b
@@ -93,4 +91,4 @@ def test_simple_object_yee():
         n = check_int(o=result)
         n.with_overrides(limits=Resources(cpu="3", mem="500Mi"))
 
-    my_dynamic2()
+    my_dynamic()

--- a/tests/flytekit/unit/core/test_dataclass_dynamic.py
+++ b/tests/flytekit/unit/core/test_dataclass_dynamic.py
@@ -73,22 +73,11 @@ def generate_int() -> int:
     return 42
 
 
-@task
-def check_int(o: int):
-    assert o == 42
-
-
 def test_simple_object_yee():
     @dynamic
     def my_dynamic():
         result = generate_result()
         n = check_result(obj=result)
-        n.with_overrides(limits=Resources(cpu="3", mem="500Mi"))
-
-    @dynamic
-    def my_dynamic2():
-        result = generate_int()
-        n = check_int(o=result)
         n.with_overrides(limits=Resources(cpu="3", mem="500Mi"))
 
     my_dynamic()

--- a/tests/flytekit/unit/core/test_dataclass_dynamic.py
+++ b/tests/flytekit/unit/core/test_dataclass_dynamic.py
@@ -1,0 +1,96 @@
+import sys
+from dataclasses import dataclass
+from typing import List, Optional
+
+import pytest
+from dataclasses_json import DataClassJsonMixin
+from mashumaro.mixins.json import DataClassJSONMixin
+from typing_extensions import Annotated
+
+from flytekit.core.task import task
+from flytekit.core.type_engine import DataclassTransformer
+from flytekit.core.workflow import workflow
+
+from dataclasses import dataclass, field
+import base64
+import pickle
+from flytekit.core.resources import Resources
+from flytekit.core.dynamic_workflow_task import dynamic
+from mashumaro.config import BaseConfig
+
+
+class SimpleObjectOriginal:
+    # Of course we COULD make this a dataclass; this is overly simple for repro purposes,
+    # and in reality this class is a lot more complex!
+    def __init__(self, a: Optional[str] = None, b: Optional[int] = None):
+        self.a = a
+        self.b = b
+
+
+def encode_object(obj: SimpleObjectOriginal) -> str:
+    s = base64.b64encode(pickle.dumps(obj)).decode("utf-8")
+    print(f"Encode object to {s}")
+    return s
+
+
+def decode_object(object_value: str) -> SimpleObjectOriginal:
+    print(f"Decoding from string {object_value}")
+    return pickle.loads(base64.b64decode(object_value.encode("utf-8")))
+
+
+@dataclass
+class SimpleObjectOriginalMixin(DataClassJsonMixin):
+    # This is a mixin that adds a SimpleObjectOriginal field to any dataclass.
+
+    simple_object: SimpleObjectOriginal = field(
+        default_factory=SimpleObjectOriginal,
+    )
+
+    class Config(BaseConfig):
+        serialization_strategy = {
+            SimpleObjectOriginal: {
+                # you can use specific str values for datetime here as well
+                "deserialize": decode_object,
+                "serialize": encode_object,
+            },
+        }
+
+
+@dataclass
+class ParentDC(SimpleObjectOriginalMixin):
+    parent_val: str = ""
+
+
+@task
+def generate_result() -> SimpleObjectOriginalMixin:
+    return SimpleObjectOriginalMixin(simple_object=SimpleObjectOriginal(a="a", b=1))
+
+
+@task
+def check_result(obj: SimpleObjectOriginalMixin):
+    assert obj.simple_object is not None
+
+@task
+def generate_int() -> int:
+    return 42
+
+
+@task
+def check_int(o: int):
+    assert o == 42
+
+
+def test_simple_object_yee():
+    @dynamic
+    def my_dynamic():
+        result = generate_result()
+        n = check_result(obj=result)
+        n.with_overrides(limits=Resources(cpu="3", mem="500Mi"))
+
+    @dynamic
+    def my_dynamic2():
+        result = generate_int()
+        n = check_int(o=result)
+        n.with_overrides(limits=Resources(cpu="3", mem="500Mi"))
+
+    my_dynamic2()


### PR DESCRIPTION
## Tracking issue
https://flyte-org.slack.com/archives/CP2HDHKE1/p1740432192774269

## Why are the changes needed?
When running the dynamic workflow locally, the subtask should return a promise/voidPromise instead of a Python value.

## What changes were proposed in this pull request?
Add LOCAL_DYNAMIC_TASK_EXECUTION mode. Change the execution mode to `LOCAL_DYNAMIC_TASK_EXECUTION` when running the dynamic task locally.

## How was this patch tested?
unit tests

### Setup process

### Screenshots 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR introduces LOCAL_DYNAMIC_TASK_EXECUTION mode, updating flytekit's core components to support local dynamic task execution. Key changes in node_creation.py and promise.py modify execution state checks to utilize the new local mode. It also cleans up obsolete test functions and removes redundant dynamic task validations, streamlining the testing environment while enhancing reliability for local workflows.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>