### PR TITLE
Add support pyspark.sql.classic.dataframe.DataFrame transformer

### DIFF
--- a/plugins/flytekit-spark/flytekitplugins/spark/schema.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/schema.py
@@ -83,8 +83,10 @@ class SparkDataFrameTransformer(TypeTransformer[pyspark.sql.DataFrame]):
         r = SparkDataFrameSchemaReader(from_path=lv.scalar.schema.uri, cols=None, fmt=SchemaFormat.PARQUET)
         return r.all()
 
+
 classic_ps_dataframe = lazy_module("pyspark.sql.classic.dataframe")
 ClassicDataFrame = classic_ps_dataframe.DataFrame
+
 
 class ClassicSparkDataFrameSchemaReader(SchemaReader[ClassicDataFrame]):
     """
@@ -103,6 +105,7 @@ class ClassicSparkDataFrameSchemaReader(SchemaReader[ClassicDataFrame]):
             return ctx.spark_session.read.parquet(self.from_path)
         raise AssertionError("Only Parquet type files are supported for classic spark dataframe currently")
 
+
 class ClassicSparkDataFrameSchemaWriter(SchemaWriter[ClassicDataFrame]):
     """
     Implements how Classic SparkDataFrame should be written using ``open`` method of FlyteSchema
@@ -120,6 +123,7 @@ class ClassicSparkDataFrameSchemaWriter(SchemaWriter[ClassicDataFrame]):
             dfs[0].write.mode("overwrite").parquet(self.to_path)
             return
         raise AssertionError("Only Parquet type files are supported for classic spark dataframe currently")
+
 
 class ClassicSparkDataFrameTransformer(TypeTransformer[ClassicDataFrame]):
     """
@@ -156,6 +160,7 @@ class ClassicSparkDataFrameTransformer(TypeTransformer[ClassicDataFrame]):
             return ClassicDataFrame()
         r = ClassicSparkDataFrameSchemaReader(from_path=lv.scalar.schema.uri, cols=None, fmt=SchemaFormat.PARQUET)
         return r.all()
+
 
 # %%
 # Registers a handle for Spark DataFrame + Flyte Schema type transition

--- a/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
@@ -76,6 +76,7 @@ StructuredDatasetTransformerEngine.register_renderer(DataFrame, SparkDataFrameRe
 classic_ps_dataframe = lazy_module("pyspark.sql.classic.dataframe")
 ClassicDataFrame = classic_ps_dataframe.DataFrame
 
+
 class ClassicSparkToParquetEncodingHandler(StructuredDatasetEncoder):
     def __init__(self):
         super().__init__(ClassicDataFrame, None, PARQUET)
@@ -98,6 +99,7 @@ class ClassicSparkToParquetEncodingHandler(StructuredDatasetEncoder):
         df.write.mode("overwrite").parquet(path=path)
         return literals.StructuredDataset(uri=path, metadata=StructuredDatasetMetadata(structured_dataset_type))
 
+
 class ParquetToClassicSparkDecodingHandler(StructuredDatasetDecoder):
     def __init__(self):
         super().__init__(ClassicDataFrame, None, PARQUET)
@@ -113,6 +115,7 @@ class ParquetToClassicSparkDecodingHandler(StructuredDatasetDecoder):
             columns = [c.name for c in current_task_metadata.structured_dataset_type.columns]
             return user_ctx.spark_session.read.parquet(flyte_value.uri).select(*columns)
         return user_ctx.spark_session.read.parquet(flyte_value.uri)
+
 
 # Register the handlers
 StructuredDatasetTransformerEngine.register(ClassicSparkToParquetEncodingHandler())

--- a/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/sd_transformers.py
@@ -72,3 +72,49 @@ class ParquetToSparkDecodingHandler(StructuredDatasetDecoder):
 StructuredDatasetTransformerEngine.register(SparkToParquetEncodingHandler())
 StructuredDatasetTransformerEngine.register(ParquetToSparkDecodingHandler())
 StructuredDatasetTransformerEngine.register_renderer(DataFrame, SparkDataFrameRenderer())
+
+classic_ps_dataframe = lazy_module("pyspark.sql.classic.dataframe")
+ClassicDataFrame = classic_ps_dataframe.DataFrame
+
+class ClassicSparkToParquetEncodingHandler(StructuredDatasetEncoder):
+    def __init__(self):
+        super().__init__(ClassicDataFrame, None, PARQUET)
+
+    def encode(
+        self,
+        ctx: FlyteContext,
+        structured_dataset: StructuredDataset,
+        structured_dataset_type: StructuredDatasetType,
+    ) -> literals.StructuredDataset:
+        path = typing.cast(str, structured_dataset.uri)
+        if not path:
+            path = ctx.file_access.join(
+                ctx.file_access.raw_output_prefix,
+                ctx.file_access.get_random_string(),
+            )
+        df = typing.cast(ClassicDataFrame, structured_dataset.dataframe)
+        ss = pyspark.sql.SparkSession.builder.getOrCreate()
+        ss.conf.set("mapreduce.fileoutputcommitter.marksuccessfuljobs", "false")
+        df.write.mode("overwrite").parquet(path=path)
+        return literals.StructuredDataset(uri=path, metadata=StructuredDatasetMetadata(structured_dataset_type))
+
+class ParquetToClassicSparkDecodingHandler(StructuredDatasetDecoder):
+    def __init__(self):
+        super().__init__(ClassicDataFrame, None, PARQUET)
+
+    def decode(
+        self,
+        ctx: FlyteContext,
+        flyte_value: literals.StructuredDataset,
+        current_task_metadata: StructuredDatasetMetadata,
+    ) -> ClassicDataFrame:
+        user_ctx = FlyteContext.current_context().user_space_params
+        if current_task_metadata.structured_dataset_type and current_task_metadata.structured_dataset_type.columns:
+            columns = [c.name for c in current_task_metadata.structured_dataset_type.columns]
+            return user_ctx.spark_session.read.parquet(flyte_value.uri).select(*columns)
+        return user_ctx.spark_session.read.parquet(flyte_value.uri)
+
+# Register the handlers
+StructuredDatasetTransformerEngine.register(ClassicSparkToParquetEncodingHandler())
+StructuredDatasetTransformerEngine.register(ParquetToClassicSparkDecodingHandler())
+StructuredDatasetTransformerEngine.register_renderer(ClassicDataFrame, SparkDataFrameRenderer())

--- a/plugins/flytekit-spark/setup.py
+++ b/plugins/flytekit-spark/setup.py
@@ -5,7 +5,7 @@ PLUGIN_NAME = "spark"
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
 # TODO: Add support spark 4.0.0, https://github.com/flyteorg/flyte/issues/6478
-plugin_requires = ["flytekit>=1.15.1", "pyspark>=3.4.0,<4.0.0", "aiohttp", "flyteidl>=1.11.0b1", "pandas"]
+plugin_requires = ["flytekit>=1.15.1", "pyspark>=3.4.0", "aiohttp", "flyteidl>=1.11.0b1", "pandas"]
 
 __version__ = "0.0.0+develop"
 

--- a/plugins/flytekit-spark/setup.py
+++ b/plugins/flytekit-spark/setup.py
@@ -4,7 +4,6 @@ PLUGIN_NAME = "spark"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-# TODO: Add support spark 4.0.0, https://github.com/flyteorg/flyte/issues/6478
 plugin_requires = ["flytekit>=1.15.1", "pyspark>=3.4.0", "aiohttp", "flyteidl>=1.11.0b1", "pandas"]
 
 __version__ = "0.0.0+develop"


### PR DESCRIPTION
## Tracking issue
[#6478](https://github.com/flyteorg/flyte/issues/6478#event-17898997613)
<!-- Remove this section if not applicable -->

## Why are the changes needed?

There is a new type of dataframe when  `pyspark`>=4.0.0. It's not recognized by the current structured dataset. Therefore, the type transformer will fail to serialize and deserialize it.

## What changes were proposed in this pull request?

Add a new type of spark dataframe and register it.

## How was this patch tested?

Github CI will fail if we don't add the new type of dataframe and pyspark>=4.0.0.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [X] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request adds support for the new `pyspark.sql.classic.dataframe.DataFrame` type for compatibility with `pyspark` version 4.0.0 and above. It includes new classes for reading and writing this DataFrame type, along with serialization and deserialization handlers. Plugin requirements have also been updated accordingly.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>