### PR TITLE
add FlyteRemote.deactivate_launchplan

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -2963,6 +2963,12 @@ class FlyteRemote(object):
         """
         self.client.update_launch_plan(id=ident, state=LaunchPlanState.ACTIVE)
 
+    def deactivate_launchplan(self, ident: Identifier):
+        """
+        Given a launchplan, deactivate it, all previous versions are deactivated.
+        """
+        self.client.update_launch_plan(id=ident, state=LaunchPlanState.INACTIVE)
+
     def download(
         self, data: typing.Union[LiteralsResolver, Literal, LiteralMap], download_to: str, recursive: bool = True
     ):


### PR DESCRIPTION
## Why are the changes needed?

We have a `FlyteRemote.activate_launchplan` convenience method, but there's no way to deactivate a launch plan from a remote object.

## What changes were proposed in this pull request?

Adds a `deactivate_launchplan` to the `FlyteRemote` class

## How was this patch tested?

Tested on local sandbox

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request adds a new method, `deactivate_launchplan`, to the `FlyteRemote` class, enabling users to deactivate launch plans. This enhancement fills a gap in functionality alongside the existing activation method. Local tests were conducted to verify its proper operation.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-defined, making the review process relatively simple.
-->
</div>