### PR TITLE
feat: Add timeout to container task

### DIFF
--- a/flytekit/core/container_task.py
+++ b/flytekit/core/container_task.py
@@ -76,6 +76,9 @@ class ContainerTask(PythonTask):
         metadata = metadata or TaskMetadata()
         metadata.pod_template_name = pod_template_name
 
+        if timeout is not None:
+            metadata.timeout = timeout
+
         super().__init__(
             task_type="raw-container",
             name=name,
@@ -283,7 +286,6 @@ class ContainerTask(PythonTask):
             self._image, command=commands, remove=True, volumes=volume_bindings, detach=True
         )
 
-        # Wait for the container to finish the task, with timeout if specified
         timeout_seconds = None
         if self._timeout is not None:
             timeout_seconds = self._timeout.total_seconds()


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->

Related to flyteorg/flyte#6351
<!-- Remove this section if not applicable -->

## Why are the changes needed?
Currently, `ContainerTask` lacks built-in timeout functionality, which is available for regular Python tasks via the `@task` decorator. 
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
This PR adds a `timeout` parameter to `ContainerTask` that accepts `datetime.timedelta` objects:
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
1. **`test_container_task_timeout()`**: Tests local execution timeout with timedelta
2. **`test_container_task_timeout_k8s_serialization()`**: Verifies K8s `activeDeadlineSeconds` serialization
3. **`test_container_task_no_timeout()`**: Ensures normal execution works with sufficient timeout
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the ContainerTask functionality by adding a timeout parameter for maximum execution duration, enabling it to accept a timeout parameter via a datetime.timedelta object. Modifications include updates to the ContainerTask class and Kubernetes pod specification, along with new unit tests to verify the feature's functionality during local execution and Kubernetes serialization, enhancing the task's capabilities to match those of standard Python tasks.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>