### PR TITLE
Make image_spec.tag a cached property

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -489,7 +489,7 @@ class DefaultImageBuilder(ImageSpecBuilder):
 
             initial_image_tag = image_spec.tag
             create_docker_context(image_spec, tmp_path)
-            
+
             # Check that hash-based image tag didn't change while creating the context.
             # This doesn't cover all the cases, but this is a good check.
             del image_spec.tag

--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -486,7 +486,18 @@ class DefaultImageBuilder(ImageSpecBuilder):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir)
+
+            initial_image_tag = image_spec.tag
             create_docker_context(image_spec, tmp_path)
+            
+            # Check that hash-based image tag didn't change while creating the context.
+            # This doesn't cover all the cases, but this is a good check.
+            del image_spec.tag
+            if image_spec.tag != initial_image_tag:
+                raise ValueError(
+                    f"Hash-based image tag changed from {initial_image_tag} to {image_spec.tag} while creating the context,"
+                    f"indicating the content has been modified. Aborting because image tag may not match what is built."
+                )
 
             command = [
                 "docker",

--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -186,7 +186,7 @@ class ImageSpec:
     def __hash__(self):
         return hash(self.id)
 
-    @property
+    @cached_property
     def tag(self) -> str:
         """
         Calculate a hash from the image spec. The hash will be the tag of the image.

--- a/tests/flytekit/unit/core/image_spec/test_default_builder.py
+++ b/tests/flytekit/unit/core/image_spec/test_default_builder.py
@@ -300,7 +300,7 @@ def test_uv_lock_error_no_packages(monkeypatch, tmp_path, lock_file):
     image_spec = ImageSpec(
         name="FLYTEKIT",
         python_version="3.12",
-        requirements=os.fspath(lock_file),
+        requirements=os.fspath(lock_file_path),
         packages=["ruff"],
     )
     builder = DefaultImageBuilder()

--- a/tests/flytekit/unit/core/image_spec/test_default_builder.py
+++ b/tests/flytekit/unit/core/image_spec/test_default_builder.py
@@ -225,6 +225,14 @@ def test_should_push_env(monkeypatch, push_image_spec):
         assert "--push" in call_args[0]
 
 
+def test_build_raises_if_tag_changed():
+    image_spec = ImageSpec(name="my_flytekit", python_version="3.12", registry="localhost:30000")
+    image_spec.tag = "arbitrarily_set_cached_tag" # This simulates a tag change due to file changes.
+    builder = DefaultImageBuilder()
+    with pytest.raises(ValueError, match="image tag changed"):
+        builder.build_image(image_spec)
+
+
 def test_create_docker_context_uv_lock(tmp_path):
     docker_context_path = tmp_path / "builder_root"
     docker_context_path.mkdir()


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?
Currently, `image_spec.tag` used by `image_spec.image_name()` calculates hash based on file contents every time. 
1. This may lead to "ImagePullBackOff" when running the registered component, because flyte uses different image_name for registration from what is used in image build and push if the file content was modified while the image is built.
2. Going through files every time isn't efficient

## What changes were proposed in this pull request?

1. Make the `image_spec.tag` a cached_property, to avoid unnecessary recomputes.
2. If the image is actually built, check that the tag is still consistent with what was in the cache. This doesn't prevent if the content was just modified while creating docker context, but it should be rare. Alternative is to make image tag based on the created temporary context, but it will be a much bigger change.
3. This check is put right after context creation but before the build, because build is typically takes much longer and there is a higher chance of false alarm.

## How was this patch tested?

Added a test to check if image build raises if cached tag is not consistent with the newly computed tag after context is created.

I also manually checked that `ValueError` is raised at by `builder.build_image(image_spec)` if some file content is modified after `image_spec.image_name()` was called.
```
from flytekit.image_spec import ImageSpec
from flytekit.image_spec.default_builder import DefaultImageBuilder                                          
image_spec = ImageSpec(name="my_flytekit", python_version="3.12", registry="localhost:30000", copy=['README.md'])
print(image_spec.image_name())
open('README.md', 'w').close()
builder = DefaultImageBuilder()
builder.build_image(image_spec)
```
raises
```
ValueError: Hash-based image tag changed from hcychPh46DxCaAFG984sAg to AkFsLDxgsB7R45XBhl9EfA while creating the
context,indicating the content has been modified. Aborting because image tag may not match what is built.
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances the image_spec module with a cached_property for image tag computation, improving performance and reducing redundant file operations. It adds verification that hash-based tags remain unchanged during Docker context creation, ensuring image naming consistency and build reliability. The changes also fix a test to use the correct lock file path.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>