### PR TITLE
sort input bound

### DIFF
--- a/flytekit/models/core/workflow.py
+++ b/flytekit/models/core/workflow.py
@@ -423,7 +423,7 @@ class ArrayNode(_common.FlyteIdlEntity):
             execution_mode=self._execution_mode,
             is_original_sub_node_interface=BoolValue(value=self._is_original_sub_node_interface),
             data_mode=self._data_mode,
-            bound_inputs=self._bound_inputs,
+            bound_inputs=sorted(self._bound_inputs),
         )
 
     @classmethod


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
Fails to register the map task with partial inputs because the _bound_inputs are not in order. If the order changes, Admin receives a different TaskTemplate and raises an error at registration time.

## What changes were proposed in this pull request?
sort _bound_inputs

## How was this patch tested?
```python
import functools

from union import workflow, task, ImageSpec, map

image = ImageSpec(
    builder="union",
    packages=["union==0.1.182"],
)


@task(container_image=image)
def my_task(a: int, b: int, c: int, d: int, e: int) -> int:
    print("adding one...")
    return 2


@workflow
def wf():
    vals = [1,2,3,4,5]
    # t1 = functools.partial(my_task, b=1, c=1)
    # _ = map(t1, bound_inputs={"b", "c"})(a=vals)
    _ = map(my_task, bound_inputs={"b": 1, "c": 1, "d": 1, "e": 1})(a=vals)
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request improves the workflow model by sorting bound inputs, addressing issues with unsorted inputs that could cause registration errors for map tasks. This enhancement increases the reliability of task registration.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve sorting logic, making the review process relatively simple.
-->
</div>