### PR TITLE
Fix issue where pod template override pod spec was missing

### DIFF
--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -461,8 +461,9 @@ def get_serializable_node(
     elif isinstance(entity.flyte_entity, PythonTask):
         # handle pod template overrides
         override_pod_spec = {}
-        if entity._pod_template is not None and settings.should_fast_serialize():
-            entity.flyte_entity.set_command_fn(_fast_serialize_command_fn(settings, entity.flyte_entity))
+        if entity._pod_template is not None:
+            if settings.should_fast_serialize():
+                entity.flyte_entity.set_command_fn(_fast_serialize_command_fn(settings, entity.flyte_entity))
             override_pod_spec = _serialize_pod_spec(
                 entity._pod_template, entity.flyte_entity._get_container(settings), settings
             )

--- a/tests/flytekit/unit/test_translator.py
+++ b/tests/flytekit/unit/test_translator.py
@@ -2,7 +2,7 @@ import typing
 from collections import OrderedDict
 
 import flytekit.configuration
-from flytekit import ContainerTask, Resources
+from flytekit import ContainerTask, Resources, PodTemplate
 from flytekit.configuration import FastSerializationSettings, Image, ImageConfig
 from flytekit.core.base_task import kwtypes
 from flytekit.core.launch_plan import LaunchPlan, ReferenceLaunchPlan
@@ -12,7 +12,9 @@ from flytekit.core.workflow import ReferenceWorkflow, workflow
 from flytekit.deck import Deck
 from flytekit.models.core import identifier as identifier_models
 from flytekit.models.task import Resources as resource_model
-from flytekit.tools.translator import get_serializable, Options
+from flytekit.tools.translator import get_serializable
+from kubernetes import client
+from kubernetes.client import V1PodSpec, V1Container
 import pytest
 
 default_img = Image(name="default", fqn="test", tag="tag")
@@ -183,3 +185,35 @@ def test_launch_plan_with_fixed_input():
     assert len(task_spec.template.interface.outputs) == 1
     assert len(task_spec.template.nodes) == 1
     assert len(task_spec.template.nodes[0].inputs) == 2
+
+def test_task_with_pod_template_override():
+
+    custom_pod_template = PodTemplate(pod_spec=V1PodSpec(
+        containers=[
+            V1Container(
+                name="primary",
+                env=[
+                    client.V1EnvVar(name="MY_KEY", value="MY_VALUE"),
+                ]
+            )
+        ]
+    ))
+
+    @task
+    def t(a: str) -> str:
+        return a
+
+    @workflow
+    def wf():
+        t("Hello World").with_overrides(pod_template=custom_pod_template)
+
+    task_spec = get_serializable(OrderedDict(), serialization_settings, wf)
+    assert len(task_spec.template.nodes) == 1
+    node = task_spec.template.nodes[0]
+    assert node.metadata.name == "t"
+    assert node.task_node.overrides.pod_template is not None
+    pod_template_override = node.task_node.overrides.pod_template
+    assert pod_template_override.pod_spec # validate not empty
+    assert len(pod_template_override.pod_spec['containers']) == 1
+    container = pod_template_override.pod_spec['containers'][0]
+    assert container['env'] == [{'name': 'MY_KEY', 'value': 'MY_VALUE'}]


### PR DESCRIPTION
## Tracking issue
Fixes https://github.com/flyteorg/flyte/issues/6463

## Why are the changes needed?
The pod_spec was not included in the pod template when not using fast registration. This would lead to bad task specification errors on the backend since there would be no pod spec but a primary container name was configured.

Although this comes from our custom Armada plugin, the plugin is just using common pod_helpers code. 

> RuntimeExecutionError: max number of system retry attempts [31/30] exhausted. Last known status message: failed at Node[n0-n0]. RuntimeExecutionError: failed during plugin execution, caused by: failed to execute handle for plugin [armada]: generating job request: [BadTaskSpecification] invalid TaskSpecification, primary container [primary] not defined

After debugging I found that this was logged from propeller pod_helpers.go code.
```
podTemplate=metadata:{} pod_spec:{} primary_container_name:"primary"
```

## What changes were proposed in this pull request?
Updates the translation code to render the pod template pod spec unconditionally.

## How was this patch tested?
Tested in a production environment.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request resolves an issue with the pod template override and the pod specification missing during non-fast registration, ensuring the pod spec is rendered unconditionally and enhancing task execution reliability. The changes were validated in a production environment.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>