### PR TITLE
Move marshmallow-jsonschema to optional dependency to fix CVE-2024-6345

### DIFF
--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,4 +1,4 @@
--e file:.
+-e file:.[marshmallow-jsonschema]
 
 coverage[toml]
 hypothesis

--- a/flytekit/core/type_engine.py
+++ b/flytekit/core/type_engine.py
@@ -495,33 +495,35 @@ class DataclassTransformer(TypeTransformer[object]):
             (1) Convert MessagePack Bytes to a dataclass using mashumaro.
             (2) Handle dataclass attributes to ensure they are of the correct types.
 
-        For Json Schema, we use https://github.com/fuhrysteve/marshmallow-jsonschema library.
+        For JSON Schema, mashumaro is the primary generator. If it fails (e.g. for
+        DataClassJsonMixin classes), marshmallow-jsonschema is used as a fallback when
+        the ``marshmallow-jsonschema`` optional extra is installed.
 
         Example
 
         ```python
+        from dataclasses import dataclass
+        from mashumaro.jsonschema import build_json_schema
+
         @dataclass
-        class Test(DataClassJsonMixin):
+        class Test:
             a: int
             b: str
 
-        from marshmallow_jsonschema import JSONSchema
-        t = Test(a=10,b="e")
-        JSONSchema().dump(t.schema())
+        build_json_schema(Test).to_dict()
         ```
 
         Output will look like
 
         ```python
-        {'$schema': 'http://json-schema.org/draft-07/schema#',
-            'definitions': {'TestSchema': {'properties': {'a': {'title': 'a',
-                'type': 'number',
-                'format': 'integer'},
-            'b': {'title': 'b', 'type': 'string'}},
-            'type': 'object',
-            'additionalProperties': False}},
-            '$ref': '#/definitions/TestSchema'}
-    ```
+        {'type': 'object',
+            'title': 'Test',
+            'properties': {
+                'a': {'type': 'integer'},
+                'b': {'type': 'string'}},
+            'additionalProperties': False,
+            'required': ['a', 'b']}
+        ```
 
         > [!NOTE]
         > The schema support is experimental and is useful for auto-completing in the UI/CLI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<70", "setuptools_scm"]
+requires = ["setuptools>=70", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -36,9 +36,6 @@ dependencies = [
     "keyring>=18.0.1",
     "markdown-it-py",
     "marshmallow>=3,<4",
-    "marshmallow-enum",
-    "marshmallow-jsonschema>=0.12.0",
-    "setuptools<70",
     "mashumaro>=3.15",
     "msgpack>=1.1.0",
     "protobuf!=4.25.0",
@@ -162,4 +159,12 @@ connector = [
     "grpcio-health-checking<=1.68.0",
     "httpx",
     "prometheus-client",
+]
+
+# marshmallow-jsonschema is used as a fallback for JSON Schema generation when
+# mashumaro fails. It requires setuptools<82 for pkg_resources at runtime.
+marshmallow-jsonschema = [
+    "marshmallow-enum",
+    "marshmallow-jsonschema>=0.12.0",
+    "setuptools>=70,<82",
 ]


### PR DESCRIPTION
## Tracking issue

https://www.cve.org/CVERecord?id=CVE-2024-6345

## Why are the changes needed?

`setuptools` was pinned `<70` in #3388 as a runtime dependency solely because `marshmallow-jsonschema` imports `pkg_resources` at runtime.
This forces all flytekit users onto a setuptools version affected by [CVE-2024-6345](https://www.cve.org/CVERecord?id=CVE-2024-6345).

The `marshmallow-jsonschema` code path is only a fallback — `mashumaro` is the primary JSON Schema generator, and the marshmallow path only triggers when mashumaro fails for `DataClassJsonMixin` classes.
The imports are already guarded by try/except, so nothing breaks when the package is absent.

`marshmallow-jsonschema` itself appears unmaintained (last commit Oct 2023, multiple open PRs to remove `pkg_resources` unmerged).

An alternative would be to drop `marshmallow-jsonschema` support entirely, since `mashumaro` already covers the primary path.

## What changes were proposed in this pull request?

- Remove `marshmallow-jsonschema`, `marshmallow-enum`, and `setuptools` from core dependencies
- Add a new `marshmallow-jsonschema` optional extra with those packages (`setuptools>=70,<82`)
- Bump build-system setuptools to `>=70`
- Update `dev-requirements.in` to install the extra for tests
- Update docstring to reflect mashumaro as the primary JSON Schema generator

## How was this patch tested?

Ran `test_type_engine.py` and `test_generice_idl_type_engine.py` — 416 passed, 2 skipped.

## Check all the applicable boxes

- [x] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.

## Related PRs

#3388