### PR TITLE
(backport) Fast registration runs into infinite loop

### DIFF
--- a/plugins/flytekit-spark/flytekitplugins/spark/task.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/task.py
@@ -1,6 +1,7 @@
 import dataclasses
 import os
 import shutil
+import tempfile
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Union, cast
 
@@ -204,10 +205,11 @@ class PysparkFunctionTask(AsyncAgentExecutorMixin, PythonFunctionTask[Spark]):
             and ctx.execution_state
             and ctx.execution_state.mode == ExecutionState.Mode.TASK_EXECUTION
         ):
+            base_dir = tempfile.mkdtemp()
             file_name = "flyte_wf"
             file_format = "zip"
-            shutil.make_archive(file_name, file_format, os.getcwd())
-            self.sess.sparkContext.addPyFile(f"{file_name}.{file_format}")
+            shutil.make_archive(f"{base_dir}/{file_name}", file_format, os.getcwd())
+            self.sess.sparkContext.addPyFile(f"{base_dir}/{file_name}.{file_format}")
 
         return user_params.builder().add_attr("SPARK_SESSION", self.sess).build()
 


### PR DESCRIPTION
## Tracking issue
Closes flyteorg/flyte#6405

## Why are the changes needed?
In Spark fast registration workflows, `entrypoint.py` runs into an infinite loop while preparing to run the job

`flytekit` is taking everything in the current working directory and zip it, the archive file (`flyte_wf.zip`) is placed in the same directory that is being archived.

`shutil.make_archive` creates a zip file and archives the whole directory, including the zip file itself. In the case of Databricks clusters, it triggers a recursion and runs into an endless zipping loop.

## What changes were proposed in this pull request?
The easiest way to fix this issue to create the archive outside of the directory to be archived.

## How was this patch tested?
Built a docker image with the fixed flytekit version and tested it E2E.

### Setup process

### Screenshots

## Check all the applicable boxes
- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs


## Docs link 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request addresses a critical bug in Spark fast registration workflows by preventing an infinite zipping loop through relocating archive creation to a temporary directory. It also fixes several issues including dependency constraints in pyproject.toml, potential uninitialized variable errors, improper FlyteFile API usage, and type mismatches in structured datasets.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 5
</div>