### PR TITLE
add short_description to Task and Workflow model

### DIFF
--- a/flytekit/models/admin/workflow.py
+++ b/flytekit/models/admin/workflow.py
@@ -72,7 +72,7 @@ class WorkflowSpec(_common.FlyteIdlEntity):
 
 
 class Workflow(_common.FlyteIdlEntity):
-    def __init__(self, id, closure, short_description):
+    def __init__(self, id, closure, short_description=None):
         """
         :param flytekit.models.core.identifier.Identifier id:
         :param WorkflowClosure closure:

--- a/flytekit/models/admin/workflow.py
+++ b/flytekit/models/admin/workflow.py
@@ -72,13 +72,14 @@ class WorkflowSpec(_common.FlyteIdlEntity):
 
 
 class Workflow(_common.FlyteIdlEntity):
-    def __init__(self, id, closure):
+    def __init__(self, id, closure, short_description):
         """
         :param flytekit.models.core.identifier.Identifier id:
         :param WorkflowClosure closure:
         """
         self._id = id
         self._closure = closure
+        self._short_description = short_description
 
     @property
     def id(self):
@@ -94,11 +95,22 @@ class Workflow(_common.FlyteIdlEntity):
         """
         return self._closure
 
+    @property
+    def short_description(self):
+        """
+        :rtype: str
+        """
+        return self._short_description
+
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.admin.workflow_pb2.Workflow
         """
-        return _admin_workflow.Workflow(id=self.id.to_flyte_idl(), closure=self.closure.to_flyte_idl())
+        return _admin_workflow.Workflow(
+            id=self.id.to_flyte_idl(),
+            closure=self.closure.to_flyte_idl(),
+            short_description=self.short_description,
+        )
 
     @classmethod
     def from_flyte_idl(cls, pb2_object):
@@ -109,6 +121,7 @@ class Workflow(_common.FlyteIdlEntity):
         return cls(
             id=_identifier.Identifier.from_flyte_idl(pb2_object.id),
             closure=WorkflowClosure.from_flyte_idl(pb2_object.closure),
+            short_description=pb2_object.short_description,
         )
 
 

--- a/flytekit/models/task.py
+++ b/flytekit/models/task.py
@@ -701,13 +701,14 @@ class TaskSpec(_common.FlyteIdlEntity):
 
 
 class Task(_common.FlyteIdlEntity):
-    def __init__(self, id, closure):
+    def __init__(self, id, closure, short_description):
         """
         :param flytekit.models.core.identifier.Identifier id: The (project, domain, name) identifier for this task.
         :param TaskClosure closure: The closure for the underlying workload.
         """
         self._id = id
         self._closure = closure
+        self._short_description = short_description
 
     @property
     def id(self):
@@ -725,6 +726,13 @@ class Task(_common.FlyteIdlEntity):
         """
         return self._closure
 
+    @property
+    def short_description(self):
+        """
+        :rtype: str
+        """
+        return self._short_description
+
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.admin.task_pb2.Task
@@ -732,6 +740,7 @@ class Task(_common.FlyteIdlEntity):
         return _admin_task.Task(
             closure=self.closure.to_flyte_idl(),
             id=self.id.to_flyte_idl(),
+            short_description=self.short_description,
         )
 
     @classmethod
@@ -743,6 +752,7 @@ class Task(_common.FlyteIdlEntity):
         return cls(
             closure=TaskClosure.from_flyte_idl(pb2_object.closure),
             id=_identifier.Identifier.from_flyte_idl(pb2_object.id),
+            short_description=pb2_object.short_description,
         )
 
 

--- a/flytekit/models/task.py
+++ b/flytekit/models/task.py
@@ -701,7 +701,7 @@ class TaskSpec(_common.FlyteIdlEntity):
 
 
 class Task(_common.FlyteIdlEntity):
-    def __init__(self, id, closure, short_description):
+    def __init__(self, id, closure, short_description=None):
         """
         :param flytekit.models.core.identifier.Identifier id: The (project, domain, name) identifier for this task.
         :param TaskClosure closure: The closure for the underlying workload.
@@ -729,6 +729,7 @@ class Task(_common.FlyteIdlEntity):
     @property
     def short_description(self):
         """
+        The short description of the task.
         :rtype: str
         """
         return self._short_description

--- a/tests/flytekit/unit/models/test_tasks.py
+++ b/tests/flytekit/unit/models/test_tasks.py
@@ -299,6 +299,7 @@ def test_task(task_closure):
     obj = task.Task(
         identifier.Identifier(identifier.ResourceType.TASK, "project", "domain", "name", "version"),
         task_closure,
+        "my short description",
     )
     assert obj.id.project == "project"
     assert obj.id.domain == "domain"

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -390,12 +390,15 @@ def get_compiled_workflow_closure():
 def test_fetch_lazy(remote):
     mock_client = remote._client
     mock_client.get_task.return_value = Task(
-        id=Identifier(ResourceType.TASK, "p", "d", "n", "v"), closure=LIST_OF_TASK_CLOSURES[0]
+        id=Identifier(ResourceType.TASK, "p", "d", "n", "v"),
+        closure=LIST_OF_TASK_CLOSURES[0],
+        short_description="task description",
     )
 
     mock_client.get_workflow.return_value = Workflow(
         id=Identifier(ResourceType.TASK, "p", "d", "n", "v"),
         closure=WorkflowClosure(compiled_workflow=get_compiled_workflow_closure()),
+        short_description="workflow description",
     )
 
     lw = remote.fetch_workflow_lazy(name="wn", version="v")
@@ -453,8 +456,9 @@ def test_launch_backfill(remote):
     mock_client.get_workflow.return_value = Workflow(
         id=Identifier(ResourceType.WORKFLOW, "p", "d", "daily2", "v"),
         closure=WorkflowClosure(
-            compiled_workflow=CompiledWorkflowClosure(primary=ser_wf, sub_workflows=[], tasks=tasks)
+            compiled_workflow=CompiledWorkflowClosure(primary=ser_wf, sub_workflows=[], tasks=tasks),
         ),
+        short_description="workflow description",
     )
 
     wf = remote.launch_backfill(
@@ -478,6 +482,7 @@ def test_fetch_workflow_with_branch(mock_promote, mock_workflow, remote):
     mock_client.get_workflow.return_value = Workflow(
         id=Identifier(ResourceType.TASK, "p", "d", "n", "v"),
         closure=WorkflowClosure(compiled_workflow=MagicMock()),
+        short_description="workflow description",
     )
 
     admin_launch_plan = MagicMock()
@@ -496,6 +501,7 @@ def test_fetch_workflow_with_nested_branch(mock_promote, mock_workflow, remote):
     mock_client.get_workflow.return_value = Workflow(
         id=Identifier(ResourceType.TASK, "p", "d", "n", "v"),
         closure=WorkflowClosure(compiled_workflow=MagicMock()),
+        short_description="workflow description",
     )
     admin_launch_plan = MagicMock()
     admin_launch_plan.spec = {"workflow_id": 123}
@@ -865,7 +871,6 @@ def test_register_task_with_node_dependency_hints(mock_flyte_remote_client):
     registered_workflow = rr.register_workflow(workflow1, ss)
     assert isinstance(registered_workflow, FlyteWorkflow)
     assert registered_workflow.id == Identifier(ResourceType.WORKFLOW, "flytesnacks", "development", "tests.flytekit.unit.remote.test_remote.workflow1", "dummy_version")
-
 
 @mock.patch("flytekit.remote.remote.get_serializable")
 @mock.patch("flytekit.remote.remote.FlyteRemote.fetch_launch_plan")


### PR DESCRIPTION
## Why are the changes needed?

Currently, `short_description` is defined in the Task and Workflow protos but are not being piped through in the `flytekit` Task and Workflow models.

## What changes were proposed in this pull request?

- `flytekit.models.tasks.Task` now takes a `short_description` as input
- `flytekit.models.admin.workflow.Workflow` now takes a `short_description` as input

## How was this patch tested?

Unit tests were updates 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR adds a new short_description parameter to Task and Workflow classes in flytekit models, including constructor modifications, property methods, and updated serialization for protocol buffer conversion. Tests have been updated to verify these new capabilities.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>