### PR TITLE
[Fix] Issue when using FlyteFile with Elastic

### DIFF
--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -40,6 +40,24 @@ from flytekit.types.pickle.pickle import FlytePickleTransformer
 def noop(): ...
 
 
+class _FlyteFileDownloader:
+    """Downloader for FlyteFile that uses current context when called."""
+    
+    def __init__(self, remote_path: str, local_path: str, is_multipart: bool = False):
+        self.remote_path = remote_path
+        self.local_path = local_path  
+        self.is_multipart = is_multipart
+    
+    def __call__(self):
+        """Download the file using current context's synced get_data method."""
+        current_ctx = FlyteContextManager.current_context()
+        return current_ctx.file_access.get_data(
+            remote_path=self.remote_path,
+            local_path=self.local_path,
+            is_multipart=self.is_multipart
+        )
+
+
 T = typing.TypeVar("T")
 
 
@@ -318,10 +336,8 @@ class FlyteFile(SerializableType, os.PathLike, typing.Generic[T], DataClassJSONM
         if ctx.file_access.is_remote(self.path):
             self._remote_source = self.path
             self._local_path = ctx.file_access.get_random_local_path(self._remote_source)
-            self._downloader = partial(
-                ctx.file_access.get_data,
-                ctx=ctx,
-                remote_path=self._remote_source,  # type: ignore
+            self._downloader = _FlyteFileDownloader(
+                remote_path=str(self._remote_source),  # type: ignore
                 local_path=self._local_path,
             )
 
@@ -755,7 +771,11 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
         # For the remote case, return an FlyteFile object that can download
         local_path = ctx.file_access.get_random_local_path(uri)
 
-        _downloader = partial(ctx.file_access.get_data, remote_path=uri, local_path=local_path, is_multipart=False)
+        _downloader = _FlyteFileDownloader(
+            remote_path=uri,
+            local_path=local_path,
+            is_multipart=False
+        )
 
         expected_format = FlyteFilePathTransformer.get_format(expected_python_type)
         ff = FlyteFile.__class_getitem__(expected_format)(path=local_path, downloader=_downloader, metadata=metadata)

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -7,7 +7,6 @@ import pathlib
 import typing
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from functools import partial
 from typing import Dict, cast
 from urllib.parse import unquote
 
@@ -42,19 +41,17 @@ def noop(): ...
 
 class _FlyteFileDownloader:
     """Downloader for FlyteFile that uses current context when called."""
-    
+
     def __init__(self, remote_path: str, local_path: str, is_multipart: bool = False):
         self.remote_path = remote_path
-        self.local_path = local_path  
+        self.local_path = local_path
         self.is_multipart = is_multipart
-    
+
     def __call__(self):
         """Download the file using current context's synced get_data method."""
         current_ctx = FlyteContextManager.current_context()
         return current_ctx.file_access.get_data(
-            remote_path=self.remote_path,
-            local_path=self.local_path,
-            is_multipart=self.is_multipart
+            remote_path=self.remote_path, local_path=self.local_path, is_multipart=self.is_multipart
         )
 
 
@@ -338,7 +335,7 @@ class FlyteFile(SerializableType, os.PathLike, typing.Generic[T], DataClassJSONM
             self._local_path = ctx.file_access.get_random_local_path(self._remote_source)
             self._downloader = _FlyteFileDownloader(
                 remote_path=str(self._remote_source),  # type: ignore
-                local_path=self._local_path,
+                local_path=str(self._local_path),
             )
 
     def __fspath__(self):
@@ -771,11 +768,7 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
         # For the remote case, return an FlyteFile object that can download
         local_path = ctx.file_access.get_random_local_path(uri)
 
-        _downloader = _FlyteFileDownloader(
-            remote_path=uri,
-            local_path=local_path,
-            is_multipart=False
-        )
+        _downloader = _FlyteFileDownloader(remote_path=uri, local_path=local_path, is_multipart=False)
 
         expected_format = FlyteFilePathTransformer.get_format(expected_python_type)
         ff = FlyteFile.__class_getitem__(expected_format)(path=local_path, downloader=_downloader, metadata=metadata)


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?

Related to the discussion in the [slack channel](https://flyte-org.slack.com/archives/CP2HDHKE1/p1753270501631199), when using `FlyteFile` with `Elastic`, the file cannot be downloaded and we will get warning:

```sh
.venv/lib/python3.12/site-packages/flytekit/types/file/file.py:356: RuntimeWarning: coroutine 'FileAccessProvider.async_get_data' was never awaited
```
It seems like the `FlyteFile` does not play well with underlying multiprocessing spawn

Based on my experiment, when we create the `_downloader` partial function, we use the
context in main process: https://github.com/flyteorg/flytekit/blob/eb5a67f76aaef96a44bde04afb72b87592cc8b7a/flytekit/types/file/file.py#L321-L326
But when we use `Elastic` and run the `FlyteFile` within each process via spawn, the memory
is not shared, but our `_downloader` function still use main process's context, which
cannot be found in the sub-process. While the context required to convert the coroutine to a
sync call (`loop_manager.synced`) isn’t present, the coroutine is returned as-is

Below is the script for testing out the async in spawn with different context. The "Test
2" is which causing problem, and we can find that the things returned from the partial
function is the `coroutine` (`Partial call is coroutine: {is_coro2}"` is `True`), which prove that somehow the `loop_manager.synced` doesn't work here.

https://github.com/machichima/flytekit_test_scripts/blob/main/elastic-async-fsspec/compare_direct_vs_partial.py


## What changes were proposed in this pull request?

Ensure that everytime we call `download`, we will get the `current_context` of the current process, to ensure calling the `get_data` synchronously. 

## How was this patch tested?

Test with following script:

```python
from flytekit import task, workflow, FlyteFile, ImageSpec, Resources
from flytekitplugins.kfpytorch.task import Elastic, PyTorch


DEFAULT_REMOTE_PATH = "s3://my-s3-bucket/test/test.txt"

image_spec = ImageSpec(
    registry="localhost:30000",
    packages=[
        "flytekitplugins-kfpytorch[elastic]",
        "numpy",
        "torch",
    ],
)


@task(
    task_config=Elastic(nnodes=1, nproc_per_node=4),
    container_image=image_spec,
    requests=Resources(cpu="4", mem="4Gi"),
    limits=Resources(cpu="4", mem="4Gi"),
)
def my_task(dataset: FlyteFile):
    path = dataset.download()
    print(f"path: {path}", flush=True)

    assert Path(path).is_file()  # will pass now

@workflow
def wf():
    file = FlyteFile(path=DEFAULT_REMOTE_PATH)

    outputs = my_task(dataset=file)
```

### Setup process

### Screenshots

Result

<img width="830" height="238" alt="image" src="https://github.com/user-attachments/assets/abbb53af-24ad-43d1-8bcf-ab5ae389653f" />

<img width="1365" height="454" alt="image" src="https://github.com/user-attachments/assets/422ffea0-49c5-45b0-9322-080f993b8c11" />


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the FlyteFile class for better file downloads in Elastic by implementing a new downloader class and resolving an issue with the FlyteFile class, improving file download reliability by using the current process context for synchronous calls. It also removes an unnecessary dependency on 'flytekit' to streamline setup, replacing the previous approach that caused coroutine warnings and improving reliability in multiprocessing scenarios.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>