### PR TITLE
docker build: make sure venvs are owned by flytekit

### DIFF
--- a/flytekit/image_spec/default_builder.py
+++ b/flytekit/image_spec/default_builder.py
@@ -29,7 +29,8 @@ RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
     --mount=type=bind,target=uv.lock,src=uv.lock \
     --mount=type=bind,target=pyproject.toml,src=pyproject.toml \
     $PIP_SECRET_MOUNT \
-    uv sync $PIP_INSTALL_ARGS
+    uv sync $PIP_INSTALL_ARGS && \
+    chown -R flytekit /root/.venv
 WORKDIR /
 
 # Update PATH and UV_PYTHON to point to the venv created by uv sync
@@ -54,12 +55,12 @@ RUN --mount=type=cache,sharing=locked,mode=0777,target=/tmp/poetry_cache,id=poet
     --mount=type=bind,target=poetry.lock,src=poetry.lock \
     --mount=type=bind,target=pyproject.toml,src=pyproject.toml \
     $PIP_SECRET_MOUNT \
-    poetry install $PIP_INSTALL_ARGS
-
+    poetry install $PIP_INSTALL_ARGS && \
+    chown -R flytekit /root/.venv
 WORKDIR /
 
 # Update PATH and UV_PYTHON to point to venv
-ENV PATH="/root/.venv/bin:$$PATH" \
+ENV PATH="/root/.venv/bin:$$PATH"  \
     UV_PYTHON=/root/.venv/bin/python
 """
 )
@@ -81,6 +82,7 @@ RUN --mount=type=cache,sharing=locked,mode=0777,target=/var/cache/apt,id=apt \
     $APT_PACKAGES
 """)
 
+# make sure that micromamba python installation is owned by flytekit user
 MICROMAMBA_INSTALL_COMMAND_TEMPLATE = Template("""\
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/opt/micromamba/pkgs,\
 id=micromamba \
@@ -91,7 +93,8 @@ id=micromamba \
     python=$PYTHON_VERSION $CONDA_PACKAGES \
     || micromamba install -n runtime --root-prefix /opt/micromamba \
     -c conda-forge $CONDA_CHANNELS \
-    python=$PYTHON_VERSION $CONDA_PACKAGES )
+    python=$PYTHON_VERSION $CONDA_PACKAGES ) && \
+    chown -R flytekit /opt/micromamba
 """)
 
 DOCKER_FILE_TEMPLATE = Template("""\
@@ -108,6 +111,9 @@ RUN --mount=from=micromamba,source=/etc/ssl/certs/ca-certificates.crt,target=/tm
     [ -f /etc/ssl/certs/ca-certificates.crt ] || \
     mkdir -p /etc/ssl/certs/ && cp /tmp/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
+RUN id -u flytekit || useradd --create-home --shell /bin/bash flytekit
+RUN chown -R flytekit /root && chown -R flytekit /home
+
 $INSTALL_PYTHON_TEMPLATE
 
 # Configure user space
@@ -119,7 +125,7 @@ ENV PATH="$EXTRA_PATH:$$PATH" \
     SSL_CERT_DIR=/etc/ssl/certs \
     $ENV
 
-$UV_PYTHON_INSTALL_COMMAND
+$PYTHON_INSTALL_COMMAND
 
 # Adds nvidia just in case it exists
 ENV PATH="$$PATH:/usr/local/nvidia/bin:/usr/local/cuda/bin" \
@@ -133,9 +139,6 @@ $EXTRA_COPY_CMDS
 
 RUN --mount=type=cache,sharing=locked,mode=0777,target=/root/.cache/uv,id=uv \
     --mount=from=uv,source=/uv,target=/usr/bin/uv $RUN_COMMANDS
-
-RUN id -u flytekit || useradd --create-home --shell /bin/bash flytekit
-RUN chown -R flytekit /root && chown -R flytekit /home
 
 WORKDIR /root
 SHELL ["/bin/bash", "-c"]
@@ -340,7 +343,7 @@ def create_docker_context(image_spec: ImageSpec, tmp_dir: Path):
         )
         raise ValueError(msg)
 
-    uv_python_install_command = prepare_python_install(image_spec, tmp_dir)
+    python_install_command = prepare_python_install(image_spec, tmp_dir)
     env_dict = {"PYTHONPATH": "/root"}
 
     if image_spec.env:
@@ -426,11 +429,11 @@ def create_docker_context(image_spec: ImageSpec, tmp_dir: Path):
     _f_img_id_env = f"{_F_IMG_ID}={image_spec.id}"
 
     docker_content = DOCKER_FILE_TEMPLATE.substitute(
-        UV_PYTHON_INSTALL_COMMAND=uv_python_install_command,
-        APT_INSTALL_COMMAND=apt_install_command,
         INSTALL_PYTHON_TEMPLATE=python_install_template.template,
         EXTRA_PATH=python_install_template.extra_path,
         PYTHON_EXEC=python_install_template.python_exec,
+        APT_INSTALL_COMMAND=apt_install_command,
+        PYTHON_INSTALL_COMMAND=python_install_command,
         BASE_IMAGE=base_image,
         ENV=env,
         _F_IMG_ID_ENV=_f_img_id_env,


### PR DESCRIPTION
This PR optimizes docker image size by giving ownership of the micromamba python installation and virtual environments created during the image build process on the same layer that creates the virtual environment. This avoids layer duplication.

Note: Setting `USER flytekit` before the python venv installation commands leads to various issues, e.g. `poetry` package installation doesn't work because the `flytekit` user doesn't seem to have certain necessary network access while `root` does. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request optimizes the Docker image build process by ensuring that virtual environments and micromamba Python installations are owned by the flytekit user, reducing image size and avoiding layer duplication. Adjustments to the Dockerfile commands address issues with running as a non-root user.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>