### PR TITLE
fix name of nvidia H100/H200 accelerators

### DIFF
--- a/flytekit/extras/accelerators.py
+++ b/flytekit/extras/accelerators.py
@@ -136,11 +136,11 @@ V100 = GPUAccelerator("nvidia-tesla-v100")
 
 #: use this constant to specify that the task should run on an
 #: `NVIDIA H100 GPU https://www.nvidia.com/en-us/data-center/h100
-H100 = GPUAccelerator("nvidia-tesla-h100")
+H100 = GPUAccelerator("nvidia-h100")
 
 #: use this constant to specify that the task should run on an
 #: `NVIDIA H200 GPU https://www.nvidia.com/en-us/data-center/h200
-H200 = GPUAccelerator("nvidia-tesla-h200")
+H200 = GPUAccelerator("nvidia-h200")
 
 
 class MultiInstanceGPUAccelerator(BaseAccelerator):


### PR DESCRIPTION
Fix the name of the H100 and H200 accelerators 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug by correcting the names of the NVIDIA H100 and H200 GPU accelerators, ensuring alignment with official naming conventions. This enhancement improves clarity and reduces potential confusion in future implementations.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve correcting identifiers, making the review process relatively simple.
-->
</div>