### PR TITLE
Replacing deprecated disable_deck with new enable_deck property

### DIFF
--- a/flytekit/core/base_task.py
+++ b/flytekit/core/base_task.py
@@ -525,7 +525,7 @@ class PythonTask(TrackedInstance, Task, Generic[T]):
         else:
             self._disable_deck = True
 
-        self._deck_fields = list(deck_fields) if (deck_fields is not None and self.disable_deck is False) else []
+        self._deck_fields = list(deck_fields) if (deck_fields is not None and self.enable_deck) else []
 
         deck_members = set([_field for _field in DeckField])
         # enumerate additional decks, check if any of them are invalid


### PR DESCRIPTION
`disable_deck` is deprecated. This makes my tests go yellow which is obviously an unbearable situation. Should be a straightforward merge. Searching for "self.disable_deck" does not return any matches after this fix.

Happy monday! 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR updates the task configuration by replacing the deprecated disable_deck property with enable_deck in flytekit/core/base_task.py. The change improves deck field assignment logic, ensuring deck_fields are only set when explicitly provided and enable_deck is true, which resolves previous testing issues.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>