### PR TITLE
Specify pandas version for Python 3.9 for deck plugin

### DIFF
--- a/plugins/flytekit-deck-standard/dev-requirements.in
+++ b/plugins/flytekit-deck-standard/dev-requirements.in
@@ -1,5 +1,6 @@
 markdown
-pandas
+pandas<=2.2.3; python_version < '3.10'
+pandas>=1.0.0; python_version > '3.9'
 plotly
 pygments
 ydata-profiling

--- a/plugins/flytekit-deck-standard/setup.py
+++ b/plugins/flytekit-deck-standard/setup.py
@@ -20,7 +20,7 @@ extras = {
         "ydata-profiling",
         "markdown",
         "plotly",
-        "pygments"
+        "pygments",
     ],
 }
 

--- a/plugins/flytekit-deck-standard/setup.py
+++ b/plugins/flytekit-deck-standard/setup.py
@@ -14,8 +14,8 @@ extras = {
     "plotly": ["plotly"],
     "pygments": ["pygments"],
     "all": [
-        "pandas<=2.2.3; python_version==3.9",
-        "pandas; python_version>3.9",
+        "pandas<=2.2.3; python_version=='3.9'",
+        "pandas; python_version>'3.9'",
         "pillow",
         "ydata-profiling",
         "markdown",

--- a/plugins/flytekit-deck-standard/setup.py
+++ b/plugins/flytekit-deck-standard/setup.py
@@ -13,7 +13,15 @@ extras = {
     "markdown": ["markdown"],
     "plotly": ["plotly"],
     "pygments": ["pygments"],
-    "all": ["pandas", "pillow", "ydata-profiling", "markdown", "plotly", "pygments"],
+    "all": [
+        "pandas<=2.2.3; python_version==3.9",
+        "pandas; python_version>3.9",
+        "pillow",
+        "ydata-profiling",
+        "markdown",
+        "plotly",
+        "pygments"
+    ],
 }
 
 __version__ = "0.0.0+develop"

--- a/plugins/flytekit-deck-standard/setup.py
+++ b/plugins/flytekit-deck-standard/setup.py
@@ -14,12 +14,13 @@ extras = {
     "plotly": ["plotly"],
     "pygments": ["pygments"],
     "all": [
-        "pandas"
+        "pandas<=2.2.3; python_version < '3.10'",
+        "pandas; python_version > '3.9'",
         "pillow",
         "ydata-profiling",
         "markdown",
         "plotly",
-        "pygments<=2.19.1"
+        "pygments"
     ],
 }
 

--- a/plugins/flytekit-deck-standard/setup.py
+++ b/plugins/flytekit-deck-standard/setup.py
@@ -14,13 +14,12 @@ extras = {
     "plotly": ["plotly"],
     "pygments": ["pygments"],
     "all": [
-        "pandas<=2.2.3; python_version=='3.9'",
-        "pandas; python_version>'3.9'",
+        "pandas"
         "pillow",
         "ydata-profiling",
         "markdown",
         "plotly",
-        "pygments"
+        "pygments<=2.19.1"
     ],
 }
 


### PR DESCRIPTION
This pull request updates the dependency management in `plugins/flytekit-deck-standard/setup.py` to ensure compatibility with different Python versions.

Dependency management updates:

* Modified the `all` extras group to include a version-specific constraint for `pandas` when using Python 3.9, ensuring compatibility (`pandas<=2.2.3; python_version==3.9`), while keeping the latest version for Python versions above 3.9 (`pandas; python_version>3.9`). 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request updates the dependency management in the `setup.py` file for the `flytekit-deck-standard` plugin by introducing version-specific constraints for the `pandas` library, ensuring compatibility with Python 3.9 and later versions. These changes enhance the stability and compatibility of the plugin across different Python environments.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>