### PR TITLE
enable notebook task/workflow registration

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1523,9 +1523,7 @@ class FlyteRemote(object):
         launch_plan_model = get_serializable(
             OrderedDict(), settings=serialization_settings, entity=entity, options=options
         )
-        ident = self.raw_register(
-            launch_plan_model, serialization_settings, version, create_default_launchplan=False
-        )
+        ident = self.raw_register(launch_plan_model, serialization_settings, version, create_default_launchplan=False)
         if ident is None:
             raise ValueError("Failed to register launch plan, identifier returned was empty...")
 

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -212,6 +212,7 @@ def _get_git_repo_url(source_path: str):
         return ""
 
 
+@functools.lru_cache
 def _get_pickled_target_dict(
     root_entity: typing.Union[WorkflowBase, PythonTask],
 ) -> typing.Tuple[bytes, PickledEntity]:
@@ -1078,7 +1079,6 @@ class FlyteRemote(object):
                     *FlyteRemote._get_pod_template_hash(entity),
                 )
 
-        if self.interactive_mode_enabled:
             serialization_settings.fast_serialization_settings = self._pickle_and_upload_entity(
                 entity,
                 pickled_target_dict,
@@ -1130,7 +1130,6 @@ class FlyteRemote(object):
                     *FlyteRemote._get_pod_template_hash(entity),
                 )
 
-        if self.interactive_mode_enabled:
             serialization_settings.fast_serialization_settings = self._pickle_and_upload_entity(
                 entity,
                 pickled_target_dict,


### PR DESCRIPTION
## Why are the changes needed?

Currently, registering tasks, workflows, and launchplans via notebooks doesn't work. This is because uploading the pickle-serialized task functions only happens in the `execute_local_*` methods.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the registration process for tasks, workflows, and launch plans by introducing serialization of task functions in interactive mode. It prevents duplicate workflows, improving workflow management, and adds a caching mechanism for optimized retrieval of pickled target dictionaries. Additionally, it resolves previous issues with notebook-based task registration.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>