### PR TITLE
[FIX] Limit click version <8.2.0 to prevent `build-with-pandas` CI fail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.9,<3.13"
 dependencies = [
     # Please maintain an alphabetical order in the following list
     "adlfs>=2023.3.0",
-    "click>=6.6",
+    "click>=6.6,<8.2.0",
     "cloudpickle>=2.0.0",
     "croniter>=0.3.20",
     "dataclasses-json>=0.5.2,<0.5.12", # TODO: remove upper-bound after fixing change in contract


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?

Currently, most of the PRs are failing on `build-with-pandas` CI, which is cased by click add the `ctx` args in `click.ParamType.get_metavar()` in version 8.2.0 (see [here](https://github.com/pallets/click/blob/219206a18666624072fdbb803901e5eb7ce575a1/src/click/types.py#L92))

## What changes were proposed in this pull request?

Limiting the click version to `<8.2.0` to prevent this issue.

## How was this patch tested?


### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
