### PR TITLE
[Fix] Add .dockerignore to reduce build context size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,89 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+
+# CI
+.codeclimate.yml
+.travis.yml
+.taskcluster.yml
+
+# Docker
+docker-compose.yml
+Dockerfile
+.docker
+.dockerignore
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env
+.venv/
+venv/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+.ropeproject
+**/.ropeproject
+
+# Vim swap files
+**/*.swp
+
+# VS Code
+.vscode/


### PR DESCRIPTION
## Tracking issue

## Why are the changes needed?
Docker builds were extremely slow due to transferring 8.8GB of build context, including the large .venv/ directory, .git/  Python cache files, and other development artifacts. Adding `.dockerignore` reduces context transfer to ~160MB, significantly speeding up integration test container builds.

- Before:
<img width="464" height="279" alt="image" src="https://github.com/user-attachments/assets/ceb56631-812c-4e2e-9e4e-0549b7ae4078" />

- After:
<img width="611" height="278" alt="image" src="https://github.com/user-attachments/assets/f64648ba-ad13-4159-97c0-85bfc4ae4313" />

## What changes were proposed in this pull request?

Add `.dockerignore` file to exclude development artifacts from Docker build context. Refer `.dockerignore` file setting here: https://gist.github.com/KernelA/04b4d7691f28e264f72e76cfd724d448


## How was this patch tested?

Running `make build-dev` to ensure the context size is reduced

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
