### PR TITLE
ci: Update workflows and Dockerfile for pre-releases

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -3,15 +3,6 @@ name: Publish Python Packages and Official Images
 on:
   release:
     types: [published]
-  pull_request:
-    paths:
-      - '.github/workflows/pythonpublish.yml'
-      - 'Dockerfile'
-      - 'Dockerfile.connector'
-      - './plugins/flytekit-sqlalchemy/Dockerfile'
-      - './plugins/flytekit-openai/Dockerfile.batch'
-      - './plugins/flytekit-spark/Dockerfile'
-      - './plugins/flytekit-flyteinteractive/Dockerfile'
 
 jobs:
   deploy:
@@ -103,7 +94,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
-        if: ${{ github.event_name == 'release' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -3,6 +3,15 @@ name: Publish Python Packages and Official Images
 on:
   release:
     types: [published]
+  pull_request:
+    paths:
+      - '.github/workflows/pythonpublish.yml'
+      - 'Dockerfile'
+      - 'Dockerfile.connector'
+      - './plugins/flytekit-sqlalchemy/Dockerfile'
+      - './plugins/flytekit-openai/Dockerfile.batch'
+      - './plugins/flytekit-spark/Dockerfile'
+      - './plugins/flytekit-flyteinteractive/Dockerfile'
 
 jobs:
   deploy:
@@ -39,14 +48,18 @@ jobs:
           VERSION=$(echo $GITHUB_REF | sed 's|refs/tags/v||')
           VERSION=$VERSION make -C plugins update_all_versions
         shell: bash
-      - name: Build all Plugins and publish
+      - name: Build all plugins
+        run: |
+          make -C plugins build_all_plugins
+      - name: Publish all plugins
+        if: ${{ github.event_name == 'release' }}
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          make -C plugins build_all_plugins
           make -C plugins publish_all_plugins
       - name: Sleep until pypi is available
+        if: ${{ github.event_name == 'release' }}
         id: pypiwait
         run: |
           # from 'refs/tags/v1.2.3 get 1.2.3' and make sure it's not an empty string

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   deploy:
+    if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -48,18 +49,14 @@ jobs:
           VERSION=$(echo $GITHUB_REF | sed 's|refs/tags/v||')
           VERSION=$VERSION make -C plugins update_all_versions
         shell: bash
-      - name: Build all plugins
-        run: |
-          make -C plugins build_all_plugins
-      - name: Publish all plugins
-        if: ${{ github.event_name == 'release' }}
+      - name: Build all Plugins and publish
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
+          make -C plugins build_all_plugins
           make -C plugins publish_all_plugins
       - name: Sleep until pypi is available
-        if: ${{ github.event_name == 'release' }}
         id: pypiwait
         run: |
           # from 'refs/tags/v1.2.3 get 1.2.3' and make sure it's not an empty string

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   deploy:
-    if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -94,6 +93,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
+        if: ${{ github.event_name == 'release' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG DOCKER_IMAGE
 # 4. Create a non-root user 'flytekit' and set appropriate permissions for directories.
 RUN apt-get update && apt-get install build-essential -y \
     && pip install uv \
-    && uv pip install --system --no-cache-dir -U flytekit==$VERSION \
+    && uv pip install --system --no-cache-dir --pre -U flytekit==$VERSION \
         kubernetes \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \

--- a/Dockerfile.connector
+++ b/Dockerfile.connector
@@ -8,7 +8,7 @@ ARG VERSION
 RUN apt-get update && apt-get install build-essential -y \
     && pip install uv
 
-RUN uv pip install --system --no-cache-dir -U flytekit[connector]==$VERSION \
+RUN uv pip install --system --no-cache-dir -U --pre flytekit[connector]==$VERSION \
   flytekitplugins-airflow==$VERSION \
   flytekitplugins-bigquery==$VERSION \
   flytekitplugins-k8sdataservice==$VERSION \
@@ -26,6 +26,6 @@ CMD ["pyflyte", "serve", "connector", "--port", "8000"]
 FROM connector-slim AS connector-all
 ARG VERSION
 
-RUN uv pip install --system --no-cache-dir -U \
+RUN uv pip install --system --pre --no-cache-dir -U \
   flytekitplugins-mmcloud==$VERSION \
   flytekitplugins-spark==$VERSION

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -35,7 +35,7 @@ COPY . /flytekit
 # Use a future version of SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLYTEIDL such that uv resolution works.
 RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLYTEKIT=$PSEUDO_VERSION \
     SETUPTOOLS_SCM_PRETEND_VERSION_FOR_FLYTEIDL=3.0.0dev0 \
-        uv pip install --system --no-cache-dir -U \
+        uv pip install --system --no-cache-dir --pre -U \
             "git+https://github.com/flyteorg/flyte.git@master#subdirectory=flyteidl" \
             -e /flytekit \
             -e /flytekit/plugins/flytekit-deck-standard \

--- a/plugins/flytekit-flyteinteractive/Dockerfile
+++ b/plugins/flytekit-flyteinteractive/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
     && wget --no-check-certificate https://open-vsx.org/api/ms-python/python/2023.20.0/file/ms-python.python-2023.20.0.vsix -P /tmp/code-server \
     && wget --no-check-certificate https://open-vsx.org/api/ms-toolsai/jupyter/2023.9.100/file/ms-toolsai.jupyter-2023.9.100.vsix -P /tmp/code-server \
     && pip install --no-cache-dir uv \
-    && uv pip install --system --no-cache-dir -U flytekitplugins-flyteinteractive==$VERSION flytekit==$VERSION \
+    && uv pip install --system --pre --no-cache-dir -U flytekitplugins-flyteinteractive==$VERSION flytekit==$VERSION \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/ \

--- a/plugins/flytekit-openai/Dockerfile.batch
+++ b/plugins/flytekit-openai/Dockerfile.batch
@@ -9,7 +9,7 @@ ENV PYTHONPATH /root
 ARG VERSION
 
 RUN pip install uv --no-cache-dir \
-  && uv pip install --system --no-cache-dir -U flytekitplugins-openai==$VERSION \
+  && uv pip install --system --pre --no-cache-dir -U flytekitplugins-openai==$VERSION \
     flytekit==$VERSION
 
 RUN useradd -u 1000 flytekit

--- a/plugins/flytekit-spark/Dockerfile
+++ b/plugins/flytekit-spark/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y wget
 ARG VERSION
 
 RUN pip install uv --no-cache-dir \
-  && uv pip install --system --no-cache-dir -U flytekitplugins-spark==$VERSION flytekit==$VERSION
+  && uv pip install --system --no-cache-dir --pre -U flytekitplugins-spark==$VERSION flytekit==$VERSION
 
 RUN wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.4.0/hadoop-aws-3.4.0.jar -P /opt/spark/jars && \
     wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar -P /opt/spark/jars && \

--- a/plugins/flytekit-sqlalchemy/Dockerfile
+++ b/plugins/flytekit-sqlalchemy/Dockerfile
@@ -9,7 +9,7 @@ ENV PYTHONPATH /root
 ARG VERSION
 
 RUN pip install uv --no-cache-dir \
-  && uv pip install --system --no-cache-dir -U \
+  && uv pip install --system --pre --no-cache-dir -U \
     sqlalchemy \
     psycopg2-binary \
     pymysql \


### PR DESCRIPTION
This pull request updates several `Dockerfile` configurations across the project to include the `--pre` flag when installing `flytekit` and its plugins. This ensures that pre-release versions of the packages are used, likely to test or adopt new features and fixes early.

### Changes to Package Installation:

* **Core Flytekit Installation**:
  - Added the `--pre` flag to the `uv pip install` command for `flytekit` in the main `Dockerfile`. This allows pre-release versions of `flytekit` to be installed. (`Dockerfile`, [DockerfileL25-R25](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L25-R25))

* **Flytekit Plugins**:
  - Updated the `Dockerfile.connector` to include the `--pre` flag for installing `flytekit[connector]` and other plugins like `flytekitplugins-airflow`, `flytekitplugins-bigquery`, and `flytekitplugins-k8sdataservice`. (`Dockerfile.connector`, [[1]](diffhunk://#diff-d0e3291210cda0b57989189dbf9c5ab8e7e5075cf644a25c9cda77c34b4cb288L11-R11) [[2]](diffhunk://#diff-d0e3291210cda0b57989189dbf9c5ab8e7e5075cf644a25c9cda77c34b4cb288L29-R29)
  - Modified the `Dockerfile.dev` to add the `--pre` flag for installing `flytekit` and its dependencies from the `master` branch. (`Dockerfile.dev`, [Dockerfile.devL38-R38](diffhunk://#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcacL38-R38))
  - Updated plugin-specific `Dockerfile`s (e.g., `flytekit-flyteinteractive`, `flytekit-openai`, `flytekit-spark`, and `flytekit-sqlalchemy`) to use the `--pre` flag for installing their respective plugins and `flytekit`. (`plugins/flytekit-flyteinteractive/Dockerfile`, [[1]](diffhunk://#diff-1c04d0f4955f3e5dc8335417dc789cf64b1cac2e44eec609f5625dbbe67adf7aL26-R26); `plugins/flytekit-openai/Dockerfile.batch`, [[2]](diffhunk://#diff-8bb210859a8f736b68bbef94ff6d546cf652e17132027001fce0b4989c51dd10L12-R12); `plugins/flytekit-spark/Dockerfile`, [[3]](diffhunk://#diff-da12dc064c07f2ee51e5561052b7b384d84c27806bea5d47d9e27d369f48c2aaL13-R13); `plugins/flytekit-sqlalchemy/Dockerfile`, [[4]](diffhunk://#diff-c2cf10472dd6adbc619dcd5a1b3ca822bcce2befbf3b9d0063e8284760555d41L12-R12) 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request updates Dockerfile configurations to include the --pre flag for installing flytekit and its plugins, enabling the use of pre-release versions. The changes ensure all relevant components are aligned with this new installation strategy for early testing and feature adoption.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>