### PR TITLE
[cherry-pick]  KeyError: 'sparkConf' occurs when running a Databricks task without spark_conf

### DIFF
--- a/plugins/flytekit-spark/flytekitplugins/spark/agent.py
+++ b/plugins/flytekit-spark/flytekitplugins/spark/agent.py
@@ -38,7 +38,7 @@ def _get_databricks_job_spec(task_template: TaskTemplate) -> dict:
         if not new_cluster.get("docker_image"):
             new_cluster["docker_image"] = {"url": container.image}
         if not new_cluster.get("spark_conf"):
-            new_cluster["spark_conf"] = custom["sparkConf"]
+            new_cluster["spark_conf"] = custom.get("sparkConf", {})
         if not new_cluster.get("spark_env_vars"):
             new_cluster["spark_env_vars"] = {k: v for k, v in envs.items()}
         else:

--- a/plugins/flytekit-spark/tests/test_spark_task.py
+++ b/plugins/flytekit-spark/tests/test_spark_task.py
@@ -7,7 +7,7 @@ import pytest
 
 from flytekit.core import context_manager
 from flytekitplugins.spark import Spark
-from flytekitplugins.spark.task import Databricks, new_spark_session
+from flytekitplugins.spark.task import Databricks, DatabricksV2, new_spark_session
 from pyspark.sql import SparkSession
 
 import flytekit
@@ -103,6 +103,45 @@ def test_spark_task(reset_spark_session):
     assert my_databricks.task_config.databricks_instance == databricks_instance
     assert my_databricks(a=3) == 3
 
+
+@pytest.mark.parametrize("spark_conf", [None, {"spark": "2"}])
+def test_databricks_v2(reset_spark_session, spark_conf):
+    databricks_conf = {
+        "name": "flytekit databricks plugin example",
+        "new_cluster": {
+            "spark_version": "11.0.x-scala2.12",
+            "node_type_id": "r3.xlarge",
+            "aws_attributes": {"availability": "ON_DEMAND"},
+            "num_workers": 4,
+            "docker_image": {"url": "pingsutw/databricks:latest"},
+        },
+        "timeout_seconds": 3600,
+        "max_retries": 1,
+        "spark_python_task": {
+            "python_file": "dbfs:///FileStore/tables/entrypoint-1.py",
+            "parameters": "ls",
+        },
+    }
+
+    databricks_instance = "account.cloud.databricks.com"
+
+    @task(
+        task_config=DatabricksV2(
+            databricks_conf=databricks_conf,
+            databricks_instance=databricks_instance,
+            spark_conf=spark_conf,
+        )
+    )
+    def my_databricks(a: int) -> int:
+        session = flytekit.current_context().spark_session
+        assert session.sparkContext.appName == "FlyteSpark: ex:local:local:local"
+        return a
+
+    assert my_databricks.task_config is not None
+    assert my_databricks.task_config.databricks_conf == databricks_conf
+    assert my_databricks.task_config.databricks_instance == databricks_instance
+    assert my_databricks.task_config.spark_conf == (spark_conf or {})
+    assert my_databricks(a=3) == 3
 
 def test_new_spark_session():
     name = "SessionName"

--- a/tests/flytekit/unit/experimental/test_eager_workflows.py
+++ b/tests/flytekit/unit/experimental/test_eager_workflows.py
@@ -291,6 +291,7 @@ def test_eager_workflow_dispatch(mock_write_to_file, mock_put_data, mock_get_dat
     """Test that event loop is preserved after executing eager workflow via dispatch."""
 
     event_loop = asyncio.get_event_loop_policy().get_event_loop()
+
     @eager
     async def eager_wf():
         await asyncio.sleep(0.1)

--- a/tests/flytekit/unit/experimental/test_eager_workflows.py
+++ b/tests/flytekit/unit/experimental/test_eager_workflows.py
@@ -287,9 +287,10 @@ def test_eager_workflow_with_offloaded_types():
 @mock.patch("flytekit.core.data_persistence.FileAccessProvider.get_data")
 @mock.patch("flytekit.core.data_persistence.FileAccessProvider.put_data")
 @mock.patch("flytekit.core.utils.write_proto_to_file")
-def test_eager_workflow_dispatch(mock_write_to_file, mock_put_data, mock_get_data, mock_load_proto, event_loop):
+def test_eager_workflow_dispatch(mock_write_to_file, mock_put_data, mock_get_data, mock_load_proto):
     """Test that event loop is preserved after executing eager workflow via dispatch."""
 
+    event_loop = asyncio.get_event_loop_policy().get_event_loop()
     @eager
     async def eager_wf():
         await asyncio.sleep(0.1)

--- a/tests/flytekit/unit/experimental/test_eager_workflows.py
+++ b/tests/flytekit/unit/experimental/test_eager_workflows.py
@@ -290,7 +290,11 @@ def test_eager_workflow_with_offloaded_types():
 def test_eager_workflow_dispatch(mock_write_to_file, mock_put_data, mock_get_data, mock_load_proto):
     """Test that event loop is preserved after executing eager workflow via dispatch."""
 
-    event_loop = asyncio.get_event_loop_policy().get_event_loop()
+    try:
+        event_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        event_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(event_loop)
 
     @eager
     async def eager_wf():


### PR DESCRIPTION
## Tracking issue
Closes https://github.com/flyteorg/flyte/issues/6471

## Why are the changes needed?

Using Databricks connector without setting optional `spark_conf` field will cause `KeyError: 'sparkConf'`

## What changes were proposed in this pull request?

If `sparkConf` is empty, use `{}`

## How was this patch tested?

Added unit test for DatabricksV2 with and without `spark_conf`

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request resolves a KeyError in Databricks tasks by using an empty dictionary when the optional spark_conf field is absent. It also includes unit tests for the new DatabricksV2 configuration to ensure functionality in both scenarios.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>