### PR TITLE
Dynamic platform detection for ImageSpec to support cross-platform development

### DIFF
--- a/flytekit/image_spec/image_spec.py
+++ b/flytekit/image_spec/image_spec.py
@@ -4,6 +4,7 @@ import dataclasses
 import hashlib
 import os
 import pathlib
+import platform
 import re
 import sys
 import typing
@@ -135,6 +136,9 @@ class ImageSpec:
         if self.builder is None and builder_registry:
             # Use the builder with the highest priority by default
             self.builder = max(builder_registry, key=lambda name: builder_registry[name][1])
+
+        if platform.machine() == "arm64":
+            self.platform = "linux/arm64"
 
         parameters_str_list = [
             "packages",


### PR DESCRIPTION
Closes flyteorg/flyte#6565

## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?
The ImageSpec should automatically detect the current machine's architecture and set an appropriate default platform:
"linux/arm64" for Apple Silicon Macs (ARM64)
"linux/amd64" for Intel Macs (x86_64)
<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?
Use platform.machine() to detect the current machine's architecture
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?
Unit test
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] All commits are signed-off.
