### PR TITLE
fix: Fix async s3fs to handle latest changes to FlyteFile

### DIFF
--- a/plugins/flytekit-async-fsspec/flytekitplugins/async_fsspec/s3fs/s3fs.py
+++ b/plugins/flytekit-async-fsspec/flytekitplugins/async_fsspec/s3fs/s3fs.py
@@ -123,6 +123,7 @@ class AsyncS3FileSystem(S3FileSystem):
             callback (function, optional): The callback function.
             chunksize (int, optional): Download chunksize. Defaults to 50 * 2**20 (50MB).
             version_id (str, optional): The version id of the file. Defaults to None.
+            concurrent_download (int, optional): The number of concurrent threads when using multipart download. Defaults to 4.
             **kwargs (Any, optional): Additional arguments for extensibility or future use.
         """
         if os.path.isdir(lpath):

--- a/plugins/flytekit-async-fsspec/flytekitplugins/async_fsspec/s3fs/s3fs.py
+++ b/plugins/flytekit-async-fsspec/flytekitplugins/async_fsspec/s3fs/s3fs.py
@@ -1,6 +1,7 @@
 import asyncio
 import mimetypes
 import os
+from typing import Any, Callable, Optional
 
 from fsspec.callbacks import _DEFAULT_CALLBACK
 from s3fs import S3FileSystem
@@ -22,21 +23,22 @@ class AsyncS3FileSystem(S3FileSystem):
 
     async def _put_file(
         self,
-        lpath,
-        rpath,
-        callback=_DEFAULT_CALLBACK,
-        chunksize=DEFAULT_UPLOAD_CHUNK_SIZE,
-        concurrent_upload=DEFAULT_CONCURRENT_UPLOAD,
-        **kwargs,
+        lpath: str,
+        rpath: str,
+        callback: Callable = _DEFAULT_CALLBACK,
+        chunksize: int = DEFAULT_UPLOAD_CHUNK_SIZE,
+        concurrent_upload: int = DEFAULT_CONCURRENT_UPLOAD,
+        **kwargs: Any,
     ):
         """
         Put a file from lpath to rpath.
         Args:
             lpath (str): The local path of the file to be uploaded.
             rpath (str): The remote path which the file should be uploaded to.
-            callback (function, optional): The callback function.
-            chunksize (int, optional): Upload chunksize. Defaults to 50 * 2**20 (50MB).
-            concurrent_upload (int, optional): The number of concurrent upload when using multipart upload. Defaults to 4.
+            callback (Callable): The callback function.
+            chunksize (int): Upload chunksize. Defaults to 50 * 2**20 (50MB).
+            concurrent_upload (int): The number of concurrent upload when using multipart upload. Defaults to 4.
+            **kwargs (Any): Additional arguments passed to S3 calls.
         """
         bucket, key, _ = self.split_path(rpath)
         if os.path.isdir(lpath):
@@ -107,24 +109,24 @@ class AsyncS3FileSystem(S3FileSystem):
 
     async def _get_file(
         self,
-        rpath,
-        lpath,
-        callback=_DEFAULT_CALLBACK,
-        version_id=None,
-        chunksize=DEFAULT_DOWNLOAD_CHUNK_SIZE,
-        concurrent_download=DEFAULT_CONCURRENT_DOWNLOAD,
-        **kwargs, # noqa Used for extensibility or future arguments
+        rpath: str,
+        lpath: str,
+        callback: Callable = _DEFAULT_CALLBACK,
+        version_id: Optional[str] = None,
+        chunksize: int = DEFAULT_DOWNLOAD_CHUNK_SIZE,
+        concurrent_download: int = DEFAULT_CONCURRENT_DOWNLOAD,
+        **kwargs: Any,  # noqa Used for extensibility or future arguments
     ):
         """
         Get a file from rpath to lpath.
         Args:
             rpath (str): The remote path of the file to be downloaded.
             lpath (str): The local path which the file should be downloaded to.
-            callback (function, optional): The callback function.
-            chunksize (int, optional): Download chunksize. Defaults to 50 * 2**20 (50MB).
-            version_id (str, optional): The version id of the file. Defaults to None.
-            concurrent_download (int, optional): The number of concurrent threads when using multipart download. Defaults to 4.
-            **kwargs (Any, optional): Additional arguments for extensibility or future use.
+            callback (Callable): The callback function.
+            version_id (Optional[str]): The version id of the file. Defaults to None.
+            chunksize (int): Download chunksize. Defaults to 50 * 2**20 (50MB).
+            concurrent_download (int): The number of concurrent threads when using multipart download. Defaults to 4.
+            **kwargs (Any): Additional arguments for extensibility or future use.
         """
         if os.path.isdir(lpath):
             return

--- a/plugins/flytekit-async-fsspec/flytekitplugins/async_fsspec/s3fs/s3fs.py
+++ b/plugins/flytekit-async-fsspec/flytekitplugins/async_fsspec/s3fs/s3fs.py
@@ -123,6 +123,7 @@ class AsyncS3FileSystem(S3FileSystem):
             callback (function, optional): The callback function.
             chunksize (int, optional): Download chunksize. Defaults to 50 * 2**20 (50MB).
             version_id (str, optional): The version id of the file. Defaults to None.
+            **kwargs (Any, optional): Additional arguments for extensibility or future use.
         """
         if os.path.isdir(lpath):
             return

--- a/plugins/flytekit-async-fsspec/flytekitplugins/async_fsspec/s3fs/s3fs.py
+++ b/plugins/flytekit-async-fsspec/flytekitplugins/async_fsspec/s3fs/s3fs.py
@@ -113,6 +113,7 @@ class AsyncS3FileSystem(S3FileSystem):
         version_id=None,
         chunksize=DEFAULT_DOWNLOAD_CHUNK_SIZE,
         concurrent_download=DEFAULT_CONCURRENT_DOWNLOAD,
+        **kwargs, # noqa Used for extensibility or future arguments
     ):
         """
         Get a file from rpath to lpath.

--- a/pydoclint-errors-baseline.txt
+++ b/pydoclint-errors-baseline.txt
@@ -428,15 +428,7 @@ flytekit/types/structured/structured_dataset.py
     DOC301: Class `StructuredDatasetDecoder`: __init__() should not have a docstring; please combine it with the docstring of the class
 --------------------
 plugins/flytekit-async-fsspec/flytekitplugins/async_fsspec/s3fs/s3fs.py
-    DOC101: Method `AsyncS3FileSystem._put_file`: Docstring contains fewer arguments than in function signature.
-    DOC106: Method `AsyncS3FileSystem._put_file`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
-    DOC107: Method `AsyncS3FileSystem._put_file`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC103: Method `AsyncS3FileSystem._put_file`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
     DOC201: Method `AsyncS3FileSystem._put_file` does not have a return section in docstring
-    DOC101: Method `AsyncS3FileSystem._get_file`: Docstring contains fewer arguments than in function signature.
-    DOC106: Method `AsyncS3FileSystem._get_file`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
-    DOC107: Method `AsyncS3FileSystem._get_file`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC103: Method `AsyncS3FileSystem._get_file`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [concurrent_download: ].
     DOC201: Method `AsyncS3FileSystem._get_file` does not have a return section in docstring
 --------------------
 plugins/flytekit-aws-athena/flytekitplugins/athena/task.py


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?
AsyncS3FileSystem does not work with latest changes to FlyteFile [here](https://github.com/flyteorg/flytekit/blob/2e2d2c2a561c76fa5a7642dd12544c250cff1a19/flytekit/types/file/file.py#L321)
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
1. Install both `flytekit` and `flytekitplugins-async-fsspec`
2. Run `FlyteFile(<remote-file>).__fspath__()`
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
