### PR TITLE
Re-translate LaunchPlan fixed inputs with remote context on registration

### DIFF
--- a/flytekit/core/launch_plan.py
+++ b/flytekit/core/launch_plan.py
@@ -177,6 +177,7 @@ class LaunchPlan(object):
         # we don't have to reverse it back every time.
         default_inputs.update(fixed_inputs)
         lp._saved_inputs = default_inputs
+        lp._raw_fixed_inputs = fixed_inputs
 
         if name in cls.CACHE:
             raise AssertionError(f"Launch plan named {name} was already created! Make sure your names are unique.")
@@ -347,6 +348,7 @@ class LaunchPlan(object):
         self._fixed_inputs = fixed_inputs
         # See create() for additional information
         self._saved_inputs: Dict[str, Any] = {}
+        self._raw_fixed_inputs: Dict[str, Any] = {}
 
         self._schedule = schedule
         self._notifications = notifications or []
@@ -422,6 +424,10 @@ class LaunchPlan(object):
     @property
     def workflow(self) -> _annotated_workflow.WorkflowBase:
         return self._workflow
+
+    @property
+    def raw_fixed_inputs(self) -> Dict[str, Any]:
+        return self._raw_fixed_inputs.copy()
 
     @property
     def saved_inputs(self) -> Dict[str, Any]:

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -48,6 +48,7 @@ from flytekit.core.context_manager import FlyteContext, FlyteContextManager
 from flytekit.core.data_persistence import FileAccessProvider
 from flytekit.core.launch_plan import LaunchPlan, ReferenceLaunchPlan
 from flytekit.core.node import Node as CoreNode
+from flytekit.core.promise import translate_inputs_to_literals
 from flytekit.core.python_auto_container import (
     PICKLE_FILE_PATH,
     PickledEntity,
@@ -1536,6 +1537,15 @@ class FlyteRemote(object):
             self.register_workflow(
                 entity.workflow, serialization_settings, version, default_launch_plan=False, options=options
             )
+
+        if entity.raw_fixed_inputs:
+            fixed_literals = translate_inputs_to_literals(
+                self.context,
+                incoming_values=entity.raw_fixed_inputs,
+                flyte_interface_types=entity.workflow.interface.inputs,
+                native_types=entity.workflow.python_interface.inputs,
+            )
+            entity._fixed_inputs = literal_models.LiteralMap(literals=fixed_literals)
 
         # Underlying workflow, exists, only register the launch plan itself
         launch_plan_model = get_serializable(

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -911,3 +911,54 @@ def test_register_launch_plan(mock_serialize_and_register, mock_raw_register,moc
     assert remote_lp is mock_remote_lp
     assert not mock_serialize_and_register.called
     assert mock_raw_register.called
+
+
+@mock.patch("flytekit.remote.remote.translate_inputs_to_literals")
+@mock.patch("flytekit.remote.remote.get_serializable")
+@mock.patch("flytekit.remote.remote.FlyteRemote.fetch_launch_plan")
+@mock.patch("flytekit.remote.remote.FlyteRemote.raw_register")
+@mock.patch("flytekit.remote.remote.FlyteRemote._serialize_and_register")
+def test_register_launch_plan_retranslates_fixed_inputs_with_remote_context(
+    mock_serialize_and_register, mock_raw_register, mock_fetch_launch_plan,
+    mock_get_serializable, mock_translate, mock_flyte_remote_client
+):
+    from flytekit.types.file import FlyteFile
+
+    @task
+    def t_with_file(f: FlyteFile) -> str:
+        return str(f)
+
+    @workflow
+    def wf_with_file(f: FlyteFile) -> str:
+        return t_with_file(f=f)
+
+    with tempfile.NamedTemporaryFile() as tmp:
+        ff = FlyteFile(path=tmp.name)
+        lp = LaunchPlan.get_or_create(
+            workflow=wf_with_file,
+            name="lp_with_flytefile_fixed",
+            fixed_inputs={"f": ff},
+        )
+
+    assert lp.raw_fixed_inputs == {"f": ff}
+
+    rr = FlyteRemote(
+        Config.for_sandbox(),
+        default_project="flytesnacks",
+        default_domain="development",
+    )
+
+    mock_translate.return_value = {"f": MagicMock()}
+    mock_get_serializable.return_value = MagicMock()
+    mock_flyte_remote_client.get_workflow.return_value = MagicMock()
+    mock_fetch_launch_plan.return_value = MagicMock()
+
+    ss = SerializationSettings(image_config=ImageConfig.auto_default_image(), version="v1")
+    rr.register_launch_plan(lp, version="v1", serialization_settings=ss)
+
+    mock_translate.assert_called_once_with(
+        rr.context,
+        incoming_values={"f": ff},
+        flyte_interface_types=wf_with_file.interface.inputs,
+        native_types=wf_with_file.python_interface.inputs,
+    )

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -932,33 +932,39 @@ def test_register_launch_plan_retranslates_fixed_inputs_with_remote_context(
     def wf_with_file(f: FlyteFile) -> str:
         return t_with_file(f=f)
 
-    with tempfile.NamedTemporaryFile() as tmp:
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    try:
         ff = FlyteFile(path=tmp.name)
         lp = LaunchPlan.get_or_create(
             workflow=wf_with_file,
             name="lp_with_flytefile_fixed",
             fixed_inputs={"f": ff},
         )
+    finally:
+        tmp.close()
 
-    assert lp.raw_fixed_inputs == {"f": ff}
+    try:
+        assert lp.raw_fixed_inputs == {"f": ff}
 
-    rr = FlyteRemote(
-        Config.for_sandbox(),
-        default_project="flytesnacks",
-        default_domain="development",
-    )
+        rr = FlyteRemote(
+            Config.for_sandbox(),
+            default_project="flytesnacks",
+            default_domain="development",
+        )
 
-    mock_translate.return_value = {"f": MagicMock()}
-    mock_get_serializable.return_value = MagicMock()
-    mock_flyte_remote_client.get_workflow.return_value = MagicMock()
-    mock_fetch_launch_plan.return_value = MagicMock()
+        mock_translate.return_value = {"f": MagicMock()}
+        mock_get_serializable.return_value = MagicMock()
+        mock_flyte_remote_client.get_workflow.return_value = MagicMock()
+        mock_fetch_launch_plan.return_value = MagicMock()
 
-    ss = SerializationSettings(image_config=ImageConfig.auto_default_image(), version="v1")
-    rr.register_launch_plan(lp, version="v1", serialization_settings=ss)
+        ss = SerializationSettings(image_config=ImageConfig.auto_default_image(), version="v1")
+        rr.register_launch_plan(lp, version="v1", serialization_settings=ss)
 
-    mock_translate.assert_called_once_with(
-        rr.context,
-        incoming_values={"f": ff},
-        flyte_interface_types=wf_with_file.interface.inputs,
-        native_types=wf_with_file.python_interface.inputs,
-    )
+        mock_translate.assert_called_once_with(
+            rr.context,
+            incoming_values={"f": ff},
+            flyte_interface_types=wf_with_file.interface.inputs,
+            native_types=wf_with_file.python_interface.inputs,
+        )
+    finally:
+        os.unlink(tmp.name)


### PR DESCRIPTION
## Why are the changes needed?

When a `LaunchPlan` is created with a `StructuredDataset` or `FlyteFile` as a `fixed_input`, flytekit eagerly serializes those inputs to Flyte literals at `LaunchPlan.create()` time using the local `FlyteContext`. At that point, the `FileAccessProvider` points to a local `/tmp` directory, so any file or dataset upload goes there instead of remote storage. When the launch plan is later registered, the serialized literal contains a `/tmp` path that the remote Flyte cluster cannot access.


## What changes were proposed in this pull request?


- `LaunchPlan.__init__` now stores `_raw_fixed_inputs`, the original Python native values passed as `fixed_inputs` before they are serialized to a `LiteralMap`.
- `LaunchPlan.create()` populates `_raw_fixed_inputs` alongside the existing `_saved_inputs`.
- `FlyteRemote.register_launch_plan()` now re-translates `raw_fixed_inputs` using `self.context`, which has a `FileAccessProvider` configured for remote storage. This overwrites the stale local literals before the launch plan is serialized and sent to Flyte Admin.


## How was this patch tested?

Added `test_register_launch_plan_retranslates_fixed_inputs_with_remote_context` in `tests/flytekit/unit/remote/test_remote.py`. The test creates a `LaunchPlan` with a `FlyteFile` fixed input and asserts that `translate_inputs_to_literals` is called with the remote context (`rr.context`) during `register_launch_plan`. The test was also verified to fail against the pre-fix code, confirming it catches the regression.

