### PR TITLE
[backport] Fix launch plan CLI registration

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1326,6 +1326,7 @@ class FlyteRemote(object):
                 md5_bytes, serialization_settings, default_inputs, *self._get_image_names(entity)
             )
 
+        serialization_settings.version = version
         if isinstance(entity, PythonTask):
             return self.register_task(entity, serialization_settings, version)
 


### PR DESCRIPTION
https://github.com/flyteorg/flytekit/pull/3285

This pull request includes a small change to the register_script method in flytekit/remote/remote.py. The change sets the version attribute of serialization_settings before proceeding with entity registration.This pull request includes a minor update to the register_script method in flytekit/remote/remote.py. The change assigns the version to the serialization_settings object before registering the entity.

