### PR TITLE
Jan/generic spark task

### DIFF
--- a/plugins/flytekit-spark/flytekitplugins/spark/__init__.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/__init__.py
@@ -18,6 +18,7 @@ This package contains things that are useful when extending Flytekit.
 from flytekit.configuration import internal as _internal
 
 from .connector import DatabricksConnector
+from .generic_task import GenericSparkConf
 from .pyspark_transformers import PySparkPipelineModelTransformer
 from .schema import SparkDataFrameSchemaReader, SparkDataFrameSchemaWriter, SparkDataFrameTransformer  # noqa
 from .sd_transformers import ParquetToSparkDecodingHandler, SparkToParquetEncodingHandler

--- a/plugins/flytekit-spark/flytekitplugins/spark/generic_task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/generic_task.py
@@ -28,7 +28,6 @@ class GenericSparkConf(object):
 
 
 class GenericSparkTask(PythonFunctionTask[GenericSparkConf]):
-
     def __init__(
         self,
         task_config: GenericSparkConf,

--- a/plugins/flytekit-spark/flytekitplugins/spark/generic_task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/generic_task.py
@@ -1,0 +1,70 @@
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional, Union
+
+from google.protobuf.json_format import MessageToDict
+
+from flytekit import PythonFunctionTask
+from flytekit.configuration import SerializationSettings
+from flytekit.extend import TaskPlugins
+from flytekit.image_spec import ImageSpec
+
+from .models import SparkJob, SparkType
+
+
+@dataclass
+class GenericSparkConf(object):
+    main_class: str
+    executor_path: Optional[str] = None
+    applications_path: Optional[str] = None
+    spark_type: SparkType = SparkType.JAVA
+    spark_conf: Optional[Dict[str, str]] = None
+    hadoop_conf: Optional[Dict[str, str]] = None
+
+    def __post_init__(self):
+        if self.spark_conf is None:
+            self.spark_conf = {}
+
+        if self.hadoop_conf is None:
+            self.hadoop_conf = {}
+
+
+class GenericSparkTask(PythonFunctionTask[GenericSparkConf]):
+    _SPARK_TASK_TYPE = "spark"
+
+    def __init__(
+        self,
+        task_config: GenericSparkConf,
+        task_function: Callable,
+        container_image: Optional[Union[str, ImageSpec]] = None,
+        **kwargs,
+    ):
+        self._default_executor_path: str = task_config.executor_path
+        self._default_applications_path: str = task_config.applications_path
+        self._container_image = container_image
+        super(GenericSparkTask, self).__init__(
+            task_config=task_config,
+            task_type="spark",
+            task_function=task_function,
+            container_image=container_image,
+            **kwargs,
+        )
+
+    def get_custom(self, settings: SerializationSettings) -> Dict[str, Any]:
+        job = SparkJob(
+            spark_conf=self.task_config.spark_conf,
+            hadoop_conf=self.task_config.hadoop_conf,
+            application_file="local://" + self.task_config.applications_path,
+            executor_path=settings.python_interpreter,
+            main_class=self.task_config.main_class,
+            spark_type=SparkType.PYTHON,
+        )
+        return MessageToDict(job.to_flyte_idl())
+
+    def execute(self):
+        spark_submit_cmd = f"spark-submit  --class {self.task_config.main_class}  --master 'local[*]' {self.task_config.applications_path}"
+        subprocess.run(spark_submit_cmd, shell=True, check=True)
+
+
+# Inject the Spark plugin into flytekits dynamic plugin loading system
+TaskPlugins.register_pythontask_plugin(GenericSparkConf, GenericSparkTask)

--- a/plugins/flytekit-spark/flytekitplugins/spark/generic_task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/generic_task.py
@@ -15,9 +15,7 @@ from .models import SparkJob, SparkType
 @dataclass
 class GenericSparkConf(object):
     main_class: str
-    executor_path: Optional[str] = None
-    applications_path: Optional[str] = None
-    spark_type: SparkType = SparkType.JAVA
+    applications_path: str
     spark_conf: Optional[Dict[str, str]] = None
     hadoop_conf: Optional[Dict[str, str]] = None
 
@@ -30,7 +28,6 @@ class GenericSparkConf(object):
 
 
 class GenericSparkTask(PythonFunctionTask[GenericSparkConf]):
-    _SPARK_TASK_TYPE = "spark"
 
     def __init__(
         self,
@@ -39,9 +36,6 @@ class GenericSparkTask(PythonFunctionTask[GenericSparkConf]):
         container_image: Optional[Union[str, ImageSpec]] = None,
         **kwargs,
     ):
-        self._default_executor_path: str = task_config.executor_path
-        self._default_applications_path: str = task_config.applications_path
-        self._container_image = container_image
         super(GenericSparkTask, self).__init__(
             task_config=task_config,
             task_type="spark",


### PR DESCRIPTION
## Why are the changes needed?
- With the current state of the spark plugin only pyspark is supported, this PR enables running generic Spark jobs in Flyte like Spark jobs written in Java 

## What changes were proposed in this pull request?
- Introducing `GenericSparkTask` by configuring `GenericSparkConf` for given Flyte tasks

## How was this patch tested?
- Running the following workflow successfully locally and remotely
``` python
from flytekit import workflow, task, ImageSpec
from flytekitplugins.spark import GenericSparkConf

branch = "jan/generic_spark_task"
flytekit_spark_generic = f"git+https://github.com/flyteorg/flytekit.git@{branch}#subdirectory=plugins/flytekit-spark"

container_image = ImageSpec(
    name="genericspark",
    base_image="ghcr.io/fiedlernr9/sparkfun:CLADEqpZcRJqAgyCVmuVtg",
    apt_packages=["git"],
    packages=[flytekit_spark_generic],
    copy=[
        "javathings/WordCount/WordCount.jar",
    ],
    registry="ghcr.io/fiedlernr9",
)


@task(
    task_config=GenericSparkConf(
        main_class="WordCount",
        applications_path="/root/javathings/WordCount/WordCount.jar",
        spark_conf={
            "spark.driver.memory": "5000M",
            "spark.executor.memory": "2000M",
            "spark.executor.cores": "1",
            "spark.executor.instances": "1",
            "spark.driver.cores": "2",
        },
    ),
    container_image=container_image,
)
def foo(): ...


@workflow
def wf():
    foo()
```
- where `WordCount.jar` is the following compiled java code:

``` java
import org.apache.spark.api.java.JavaRDD;
import org.apache.spark.api.java.JavaSparkContext;
import org.apache.spark.api.java.JavaPairRDD;
import org.apache.spark.SparkConf;
import scala.Tuple2;
import java.util.Arrays;
import java.util.List;
import java.util.ArrayList;
import java.util.Random;

public class WordCount {
    public static void main(String[] args) {
        // Create a Spark Configuration and Context
        SparkConf conf = new SparkConf().setAppName("WordCount"); //.setMaster();
        JavaSparkContext sc = new JavaSparkContext(conf);

        List<String> data = generateRandomList(100000);

        // Create an RDD from the hardcoded list
        JavaRDD<String> input = sc.parallelize(data);

        // Split the lines into words
        JavaRDD<String> words = input.flatMap(line -> Arrays.asList(line.split(" ")).iterator());

        // Map each word to a tuple (word, 1)
        JavaPairRDD<String, Integer> wordPairs = words.mapToPair(word -> new Tuple2<>(word, 1));

        // Reduce by key (word) to count occurrences
        JavaPairRDD<String, Integer> wordCounts = wordPairs.reduceByKey(Integer::sum);

        // Print the results
        wordCounts.foreach(wordCount -> System.out.println(wordCount._1() + " : " + wordCount._2()));

        // Stop the Spark context
        sc.stop();
    }
    // Method to generate a random list of sentences
    public static List<String> generateRandomList(int size) {
        String[] words = {"hello", "world", "java", "spark", "big", "data", "science", "cloud", "compute", "stream"};
        Random random = new Random();
        List<String> randomList = new ArrayList<>();

        for (int i = 0; i < size; i++) {
            String sentence = words[random.nextInt(words.length)] + " " + words[random.nextInt(words.length)];
            randomList.add(sentence);
        }

        return randomList;
    }
}
```
### Screenshots
![image](https://github.com/user-attachments/assets/544584fe-cb63-4cfd-abb3-128d812071b5)

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request introduces a new generic spark task feature to the flytekit framework, defining configuration and execution logic for spark tasks with plugin registration. The update expands spark support by providing a robust task interface that integrates with the existing plugin ecosystem.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>