### PR TITLE
fix(flytekit-airflow): pin apache-airflow version < 3.0.0

### DIFF
--- a/plugins/flytekit-airflow/setup.py
+++ b/plugins/flytekit-airflow/setup.py
@@ -5,7 +5,7 @@ PLUGIN_NAME = "airflow"
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 plugin_requires = [
-    "apache-airflow",
+    "apache-airflow<3.0.0",
     "apache-airflow-providers-google<12.0.0",
     "flytekit>1.10.7",
     "flyteidl>1.10.7",


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
The unit test in the Airflow plugins is failing since it's not compatible with airflow 3

## What changes were proposed in this pull request?
pin apache-airflow version < 3.0.0

## How was this patch tested?
CI

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR pins the apache-airflow dependency in setup.py to remain below version 3.0.0. The change prevents unit test failures associated with Airflow 3 and ensures environment stability. This is a straightforward dependency update with no functional code changes.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>