### PR TITLE
Fix click option parameter declaration to remove short flag conflict

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -160,7 +160,7 @@ class RunLevelParams(PyFlyteParams):
     )
     poll_interval: int = make_click_option_field(
         click.Option(
-            param_decls=["-i", "--poll-interval", "poll_interval"],
+            param_decls=["--poll-interval", "poll_interval"],
             required=False,
             type=int,
             default=None,


### PR DESCRIPTION
## Summary
- Remove `-i` short flag from `poll_interval` parameter to avoid conflicts with other CLI options

## Test plan
- [ ] Verify CLI options work without conflicts
- [ ] Test that `--poll-interval` parameter functions correctly
- [ ] Ensure no regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)