### PR TITLE
feat: add geopandas plugin

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -310,6 +310,7 @@ jobs:
           - flytekit-duckdb
           - flytekit-envd
           - flytekit-flyteinteractive
+          - flytekit-geopandas
           - flytekit-greatexpectations
           - flytekit-hive
           - flytekit-huggingface

--- a/plugins/flytekit-geopandas/README.md
+++ b/plugins/flytekit-geopandas/README.md
@@ -1,0 +1,10 @@
+# Flytekit GeoPandas Plugin
+[GeoPandas](https://geopandas.org/en/stable/) GeoPandas is an open source project to make working with geospatial data in python easier.
+
+This plugin supports `gpd.GeoDataFrame` as a data type with [StructuredDataset](https://docs.flyte.org/en/latest/user_guide/data_types_and_io/structureddataset.html).
+
+To install the plugin, run the following command:
+
+```bash
+pip install flytekitplugins-geopandas
+```

--- a/plugins/flytekit-geopandas/flytekitplugins/geopandas/__init__.py
+++ b/plugins/flytekit-geopandas/flytekitplugins/geopandas/__init__.py
@@ -1,0 +1,14 @@
+"""
+.. currentmodule:: flytekitplugins.geopandas
+
+This package contains things that are useful when extending Flytekit.
+
+.. autosummary::
+   :template: custom.rst
+   :toctree: generated/
+
+   GeoPandasDecodingHandler
+   GeoPandasEncodingHandler
+"""
+
+from .gdf_transformers import GeoPandasDecodingHandler, GeoPandasEncodingHandler

--- a/plugins/flytekit-geopandas/flytekitplugins/geopandas/gdf_transformers.py
+++ b/plugins/flytekit-geopandas/flytekitplugins/geopandas/gdf_transformers.py
@@ -1,0 +1,74 @@
+import typing
+from pathlib import Path
+
+from flytekit import FlyteContext, lazy_module
+from flytekit.models import literals
+from flytekit.models.literals import StructuredDatasetMetadata
+from flytekit.models.types import StructuredDatasetType
+from flytekit.types.structured.structured_dataset import (
+    PARQUET,
+    StructuredDataset,
+    StructuredDatasetDecoder,
+    StructuredDatasetEncoder,
+    StructuredDatasetTransformerEngine,
+)
+
+if typing.TYPE_CHECKING:
+    import pyarrow
+
+    import geopandas as gpd
+else:
+    gpd = lazy_module("geopandas")
+    pyarrow = lazy_module("pyarrow")
+
+
+class GeoPandasDataFrameRenderer:
+    """
+    The Geopandas DataFrame summary statistics are rendered as an HTML table.
+    """
+
+    def to_html(self, df: gpd.GeoDataFrame) -> str:
+        assert isinstance(df, gpd.GeoDataFrame)
+        return df.describe()._repr_html_()
+
+
+class GeoPandasEncodingHandler(StructuredDatasetEncoder):
+    def encode(
+        self,
+        ctx: FlyteContext,
+        structured_dataset: StructuredDataset,
+        structured_dataset_type: StructuredDatasetType,
+    ) -> literals.StructuredDataset:
+        uri = typing.cast(str, structured_dataset.uri) or ctx.file_access.join(
+            ctx.file_access.raw_output_prefix, ctx.file_access.get_random_string()
+        )
+        if not ctx.file_access.is_remote(uri):
+            Path(uri).mkdir(parents=True, exist_ok=True)
+        uri = str(Path(uri) / "data.parquet")
+        df = typing.cast(gpd.GeoDataFrame, structured_dataset.dataframe)
+        df.to_parquet(uri)
+        structured_dataset_type.format = PARQUET
+        return literals.StructuredDataset(uri=uri, metadata=StructuredDatasetMetadata(structured_dataset_type))
+
+
+class GeoPandasDecodingHandler(StructuredDatasetDecoder):
+    def decode(
+        self,
+        ctx: FlyteContext,
+        flyte_value: literals.StructuredDataset,
+        current_task_metadata: StructuredDatasetMetadata,
+    ) -> gpd.GeoDataFrame:
+        # a user may want to bring a non-parquet gdf, which uses a different
+        # opening method.
+        try:
+            return gpd.read_parquet(flyte_value.uri)
+        except pyarrow.lib.ArrowInvalid:
+            return gpd.read_file(flyte_value.uri)
+
+
+StructuredDatasetTransformerEngine.register_renderer(gpd.GeoDataFrame, GeoPandasDataFrameRenderer())
+# We register GeoPandas encoder to support parquet between and from tasks / workflows
+StructuredDatasetTransformerEngine.register(GeoPandasEncodingHandler(gpd.GeoDataFrame, None, PARQUET))
+# We register to any format for decoder in the event a user provides geopackage,
+# shape file, parquet, etc.
+StructuredDatasetTransformerEngine.register(GeoPandasDecodingHandler(gpd.GeoDataFrame, None, None))

--- a/plugins/flytekit-geopandas/setup.py
+++ b/plugins/flytekit-geopandas/setup.py
@@ -1,0 +1,35 @@
+from setuptools import setup
+
+PLUGIN_NAME = "geopandas"
+
+microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
+
+plugin_requires = ["flytekit>=1.3.0b2,<2.0.0", "geopandas>=1.0.0,<2.0.0", "pandas"]
+
+__version__ = "0.0.0+develop"
+
+setup(
+    name=microlib_name,
+    version=__version__,
+    author="flyteorg",
+    author_email="admin@flyte.org",
+    description="Geopandas plugin for flytekit",
+    namespace_packages=["flytekitplugins"],
+    packages=[f"flytekitplugins.{PLUGIN_NAME}"],
+    install_requires=plugin_requires,
+    license="apache2",
+    python_requires=">=3.9",
+    classifiers=[
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Software Development",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+    entry_points={"flytekit.plugins": [f"{PLUGIN_NAME}=flytekitplugins.{PLUGIN_NAME}"]},
+)

--- a/plugins/flytekit-geopandas/tests/test_geopandas_plugin.py
+++ b/plugins/flytekit-geopandas/tests/test_geopandas_plugin.py
@@ -1,0 +1,64 @@
+import geopandas as gpd
+from flytekitplugins.geopandas.gdf_transformers import GeoPandasDataFrameRenderer
+from pathlib import Path
+
+import pytest
+
+from flytekit import task
+from flytekit.types.structured.structured_dataset import StructuredDataset
+from pyproj import CRS
+import numpy as np
+
+
+def test_geopandas_encodes_decodes():
+    @task
+    def _gdf_task(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+        return gdf
+
+    gdf = gpd.GeoDataFrame(
+        {"geometry": gpd.points_from_xy([0, 1], [0, 1]), "other_column": [1, 2]},
+        crs="EPSG:4326",
+    )
+    rt_gdf = _gdf_task(gdf)
+    assert rt_gdf.equals(gdf)
+
+
+@pytest.mark.parametrize("file_name", ["output.geojson", "output.gpkg"])
+def test_geopandas_encodes_common_formats(tmp_path: Path, file_name: str):
+    @task
+    def _gdf_task(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+        return gdf
+
+    gdf = gpd.GeoDataFrame(
+        {"other": np.array([1.0, 2.0])},
+        geometry=gpd.points_from_xy([0, 1], [0, 1]),
+        crs="EPSG:4326",
+    )
+    uri = str(tmp_path / file_name)
+    gdf.to_file(uri)
+    rt_gdf = _gdf_task(gdf=StructuredDataset(uri=uri))
+    assert rt_gdf.equals(gdf)
+
+
+def test_geopandas_encodes_shp_not_yet_supported(tmp_path: Path):
+    @task
+    def _gdf_task(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+        return gdf
+
+    gdf = gpd.GeoDataFrame(
+        {"geometry": gpd.points_from_xy([0, 1], [0, 1]), "other": [1, 2]},
+        crs="EPSG:4326",
+    )
+    uri = str(tmp_path / "output.shp")
+    gdf.to_file(uri)
+    with pytest.raises(ValueError, match=r"Set SHAPE_RESTORE_SHX config option to YES"):
+        rt_gdf = _gdf_task(gdf=StructuredDataset(uri=uri))
+
+
+def test_gdf_renderer():
+    gdf = gpd.GeoDataFrame(
+        {"geometry": gpd.points_from_xy([0, 1], [0, 1]), "other_column": [1, 2]},
+        crs="EPSG:4326",
+    )
+    described = gdf.describe()._repr_html_()
+    assert GeoPandasDataFrameRenderer().to_html(gdf) == described

--- a/plugins/setup.py
+++ b/plugins/setup.py
@@ -25,6 +25,7 @@ SOURCES = {
     "flytekitplugins-envd": "flytekit-envd",
     "flytekitplugins-flyteinteractive": "flytekit-flyteinteractive",
     "flytekitplugins-great_expectations": "flytekit-greatexpectations",
+    "flytekitplugins-geopandas": "flytekit-geopandas",
     "flytekitplugins-hive": "flytekit-hive",
     "flytekitplugins-huggingface": "flytekit-huggingface",
     "flytekitplugins-inference": "flytekit-inference",


### PR DESCRIPTION
## Why are the changes needed?
Currently, there is no support for geopandas dataframes and one must likely return FlyteFile's instead of gpd.GeoDataFrame objects. 

## What changes were proposed in this pull request?
This plugin adds support for encoding/decoding StructuredDatasets for geopandas dataframes. Specifically, we allow encoding to parquet and decoding from parquet, geojson and geopackage. This PR does **not** add support for shape files. 

## How was this patch tested?
Plugin level tests

### Setup process

### Screenshots
TODO: register, run remotely, take screenshots.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR adds a new geopandas plugin to Flytekit, enabling encoding and decoding of geopandas dataframes. It implements data rendering, parquet encoding, and multi-format decoding with lazy module loading. The implementation includes both plugin-specific and global setup configurations, with comprehensive test coverage.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>