### PR TITLE
Bugfix for issue #6405: Fast registration runs into infinite loop

### DIFF
--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -1,6 +1,7 @@
 import dataclasses
 import os
 import shutil
+import tempfile
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Union, cast
 
@@ -237,10 +238,11 @@ class PysparkFunctionTask(AsyncConnectorExecutorMixin, PythonFunctionTask[Spark]
             and ctx.execution_state
             and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION
         ):
+            base_dir = tempfile.TemporaryDirectory().name
             file_name = "flyte_wf"
             file_format = "zip"
-            shutil.make_archive(file_name, file_format, os.getcwd())
-            self.sess.sparkContext.addPyFile(f"{file_name}.{file_format}")
+            shutil.make_archive(f"{base_dir}/{file_name}", file_format, os.getcwd())
+            self.sess.sparkContext.addPyFile(f"{base_dir}/{file_name}.{file_format}")
 
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 

--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -238,7 +238,7 @@ class PysparkFunctionTask(AsyncConnectorExecutorMixin, PythonFunctionTask[Spark]
             and ctx.execution_state
             and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION
         ):
-            base_dir = tempfile.TemporaryDirectory().name
+            base_dir = tempfile.mkdtemp()
             file_name = "flyte_wf"
             file_format = "zip"
             shutil.make_archive(f"{base_dir}/{file_name}", file_format, os.getcwd())

--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pandas as pd
 import pyspark
 import pytest
+import tempfile
 
 from google.protobuf.json_format import MessageToDict
 from flytekit import PodTemplate
@@ -191,8 +192,46 @@ def test_spark_addPyFile(mock_add_pyfile):
     ) as new_ctx:
         my_spark.pre_execute(new_ctx.user_space_params)
         mock_add_pyfile.assert_called_once()
-        os.remove(os.path.join(os.getcwd(), "flyte_wf.zip"))
 
+@mock.patch("tempfile.mkdtemp", return_value="/tmp/123")
+@mock.patch("shutil.make_archive")
+@mock.patch("pyspark.context.SparkContext.addPyFile")
+def test_spark_archive_created_in_temp_dir(mock_add_pyfile, mock_shutil_make_archive, mock_tempfile_mkdtemp):
+    @task(
+        task_config=Spark(
+            spark_conf={"spark": "1"},
+        )
+    )
+    def my_spark(a: int) -> int:
+        return a
+
+    default_img = Image(name="default", fqn="test", tag="tag")
+    serialization_settings = SerializationSettings(
+        project="project",
+        domain="domain",
+        version="version",
+        env={"FOO": "baz"},
+        image_config=ImageConfig(default_image=default_img, images=[default_img]),
+        fast_serialization_settings=FastSerializationSettings(
+            enabled=True,
+            destination_dir="/User/flyte/workflows",
+            distribution_location="s3://my-s3-bucket/fast/123",
+        ),
+    )
+
+    ctx = context_manager.FlyteContextManager.current_context()
+    with context_manager.FlyteContextManager.with_context(
+        ctx.with_execution_state(
+            ctx.new_execution_state().with_params(
+                mode=ExecutionState.Mode.TASK_EXECUTION
+            )
+        ).with_serialization_settings(serialization_settings)
+    ) as new_ctx:
+        my_spark.pre_execute(new_ctx.user_space_params)
+
+        mock_tempfile_mkdtemp.assert_called_once()
+        mock_shutil_make_archive.assert_called_once_with("/tmp/123/flyte_wf", "zip", os.getcwd())   
+        mock_add_pyfile.assert_called_once_with("/tmp/123/flyte_wf.zip")
 
 def test_spark_with_image_spec():
     custom_image = ImageSpec(


### PR DESCRIPTION
## Tracking issue
Closes flyteorg/flyte#6405

## Why are the changes needed?
In Spark fast registration workflows, `entrypoint.py` runs into an infinite loop while preparing to run the job

`flytekit` is taking everything in the current working directory and zip it, the archive file (`flyte_wf.zip`) is placed in the same directory that is being archived.

`shutil.make_archive` creates a zip file and archives the whole directory, including the zip file itself. In the case of Databricks clusters, it triggers a recursion and runs into an endless zipping loop.

## What changes were proposed in this pull request?
The easiest way to fix this issue to create the archive outside of the directory to be archived.

## How was this patch tested?
Built a docker image with the fixed flytekit version and tested it E2E.

### Setup process

### Screenshots

## Check all the applicable boxes
- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs


## Docs link 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes a critical bug in Spark fast registration workflow that caused an infinite loop due to recursive archiving. The solution moves archive creation to a temporary directory, preventing the archive file from including itself. The changes also streamline function parameters and improve mock assertions for better test reliability.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>