### PR TITLE
Support recursive `ImageSpec` build by `DefaultBuilder`

### DIFF
--- a/tests/flytekit/unit/core/image_spec/test_image_spec.py
+++ b/tests/flytekit/unit/core/image_spec/test_image_spec.py
@@ -93,6 +93,29 @@ def test_image_spec(mock_image_spec_builder, monkeypatch):
     assert image_spec.commands == ["echo hello"]
 
 
+@pytest.mark.skipif(
+    os.environ.get("_FLYTEKIT_TEST_IMAGE_BUILD_ENGINE", "0") == "0",
+    reason="Set _FLYTEKIT_TEST_IMAGE_BUILD_ENGINE=1 to run this test",
+)
+def test_nested_build(monkeypatch):
+    monkeypatch.setenv("FLYTE_PUSH_IMAGE_SPEC", "0")
+    base_image = ImageSpec(
+        name="base",
+        packages=["torch"],
+        python_version="3.11"
+    )
+
+    image_spec = ImageSpec(
+        name="final",
+        packages=["pandas"],
+        python_version="3.11",
+        base_image=base_image,
+    )
+    assert image_spec._is_force_push is False
+
+    ImageBuildEngine.build(image_spec)
+
+
 def test_image_spec_engine_priority():
     new_image_name = "fqn.xyz/flytekit"
     mock_image_builder_10 = Mock()


### PR DESCRIPTION
## Tracking issue
None

## Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
`ImageBuildEngine` supports recursively build `ImageSpec` if `base_image` is also an `ImageSpec`.
https://github.com/flyteorg/flytekit/blob/147c405d11abb222f88933d5ef3ed258df92ba99/flytekit/image_spec/image_spec.py#L523
However, it doesn't work with current `DefaultBuilder`. This PR includes a few minor changes so that such recursive build works.

## What changes were proposed in this pull request?

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->
1. `micromamba create` falls back to `micromamba install` in case the micromamba environment already exists.
2. Set workdir to `/` to have consistent behavior in the second build. Otherwise, workdir is set to `/root` in the first build, and `uv run` itself uses `/root/.venv` instead of `UV_PYTHON` (if uv lock or poetry lock was used).  
3.  When there are `/root/.venv` from the first build (if uv lock or poetry lock was used), `chown -R flytekit /root` creates a duplicated layer, nearly doubling the size of the final image.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
A small example was added, which can be run
```
_FLYTEKIT_TEST_IMAGE_BUILD_ENGINE=1 python -m pytest tests/flytekit/unit/core/image_spec/test_image_spec.py -k test_nested_build -s
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the `DefaultBuilder` to support recursive builds of `ImageSpec`, optimizes the ownership change process, and sets the working directory to root for consistency. A test case for nested builds has also been introduced to ensure functionality.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>