### PR TITLE
fix: set GRPC_VERBOSITY and remove grpcio upper bound

### DIFF
--- a/flytekit/clis/sdk_in_container/__init__.py
+++ b/flytekit/clis/sdk_in_container/__init__.py
@@ -1,0 +1,7 @@
+import os
+
+# Set GRPC_VERBOSITY to NONE if not already set to silence unwanted output
+# This addresses the issue with grpcio >=1.68.0 causing unwanted output
+# https://github.com/flyteorg/flyte/issues/6082
+if "GRPC_VERBOSITY" not in os.environ:
+    os.environ["GRPC_VERBOSITY"] = "NONE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,8 @@ dependencies = [
     "fsspec>=2023.3.0",
     "gcsfs>=2023.3.0",
     "googleapis-common-protos>=1.57",
-    # Skipping those versions to account for the unwanted output coming from grpcio and grpcio-status.
-    # Issue being tracked in https://github.com/flyteorg/flyte/issues/6082.
-    "grpcio<=1.68.0",
-    "grpcio-status<=1.68.0",
+    "grpcio",
+    "grpcio-status",
     "importlib-metadata",
     "joblib",
     "jsonlines",

--- a/tests/flytekit/unit/cli/pyflyte/test_grpc_verbosity.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_grpc_verbosity.py
@@ -1,0 +1,48 @@
+import os
+
+
+def test_grpc_verbosity_set_on_import():
+    """
+    Test that GRPC_VERBOSITY is set to NONE if not already present in the environment
+    when the SDK container module is imported.
+    """
+    original_value = os.environ.get("GRPC_VERBOSITY", None)
+
+    try:
+        if "GRPC_VERBOSITY" in os.environ:
+            del os.environ["GRPC_VERBOSITY"]
+
+        import importlib
+        import flytekit.clis.sdk_in_container
+        importlib.reload(flytekit.clis.sdk_in_container)
+
+        assert "GRPC_VERBOSITY" in os.environ
+        assert os.environ["GRPC_VERBOSITY"] == "NONE"
+
+    finally:
+        if original_value is not None:
+            os.environ["GRPC_VERBOSITY"] = original_value
+        elif "GRPC_VERBOSITY" in os.environ:
+            del os.environ["GRPC_VERBOSITY"]
+
+
+def test_grpc_verbosity_not_overridden():
+    """
+    Test that GRPC_VERBOSITY is not overridden if already set in the environment.
+    """
+    original_value = os.environ.get("GRPC_VERBOSITY", None)
+
+    try:
+        os.environ["GRPC_VERBOSITY"] = "INFO"
+
+        import importlib
+        import flytekit.clis.sdk_in_container
+        importlib.reload(flytekit.clis.sdk_in_container)
+
+        assert os.environ["GRPC_VERBOSITY"] == "INFO"
+
+    finally:
+        if original_value is not None:
+            os.environ["GRPC_VERBOSITY"] = original_value
+        elif "GRPC_VERBOSITY" in os.environ:
+            del os.environ["GRPC_VERBOSITY"]


### PR DESCRIPTION
Originally noted in https://github.com/flyteorg/flyte/issues/6082

- [x] proposes to resolve https://github.com/flyteorg/flyte/issues/6353 by setting a default value `GRPC_VERBOSITY=NONE` on importing the `flytekit.clis.sdk_in_container` subpackage

See some additional discussion in the [referenced issue](https://github.com/flyteorg/flyte/issues/6353#issuecomment-2774052213). 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes issue #6082 by setting GRPC_VERBOSITY to 'NONE' by default in the SDK container module to silence unwanted grpc logging. It also removes upper bounds on grpcio and grpcio-status dependencies in pyproject.toml. Unit tests were added to validate both scenarios of environment variable presence.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>