### PR TITLE
bump dask version

### DIFF
--- a/plugins/flytekit-dask/setup.py
+++ b/plugins/flytekit-dask/setup.py
@@ -7,7 +7,7 @@ microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 plugin_requires = [
     "flyteidl>=1.3.2",
     "flytekit>=1.3.0b2,<2.0.0",
-    "dask[distributed]>=2022.10.2",
+    "dask[distributed]>=2025.4.1",
 ]
 
 __version__ = "0.0.0+develop"


### PR DESCRIPTION
## Why are the changes needed?

Flyte users have observed [this bug](https://github.com/dask/dask-kubernetes/issues/940) that originates from kubernetes dask. [This change](https://github.com/dask/dask-kubernetes/pull/941) fixed it which was included in [version 2025.4.1](https://github.com/dask/dask-kubernetes/releases/tag/2025.4.1).

## What changes were proposed in this pull request?

Set the lower bound of the dask version to 2025.4.1

## How was this patch tested?

Dask plugin unit tests and remote executions.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request updates the lower bound of the dask version in the flytekit-dask plugin to 2025.4.1, addressing a bug and ensuring compatibility with the latest features and fixes from dask.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>