### PR TITLE
[Fix] Error when using FlyteFile as default value in workflow

### DIFF
--- a/flytekit/interaction/click_types.py
+++ b/flytekit/interaction/click_types.py
@@ -158,6 +158,11 @@ class FileParamType(click.ParamType):
     ) -> typing.Any:
         if isinstance(value, ArtifactQuery):
             return value
+
+        # If value is already a FlyteFile, return it as-is to avoid creating nested FlyteFile objects
+        if isinstance(value, FlyteFile):
+            return value
+
         # set remote_directory to false if running pyflyte run locally. This makes sure that the original
         # file is used and not a random one.
         remote_path = None if getattr(ctx.obj, "is_remote", False) else False
@@ -177,6 +182,7 @@ class PickleParamType(click.ParamType):
 
         def get_metavar(self, param: Parameter, ctx: Context) -> t.Optional[str]:
             return "Python Object <Module>:<Object>"
+
     else:
 
         def get_metavar(self, param: Parameter, *args) -> t.Optional[str]:


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?

When running local workflow with the default args value set as `FlyteFile`, we will get following error:

<img width="616" height="63" alt="image" src="https://github.com/user-attachments/assets/e46a7f49-1331-428a-9d1f-3999d952c385" />


## What changes were proposed in this pull request?

1. In `FileParamType`'s `convert` function, if the value is already `FlyteFile`, directly return value to prevent creating the nested `FlyteFile`

## How was this patch tested?

Test by running script:

```python
DEFAULT_LOCAL_PATH = "./test.txt"

@task
def my_task(dataset: FlyteFile):
    print(f"path: {dataset.path}")

@workflow
def wf(file: FlyteFile = FlyteFile(DEFAULT_LOCAL_PATH)):
    outputs = my_task(dataset=file)
```

### Setup process

### Screenshots

Result after my modification

<img width="469" height="78" alt="image" src="https://github.com/user-attachments/assets/62bdd7c5-7889-43cf-afd0-dbdd66aee318" />


## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
