### PR TITLE
Fix release pipeline failures

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -12,8 +12,14 @@ jobs:
       - name: Get version from branch/tag name
         id: version
         run: |
-          # Strip leading 'v' from branch/tag name (e.g. v1.16.17 -> 1.16.17)
-          VERSION="${GITHUB_REF_NAME#v}"
+          REF_NAME="${GITHUB_REF_NAME}"
+          # If ref starts with 'v' followed by a digit (e.g. v1.16.17), strip 'v' to get the PyPI version
+          if [[ "$REF_NAME" =~ ^v[0-9] ]]; then
+            VERSION="${REF_NAME#v}"
+          else
+            echo "::error::This workflow must be run from a version tag or branch (e.g. v1.16.17), got '$REF_NAME'"
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         shell: bash
 

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -4,8 +4,22 @@ on:
   workflow_dispatch:
 
 jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Get version from branch/tag name
+        id: version
+        run: |
+          # Strip leading 'v' from branch/tag name (e.g. v1.16.17 -> 1.16.17)
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        shell: bash
+
   build-and-push-docker-images-manual:
     runs-on: ubuntu-latest
+    needs: get-version
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
@@ -32,6 +46,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/flytekit
           tags: |
             py${{ matrix.python-version }}-${{ github.sha }}
+            py${{ matrix.python-version }}-${{ needs.get-version.outputs.version }}
       - name: Build & Push Flytekit Python${{ matrix.python-version }} Docker Image to Github Registry
         uses: docker/build-push-action@v2
         with:
@@ -40,8 +55,8 @@ jobs:
           push: true
           tags: ${{ steps.flytekit-names.outputs.tags }}
           build-args: |
-            VERSION=${{ github.sha }}
-            DOCKER_IMAGE=ghcr.io/${{ github.repository_owner }}/flytekit:py${{ matrix.python-version }}-${{ github.sha }}
+            VERSION=${{ needs.get-version.outputs.version }}
+            DOCKER_IMAGE=ghcr.io/${{ github.repository_owner }}/flytekit:py${{ matrix.python-version }}-${{ needs.get-version.outputs.version }}
             PYTHON_VERSION=${{ matrix.python-version }}
           file: Dockerfile
           cache-from: type=gha
@@ -49,6 +64,7 @@ jobs:
 
   build-and-push-flyteagent-images-manual:
     runs-on: ubuntu-latest
+    needs: get-version
     steps:
       - uses: actions/checkout@v4
         with:
@@ -72,6 +88,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/flyteagent
           tags: |
             ${{ github.sha }}
+            ${{ needs.get-version.outputs.version }}
       - name: Push External Plugin Service Image to GitHub Registry
         uses: docker/build-push-action@v2
         with:
@@ -80,13 +97,14 @@ jobs:
           push: true
           tags: ${{ steps.flyteagent-names.outputs.tags }}
           build-args: |
-            VERSION=${{ github.sha }}
+            VERSION=${{ needs.get-version.outputs.version }}
           file: ./Dockerfile.connector
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   build-and-push-flyteconnector-images-manual:
     runs-on: ubuntu-latest
+    needs: get-version
     steps:
       - uses: actions/checkout@v4
         with:
@@ -110,6 +128,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/flyteconnector
           tags: |
             ${{ github.sha }}
+            ${{ needs.get-version.outputs.version }}
       - name: Push External Plugin Service Image to GitHub Registry
         uses: docker/build-push-action@v2
         with:
@@ -118,7 +137,7 @@ jobs:
           push: true
           tags: ${{ steps.flyteconnector-names.outputs.tags }}
           build-args: |
-            VERSION=${{ github.sha }}
+            VERSION=${{ needs.get-version.outputs.version }}
           file: ./Dockerfile.connector
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -12,9 +12,9 @@ jobs:
         with:
           fetch-depth: "0"
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -23,8 +23,8 @@ jobs:
         id: bump
         run: |
           # from 'refs/tags/v1.2.3' get 1.2.3
-          VERSION=$(echo $GITHUB_REF | sed 's|refs/tags/v||')
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         shell: bash
       - name: Build and publish
         env:
@@ -32,11 +32,11 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           python -m build
-          twine upload dist/*
+          twine upload --verbose --skip-existing dist/*
       - name: Autobump plugin version
+        env:
+          VERSION: ${{ steps.bump.outputs.version }}
         run: |
-          # from 'refs/tags/v1.2.3' get 1.2.3
-          VERSION=$(echo $GITHUB_REF | sed 's|refs/tags/v||')
           VERSION=$VERSION make -C plugins update_all_versions
         shell: bash
       - name: Build all Plugins and publish

--- a/plugins/Makefile
+++ b/plugins/Makefile
@@ -8,10 +8,10 @@ build_all_plugins:
 
 .PHONY: publish_all_plugins
 publish_all_plugins:
-	twine upload */dist/*
+	twine upload --verbose --skip-existing */dist/*
 	# We upload community plugins from a separate sub-directory called `community`.
 	# Check https://github.com/flyteorg/flyte/pull/5610 for more details about.
-	twine upload community/*/dist/*
+	twine upload --verbose --skip-existing community/*/dist/*
 
 .PHONY: all_requirements
 all_requirements:


### PR DESCRIPTION
## Tracking Issue

N/A - operational fix for release pipeline

## Why are the changes needed?

The v1.16.17 release pipeline failed due to multiple issues:

1. **Transient PyPI connection error**: The `flytekitplugins_dask` upload hung for 4 minutes during plugin publishing, then PyPI dropped the connection (`RemoteDisconnected`). This killed the entire `deploy` job, causing all Docker image builds to be skipped.

2. **Re-runs are not idempotent**: Re-running the failed workflow fails immediately because `twine upload` returns `400 Bad Request` for already-uploaded packages.

3. **`build_image.yml` passes `github.sha` as VERSION**: The manual image build workflow passed the commit SHA as the PyPI version, which is not a valid PEP 440 version string, causing `uv pip install flytekit==<sha>` to fail.

4. **Unstable Python version**: `actions/setup-python@v1` with `python-version: "3.x"` resolved to Python 3.14.3, which is brand new and potentially unstable for building release artifacts.

## What changes were made?

### `pythonpublish.yml`
- Upgrade `actions/setup-python` from v1 to **v5**
- Pin Python to **3.12** instead of `3.x`
- Add `--verbose --skip-existing` to `twine upload` so re-runs skip already-uploaded packages
- Use safer shell parameter expansion (`${GITHUB_REF#refs/tags/v}`) instead of piping through `sed`

### `build_image.yml`
- Add `get-version` job that extracts the semver from the branch/tag name (strips `v` prefix)
- All image build jobs now use the extracted version instead of `github.sha` as the `VERSION` build arg
- Add version-based image tags alongside SHA-based tags

### `plugins/Makefile`
- Add `--verbose --skip-existing` to both `twine upload` commands

## How was this tested?

Reviewed CI logs from the failed v1.16.17 release runs:
- https://github.com/flyteorg/flytekit/actions/runs/24267638003/attempts/1 (original failure - plugin upload connection error)
- https://github.com/flyteorg/flytekit/actions/runs/24267638003 (re-run failure - 400 already exists)
- https://github.com/flyteorg/flytekit/actions/runs/24358978725 (manual build_image failure - SHA as version)

## Check all the applicable boxes

- [x] My code follows the [style guidelines of this project](https://github.com/flyteorg/flyte/blob/master/CONTRIBUTING.md)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works