### PR TITLE
Include hash of pod template when computing fast registration version

### DIFF
--- a/flytekit/core/pod_template.py
+++ b/flytekit/core/pod_template.py
@@ -1,4 +1,6 @@
-from dataclasses import dataclass
+import hashlib
+import json
+from dataclasses import asdict, dataclass, is_dataclass
 from typing import TYPE_CHECKING, Dict, Optional
 
 from flytekit.exceptions import user as _user_exceptions
@@ -7,6 +9,24 @@ if TYPE_CHECKING:
     from kubernetes.client import V1PodSpec
 
 PRIMARY_CONTAINER_DEFAULT_NAME = "primary"
+
+
+def serialize_pod_template(obj):
+    if hasattr(obj, "to_dict"):
+        d = obj.to_dict()
+        if obj.__class__.__name__ == "V1Container":
+            image = getattr(obj, "image", None)
+            if hasattr(image, "image_name"):
+                d["image"] = image.image_name()
+        return {k: serialize_pod_template(v) for k, v in d.items()}
+    elif isinstance(obj, list):
+        return [serialize_pod_template(o) for o in obj]
+    elif isinstance(obj, dict):
+        return {k: serialize_pod_template(v) for k, v in obj.items()}
+    elif is_dataclass(obj):
+        return serialize_pod_template(asdict(obj))
+    else:
+        return obj
 
 
 @dataclass(init=True, repr=True, eq=True, frozen=False)
@@ -25,3 +45,8 @@ class PodTemplate(object):
             self.pod_spec = V1PodSpec(containers=[])
         if not self.primary_container_name:
             raise _user_exceptions.FlyteValidationException("A primary container name cannot be undefined")
+
+    def version_hash(self) -> str:
+        data = serialize_pod_template(self)
+        canonical_json = json.dumps(data, sort_keys=True)
+        return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -33,7 +33,7 @@ from flyteidl.admin.signal_pb2 import Signal, SignalListRequest, SignalSetReques
 from flyteidl.core import literals_pb2
 from rich.progress import Progress, TextColumn, TimeElapsedColumn
 
-from flytekit import ImageSpec
+from flytekit import ImageSpec, PodTemplate
 from flytekit.clients.friendly import SynchronousFlyteClient
 from flytekit.clients.helpers import iterate_node_executions, iterate_task_executions
 from flytekit.configuration import Config, DataConfig, FastSerializationSettings, ImageConfig, SerializationSettings
@@ -830,7 +830,11 @@ class FlyteRemote(object):
         if version is None and self.interactive_mode_enabled:
             md5_bytes, pickled_target_dict = _get_pickled_target_dict(entity)
             return self._version_from_hash(
-                md5_bytes, ss, entity.python_interface.default_inputs_as_kwargs, *self._get_image_names(entity)
+                md5_bytes,
+                ss,
+                entity.python_interface.default_inputs_as_kwargs,
+                *FlyteRemote._get_image_names(entity),
+                *FlyteRemote._get_pod_template_hash(entity),
             ), pickled_target_dict
         elif version is not None:
             return version, None
@@ -1286,13 +1290,25 @@ class FlyteRemote(object):
         # and does not increase entropy of the hash while making it very inconvenient to copy-and-paste.
         return base64.urlsafe_b64encode(h.digest()).decode("ascii").rstrip("=")
 
-    def _get_image_names(self, entity: typing.Union[PythonAutoContainerTask, WorkflowBase]) -> typing.List[str]:
+    @staticmethod
+    def _get_image_names(entity: typing.Union[PythonAutoContainerTask, WorkflowBase]) -> typing.List[str]:
         if isinstance(entity, PythonAutoContainerTask) and isinstance(entity.container_image, ImageSpec):
             return [entity.container_image.image_name()]
         if isinstance(entity, WorkflowBase):
             image_names = []
             for n in entity.nodes:
-                image_names.extend(self._get_image_names(n.flyte_entity))
+                image_names.extend(FlyteRemote._get_image_names(n.flyte_entity))
+            return image_names
+        return []
+
+    @staticmethod
+    def _get_pod_template_hash(entity: typing.Union[PythonAutoContainerTask, WorkflowBase]) -> typing.List[str]:
+        if isinstance(entity, PythonAutoContainerTask) and isinstance(entity.pod_template, PodTemplate):
+            return [entity.pod_template.version_hash()]
+        if isinstance(entity, WorkflowBase):
+            image_names = []
+            for n in entity.nodes:
+                image_names.extend(FlyteRemote._get_pod_template_hash(n.flyte_entity))
             return image_names
         return []
 
@@ -1381,7 +1397,11 @@ class FlyteRemote(object):
             # but we don't have to use it when registering with the Flyte backend.
             # For that add the hash of the compilation settings to hash of file
             version = self._version_from_hash(
-                md5_bytes, serialization_settings, default_inputs, *self._get_image_names(entity)
+                md5_bytes,
+                serialization_settings,
+                default_inputs,
+                *FlyteRemote._get_image_names(entity),
+                *FlyteRemote._get_pod_template_hash(entity),
             )
 
         if isinstance(entity, PythonTask):
@@ -2257,7 +2277,11 @@ class FlyteRemote(object):
         if version is None and self.interactive_mode_enabled:
             md5_bytes, pickled_target_dict = _get_pickled_target_dict(entity)
             version = self._version_from_hash(
-                md5_bytes, ss, entity.python_interface.default_inputs_as_kwargs, *self._get_image_names(entity)
+                md5_bytes,
+                ss,
+                entity.python_interface.default_inputs_as_kwargs,
+                *FlyteRemote._get_image_names(entity),
+                *FlyteRemote._get_pod_template_hash(entity),
             )
 
         resolved_identifiers = self._resolve_identifier_kwargs(entity, project, domain, name, version)

--- a/flytekit/tools/repo.py
+++ b/flytekit/tools/repo.py
@@ -11,7 +11,8 @@ from rich import print as rprint
 
 from flytekit.configuration import FastSerializationSettings, ImageConfig, SerializationSettings
 from flytekit.constants import CopyFileDetection
-from flytekit.core.context_manager import FlyteContextManager
+from flytekit.core.base_task import PythonTask
+from flytekit.core.context_manager import FlyteContextManager, FlyteEntities
 from flytekit.loggers import logger
 from flytekit.models import launch_plan, task
 from flytekit.models.core.identifier import Identifier
@@ -309,7 +310,14 @@ def register(
         )
         serialization_settings.fast_serialization_settings = fast_serialization_settings
         if not version:
-            version = remote._version_from_hash(md5_bytes, serialization_settings, service_account, raw_data_prefix)  # noqa
+            images, pod_templates = [], []
+            for entity in FlyteEntities.entities.copy():
+                if isinstance(entity, PythonTask):
+                    images.extend(FlyteRemote._get_image_names(entity))
+                    images.extend(FlyteRemote._get_pod_template_hash(entity))
+            version = remote._version_from_hash(
+                md5_bytes, serialization_settings, service_account, raw_data_prefix, *images, *pod_templates
+            )  # noqa
             serialization_settings.version = version
             click.secho(f"Computed version is {version}", fg="yellow")
 

--- a/tests/flytekit/unit/core/test_pod_template_hash.py
+++ b/tests/flytekit/unit/core/test_pod_template_hash.py
@@ -1,0 +1,166 @@
+import unittest
+
+from kubernetes.client import V1PodSpec, V1Container
+
+from flytekit import PodTemplate, task, ImageSpec
+from flytekit.configuration import SerializationSettings, ImageConfig, Image
+
+
+class TestPodTemplateHashing(unittest.TestCase):
+    """Test suite for PodTemplate.version_hash()."""
+
+    def test_default_initialization_hash_consistency(self):
+        """Tests that default PodTemplates have consistent hashes."""
+        pt1 = PodTemplate()
+        pt2 = PodTemplate()
+        self.assertEqual(pt1.version_hash(), pt2.version_hash())
+
+    def test_identical_complex_objects_hash_consistency(self):
+        """Tests that identical complex PodTemplates have the same hash."""
+        common_pod_spec = V1PodSpec(
+            containers=[
+                V1Container(name="c1", image="img1:latest", command=["/bin/sh", "-c", "echo hello"]),
+                V1Container(name="c2", image=ImageSpec(name="img2-repo/img2:v1.0"))
+            ],
+            restart_policy="Never",
+            node_selector={"disktype": "ssd"}
+        )
+        pt1 = PodTemplate(
+            pod_spec=common_pod_spec,
+            primary_container_name="c1",
+            labels={"app": "myapp", "env": "prod"},
+            annotations={"author": "tester", "version": "1.2.3"}
+        )
+        pt2 = PodTemplate(
+            pod_spec=common_pod_spec,  # Same instance, but could be an identical copy
+            primary_container_name="c1",
+            labels={"app": "myapp", "env": "prod"},  # Same content
+            annotations={"author": "tester", "version": "1.2.3"}  # Same content
+        )
+        self.assertEqual(pt1.version_hash(), pt2.version_hash())
+
+    def test_different_primary_container_name(self):
+        """Tests that different primary_container_name yields different hashes."""
+        pt1 = PodTemplate(primary_container_name="main")
+        pt2 = PodTemplate(primary_container_name="worker")
+        self.assertNotEqual(pt1.version_hash(), pt2.version_hash())
+
+    def test_different_labels(self):
+        """Tests that different labels yield different hashes."""
+        pt1 = PodTemplate(labels={"app": "app1"})
+        pt2 = PodTemplate(labels={"app": "app2"})
+        pt3 = PodTemplate(labels={"app": "app1", "version": "v1"})
+        self.assertNotEqual(pt1.version_hash(), pt2.version_hash())
+        self.assertNotEqual(pt1.version_hash(), pt3.version_hash())
+
+    def test_label_order_does_not_affect_hash(self):
+        """Tests that the order of keys in labels does not affect the hash."""
+        pt1 = PodTemplate(labels={"app": "app1", "env": "prod"})
+        pt2 = PodTemplate(labels={"env": "prod", "app": "app1"})  # Same labels, different order
+        self.assertEqual(pt1.version_hash(), pt2.version_hash())
+
+    def test_different_annotations(self):
+        """Tests that different annotations yield different hashes."""
+        pt1 = PodTemplate(annotations={"owner": "teamA"})
+        pt2 = PodTemplate(annotations={"owner": "teamB"})
+        self.assertNotEqual(pt1.version_hash(), pt2.version_hash())
+
+    def test_annotation_order_does_not_affect_hash(self):
+        """Tests that the order of keys in annotations does not affect the hash."""
+        pt1 = PodTemplate(annotations={"owner": "teamA", "contact": "a@example.com"})
+        pt2 = PodTemplate(annotations={"contact": "a@example.com", "owner": "teamA"})
+        self.assertEqual(pt1.version_hash(), pt2.version_hash())
+
+    def test_different_pod_spec_restart_policy(self):
+        """Tests that different pod_spec.restart_policy yields different hashes."""
+        # Explicitly initialize containers to an empty list
+        spec1 = V1PodSpec(containers=[], restart_policy="Always")
+        spec2 = V1PodSpec(containers=[], restart_policy="Never")
+        pt1 = PodTemplate(pod_spec=spec1)
+        pt2 = PodTemplate(pod_spec=spec2)
+        self.assertNotEqual(pt1.version_hash(), pt2.version_hash())
+
+    def test_different_pod_spec_node_selector(self):
+        """Tests that different pod_spec.node_selector yields different hashes."""
+        # Explicitly initialize containers to an empty list
+        spec1 = V1PodSpec(containers=[], node_selector={"type": "compute"})
+        spec2 = V1PodSpec(containers=[], node_selector={"type": "memory"})
+        pt1 = PodTemplate(pod_spec=spec1)
+        pt2 = PodTemplate(pod_spec=spec2)
+        self.assertNotEqual(pt1.version_hash(), pt2.version_hash())
+
+        # Test order in node_selector also with explicit containers
+        spec3 = V1PodSpec(containers=[], node_selector={"type": "compute", "region": "us-east-1"})
+        spec4 = V1PodSpec(containers=[], node_selector={"region": "us-east-1", "type": "compute"})
+        pt3 = PodTemplate(pod_spec=spec3)
+        pt4 = PodTemplate(pod_spec=spec4)
+        self.assertEqual(pt3.version_hash(), pt4.version_hash())
+
+    def test_different_container_name(self):
+        """Tests that different container names yield different hashes."""
+        spec1 = V1PodSpec(containers=[V1Container(name="container-a")])
+        spec2 = V1PodSpec(containers=[V1Container(name="container-b")])
+        pt1 = PodTemplate(pod_spec=spec1)
+        pt2 = PodTemplate(pod_spec=spec2)
+        self.assertNotEqual(pt1.version_hash(), pt2.version_hash())
+
+    def test_different_container_image_string(self):
+        """Tests that different container image strings yield different hashes."""
+        spec1 = V1PodSpec(containers=[V1Container(name="c1", image="image:v1")])
+        spec2 = V1PodSpec(containers=[V1Container(name="c1", image="image:v2")])
+        pt1 = PodTemplate(pod_spec=spec1)
+        pt2 = PodTemplate(pod_spec=spec2)
+        self.assertNotEqual(pt1.version_hash(), pt2.version_hash())
+
+    def test_different_container_image_object(self):
+        """Tests that different container ImageSpec objects yield different hashes."""
+        spec1 = V1PodSpec(containers=[V1Container(name="c1", image=ImageSpec(name="image-v1"))])
+        spec2 = V1PodSpec(containers=[V1Container(name="c1", image=ImageSpec(name="image-v2"))])
+        pt1 = PodTemplate(pod_spec=spec1)
+        pt2 = PodTemplate(pod_spec=spec2)
+        self.assertNotEqual(pt1.version_hash(), pt2.version_hash())
+
+    def test_container_image_string_vs_object(self):
+        """Tests that image as string vs ImageSpec (if names match) yields same hash due to serialization."""
+        spec1 = V1PodSpec(containers=[V1Container(name="c1", image="myimage:latest")])
+        spec2 = V1PodSpec(containers=[V1Container(name="c1", image=ImageSpec(name="myimage:latest"))])
+        pt1 = PodTemplate(pod_spec=spec1)
+        pt2 = PodTemplate(pod_spec=spec2)
+        self.assertNotEqual(pt1.version_hash(), pt2.version_hash())
+
+    def test_different_container_command(self):
+        """Tests that different container commands yield different hashes."""
+        spec1 = V1PodSpec(containers=[V1Container(name="c1", command=["echo", "hello"])])
+        spec2 = V1PodSpec(containers=[V1Container(name="c1", command=["echo", "world"])])
+        pt1 = PodTemplate(pod_spec=spec1)
+        pt2 = PodTemplate(pod_spec=spec2)
+        self.assertNotEqual(pt1.version_hash(), pt2.version_hash())
+
+    def test_order_of_containers_matters(self):
+        """Tests that the order of containers in pod_spec affects the hash."""
+        c1 = V1Container(name="c1", image="img1")
+        c2 = V1Container(name="c2", image="img2")
+        spec1 = V1PodSpec(containers=[c1, c2])
+        spec2 = V1PodSpec(containers=[c2, c1])
+        pt1 = PodTemplate(pod_spec=spec1)
+        pt2 = PodTemplate(pod_spec=spec2)
+        self.assertNotEqual(pt1.version_hash(), pt2.version_hash())
+
+    def test_pod_spec_with_none_values_in_mock(self):
+        """
+        Tests how None values in mocked K8s objects are handled by serialization.
+        """
+        container_with_nones = V1Container(name="c-none", image=None, command=None)
+        spec1 = V1PodSpec(containers=[container_with_nones], restart_policy=None)
+        pt1 = PodTemplate(pod_spec=spec1, labels=None, annotations=None)
+
+        container_copy = V1Container(name="c-none", image=None, command=None)
+        spec2 = V1PodSpec(containers=[container_copy], restart_policy=None)
+        pt2 = PodTemplate(pod_spec=spec2, labels=None, annotations=None)
+
+        self.assertEqual(pt1.version_hash(), pt2.version_hash())
+
+        container_diff = V1Container(name="c-none", image="some-image", command=None)
+        spec3 = V1PodSpec(containers=[container_diff], restart_policy=None)
+        pt3 = PodTemplate(pod_spec=spec3, labels=None, annotations=None)
+        self.assertNotEqual(pt1.version_hash(), pt3.version_hash())


### PR DESCRIPTION
## Why are the changes needed?

We need to account for changes to the image and pod template based on resolution of env variables rather than a code change. e.g. a user may have an env variable that controls the base image of an imagespec. If the env variable changes, the version we compute should change, but currently it does not.

There are two paths fast registration can take:
1. pyflyte run -> version computed in remote.py
2. pyflyte register -> version computed in repo.py

In remote.py, we account for a change in `container_image` but not `pod_template`. In repo.py, don't account for for either.

## What changes were proposed in this pull request?

1. Add a method to `PodTemplate` that hashes its contents.
2. Add a method that searches an entity for a pod template and adds its hash to a list.
3. Include the list of pod template hashes in the remote.py version computation.
4. Include the list of pod template hashes and container_images in the repo.py version computation.

## How was this patch tested?

Before:
1. Define a workflow with a pod template where the image is defined in an imagespec which takes a base image from an env variable.
2. pyflyte register with two different base images defined via the env variable -> get failure:
```
Request rejected by the API, due to Invalid input.
RPC Failed, with Status: StatusCode.INVALID_ARGUMENT
        Details: wf.get_data task with different structure already exists. (Please register a new version of the task):
/template/Target/K8SPod/pod_spec/containers/0/image:
        - ghcr.io/dansola/test-image:1b8tlwn3V2jJmbKngwS6Pg 
        + ghcr.io/dansola/test-image:r754JC2IneS_Ey0WqswIVw
```
3. pyflyte run --remote with two different base images defined via the env variable -> get the same failure as above

After:
1. Define a workflow with a pod template where the image is defined in an imagespec which takes a base image from an env variable.
2. pyflyte register with two different base images defined via the env variable -> no failure and a re-registration doesn't generate a new version
4. pyflyte run --remote with two different base images defined via the env variable -> no failure

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.


 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances versioning by incorporating pod template changes alongside container images in version computation. It adds a hashing method in PodTemplate to capture environment variable changes reflecting image modifications. The implementation spans remote.py and repo.py to ensure consistent behavior across registration and run commands, with comprehensive tests validating functionality.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>