### PR TITLE
Fix: FlyteDirectory fails for multiple files with the same name

### DIFF
--- a/flytekit/remote/remote_fs.py
+++ b/flytekit/remote/remote_fs.py
@@ -145,9 +145,9 @@ class FlyteFS(HTTPFileSystem):
         """
         prefix = kwargs.pop(_PREFIX_KEY)
         lpath = pathlib.Path(lpath)
-        relative_subdirectory = str(lpath.parent)[len(kwargs.pop(_LPATH_ROOT_KEY)):]
-        if relative_subdirectory:
-            prefix += relative_subdirectory
+        relative_subdirectory = str(lpath.parent.relative_to(pathlib.Path(kwargs.pop(_LPATH_ROOT_KEY))))
+        if relative_subdirectory != ".":
+            prefix += "/" + relative_subdirectory
         _, native_url = self._remote.upload_file(
             lpath, self._remote.default_project, self._remote.default_domain, prefix
         )
@@ -239,7 +239,7 @@ class FlyteFS(HTTPFileSystem):
 
         kwargs[_PREFIX_KEY] = prefix
         kwargs[_HASHES_KEY] = file_info
-        kwargs[_LPATH_ROOT_KEY] = lpath.rstrip(os.path.sep)
+        kwargs[_LPATH_ROOT_KEY] = lpath
         res = await super()._put(lpath, REMOTE_PLACEHOLDER, recursive, callback, batch_size, **kwargs)
         if isinstance(res, list):
             res = self.extract_common(res)

--- a/flytekit/remote/remote_fs.py
+++ b/flytekit/remote/remote_fs.py
@@ -145,9 +145,11 @@ class FlyteFS(HTTPFileSystem):
         """
         prefix = kwargs.pop(_PREFIX_KEY)
         lpath = pathlib.Path(lpath)
-        relative_subdirectory = str(lpath.parent.relative_to(pathlib.Path(kwargs.pop(_LPATH_ROOT_KEY))))
-        if relative_subdirectory != ".":
-            prefix += "/" + relative_subdirectory
+        if _LPATH_ROOT_KEY in kwargs:
+            lpath_root = pathlib.Path(kwargs.pop(_LPATH_ROOT_KEY))
+            relative_subdirectory = str(lpath.parent.relative_to(lpath_root))
+            if relative_subdirectory != ".":
+                prefix += "/" + relative_subdirectory
         _, native_url = self._remote.upload_file(
             lpath, self._remote.default_project, self._remote.default_domain, prefix
         )

--- a/flytekit/remote/remote_fs.py
+++ b/flytekit/remote/remote_fs.py
@@ -147,9 +147,10 @@ class FlyteFS(HTTPFileSystem):
         lpath = pathlib.Path(lpath)
         if _LPATH_ROOT_KEY in kwargs:
             lpath_root = pathlib.Path(kwargs.pop(_LPATH_ROOT_KEY))
-            relative_subdirectory = str(lpath.parent.relative_to(lpath_root))
-            if relative_subdirectory != ".":
-                prefix += "/" + relative_subdirectory
+            if lpath.parent.is_relative_to(lpath_root):
+                relative_subdirectory = str(lpath.parent.relative_to(lpath_root))
+                if relative_subdirectory != ".":
+                    prefix += "/" + relative_subdirectory
         _, native_url = self._remote.upload_file(
             lpath, self._remote.default_project, self._remote.default_domain, prefix
         )


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?

Persisting `FlyteDirectory` doesn't work correctly when there are multiple files with the same name in the directory.

Let's have two files:
* /home/user/my_dir/file.txt
* /home/user/my_dir/subdir/file.txt  (with identical content in both files)

And a trivial workflow:
```
@task()
def first_task(fd: fl.FlyteDirectory) -> None:
    fd.download()

@fl.workflow
def my_workflow(fd: fl.FlyteDirectory) -> None:
   first_task(fd)
```

Running with `pyflyte run ... --fd /home/user/my_dir` results in only `file.txt` being uploaded in the flyte S3 bucket. The file `subdir/file.txt` is skipped. This is of course not as expected.

In addition, note that if the files have a different content, this raises an exception in `get_upload_signed_url`!

```
USER:EntityAlreadyExists: error=None, cause=<_InactiveRpcError of RPC that terminated with:
        status = StatusCode.ALREADY_EXISTS
        details = "file already exists at location [s3://flyte/flytesnacks/development/ABSCCKRIMI35Z5XNGNQTO7FZIQ======/file.txt], specify a matching hash if you wish to rewrite"
        debug_error_string = "UNKNOWN:Error received from peer  {grpc_status:6, grpc_message:"file already exists at location [s3://flyte/flytesnacks/development/ABSCCKRIMI35Z5XNGNQTO7FZIQ======/file.txt], specify a matching hash if you wish to rewrite"}"
```

Our current workaround is to pack a directory into an archive and use `FlyteFile`.

<!--
Please clarify why the changes are needed. For instance,
1. If you propose a new API, clarify the use case for a new API.
2. If you fix a bug, you can clarify why it is a bug.
-->

## What changes were proposed in this pull request?

This bugfix is based on the observation that `get_upload_signed_url` is only provided file basename and file content hash to determine the URL. This leads to the both files ending up in the same location (the directory is flatten). To fix that, I add the path relative to the local root to the filename. This seems to work and both files are uploaded.

Disclaimer: I have no idea if there are any side effects of this fix. It can be that some other functionality gets broken. Or there might be a better fix. I would appreciate a review from the maintainers:).


<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
2. If there is design documentation, please add the link.
-->

## How was this patch tested?

Empirical test: For the minimal example above this works, the call to `super()._put` in `FlyteFS._put()` returns two objects: `['s3://flyte/flytesnacks/development/QLGCX23Y7HX3FI2LIEGVF5OW7Q======/subdir/file.txt', 's3://flyte/flytesnacks/development/QLGCX23Y7HX3FI2LIEGVF5OW7Q======/file.txt']`. This works both when the file content is identical and when it's different.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the FlyteDirectory persistence mechanism that prevented the upload of multiple files with the same name and content. By including the relative path of files in the upload process, it enhances the Flyte framework's ability to manage directories with duplicate files effectively.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on a specific bug fix, making the review process relatively simple.
-->
</div>