### PR TITLE
Restore behavior passing FlyteClient kwargs to gRPC channel creation

### DIFF
--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -49,12 +49,15 @@ class RawSynchronousFlyteClient(object):
         # StreamRemoved exception.
         # https://github.com/flyteorg/flyte/blob/e8588f3a04995a420559327e78c3f95fbf64dc01/flyteadmin/pkg/common/constants.go#L14
         # 32KB for error messages, 20MB for actual messages.
-        options = (("grpc.max_metadata_size", 32 * 1024), ("grpc.max_receive_message_length", 20 * 1024 * 1024))
+        options = [
+            ("grpc.max_metadata_size", 32 * 1024),
+            ("grpc.max_receive_message_length", 20 * 1024 * 1024),
+        ] + kwargs.pop("options", [])
         self._cfg = cfg
         self._channel = wrap_exceptions_channel(
             cfg,
             upgrade_channel_to_authenticated(
-                cfg, upgrade_channel_to_proxy_authenticated(cfg, get_channel(cfg, options=options))
+                cfg, upgrade_channel_to_proxy_authenticated(cfg, get_channel(cfg, options=options, **kwargs))
             ),
         )
         self._stub = _admin_service.AdminServiceStub(self._channel)

--- a/tests/flytekit/unit/clients/test_raw.py
+++ b/tests/flytekit/unit/clients/test_raw.py
@@ -20,3 +20,22 @@ def test_list_projects_paginated(mock_channel, mock_admin):
     project_list_request = _project_pb2.ProjectListRequest(limit=100, token="", filters=None, sort_by=None)
     client.list_projects(project_list_request)
     mock_admin.AdminServiceStub().ListProjects.assert_called_with(project_list_request, metadata=None)
+
+
+@mock.patch("flytekit.clients.raw.grpc.insecure_channel")
+def test_kwargs_passed_to_channel(mock_channel):
+    RawSynchronousFlyteClient(
+        PlatformConfig(endpoint="a.b.com", insecure=True),
+        options=[("grpc.default_authority", "foo.b.net")],
+    )
+
+    mock_channel.assert_called_with(
+        "a.b.com",
+        options=[
+            # ensure we're always passing these defaults
+            ("grpc.max_metadata_size", mock.ANY),
+            ("grpc.max_receive_message_length", mock.ANY),
+            # as well as the user-provided options
+            ("grpc.default_authority", "foo.b.net"),
+        ],
+    )


### PR DESCRIPTION
## Why are the changes needed?

The `FlyteRemote` class is documented as allowing gRPC options in the 
https://github.com/flyteorg/flytekit/blob/v1.16.3/flytekit/remote/remote.py#L284-L285.
These are still passed through to client construction, though we stopped passing these to the underlying gRPC channel creation in https://github.com/flyteorg/flytekit/pull/1458. (It's not clear to me if this was an oversight or intentional decision?)

This does mean that from v1.10.0 onward, there's no longer any way to provide additional options for the gRPC channel.
We have a custom proxy that requires additional gRPC options to be set at channel creation time (specifically, `grpc.default_authority`, though I can imagine others may be useful too). Unfortunately, it's not possible to configure this at any other point (e.g. with an interceptor).

## What changes were proposed in this pull request?

This PR restores the previous (and still-documented) behavior.

## How was this patch tested?

I added a unit test to ensure we're keeping the default options as well as adding any user-provided options.

I've also tested with this change internally and it works with pre-1.10.0 code that has the desired behavior.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request restores the ability to pass additional gRPC options when creating the gRPC channel in the FlyteClient, addressing a regression from a previous update. It ensures compatibility with both default and user-provided options, and includes a unit test to verify the functionality.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-documented, making the review process relatively quick.
-->
</div>