### PR TITLE
Add file_extension fields to BlobType

### DIFF
--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -105,6 +105,48 @@ def get_batch_size(t: Type) -> Optional[int]:
     return None
 
 
+class FileDownloadConfig:
+    """
+    This is used to annotate a FlyteFile when we want to download the file with a specific extension. For example,
+
+    ```python
+    # ContainerTask
+    def t1(file: Annotated[FlyteFile, FileDownloadConfig(file_extension="csv")]):
+        ... # copilot downloads the file to e.g. /inputs/file.csv
+    
+    versus...
+    
+    def t1(file: FlyteFile["csv"]):
+        ... # copilot downloads the file to e.g. /inputs/file
+    ```
+
+    file_extension: (Default is "") The file extension (e.g. "csv", "parquet") to use during copilot download.
+    enable_legacy_filename: (Default is False) When true and file_extension is non-empty, the copilot download phase
+    writes the blob to both the full path (with extension) and the old path (without extension), preserving backward compatibility for
+    workflows with tasks that may read from both.
+    """
+
+    def __init__(self, file_extension: str = "", enable_legacy_filename: bool = False):
+        self._file_extension = file_extension
+        self._enable_legacy_filename = enable_legacy_filename
+    
+    @property
+    def file_extension(self) -> str:
+        return self._file_extension
+    
+    @property
+    def enable_legacy_filename(self) -> bool:
+        return self._enable_legacy_filename
+
+
+def get_file_download_config(t: Type) -> Optional[FileDownloadConfig]:
+    if is_annotated(t):
+        for arg in get_args(t):
+            if isinstance(arg, FileDownloadConfig):
+                return arg
+    return None
+
+
 def modify_literal_uris(lit: Literal):
     """
     Modifies the literal object recursively to replace the URIs with the native paths in case they are of

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -106,13 +106,13 @@ def get_batch_size(t: Type) -> Optional[int]:
     return None
 
 
-class FileDownloadConfig:
+class FileExtension:
     """
     This is used to annotate a FlyteFile when we want to download the file with a specific extension. For example,
 
     ```python
     # ContainerTask
-    def t1(file: Annotated[FlyteFile, FileDownloadConfig(file_extension="csv")]):
+    def t1(file: Annotated[FlyteFile, FileExtension("csv")]):
         ... # copilot downloads the file to e.g. /inputs/file.csv
     
     versus...
@@ -121,35 +121,26 @@ class FileDownloadConfig:
         ... # copilot downloads the file to e.g. /inputs/file
     ```
 
-    file_extension: (Default is "") The file extension (e.g. "csv", "parquet") to use during copilot download.
-    enable_legacy_filename: (Default is False) When true and file_extension is non-empty, the copilot download phase
-    writes the blob to both the full path (with extension) and the old path (without extension), preserving backward compatibility for
-    workflows with tasks that may read from both.
+    val: (Default is "") The file extension (e.g. "csv", "parquet") to use during copilot download.
     """
 
-    def __init__(self, file_extension: str = "", enable_legacy_filename: bool = False):
-        self._file_extension = file_extension
-        self._enable_legacy_filename = enable_legacy_filename
+    def __init__(self, val: str = ""):
+        self._val = val
 
-        if self._file_extension is not "":
-            pattern = r"^[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*$"
-            if not re.match(pattern, self._file_extension):
-                raise ValueError(f"Invalid file extension: {self._file_extension}")
-    
+        pattern = r"^[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*$"
+        if not re.match(pattern, self._val):
+            raise ValueError(f"Invalid file extension: {self._val}")
+
     @property
-    def file_extension(self) -> str:
-        return self._file_extension
+    def val(self) -> str:
+        return self._val
     
-    @property
-    def enable_legacy_filename(self) -> bool:
-        return self._enable_legacy_filename
 
-
-def get_file_download_config(t: Type) -> Optional[FileDownloadConfig]:
+def get_file_extension(t: Type) -> Optional[str]:
     if is_annotated(t):
-        for arg in get_args(t):
-            if isinstance(arg, FileDownloadConfig):
-                return arg
+        for annotation in get_args(t)[1:]:
+            if isinstance(annotation, FileExtension):
+                return annotation.val
     return None
 
 

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -114,9 +114,9 @@ class FileExtension:
     # ContainerTask
     def t1(file: Annotated[FlyteFile, FileExtension("csv")]):
         ... # copilot downloads the file to e.g. /inputs/file.csv
-    
+
     versus...
-    
+
     def t1(file: FlyteFile["csv"]):
         ... # copilot downloads the file to e.g. /inputs/file
     ```
@@ -134,7 +134,7 @@ class FileExtension:
     @property
     def val(self) -> str:
         return self._val
-    
+
 
 def get_file_extension(t: Type) -> Optional[str]:
     if is_annotated(t):

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -10,6 +10,7 @@ import inspect
 import json
 import mimetypes
 import os
+import re
 import sys
 import textwrap
 import threading
@@ -129,6 +130,11 @@ class FileDownloadConfig:
     def __init__(self, file_extension: str = "", enable_legacy_filename: bool = False):
         self._file_extension = file_extension
         self._enable_legacy_filename = enable_legacy_filename
+
+        if self._file_extension is not "":
+            pattern = r"^[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*$"
+            if not re.match(pattern, self._file_extension):
+                raise ValueError(f"Invalid file extension: {self._file_extension}")
     
     @property
     def file_extension(self) -> str:

--- a/flytekit/models/core/types.py
+++ b/flytekit/models/core/types.py
@@ -38,13 +38,19 @@ class BlobType(_common.FlyteIdlEntity):
         SINGLE = _types_pb2.BlobType.SINGLE
         MULTIPART = _types_pb2.BlobType.MULTIPART
 
-    def __init__(self, format, dimensionality):
+    def __init__(self, format, dimensionality, file_extension="", enable_legacy_filename=False):
         """
         :param Text format: A string describing the format of the underlying blob data.
         :param int dimensionality: An integer from BlobType.BlobDimensionality enum
+        :param Text file_extension: The file extension (e.g. "csv", "parquet") to use
+            during copilot download, e.g. "csv", "parquet". Empty by default.
+        :param bool enable_legacy_filename: When True and file_extension is set, the copilot
+            download phase writes the blob to both the extended path and the base path.
         """
         self._format = format
         self._dimensionality = dimensionality
+        self._file_extension = file_extension
+        self._enable_legacy_filename = enable_legacy_filename
 
     @property
     def format(self):
@@ -62,11 +68,34 @@ class BlobType(_common.FlyteIdlEntity):
         """
         return self._dimensionality
 
+    @property
+    def file_extension(self):
+        """
+        The file extension (e.g. "csv", "parquet") to use during copilot download.
+        Default is "", which means no extension is appended.
+        :rtype: Text
+        """
+        return self._file_extension
+
+    @property
+    def enable_legacy_filename(self):
+        """
+        When True and file_extension is set, the copilot download writes the blob to
+        both the full path (with extension) and the old path (without extension).
+        :rtype: bool
+        """
+        return self._enable_legacy_filename
+
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.core.types_pb2.BlobType
         """
-        return _types_pb2.BlobType(format=self.format, dimensionality=self.dimensionality)
+        return _types_pb2.BlobType(
+            format=self.format,
+            dimensionality=self.dimensionality,
+            file_extension=self._file_extension,
+            enable_legacy_filename=self._enable_legacy_filename,
+        )
 
     @classmethod
     def from_flyte_idl(cls, proto):
@@ -74,4 +103,9 @@ class BlobType(_common.FlyteIdlEntity):
         :param flyteidl.core.types_pb2.BlobType proto:
         :rtype: BlobType
         """
-        return cls(format=proto.format, dimensionality=proto.dimensionality)
+        return cls(
+            format=proto.format,
+            dimensionality=proto.dimensionality,
+            file_extension=proto.file_extension,
+            enable_legacy_filename=proto.enable_legacy_filename,
+        )

--- a/flytekit/models/core/types.py
+++ b/flytekit/models/core/types.py
@@ -38,19 +38,16 @@ class BlobType(_common.FlyteIdlEntity):
         SINGLE = _types_pb2.BlobType.SINGLE
         MULTIPART = _types_pb2.BlobType.MULTIPART
 
-    def __init__(self, format, dimensionality, file_extension="", enable_legacy_filename=False):
+    def __init__(self, format, dimensionality, file_extension=""):
         """
         :param Text format: A string describing the format of the underlying blob data.
         :param int dimensionality: An integer from BlobType.BlobDimensionality enum
         :param Text file_extension: The file extension (e.g. "csv", "parquet") to use
             during copilot download, e.g. "csv", "parquet". Empty by default.
-        :param bool enable_legacy_filename: When True and file_extension is set, the copilot
-            download phase writes the blob to both the extended path and the base path.
         """
         self._format = format
         self._dimensionality = dimensionality
         self._file_extension = file_extension
-        self._enable_legacy_filename = enable_legacy_filename
 
     @property
     def format(self):
@@ -77,15 +74,6 @@ class BlobType(_common.FlyteIdlEntity):
         """
         return self._file_extension
 
-    @property
-    def enable_legacy_filename(self):
-        """
-        When True and file_extension is set, the copilot download writes the blob to
-        both the full path (with extension) and the old path (without extension).
-        :rtype: bool
-        """
-        return self._enable_legacy_filename
-
     def to_flyte_idl(self):
         """
         :rtype: flyteidl.core.types_pb2.BlobType
@@ -94,7 +82,6 @@ class BlobType(_common.FlyteIdlEntity):
             format=self.format,
             dimensionality=self.dimensionality,
             file_extension=self._file_extension,
-            enable_legacy_filename=self._enable_legacy_filename,
         )
 
     @classmethod
@@ -107,5 +94,4 @@ class BlobType(_common.FlyteIdlEntity):
             format=proto.format,
             dimensionality=proto.dimensionality,
             file_extension=proto.file_extension,
-            enable_legacy_filename=proto.enable_legacy_filename,
         )

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -24,6 +24,7 @@ from flytekit.core.type_engine import (
     AsyncTypeTransformer,
     TypeEngine,
     TypeTransformerFailedError,
+    get_file_download_config,
     get_underlying_type,
 )
 from flytekit.exceptions.user import FlyteAssertion
@@ -477,8 +478,26 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
             return ""
         return cast(FlyteFile, t).extension()
 
-    def _blob_type(self, format: str) -> BlobType:
-        return BlobType(format=format, dimensionality=BlobType.BlobDimensionality.SINGLE)
+    @staticmethod
+    def get_file_extension(t: typing.Union[typing.Type[FlyteFile], os.PathLike]) -> str:
+        if t is os.PathLike:
+            return ""
+        file_download_config = get_file_download_config(t)
+        if file_download_config is None:
+            return ""
+        return file_download_config.file_extension or ""
+
+    @staticmethod
+    def get_enable_legacy_filename(t: typing.Union[typing.Type[FlyteFile], os.PathLike]) -> str:
+        if t is os.PathLike:
+            return False
+        file_download_config = get_file_download_config(t)
+        if file_download_config is None:
+            return False
+        return file_download_config.enable_legacy_filename or False
+
+    def _blob_type(self, format: str, file_extension: str = "", enable_legacy_filename: bool = False) -> BlobType:
+        return BlobType(format=format, dimensionality=BlobType.BlobDimensionality.SINGLE, file_extension=file_extension, enable_legacy_filename=enable_legacy_filename)
 
     def assert_type(
         self, t: typing.Union[typing.Type[FlyteFile], os.PathLike], v: typing.Union[FlyteFile, os.PathLike, str]
@@ -491,7 +510,11 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
         )
 
     def get_literal_type(self, t: typing.Union[typing.Type[FlyteFile], os.PathLike]) -> LiteralType:
-        return LiteralType(blob=self._blob_type(format=FlyteFilePathTransformer.get_format(t)))
+        return LiteralType(blob=self._blob_type(
+            format=FlyteFilePathTransformer.get_format(t),
+            file_extension=FlyteFilePathTransformer.get_file_extension(t),
+            enable_legacy_filename=FlyteFilePathTransformer.get_enable_legacy_filename(t),
+        ))
 
     def get_mime_type_from_extension(self, extension: str) -> typing.Union[str, typing.Sequence[str]]:
         extension_to_mime_type = {
@@ -565,7 +588,11 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
             raise ValueError(f"Incorrect type {python_type}, must be either a FlyteFile or os.PathLike")
 
         # information used by all cases
-        meta = BlobMetadata(type=self._blob_type(format=FlyteFilePathTransformer.get_format(python_type)))
+        meta = BlobMetadata(type=self._blob_type(
+            format=FlyteFilePathTransformer.get_format(python_type),
+            file_extension=FlyteFilePathTransformer.get_file_extension(python_type),
+            enable_legacy_filename=FlyteFilePathTransformer.get_enable_legacy_filename(python_type),
+        ))
 
         if isinstance(python_val, FlyteFile):
             # Cast the source path to str type to avoid error raised when the source path is used as the blob uri,

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -24,7 +24,7 @@ from flytekit.core.type_engine import (
     AsyncTypeTransformer,
     TypeEngine,
     TypeTransformerFailedError,
-    get_file_download_config,
+    get_file_extension,
     get_underlying_type,
 )
 from flytekit.exceptions.user import FlyteAssertion
@@ -482,22 +482,13 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
     def get_file_extension(t: typing.Union[typing.Type[FlyteFile], os.PathLike]) -> str:
         if t is os.PathLike:
             return ""
-        file_download_config = get_file_download_config(t)
-        if file_download_config is None:
+        file_extension = get_file_extension(t)
+        if file_extension is None:
             return ""
-        return file_download_config.file_extension or ""
+        return file_extension
 
-    @staticmethod
-    def get_enable_legacy_filename(t: typing.Union[typing.Type[FlyteFile], os.PathLike]) -> str:
-        if t is os.PathLike:
-            return False
-        file_download_config = get_file_download_config(t)
-        if file_download_config is None:
-            return False
-        return file_download_config.enable_legacy_filename or False
-
-    def _blob_type(self, format: str, file_extension: str = "", enable_legacy_filename: bool = False) -> BlobType:
-        return BlobType(format=format, dimensionality=BlobType.BlobDimensionality.SINGLE, file_extension=file_extension, enable_legacy_filename=enable_legacy_filename)
+    def _blob_type(self, format: str, file_extension: str = "") -> BlobType:
+        return BlobType(format=format, dimensionality=BlobType.BlobDimensionality.SINGLE, file_extension=file_extension)
 
     def assert_type(
         self, t: typing.Union[typing.Type[FlyteFile], os.PathLike], v: typing.Union[FlyteFile, os.PathLike, str]
@@ -513,7 +504,6 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
         return LiteralType(blob=self._blob_type(
             format=FlyteFilePathTransformer.get_format(t),
             file_extension=FlyteFilePathTransformer.get_file_extension(t),
-            enable_legacy_filename=FlyteFilePathTransformer.get_enable_legacy_filename(t),
         ))
 
     def get_mime_type_from_extension(self, extension: str) -> typing.Union[str, typing.Sequence[str]]:
@@ -591,7 +581,6 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
         meta = BlobMetadata(type=self._blob_type(
             format=FlyteFilePathTransformer.get_format(python_type),
             file_extension=FlyteFilePathTransformer.get_file_extension(python_type),
-            enable_legacy_filename=FlyteFilePathTransformer.get_enable_legacy_filename(python_type),
         ))
 
         if isinstance(python_val, FlyteFile):

--- a/flytekit/types/file/file.py
+++ b/flytekit/types/file/file.py
@@ -501,10 +501,12 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
         )
 
     def get_literal_type(self, t: typing.Union[typing.Type[FlyteFile], os.PathLike]) -> LiteralType:
-        return LiteralType(blob=self._blob_type(
-            format=FlyteFilePathTransformer.get_format(t),
-            file_extension=FlyteFilePathTransformer.get_file_extension(t),
-        ))
+        return LiteralType(
+            blob=self._blob_type(
+                format=FlyteFilePathTransformer.get_format(t),
+                file_extension=FlyteFilePathTransformer.get_file_extension(t),
+            )
+        )
 
     def get_mime_type_from_extension(self, extension: str) -> typing.Union[str, typing.Sequence[str]]:
         extension_to_mime_type = {
@@ -578,10 +580,12 @@ class FlyteFilePathTransformer(AsyncTypeTransformer[FlyteFile]):
             raise ValueError(f"Incorrect type {python_type}, must be either a FlyteFile or os.PathLike")
 
         # information used by all cases
-        meta = BlobMetadata(type=self._blob_type(
-            format=FlyteFilePathTransformer.get_format(python_type),
-            file_extension=FlyteFilePathTransformer.get_file_extension(python_type),
-        ))
+        meta = BlobMetadata(
+            type=self._blob_type(
+                format=FlyteFilePathTransformer.get_format(python_type),
+                file_extension=FlyteFilePathTransformer.get_file_extension(python_type),
+            )
+        )
 
         if isinstance(python_val, FlyteFile):
             # Cast the source path to str type to avoid error raised when the source path is used as the blob uri,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "diskcache>=5.2.1",
     "docker>=4.0.0",
     "docstring-parser>=0.9.0",
-    "flyteidl>=1.16.1,<2.0.0a0",
+    "flyteidl @ git+https://github.com/dominodatalab/flyteidl.git@af517f6",
     "fsspec>=2023.3.0",
     # Bug in 2025.5.0, 2025.5.0post1 https://github.com/fsspec/gcsfs/issues/687
     # Bug in 2024.2.0 https://github.com/fsspec/gcsfs/pull/643

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "diskcache>=5.2.1",
     "docker>=4.0.0",
     "docstring-parser>=0.9.0",
-    "flyteidl @ git+https://github.com/dominodatalab/flyteidl.git@af517f6",
+    "flyteidl @ git+https://github.com/ddl-rliu/flyte.git@1ba7c1545198a2820348323e64c23a41a19e7a7d#subdirectory=flyteidl",
     "fsspec>=2023.3.0",
     # Bug in 2025.5.0, 2025.5.0post1 https://github.com/fsspec/gcsfs/issues/687
     # Bug in 2024.2.0 https://github.com/fsspec/gcsfs/pull/643

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "diskcache>=5.2.1",
     "docker>=4.0.0",
     "docstring-parser>=0.9.0",
-    "flyteidl @ git+https://github.com/ddl-rliu/flyte.git@1ba7c1545198a2820348323e64c23a41a19e7a7d#subdirectory=flyteidl",
+    "flyteidl @ git+https://github.com/ddl-rliu/flyte.git@93ff903e63de6384d41db4c9da8df155612d16db#subdirectory=flyteidl",
     "fsspec>=2023.3.0",
     # Bug in 2025.5.0, 2025.5.0post1 https://github.com/fsspec/gcsfs/issues/687
     # Bug in 2024.2.0 https://github.com/fsspec/gcsfs/pull/643

--- a/tests/flytekit/unit/core/test_flyte_file.py
+++ b/tests/flytekit/unit/core/test_flyte_file.py
@@ -17,7 +17,7 @@ from flytekit.core.dynamic_workflow_task import dynamic
 from flytekit.core.hash import HashMethod
 from flytekit.core.launch_plan import LaunchPlan
 from flytekit.core.task import task
-from flytekit.core.type_engine import TypeEngine
+from flytekit.core.type_engine import FileDownloadConfig, TypeEngine
 from flytekit.core.workflow import workflow
 from flytekit.models.core.types import BlobType
 from flytekit.models.literals import LiteralMap, Blob, BlobMetadata
@@ -762,6 +762,18 @@ def test_join():
 def test_headers():
     assert FlyteFilePathTransformer.get_additional_headers("xyz") == {}
     assert len(FlyteFilePathTransformer.get_additional_headers(".gz")) == 1
+
+
+def test_transform_flytefile_with_file_download_config():
+    csv_file_no_config = FlyteFile["csv"]
+    lt = FlyteFilePathTransformer().get_literal_type(csv_file_no_config)
+    assert lt.blob.file_extension == ""
+    assert lt.blob.enable_legacy_filename == False
+
+    legacy_file = Annotated[FlyteFile["csv"], FileDownloadConfig(file_extension="csv", enable_legacy_filename=True)]
+    lt = FlyteFilePathTransformer().get_literal_type(legacy_file)
+    assert lt.blob.file_extension == "csv"
+    assert lt.blob.enable_legacy_filename == True
 
 
 def test_new_remote_file():

--- a/tests/flytekit/unit/core/test_flyte_file.py
+++ b/tests/flytekit/unit/core/test_flyte_file.py
@@ -17,7 +17,7 @@ from flytekit.core.dynamic_workflow_task import dynamic
 from flytekit.core.hash import HashMethod
 from flytekit.core.launch_plan import LaunchPlan
 from flytekit.core.task import task
-from flytekit.core.type_engine import FileDownloadConfig, TypeEngine
+from flytekit.core.type_engine import FileExtension, TypeEngine
 from flytekit.core.workflow import workflow
 from flytekit.models.core.types import BlobType
 from flytekit.models.literals import LiteralMap, Blob, BlobMetadata
@@ -764,21 +764,19 @@ def test_headers():
     assert len(FlyteFilePathTransformer.get_additional_headers(".gz")) == 1
 
 
-def test_transform_flytefile_with_file_download_config():
-    csv_file_no_config = FlyteFile["csv"]
-    lt = FlyteFilePathTransformer().get_literal_type(csv_file_no_config)
+def test_transform_flytefile_with_file_extension():
+    csv_file_no_file_extension = FlyteFile["csv"]
+    lt = FlyteFilePathTransformer().get_literal_type(csv_file_no_file_extension)
     assert lt.blob.file_extension == ""
-    assert lt.blob.enable_legacy_filename == False
 
-    legacy_file = Annotated[FlyteFile["csv"], FileDownloadConfig(file_extension="csv", enable_legacy_filename=True)]
-    lt = FlyteFilePathTransformer().get_literal_type(legacy_file)
+    csv_file_with_file_extension = Annotated[FlyteFile["csv"], FileExtension("csv")]
+    lt = FlyteFilePathTransformer().get_literal_type(csv_file_with_file_extension)
     assert lt.blob.file_extension == "csv"
-    assert lt.blob.enable_legacy_filename == True
 
 
-def test_file_download_config_valid_compound_extension():
-    config = FileDownloadConfig(file_extension="tar.gz")
-    assert config.file_extension == "tar.gz"
+def test_file_extension_valid_compound_extension():
+    extension = FileExtension("tar.gz")
+    assert extension.val == "tar.gz"
 
 
 @pytest.mark.parametrize("bad_ext", [
@@ -787,9 +785,9 @@ def test_file_download_config_valid_compound_extension():
     "../../escape",
     "csv!",
 ])
-def test_file_download_config_rejects_invalid_extensions(bad_ext):
+def test_file_extension_rejects_invalid_extensions(bad_ext):
     with pytest.raises(ValueError, match="Invalid file extension"):
-        FileDownloadConfig(file_extension=bad_ext)
+        FileExtension(bad_ext)
 
 
 def test_new_remote_file():

--- a/tests/flytekit/unit/core/test_flyte_file.py
+++ b/tests/flytekit/unit/core/test_flyte_file.py
@@ -776,6 +776,22 @@ def test_transform_flytefile_with_file_download_config():
     assert lt.blob.enable_legacy_filename == True
 
 
+def test_file_download_config_valid_compound_extension():
+    config = FileDownloadConfig(file_extension="tar.gz")
+    assert config.file_extension == "tar.gz"
+
+
+@pytest.mark.parametrize("bad_ext", [
+    ".csv",
+    "my file",
+    "../../escape",
+    "csv!",
+])
+def test_file_download_config_rejects_invalid_extensions(bad_ext):
+    with pytest.raises(ValueError, match="Invalid file extension"):
+        FileDownloadConfig(file_extension=bad_ext)
+
+
 def test_new_remote_file():
     nf = FlyteFile.new_remote_file(name="foo.txt")
     assert isinstance(nf, FlyteFile)

--- a/tests/flytekit/unit/models/core/test_types.py
+++ b/tests/flytekit/unit/models/core/test_types.py
@@ -15,11 +15,33 @@ def test_blob_type():
     )
     assert o.format == "csv"
     assert o.dimensionality == _types.BlobType.BlobDimensionality.SINGLE
+    assert o.file_extension == ""
+    assert o.enable_legacy_filename == False
 
     o2 = _types.BlobType.from_flyte_idl(o.to_flyte_idl())
     assert o == o2
     assert o2.format == "csv"
     assert o2.dimensionality == _types.BlobType.BlobDimensionality.SINGLE
+    assert o2.file_extension == ""
+    assert o2.enable_legacy_filename == False
+
+    o = _types.BlobType(
+        format="csv",
+        dimensionality=_types.BlobType.BlobDimensionality.SINGLE,
+        file_extension="csv",
+        enable_legacy_filename=True,
+    )
+    assert o.format == "csv"
+    assert o.dimensionality == _types.BlobType.BlobDimensionality.SINGLE
+    assert o.file_extension == "csv"
+    assert o.enable_legacy_filename == True
+
+    o2 = _types.BlobType.from_flyte_idl(o.to_flyte_idl())
+    assert o == o2
+    assert o2.format == "csv"
+    assert o2.dimensionality == _types.BlobType.BlobDimensionality.SINGLE
+    assert o2.file_extension == "csv"
+    assert o2.enable_legacy_filename == True
 
 
 def test_enum_type():

--- a/tests/flytekit/unit/models/core/test_types.py
+++ b/tests/flytekit/unit/models/core/test_types.py
@@ -16,32 +16,27 @@ def test_blob_type():
     assert o.format == "csv"
     assert o.dimensionality == _types.BlobType.BlobDimensionality.SINGLE
     assert o.file_extension == ""
-    assert o.enable_legacy_filename == False
 
     o2 = _types.BlobType.from_flyte_idl(o.to_flyte_idl())
     assert o == o2
     assert o2.format == "csv"
     assert o2.dimensionality == _types.BlobType.BlobDimensionality.SINGLE
     assert o2.file_extension == ""
-    assert o2.enable_legacy_filename == False
 
     o = _types.BlobType(
         format="csv",
         dimensionality=_types.BlobType.BlobDimensionality.SINGLE,
         file_extension="csv",
-        enable_legacy_filename=True,
     )
     assert o.format == "csv"
     assert o.dimensionality == _types.BlobType.BlobDimensionality.SINGLE
     assert o.file_extension == "csv"
-    assert o.enable_legacy_filename == True
 
     o2 = _types.BlobType.from_flyte_idl(o.to_flyte_idl())
     assert o == o2
     assert o2.format == "csv"
     assert o2.dimensionality == _types.BlobType.BlobDimensionality.SINGLE
     assert o2.file_extension == "csv"
-    assert o2.enable_legacy_filename == True
 
 
 def test_enum_type():


### PR DESCRIPTION
See https://github.com/flyteorg/flyte/pull/7009

## Tracking issue

Closes https://github.com/flyteorg/flyte/issues/7024 [BUG] [copilot] File extensions are missing when copilot downloads Blob/FlyteFile inputs

## Why are the changes needed?

(Keeping this PR in draft until https://github.com/flyteorg/flyte/pull/7009/ is merged)

After https://github.com/flyteorg/flyte/pull/7009 merges, adding the new file_extension field to BlobType, this flytekit PR will enable users to configure the file extension on FlyteFile inputs. This addresses the issue where file extensions are missing when copilot downloads Blob/FlyteFile inputs.

## What changes were proposed in this pull request?

Add the file_extension field to BlobType. Add annotation "FileExtension", which is used to annotate a FlyteFile when we want to download the file with a specific extension. For example,

```python
# ContainerTask
def t1(file: Annotated[FlyteFile, FileExtension("csv")]):
    ... # copilot downloads the file to e.g. /inputs/file.csv

versus...

def t1(file: FlyteFile["csv"]):
    ... # copilot downloads the file to e.g. /inputs/file
```

Under the hood, this sets `file_extension` in BlobType.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

Ran a workflow locally to test the changes

```
# Container task python code
def t1(datasetA: Annotated[FlyteFile[TypeVar('csv')], FileExtension("csv")], datasetB: FlyteFile[TypeVar('csv')]): …

# flyte-copilot logs
2026-04-09T22:15:08.506Z: {"json":{},"level":"info","msg":"Successfully copied [1703936] bytes remote data from [s3://ls-engc-flyte-data//25d4f8d8-7eb4-492b-97c4-ab3ce8bdcf74/ae] to local [/execution-vol/flows/workflow/inputs/datasetA.csv]","ts":"2026-04-09T22:15:08Z"}
2026-04-09T22:15:08.540Z: {"json":{},"level":"info","msg":"Successfully copied [196608] bytes remote data from [s3://ls-engc-flyte-data//858fd656-11ec-41ec-b235-b3b2984f230e/ex] to local [/execution-vol/flows/workflow/inputs/datasetB]","ts":"2026-04-09T22:15:08Z"}
```

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
