### PR TITLE
[BUG] ImageSpec NoOpBuilder should always return True while calling should_build function

### DIFF
--- a/flytekit/image_spec/noop_builder.py
+++ b/flytekit/image_spec/noop_builder.py
@@ -6,6 +6,20 @@ class NoOpBuilder(ImageSpecBuilder):
 
     builder_type = "noop"
 
+    def should_build(self, image_spec: ImageSpec) -> bool:
+        """
+        The build_image function of NoOpBuilder uses the image_spec name as defined by the user without
+        checking whether the image exists in the Docker registry. Therefore, the should_build function
+        should always return True to trigger the build_image function.
+
+        Args:
+            image_spec (ImageSpec): Image specification
+
+        Returns:
+            bool: Always returns True
+        """
+        return True
+
     def build_image(self, image_spec: ImageSpec) -> str:
         if not isinstance(image_spec.base_image, str):
             msg = "base_image must be a string to use the noop image builder"

--- a/tests/flytekit/unit/core/image_spec/test_noop_builder.py
+++ b/tests/flytekit/unit/core/image_spec/test_noop_builder.py
@@ -22,3 +22,19 @@ def test_noop_builder_error(base_image):
     image_spec = ImageSpec(base_image=base_image)
     with pytest.raises(ValueError, match=msg):
         builder.build_image(image_spec)
+
+
+def test_noop_builder_should_build():
+    """Test that NoOpBuilder.should_build always returns True."""
+    builder = NoOpBuilder()
+
+    # Test with different image specs to ensure should_build always returns True
+    test_cases = [
+        ImageSpec(base_image="localhost:30000/flytekit"),
+        ImageSpec(base_image="python:3.9"),
+        ImageSpec(base_image="custom/image:latest"),
+    ]
+
+    for image_spec in test_cases:
+        result = builder.should_build(image_spec)
+        assert result is True, f"should_build should return True for {image_spec.base_image}"


### PR DESCRIPTION
## Tracking issue
closes [#6561](https://github.com/flyteorg/flyte/issues/6561)

<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?
The [NoOpBuilder](https://github.com/flyteorg/flytekit/blob/eb5a67f76aaef96a44bde04afb72b87592cc8b7a/flytekit/image_spec/noop_builder.py) should overrride [should_build](https://github.com/flyteorg/flytekit/blob/eb5a67f76aaef96a44bde04afb72b87592cc8b7a/flytekit/image_spec/image_spec.py#L454) function in order to correctly trigger [build_image](https://github.com/flyteorg/flytekit/blob/eb5a67f76aaef96a44bde04afb72b87592cc8b7a/flytekit/image_spec/noop_builder.py#L9) function in an environment that docker daemon is not running.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Make `NoOpBuilder` override `should_build` function.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Test workflow:
```
from flytekit.image_spec.noop_builder import NoOpBuilder
from flytekit import task, workflow, ImageSpec

image_spec = ImageSpec(
    name="test_image",
    builder="noop",
    base_image="localhost:30000/test_image:latest",
    registry="ghcr.io/not_exist_registry"
    
)

@task(container_image=image_spec)
def task_1(message: str) -> str:
    print(message)
    return message

@workflow
def wf() -> str:
    return task_1("hello")
```
We define a docker registry in `image_spec` that is not existed, and we expect that the SDK will still use the image user defined without actually communicating with the docker registry. After remote running the workflow, the SDK will use the user defined image as expected.
<img width="1038" height="96" alt="截圖 2025-08-11 上午11 44 59" src="https://github.com/user-attachments/assets/7183965d-7c58-439b-89d1-dc6bd9c14919" />


<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
