### PR TITLE
Use setuptools<82.0.0

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -137,8 +137,8 @@ jobs:
             pandas: "pandas<2.0.0"
           - numpy: "numpy<2.0.0"
             pandas: "pandas>=2.0.0"
-          - numpy: "numpy>=2.0.0"
-            python-version: "3.8"
+          - pandas: "pandas<2.0.0"
+            python-version: "3.12"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -79,7 +79,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/plugins/flytekit-bigquery/setup.py
+++ b/plugins/flytekit-bigquery/setup.py
@@ -9,6 +9,7 @@ plugin_requires = [
     "google-cloud-bigquery>=3.21.0",
     "google-cloud-bigquery-storage>=2.25.0",
     "flyteidl>1.10.7",
+    "numpy<2",
 ]
 
 __version__ = "0.0.0+develop"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "markdown-it-py",
     "marshmallow-enum",
     "marshmallow-jsonschema>=0.12.0",
+    "setuptools",
     "mashumaro>=3.15",
     "msgpack>=1.1.0",
     "protobuf!=4.25.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "jsonpickle",
     "keyring>=18.0.1",
     "markdown-it-py",
+    "marshmallow>=3,<4",
     "marshmallow-enum",
     "marshmallow-jsonschema>=0.12.0",
     "setuptools<70",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,9 @@ extend-exclude = ["tests/", "**/tests/**"]
 ignore-words-list = "ot,te,raison,fo,lits,assertIn"
 skip = "./docs/build,./.git,*.txt"
 
+[tool.uv.extra-build-dependencies]
+pandas = ["setuptools<70"]
+
 [project.optional-dependencies]
 # TODO: Remove it when we remove all the agent code
 agent = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "markdown-it-py",
     "marshmallow-enum",
     "marshmallow-jsonschema>=0.12.0",
-    "setuptools",
+    "setuptools<82.0.0",
     "mashumaro>=3.15",
     "msgpack>=1.1.0",
     "protobuf!=4.25.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools_scm"]
+requires = ["setuptools<70", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -37,7 +37,7 @@ dependencies = [
     "markdown-it-py",
     "marshmallow-enum",
     "marshmallow-jsonschema>=0.12.0",
-    "setuptools<82.0.0",
+    "setuptools<70",
     "mashumaro>=3.15",
     "msgpack>=1.1.0",
     "protobuf!=4.25.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,9 +149,6 @@ extend-exclude = ["tests/", "**/tests/**"]
 ignore-words-list = "ot,te,raison,fo,lits,assertIn"
 skip = "./docs/build,./.git,*.txt"
 
-[tool.uv.extra-build-dependencies]
-pandas = ["setuptools<70"]
-
 [project.optional-dependencies]
 # TODO: Remove it when we remove all the agent code
 agent = [


### PR DESCRIPTION
## Tracking issue
NA

## Why are the changes needed?
unit tests are failing
```
/opt/hostedtoolcache/Python/3.12.12/arm64/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/flytekit/unit/core/test_type_engine.py:24: in <module>
    from marshmallow_jsonschema import JSONSchema
/opt/hostedtoolcache/Python/3.12.12/arm64/lib/python3.12/site-packages/marshmallow_jsonschema/__init__.py:1: in <module>
    from pkg_resources import get_distribution
E   ModuleNotFoundError: No module named 'pkg_resources'
```

## What changes were proposed in this pull request?
The issue was that setuptools 82.0.0 (the latest version) removed pkg_resources entirely. I downgraded to setuptools 69.5.1, which still includes it

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
