### PR TITLE
Handle None in sorted bound_inputs conditionally

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -115,7 +115,7 @@ filelock==3.14.0
     # via
     #   snowflake-connector-python
     #   virtualenv
-flyteidl==1.14.3
+flyteidl>=1.15.4
     # via flytekit
 frozenlist==1.4.1
     # via

--- a/flytekit/models/core/workflow.py
+++ b/flytekit/models/core/workflow.py
@@ -423,7 +423,7 @@ class ArrayNode(_common.FlyteIdlEntity):
             execution_mode=self._execution_mode,
             is_original_sub_node_interface=BoolValue(value=self._is_original_sub_node_interface),
             data_mode=self._data_mode,
-            bound_inputs=sorted(self._bound_inputs),
+            bound_inputs=sorted(self._bound_inputs) if self._bound_inputs else None,
         )
 
     @classmethod

--- a/tests/flytekit/unit/models/core/test_workflow.py
+++ b/tests/flytekit/unit/models/core/test_workflow.py
@@ -366,3 +366,18 @@ def test_task_node_with_overrides():
 
     obj = _workflow.TaskNode.from_flyte_idl(task_node.to_flyte_idl())
     assert obj.overrides.pod_template is not None
+
+
+def test_array_node_no_bound_inputs():
+    nm = _get_sample_node_metadata()
+    task = _workflow.TaskNode(reference_id=_generic_id)
+    node = _workflow.Node(
+        id="some:node:id",
+        metadata=nm,
+        inputs=[],
+        upstream_node_ids=[],
+        output_aliases=[],
+        task_node=task,
+    )
+    array_node = _workflow.ArrayNode(node=node, parallelism=3)
+    assert len(array_node.to_flyte_idl().bound_inputs) == 0


### PR DESCRIPTION
## Tracking issue
https://github.com/flyteorg/flytekit/pull/3292#issuecomment-3189158040

## Why are the changes needed?
failed to compile if bound_inputs is none

## What changes were proposed in this pull request?
Only sort the inputs when it's not none

## How was this patch tested?
unit test

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the workflow model by improving the handling of bound inputs, updating the flyteidl dependency for better flexibility, and refining the sorting logic for None values. A new unit test has been added to ensure correct behavior of ArrayNode without bound inputs.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>