### PR TITLE
[BUG] flytekit: Cache object "policies" kwarg typing accepts a list, but errors if provided a list

### DIFF
--- a/flytekit/core/cache.py
+++ b/flytekit/core/cache.py
@@ -73,6 +73,8 @@ class Cache:
             self._policies = get_plugin().get_default_cache_policies()
         elif isinstance(self.policies, CachePolicy):
             self._policies = [self.policies]
+        elif isinstance(self.policies, list) and all(isinstance(policy, CachePolicy) for policy in self.policies):
+            self._policies = self.policies
 
         if self.version is None and not self._policies:
             raise ValueError("If version is not defined then at least one cache policy needs to be set")

--- a/tests/flytekit/unit/core/test_cache.py
+++ b/tests/flytekit/unit/core/test_cache.py
@@ -131,7 +131,7 @@ def test_basic_salt_cache_policy(default_serialization_settings):
     @task(cache=Cache(salt="a-sprinkle-of-salt", policies=[SaltCachePolicy(), SaltCachePolicy()]))
     def t_cached_with_multiple_policies(a: int) -> int:
         return a + 2
-    
+
     serialized_t_cached = get_serializable_task(OrderedDict(), default_serialization_settings, t_cached_with_multiple_policies)
     assert serialized_t_cached.template.metadata.discoverable == True
 

--- a/tests/flytekit/unit/core/test_cache.py
+++ b/tests/flytekit/unit/core/test_cache.py
@@ -127,6 +127,14 @@ def test_basic_salt_cache_policy(default_serialization_settings):
     assert serialized_t_cached.template.metadata.discoverable == True
     assert serialized_t_cached.template.metadata.discovery_version == "348b4b8c52d8868e0c202ce4d26d59906c13716197b611a0a7a215074159df79"
 
+    # test successfully create task while passing a CachePolicy list
+    @task(cache=Cache(salt="a-sprinkle-of-salt", policies=[SaltCachePolicy(), SaltCachePolicy()]))
+    def t_cached_with_multiple_policies(a: int) -> int:
+        return a + 2
+    
+    serialized_t_cached = get_serializable_task(OrderedDict(), default_serialization_settings, t_cached_with_multiple_policies)
+    assert serialized_t_cached.template.metadata.discoverable == True
+
 
 @mock.patch("flytekit.configuration.plugin.FlytekitPlugin.get_default_cache_policies")
 def test_set_default_policies(mock_get_default_cache_policies, default_serialization_settings):


### PR DESCRIPTION
## Tracking issue

Closes flyteorg/flyte#6420
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?
The `Cache` constructor's policies kwarg is typed `Optional[Union[List[CachePolicy], CachePolicy]]`, so it should accept a list of policies. But it throws an error when passing a `CachePolicy` list while initializing a Cache instance.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Fix flytekit code to correctly accept `CachePolicy` list while initializing a new Cache instance.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
The test code:
<img width="566" alt="image" src="https://github.com/user-attachments/assets/ae9f54d2-9948-40e8-ae37-80d8a9e6db68" />

Before the code fix, an error occured:
![image](https://github.com/user-attachments/assets/c8d45d44-e993-4507-8757-dc395942f06c)

After the code fix, the error is gone:
![image](https://github.com/user-attachments/assets/1eb141b5-9503-4180-b076-04ae2cc62248)


<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] All new and existing tests passed.
- [X] All commits are signed-off. 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes a bug in the cache initialization process by adding proper handling for lists of CachePolicy objects. The change ensures the Cache constructor correctly processes policy lists, preventing type mismatch errors. The update includes test improvements to verify list acceptance functionality and enhances cache initialization robustness by ensuring proper type compatibility.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>