### PR TITLE
support using cache policies in with_overrides

### DIFF
--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -184,6 +184,8 @@ class Node(object):
 
         if cache is not None:
             assert_not_promise(cache, "cache")
+
+            # Note: any future changes should look into how these cache params are set in tasks
             # If the cache is of type bool but cache_version is not set, then assume that we want to use the
             # default cache policies in Cache
             if isinstance(cache, bool) and cache is True and cache_version is None:

--- a/flytekit/core/node.py
+++ b/flytekit/core/node.py
@@ -150,6 +150,7 @@ class Node(object):
         # while cleaning up the task function definition.
         cache_serialize = kwargs.get("cache_serialize")
         cache_version = kwargs.get("cache_version")
+        # TODO support ignore_input_vars in with_overrides
         cache_ignore_input_vars = kwargs.get("cache_ignore_input_vars")
 
         if isinstance(self.flyte_entity, ArrayNodeMapTask):
@@ -199,16 +200,15 @@ class Node(object):
                         "cache_serialize, cache_version, and cache_ignore_input_vars are deprecated. Please use Cache object"
                     )
 
-                # TODO support unset cache version
+                # TODO support unset cache version in with_overrides
                 if cache.version is None:
                     raise ValueError("must specify cache version when overriding")
 
                 cache_version = cache.version
                 cache_serialize = cache.serialize
-                cache_ignore_input_vars = cache.get_ignored_inputs()
                 cache = True
 
-            node_metadata._cacheable = cache
+        node_metadata._cacheable = cache
 
         if cache_version is not None:
             assert_not_promise(cache_version, "cache_version")
@@ -217,10 +217,6 @@ class Node(object):
         if cache_serialize is not None:
             assert_not_promise(cache_serialize, "cache_serialize")
             node_metadata._cache_serializable = cache_serialize
-
-        if cache_ignore_input_vars is not None:
-            assert_not_promise(cache_serialize, "cache_serialize")
-            node_metadata._cache_cache_ignore_input_vars = cache_serialize
 
     def with_overrides(
         self,

--- a/flytekit/core/promise.py
+++ b/flytekit/core/promise.py
@@ -15,6 +15,7 @@ from flytekit.core import constants as _common_constants
 from flytekit.core import context_manager as _flyte_context
 from flytekit.core import interface as flyte_interface
 from flytekit.core import type_engine
+from flytekit.core.cache import Cache
 from flytekit.core.context_manager import (
     BranchEvalMode,
     ExecutionParameters,
@@ -593,9 +594,7 @@ class Promise(object):
         task_config: Optional[Any] = None,
         container_image: Optional[str] = None,
         accelerator: Optional[BaseAccelerator] = None,
-        cache: Optional[bool] = None,
-        cache_version: Optional[str] = None,
-        cache_serialize: Optional[bool] = None,
+        cache: Optional[Union[bool, Cache]] = None,
         *args,
         **kwargs,
     ):
@@ -614,8 +613,6 @@ class Promise(object):
                 container_image=container_image,
                 accelerator=accelerator,
                 cache=cache,
-                cache_version=cache_version,
-                cache_serialize=cache_serialize,
                 *args,
                 **kwargs,
             )

--- a/flytekit/core/task.py
+++ b/flytekit/core/task.py
@@ -360,6 +360,7 @@ def task(
     def wrapper(fn: Callable[P, FuncOut]) -> PythonFunctionTask[T]:
         nonlocal cache, cache_serialize, cache_version, cache_ignore_input_vars
 
+        # Note: any future changes should look into how these cache params are set in with_overrides for nodes
         # If the cache is of type bool but cache_version is not set, then assume that we want to use the
         # default cache policies in Cache
         if isinstance(cache, bool) and cache is True and cache_version is None:


### PR DESCRIPTION
## Tracking issue
fixes: https://linear.app/unionai/issue/BB-4976/cache-policies-dont-work-w-caching-subworkflows

Follow up changes:
- https://linear.app/unionai/issue/BB-4977/with-overrides-cache-doesnt-support-ignore-input-vars 
(need idl change)
- https://linear.app/unionai/issue/BB-4978/add-support-for-not-setting-cache-version-in-with-overrides

## Why are the changes needed?
with_overrides doesn't work when setting Cache object



## What changes were proposed in this pull request?
support setting Cache object in with_overrides + maintain backwards compatibility w/ existing params 

## How was this patch tested?
- added unit test
https://dogfood.cloud-staging.union.ai/console/projects/flytesnacks/domains/development/executions/acmrgrn887lb2kzn59dk/nodes
https://dogfood.cloud-staging.union.ai/console/projects/flytesnacks/domains/development/executions/avwrqd2cq7796skz6xqc
https://dogfood.cloud-staging.union.ai/console/projects/flytesnacks/domains/development/executions/advd5c2952qkmzj59hfh

```
import union

@union.task
def sum(a: int, b: int, c: int) -> int:
    return a + b + c


@union.workflow
def child_wf(a: int=1, b: int=2, c: int=3) -> list[int]:
    return [
        sum(a=a, b=b, c=c).with_overrides(cache=union.Cache(version="1.0", serialize=True, ignored_inputs=["a"]))
        for _ in range(5)
    ]


child_lp = union.LaunchPlan.get_or_create(child_wf)


@union.workflow
def parent_wf_with_subwf(input: int = 0):
    return [
        # Enable caching on the subworkflow
        child_wf(a=input, b=3, c=4).with_overrides(cache=union.Cache(version="1.0", serialize=True, ignored_inputs=["a"]))
        for i in [1, 2, 3]
    ]

@union.workflow
def parent_wf_with_sublp(input: int = 0):
     return [
        child_lp(a=input, b=1, c=2).with_overrides(cache=union.Cache(version="1.0", serialize=True, ignored_inputs=["a"]))
        for i in [1, 2, 3]
    ]
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances caching functionality by supporting Cache objects in with_overrides method across core modules. It refines Node, Promise, and Task classes to handle boolean or Cache objects while phasing out deprecated parameters. The changes include improved error handling and backward compatibility logic.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>