### PR TITLE
[BUG]Invalid cron date schedule creates infinite loop in flytescheduler

### DIFF
--- a/flytekit/core/schedule.py
+++ b/flytekit/core/schedule.py
@@ -142,11 +142,20 @@ class CronSchedule(_schedule_models.Schedule):
     def _validate_schedule(schedule: str):
         if schedule.lower() not in CronSchedule._VALID_CRON_ALIASES:
             try:
-                croniter.croniter(schedule)
+                cron = croniter.croniter(schedule)
             except Exception:
                 raise ValueError(
                     "Schedule is invalid. It must be set to either a cron alias or valid cron expression."
                     f" Provided schedule: {schedule}"
+                )
+            # Check if the cron expression can actually produce valid dates
+            try:
+                # Try to get the next occurrence to validate the schedule
+                cron.get_next(datetime.datetime)
+            except Exception as e:
+                raise ValueError(
+                    f"Schedule contains invalid date combinations."
+                    f"Provided schedule: {schedule}. Error: {str(e)}"
                 )
 
     @staticmethod

--- a/flytekit/core/schedule.py
+++ b/flytekit/core/schedule.py
@@ -142,20 +142,12 @@ class CronSchedule(_schedule_models.Schedule):
     def _validate_schedule(schedule: str):
         if schedule.lower() not in CronSchedule._VALID_CRON_ALIASES:
             try:
+                # Validate the cron expression
                 cron = croniter.croniter(schedule)
-            except Exception:
-                raise ValueError(
-                    "Schedule is invalid. It must be set to either a cron alias or valid cron expression."
-                    f" Provided schedule: {schedule}"
-                )
-            # Check if the cron expression can actually produce valid dates
-            try:
                 # Try to get the next occurrence to validate the schedule
                 cron.get_next(datetime.datetime)
             except Exception as e:
-                raise ValueError(
-                    f"Schedule contains invalid date combinations." f"Provided schedule: {schedule}. Error: {str(e)}"
-                )
+                raise ValueError(f"Schedule is invalid. Provided schedule: {schedule} Error: {str(e)}")
 
     @staticmethod
     def _validate_offset(offset: str):

--- a/flytekit/core/schedule.py
+++ b/flytekit/core/schedule.py
@@ -154,8 +154,7 @@ class CronSchedule(_schedule_models.Schedule):
                 cron.get_next(datetime.datetime)
             except Exception as e:
                 raise ValueError(
-                    f"Schedule contains invalid date combinations."
-                    f"Provided schedule: {schedule}. Error: {str(e)}"
+                    f"Schedule contains invalid date combinations." f"Provided schedule: {schedule}. Error: {str(e)}"
                 )
 
     @staticmethod

--- a/tests/flytekit/unit/core/test_schedule.py
+++ b/tests/flytekit/unit/core/test_schedule.py
@@ -155,31 +155,33 @@ def test_schedule_with_lp():
     )
 
 
-def test_cron_invalid_date_combinations():
-    """Test that CronSchedule rejects invalid date combinations like 31st of February."""
-
-    # Test invalid date combinations
-    invalid_schedules = [
+@pytest.mark.parametrize(
+    "invalid_schedule",
+    [
         "0 0 31 2 *",    # February 31st (does not exist)
         "0 0 30 2 *",    # February 30th (does not exist)
         "0 0 31 4 *",    # April 31st (does not exist)
         "0 0 31 6 *",    # June 31st (does not exist)
-    ]
+    ],
+)
+def test_cron_invalid_date_combinations(invalid_schedule):
+    """Test that CronSchedule rejects invalid date combinations like 31st of February."""
+    with pytest.raises(ValueError, match="Schedule is invalid."):
+        CronSchedule(schedule=invalid_schedule)
 
-    for invalid_schedule in invalid_schedules:
-        with pytest.raises(ValueError, match="Schedule contains invalid date combinations"):
-            CronSchedule(schedule=invalid_schedule)
 
-    # Test valid date combinations that should pass
-    valid_schedules = [
+@pytest.mark.parametrize(
+    "valid_schedule",
+    [
         "0 0 28 2 *",    # February 28th (always valid)
         "0 0 29 2 *",    # February 29th (valid in leap years - handled by croniter)
         "0 0 30 4 *",    # April 30th (valid)
         "0 0 31 1 *",    # January 31st (valid)
         "0 0 31 3 *",    # March 31st (valid)
-    ]
-
-    for valid_schedule in valid_schedules:
-        # These should not raise any exceptions
-        obj = CronSchedule(schedule=valid_schedule)
-        assert obj.cron_schedule.schedule == valid_schedule
+    ],
+)
+def test_cron_valid_date_combinations(valid_schedule):
+    """Test that CronSchedule accepts valid date combinations."""
+    # These should not raise any exceptions
+    obj = CronSchedule(schedule=valid_schedule)
+    assert obj.cron_schedule.schedule == valid_schedule

--- a/tests/flytekit/unit/core/test_schedule.py
+++ b/tests/flytekit/unit/core/test_schedule.py
@@ -157,7 +157,7 @@ def test_schedule_with_lp():
 
 def test_cron_invalid_date_combinations():
     """Test that CronSchedule rejects invalid date combinations like 31st of February."""
-    
+
     # Test invalid date combinations
     invalid_schedules = [
         "0 0 31 2 *",    # February 31st (does not exist)
@@ -165,11 +165,11 @@ def test_cron_invalid_date_combinations():
         "0 0 31 4 *",    # April 31st (does not exist)
         "0 0 31 6 *",    # June 31st (does not exist)
     ]
-    
+
     for invalid_schedule in invalid_schedules:
         with pytest.raises(ValueError, match="Schedule contains invalid date combinations"):
             CronSchedule(schedule=invalid_schedule)
-    
+
     # Test valid date combinations that should pass
     valid_schedules = [
         "0 0 28 2 *",    # February 28th (always valid)
@@ -178,7 +178,7 @@ def test_cron_invalid_date_combinations():
         "0 0 31 1 *",    # January 31st (valid)
         "0 0 31 3 *",    # March 31st (valid)
     ]
-    
+
     for valid_schedule in valid_schedules:
         # These should not raise any exceptions
         obj = CronSchedule(schedule=valid_schedule)


### PR DESCRIPTION
## Tracking issue
Related to [#6470](https://github.com/flyteorg/flyte/issues/6470)

<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?
In the Flytekit SDK, it is proposed that an error be raised if the user enters a cron job with an invalid date (e.g., 0 0 31 2 *), preventing the schedule from being sent to the backend.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Add schedule date validation check in flytekit SDK.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Test workflow:
```
from datetime import datetime

from flytekit import task, workflow, CronSchedule, LaunchPlan


@task
def task_1(message: str) -> str:
    return message


@workflow
def date_formatter_wf2() -> str:
    return task_1("hello")

cron_lp = LaunchPlan.get_or_create(
    name="cron_scheduled_lp",
    workflow=date_formatter_wf2,
    schedule=CronSchedule(
        schedule="0 0 31 2 *",
    ),
)
```

After registering the launch_plan with invalid schedule date, the SDK throws error as expected.
<img width="854" height="219" alt="截圖 2025-08-14 上午11 48 56" src="https://github.com/user-attachments/assets/0db493df-3b5f-4da0-afc1-18ac617da07f" />


<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [X] All new and existing tests passed.
- [X] All commits are signed-off. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the Flytekit SDK related to invalid cron date schedules that could cause an infinite loop by adding validation for cron schedules. It introduces error handling for invalid cron expressions and includes comprehensive tests to ensure correct behavior for both valid and invalid inputs, improving the scheduling feature's robustness.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>