### PR TITLE
feat: Add faulthandler registration for SIGUSR1

### DIFF
--- a/flytekit/bin/entrypoint.py
+++ b/flytekit/bin/entrypoint.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import datetime
+import faulthandler
 import os
 import pathlib
 import signal
@@ -727,6 +728,9 @@ def execute_task_cmd(
     resolver,
     resolver_args,
 ):
+    logger.info("Registering faulthandler for SIGUSR1")
+    faulthandler.register(signal.SIGUSR1)
+
     logger.info(get_version_message())
     # We get weird errors if there are no click echo messages at all, so emit an empty string so that unit tests pass.
     click.echo("")


### PR DESCRIPTION
## Why are the changes needed?
No log or stack trace when the task is hanging.

## What changes were proposed in this pull request?
Register a signal handler, so that we can see the stacktrace when the task gets killed

## How was this patch tested?
Run a task, and kill the pod.

Locally,
```
$ cat > x.py
import faulthandler
import signal
faulthandler.register(signal.SIGUSR1)
import asyncio
asyncio.run(asyncio.sleep(100))
^C
$ python x.py &
[1] 68306
$ kill -USR1 68306
Current thread 0x00000001f8b74c80 (most recent call first):
  File "/Users/ytong/.local/share/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/selectors.py", line 548 in select
  File %                                                                                                                                                                   "/Users/ytong/.local/share/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/asyncio/base_events.py", line 1995 in _run_once
  File "/Users/ytong/.local/share/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/asyncio/base_events.py", line 678 in run_forever
  File "/Users/ytong/.local/share/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/asyncio/base_events.py", line 707 in run_until_complete
  File "/Users/ytong/.local/share/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/asyncio/runners.py", line 118 in run
  File "/Users/ytong/.local/share/uv/python/cpython-3.13.1-macos-aarch64-none/lib/python3.13/asyncio/runners.py", line 194 in run
  File "/Users/ytong/x.py", line 5 in <module>
```

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances signal handling in the Flytekit library by registering the faulthandler for SIGUSR1, enabling stack trace capture for better debugging when tasks hang or are terminated.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve signal handling improvements, making the review process relatively simple.
-->
</div>