### PR TITLE
[Core feature] Reuse same literals in the dynamic task

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -46,6 +46,7 @@ types-protobuf<5
 types-croniter
 types-decorator
 types-mock
+types-cachetools
 autoflake
 
 pillow

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -1383,22 +1383,16 @@ class TypeEngine(typing.Generic[T]):
     def make_key(cls, python_val: typing.Any, python_type: Type[T]) -> Optional[tuple]:
         import cloudpickle
 
-        val_hash: typing.Any
-        type_hash: typing.Any
+        val_hash: int
+        type_hash: int
         try:
-            try:
-                val_hash = hash(python_val)
-            except Exception:
-                val_hash = hash(cloudpickle.dumps(python_val))
-
-            try:
-                type_hash = hash(python_type)
-            except Exception:
-                type_hash = hash(cloudpickle.dumps(python_type))
+            val_hash = hash(cloudpickle.dumps(python_val))
+            type_hash = hash(cloudpickle.dumps(python_type))
 
             return (val_hash, type_hash)
 
         except Exception:
+            logger.warning(f"Could not hash python_val: {python_val} or python_type: {python_type}")
             return None
 
     @classmethod

--- a/tests/flytekit/unit/core/test_list.py
+++ b/tests/flytekit/unit/core/test_list.py
@@ -84,6 +84,7 @@ async def test_coroutine_batching_of_list_transformer():
         with pytest.raises(ValueError):
             TypeEngine.to_literal(ctx, python_val_2, typing.List[MyInt], lt)
 
+    # Cache hit for python_val prevents async_to_literal calls, avoiding the batch size limit of 2 error defined in MyIntAsyncTransformer
     with mock.patch("flytekit.core.type_engine._TYPE_ENGINE_COROS_BATCH_SIZE", 5):
             TypeEngine.to_literal(ctx, python_val, typing.List[MyInt], lt)
 

--- a/tests/flytekit/unit/core/test_list.py
+++ b/tests/flytekit/unit/core/test_list.py
@@ -84,4 +84,7 @@ async def test_coroutine_batching_of_list_transformer():
         with pytest.raises(ValueError):
             TypeEngine.to_literal(ctx, python_val_2, typing.List[MyInt], lt)
 
+    with mock.patch("flytekit.core.type_engine._TYPE_ENGINE_COROS_BATCH_SIZE", 5):
+            TypeEngine.to_literal(ctx, python_val, typing.List[MyInt], lt)
+
     del TypeEngine._REGISTRY[MyInt]

--- a/tests/flytekit/unit/core/test_list.py
+++ b/tests/flytekit/unit/core/test_list.py
@@ -73,6 +73,8 @@ async def test_coroutine_batching_of_list_transformer():
 
     lt = LiteralType(simple=SimpleType.INTEGER)
     python_val = [MyInt(10), MyInt(11), MyInt(12), MyInt(13), MyInt(14)]
+    # Use the different python_val to avoid hitting the cache
+    python_val_2 = [MyInt(11), MyInt(10), MyInt(12), MyInt(13), MyInt(14)]
     ctx = FlyteContext.current_context()
 
     with mock.patch("flytekit.core.type_engine._TYPE_ENGINE_COROS_BATCH_SIZE", 2):
@@ -80,6 +82,6 @@ async def test_coroutine_batching_of_list_transformer():
 
     with mock.patch("flytekit.core.type_engine._TYPE_ENGINE_COROS_BATCH_SIZE", 5):
         with pytest.raises(ValueError):
-            TypeEngine.to_literal(ctx, python_val, typing.List[MyInt], lt)
+            TypeEngine.to_literal(ctx, python_val_2, typing.List[MyInt], lt)
 
     del TypeEngine._REGISTRY[MyInt]

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -3870,7 +3870,6 @@ def test_type_engine_cache_with_list():
 
         # First call
         literal1 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
-        assert mock_async_to_literal.call_count == 1
 
         key = TypeEngine.make_key(python_val, python_type)
         assert key is not None
@@ -3879,7 +3878,7 @@ def test_type_engine_cache_with_list():
         # Second call with same DataFrame
         literal2 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
 
-        # Verify async_to_literal was called
+        # Verify async_to_literal was only called once
         assert mock_async_to_literal.call_count == 1
 
         assert literal1 is literal2
@@ -3917,7 +3916,6 @@ def test_type_engine_cache_with_dict():
 
         # First call
         literal1 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
-        assert mock_async_to_literal.call_count == 1
 
         key = TypeEngine.make_key(python_val, python_type)
         assert key is not None
@@ -3926,7 +3924,7 @@ def test_type_engine_cache_with_dict():
         # Second call with same DataFrame
         literal2 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
 
-        # Verify async_to_literal was called
+        # Verify async_to_literal was only called once
         assert mock_async_to_literal.call_count == 1
 
         assert literal1 is literal2
@@ -3960,7 +3958,6 @@ def test_type_engine_cache_with_pandas():
 
         # First call
         literal1 = TypeEngine.to_literal(ctx, df, df_type, df_expected)
-        assert mock_async_to_literal.call_count == 1
 
         # Second call with same DataFrame
         literal2 = TypeEngine.to_literal(ctx, df, df_type, df_expected)
@@ -3988,7 +3985,6 @@ def test_type_engine_cache_with_flytefile():
 
         # Test 1: Upload local file to remote
         lv1 = TypeEngine.to_literal(ctx, file_path, FlyteFile, lt)
-        assert mock_async_to_literal.call_count == 1
 
         # Second call with same DataFrame
         lv2 = TypeEngine.to_literal(ctx, file_path, FlyteFile, lt)

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -3941,9 +3941,8 @@ def test_make_key_with_annotated_types():
     assert key_without_annotation is not None
     assert key != key_without_annotation
 
-@pytest.mark.skipif("pandas" not in sys.modules, reason="Pandas is not installed.")
 def test_type_engine_cache_with_pandas():
-    import pandas as pd
+    pd = pytest.importorskip("pandas")
     ctx = FlyteContext.current_context()
     # Create DataFrame
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -3888,8 +3888,8 @@ def test_type_engine_cache():
     # Verify different literals are different objects
     assert literal1 is not literal3
 
-    # Test cache with unhashable objects (should not cache)
-    python_val = {"a": [1, 2, 3]}  # dict with list is unhashable
+    # Test cache with unhashable objects
+    python_val = {"a": [1, 2, 3]}
     python_type = typing.Dict[str, typing.List[int]]
     expected = TypeEngine.to_literal_type(python_type)
 
@@ -3902,7 +3902,7 @@ def test_type_engine_cache():
     # Second call with same unhashable data
     literal5 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
 
-    # Should be different objects since unhashable objects can't be cached
+    # Should be the same object since unhashable objects will fallback to cloudpickle to hash
     assert literal4 is literal5
 
     # Add many different values to test cache size limit

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -3852,29 +3852,37 @@ async def test_dict_transformer_annotated_type():
     literal3 = await TypeEngine.async_to_literal(ctx, nested_dict, nested_dict_type, expected_type)
     assert literal3.map.literals["outer"].map.literals["inner"].scalar.primitive.integer == 42
 
-def test_type_engine_cache():
-    # Clear cache before test
+@pytest.fixture(autouse=True)
+def clear_type_engine_cache():
+    """Clear TypeEngine cache before and after each test"""
+    TypeEngine._CACHE.clear()
+    yield
     TypeEngine._CACHE.clear()
 
-    # Test data
+def test_type_engine_cache_with_list():
     ctx = FlyteContext.current_context()
     python_val = [1, 2, 3, 4, 5]
     python_type = typing.List[int]
     expected = TypeEngine.to_literal_type(python_type)
+    list_transformer = TypeEngine.get_transformer(typing.List[int])
+    with mock.patch.object(list_transformer, 'async_to_literal',
+                          wraps=list_transformer.async_to_literal) as mock_async_to_literal:
 
-    # First call - should not use cache
-    literal1 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
+        # First call
+        literal1 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
+        assert mock_async_to_literal.call_count == 1
 
-    # Verify cache is populated
-    key = TypeEngine.make_key(python_val, python_type)
-    assert key is not None
-    assert key in TypeEngine._CACHE
+        key = TypeEngine.make_key(python_val, python_type)
+        assert key is not None
+        assert key in TypeEngine._CACHE
 
-    # Second call with same parameters - should use cache
-    literal2 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
+        # Second call with same DataFrame
+        literal2 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
 
-    # Verify both literals are identical (same object from cache)
-    assert literal1 is literal2
+        # Verify async_to_literal was called
+        assert mock_async_to_literal.call_count == 1
+
+        assert literal1 is literal2
 
     # Test with different data - should not use cache
     different_val = [2, 1, 3, 4, 5]
@@ -3888,23 +3896,6 @@ def test_type_engine_cache():
     # Verify different literals are different objects
     assert literal1 is not literal3
 
-    # Test cache with unhashable objects
-    python_val = {"a": [1, 2, 3]}
-    python_type = typing.Dict[str, typing.List[int]]
-    expected = TypeEngine.to_literal_type(python_type)
-
-    # First call
-    literal4 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
-    key = TypeEngine.make_key(python_val, python_type)
-    assert key is not None
-    assert key in TypeEngine._CACHE
-
-    # Second call with same unhashable data
-    literal5 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
-
-    # Should be the same object since unhashable objects will fallback to cloudpickle to hash
-    assert literal4 is literal5
-
     # Add many different values to test cache size limit
     for i in range(200):  # More than the default maxsize of 128
         test_val = [i, i+1, i+2]
@@ -3915,30 +3906,30 @@ def test_type_engine_cache():
     # Cache should not exceed maxsize
     assert len(TypeEngine._CACHE) == 128
 
-    # Test cache with pandas DataFrame (if available)
-    try:
-        import pandas as pd
-
-        # Create DataFrame
-        df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-        df_type = pd.DataFrame
-        df_expected = TypeEngine.to_literal_type(df_type)
+def test_type_engine_cache_with_dict():
+    ctx = FlyteContext.current_context()
+    python_val = {"a": [1, 2, 3]}
+    python_type = typing.Dict[str, typing.List[int]]
+    expected = TypeEngine.to_literal_type(python_type)
+    dict_transformer = TypeEngine.get_transformer(typing.Dict[str, typing.List[int]])
+    with mock.patch.object(dict_transformer, 'async_to_literal',
+                          wraps=dict_transformer.async_to_literal) as mock_async_to_literal:
 
         # First call
-        literal6 = TypeEngine.to_literal(ctx, df, df_type, df_expected)
+        literal1 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
+        assert mock_async_to_literal.call_count == 1
+
+        key = TypeEngine.make_key(python_val, python_type)
+        assert key is not None
+        assert key in TypeEngine._CACHE
 
         # Second call with same DataFrame
-        literal7 = TypeEngine.to_literal(ctx, df, df_type, df_expected)
+        literal2 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
 
-        # Should be same object (DataFrame should be hashable via cloudpickle)
-        assert literal6 is literal7
+        # Verify async_to_literal was called
+        assert mock_async_to_literal.call_count == 1
 
-    except ImportError:
-        # Skip pandas test if not available
-        pass
-
-    # Clean up
-    TypeEngine._CACHE.clear()
+        assert literal1 is literal2
 
 def test_make_key_with_annotated_types():
     # Test with Annotated type
@@ -3951,3 +3942,58 @@ def test_make_key_with_annotated_types():
     assert key is not None
     assert key_without_annotation is not None
     assert key != key_without_annotation
+
+def test_type_engine_cache_with_pandas():
+    import pandas as pd
+    ctx = FlyteContext.current_context()
+    # Create DataFrame
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    df_type = pd.DataFrame
+    df_expected = TypeEngine.to_literal_type(df_type)
+
+    # Get the transformer for DataFrame
+    df_transformer = TypeEngine._REGISTRY[pd.DataFrame]
+
+    # Mock the async_to_literal method with wraps to track calls
+    with mock.patch.object(df_transformer, 'async_to_literal',
+                          wraps=df_transformer.async_to_literal) as mock_async_to_literal:
+
+        # First call
+        literal1 = TypeEngine.to_literal(ctx, df, df_type, df_expected)
+        assert mock_async_to_literal.call_count == 1
+
+        # Second call with same DataFrame
+        literal2 = TypeEngine.to_literal(ctx, df, df_type, df_expected)
+
+        # Verify async_to_literal was called
+        assert mock_async_to_literal.call_count == 1
+
+        assert literal1 is literal2
+
+def test_type_engine_cache_with_flytefile():
+
+    transformer = TypeEngine.get_transformer(FlyteFile)
+    ctx = FlyteContext.current_context()
+
+    temp_dir = tempfile.mkdtemp(prefix="temp_example_")
+    file_path = os.path.join(temp_dir, "file.txt")
+    with open(file_path, "w") as file1:
+        file1.write("hello world")
+
+    lt = TypeEngine.to_literal_type(FlyteFile)
+
+    # Mock the file upload
+    with mock.patch.object(transformer, 'async_to_literal',
+                          wraps=transformer.async_to_literal) as mock_async_to_literal:
+
+        # Test 1: Upload local file to remote
+        lv1 = TypeEngine.to_literal(ctx, file_path, FlyteFile, lt)
+        assert mock_async_to_literal.call_count == 1
+
+        # Second call with same DataFrame
+        lv2 = TypeEngine.to_literal(ctx, file_path, FlyteFile, lt)
+
+        # Verify async_to_literal was called
+        assert mock_async_to_literal.call_count == 1
+
+        assert lv1 is lv2

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -3941,6 +3941,7 @@ def test_make_key_with_annotated_types():
     assert key_without_annotation is not None
     assert key != key_without_annotation
 
+@pytest.mark.skipif("pandas" not in sys.modules, reason="Pandas is not installed.")
 def test_type_engine_cache_with_pandas():
     import pandas as pd
     ctx = FlyteContext.current_context()

--- a/tests/flytekit/unit/core/test_type_engine.py
+++ b/tests/flytekit/unit/core/test_type_engine.py
@@ -3855,9 +3855,9 @@ async def test_dict_transformer_annotated_type():
 @pytest.fixture(autouse=True)
 def clear_type_engine_cache():
     """Clear TypeEngine cache before and after each test"""
-    TypeEngine._CACHE.clear()
+    TypeEngine._LITERAL_CACHE.clear()
     yield
-    TypeEngine._CACHE.clear()
+    TypeEngine._LITERAL_CACHE.clear()
 
 def test_type_engine_cache_with_list():
     ctx = FlyteContext.current_context()
@@ -3871,9 +3871,9 @@ def test_type_engine_cache_with_list():
         # First call
         literal1 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
 
-        key = TypeEngine.make_key(python_val, python_type)
+        key = TypeEngine._get_literal_cache_key(python_val, python_type)
         assert key is not None
-        assert key in TypeEngine._CACHE
+        assert key in TypeEngine._LITERAL_CACHE
 
         # Second call with same DataFrame
         literal2 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
@@ -3886,11 +3886,11 @@ def test_type_engine_cache_with_list():
     # Test with different data - should not use cache
     different_val = [2, 1, 3, 4, 5]
     literal3 = TypeEngine.to_literal(ctx, different_val, python_type, expected)
-    key_different = TypeEngine.make_key(different_val, python_type)
+    key_different = TypeEngine._get_literal_cache_key(different_val, python_type)
 
     assert key_different is not key
     assert key_different is not None
-    assert key_different in TypeEngine._CACHE
+    assert key_different in TypeEngine._LITERAL_CACHE
 
     # Verify different literals are different objects
     assert literal1 is not literal3
@@ -3903,7 +3903,7 @@ def test_type_engine_cache_with_list():
         TypeEngine.to_literal(ctx, test_val, test_type, test_expected)
 
     # Cache should not exceed maxsize
-    assert len(TypeEngine._CACHE) == 128
+    assert len(TypeEngine._LITERAL_CACHE) == 128
 
 def test_type_engine_cache_with_dict():
     ctx = FlyteContext.current_context()
@@ -3917,9 +3917,9 @@ def test_type_engine_cache_with_dict():
         # First call
         literal1 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
 
-        key = TypeEngine.make_key(python_val, python_type)
+        key = TypeEngine._get_literal_cache_key(python_val, python_type)
         assert key is not None
-        assert key in TypeEngine._CACHE
+        assert key in TypeEngine._LITERAL_CACHE
 
         # Second call with same DataFrame
         literal2 = TypeEngine.to_literal(ctx, python_val, python_type, expected)
@@ -3934,8 +3934,8 @@ def test_make_key_with_annotated_types():
     annotated_val = [1, 2, 3]
     annotated_type = typing.Annotated[typing.List[int], "test_annotation"]
 
-    key = TypeEngine.make_key(annotated_val, annotated_type)
-    key_without_annotation = TypeEngine.make_key(annotated_val, typing.List[int])
+    key = TypeEngine._get_literal_cache_key(annotated_val, annotated_type)
+    key_without_annotation = TypeEngine._get_literal_cache_key(annotated_val, typing.List[int])
     # Should handle Annotated types correctly
     assert key is not None
     assert key_without_annotation is not None


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->
Closes flyteorg/flyte#6032
## Why are the changes needed?
We should only serialize the variable and upload it once to reuse the same input.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->
To make the same Python value reuse the literal.

## What changes were proposed in this pull request?
Add a local cache to store the literal that has been serialized.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Unit test
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the Flyte framework by implementing a local caching mechanism using an LRU cache for serialized literals, replacing the previous cache. This improvement boosts efficiency by reducing redundant serialization and uploads of identical Python values. A new unit test has been added to verify caching behavior when pandas is unavailable, and existing unit tests have been updated to ensure the new caching behavior is validated.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>