### PR TITLE
ci: Update version extraction in workflows

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Put version in environment
         id: bump
         run: |
-          # from refs/tags/v1.2.3 get 1.2.3
-          VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
+          # from 'refs/tags/v1.2.3' get 1.2.3
+          VERSION=$(echo $GITHUB_REF | sed 's|refs/tags/||')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
         shell: bash
       - name: Build and publish
@@ -35,8 +35,8 @@ jobs:
           twine upload dist/*
       - name: Autobump plugin version
         run: |
-          # from refs/tags/v1.2.3 get 1.2.3
-          VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
+          # from 'refs/tags/v1.2.3' get 1.2.3
+          VERSION=$(echo $GITHUB_REF | sed 's|refs/tags/||')
           VERSION=$VERSION make -C plugins update_all_versions
         shell: bash
       - name: Build all Plugins and publish
@@ -49,8 +49,8 @@ jobs:
       - name: Sleep until pypi is available
         id: pypiwait
         run: |
-          # from refs/tags/v1.2.3 get 1.2.3 and make sure it's not an empty string
-          VERSION=$(echo $GITHUB_REF | sed 's#.*/v##')
+          # from 'refs/tags/v1.2.3 get 1.2.3' and make sure it's not an empty string
+          VERSION=$(echo $GITHUB_REF | sed 's|refs/tags/||')
           if [ -z "$VERSION" ]
           then
             echo "No tagged version found, exiting"


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
CI is failing https://github.com/flyteorg/flytekit/actions/runs/14371904608/job/40296421255

## What changes were proposed in this pull request?
`$GITHUB_REF` returns `'refs/tags/v1.2.3'` now instead of `refs/tags/v1.2.3`

## How was this patch tested?
```
echo 'refs/tags/1.16.0b4' | sed 's|refs/tags/||'
```

