### PR TITLE
Add remote workflow version execution support to pyflyte run

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -810,6 +810,7 @@ class DynamicEntityLaunchCommand(click.RichCommand):
 
     LP_LAUNCHER = "lp"
     TASK_LAUNCHER = "task"
+    WORKFLOW_LAUNCHER = "workflow"
 
     def __init__(self, name: str, h: str, entity_name: str, launcher: str, **kwargs):
         super().__init__(name=name, help=h, **kwargs)
@@ -817,7 +818,7 @@ class DynamicEntityLaunchCommand(click.RichCommand):
         self._launcher = launcher
         self._entity = None
 
-    def _fetch_entity(self, ctx: click.Context) -> typing.Union[FlyteLaunchPlan, FlyteTask]:
+    def _fetch_entity(self, ctx: click.Context) -> typing.Union[FlyteLaunchPlan, FlyteTask, FlyteWorkflow]:
         if self._entity:
             return self._entity
         run_level_params: RunLevelParams = ctx.obj
@@ -837,6 +838,12 @@ class DynamicEntityLaunchCommand(click.RichCommand):
                         )
                     )
                     entity = r.fetch_launch_plan(run_level_params.project, run_level_params.domain, self._entity_name)
+        elif self._launcher == self.WORKFLOW_LAUNCHER:
+            parts = self._entity_name.split(":")
+            if len(parts) == 2:
+                entity = r.fetch_workflow(run_level_params.project, run_level_params.domain, parts[0], parts[1])
+            else:
+                entity = r.fetch_workflow(run_level_params.project, run_level_params.domain, self._entity_name)
         else:
             parts = self._entity_name.split(":")
             if len(parts) == 2:
@@ -973,12 +980,19 @@ class RemoteEntityGroup(click.RichGroup):
                 return []
 
     def get_command(self, ctx, name):
-        if self._command_name in [self.LAUNCHPLAN_COMMAND, self.WORKFLOW_COMMAND]:
+        if self._command_name == self.LAUNCHPLAN_COMMAND:
             return DynamicEntityLaunchCommand(
                 name=name,
                 h=f"Execute a {self._command_name}.",
                 entity_name=name,
                 launcher=DynamicEntityLaunchCommand.LP_LAUNCHER,
+            )
+        elif self._command_name == self.WORKFLOW_COMMAND:
+            return DynamicEntityLaunchCommand(
+                name=name,
+                h=f"Execute a {self._command_name}.",
+                entity_name=name,
+                launcher=DynamicEntityLaunchCommand.WORKFLOW_LAUNCHER,
             )
         return DynamicEntityLaunchCommand(
             name=name,


### PR DESCRIPTION
## Tracking issue
N/A

## Why are the changes needed?

Currently, the `pyflyte run` command supports executing remote tasks (`remote-task`) and remote launch plans (`remote-launchplan`), but lacks support for executing exact version of remote workflows directly. This creates an inconsistent user experience and limits flexibility when users want to execute workflows that are already registered in a Flyte backend.

## What changes were proposed in this pull request?

This PR adds support for executing remote workflows via the `pyflyte run remote-workflow` command, bringing feature parity with the existing remote task and launch plan execution capabilities.

**Changes include:**
1. Added `WORKFLOW_LAUNCHER` constant to `DynamicEntityLaunchCommand` class
2. Updated `_fetch_entity()` method to handle the workflow launcher type by calling `fetch_workflow()` on the remote instance
3. Added support for version-specific workflow execution using the `name:version` syntax
4. Updated `get_command()` in `RemoteEntityGroup` to create a `DynamicEntityLaunchCommand` with the workflow launcher when the command is `remote-workflow`
5. Added comprehensive unit tests (`test_remote_workflow` and `test_remote_workflow_with_version`) to verify the functionality

## How was this patch tested?

Added two new unit tests in `tests/flytekit/unit/cli/pyflyte/test_run.py`:

1. **`test_remote_workflow`**: Tests basic remote workflow execution with parameters
2. **`test_remote_workflow_with_version`**: Tests version-specific workflow execution using the `name:version` syntax

Both tests:
- Mock `FlyteRemote` and `run_remote` to verify correct behavior
- Use the `CliRunner` to simulate command-line execution
- Verify that `fetch_workflow()` is called with the correct arguments
- Ensure the workflow executes successfully with provided inputs

All tests pass successfully:
```
pytest tests/flytekit/unit/cli/pyflyte/test_run.py::test_remote_workflow tests/flytekit/unit/cli/pyflyte/test_run.py::test_remote_workflow_with_version -v
```

### Setup process
N/A

### Screenshots
N/A

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs
N/A

## Docs link
N/A 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the pyflyte run command by enabling the execution of remote workflows, introducing a WORKFLOW_LAUNCHER constant, and modifying the _fetch_entity method for workflow compatibility. It also supports version-specific workflows and includes comprehensive unit tests for reliability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>