### PR TITLE
Version hash should include the image from launchPlan.workflow.nodes

### DIFF
--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -1338,6 +1338,11 @@ class FlyteRemote(object):
             for n in entity.nodes:
                 image_names.extend(FlyteRemote._get_image_names(n.flyte_entity))
             return image_names
+        if isinstance(entity, LaunchPlan):
+            image_names = []
+            for n in entity.workflow.nodes:
+                image_names.extend(FlyteRemote._get_image_names(n.flyte_entity))
+            return image_names
         return []
 
     @staticmethod


### PR DESCRIPTION


## Why are the changes needed?
The version won’t change if you update the requirements.txt file in the imageSpec and run a launch plan with Pyflyte.

```python
from union import workflow, task, LaunchPlan, ImageSpec

custom_image = ImageSpec(
    name="runlp",
    requirements="requirements.txt",
    registry="pingsutw",
    builder="default",
    pip_extra_args="--prerelease=allow",
)


@task(container_image=custom_image)
def something(region: str, start_date: str) -> str:
    return f"{start_date}-{region}"


@workflow
def wf(region: str = "eu", start_date: str = "2024-01") -> str:
    return something(region=region, start_date=start_date)


qa_lp = LaunchPlan.get_or_create(
    name="qa_lp",
    workflow=wf,
)
```

## What changes were proposed in this pull request?

This pull request updates the `_get_image_names` method in `flytekit/remote/remote.py` to handle `LaunchPlan` entities. The most important change is the addition of logic to extract image names from the nodes of a `LaunchPlan`'s associated workflow.

### Key Changes:

#### Enhancement to `_get_image_names` method:
* Added a condition to check if the `entity` is a `LaunchPlan`. If true, the method now iterates over the nodes in the `LaunchPlan`'s workflow to collect image names, ensuring proper handling of this entity type. (`[flytekit/remote/remote.pyR1341-R1345](diffhunk://#diff-c56afc489e5060224889036253b85ae7c7f1df9f0f7b1130916d9c614293cbb9R1341-R1345)`)## Tracking issue
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the `_get_image_names` method in `flytekit/remote/remote.py` by adding logic to handle `LaunchPlan` entities, enabling the correct extraction of image names from associated workflow nodes. This addresses a limitation in the previous implementation.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>