### PR TITLE
[CI] fix flytekit-deck-standard python 3.9 test

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -50,7 +50,7 @@ autoflake
 
 pillow
 numpy
-pandas
+pandas!=2.3.0
 pyarrow
 scikit-learn
 types-requests


### PR DESCRIPTION
as title.
based on the pandas's release history and CI's log, I think pandas's version is the root cause.

pandas's release history: https://pypi.org/project/pandas/2.3.0/#history
CI failure log: https://github.com/flyteorg/flytekit/actions/runs/15499773618/job/43645093140