### PR TITLE
Make optional arguments not required in click option

### DIFF
--- a/flytekit/clis/sdk_in_container/run.py
+++ b/flytekit/clis/sdk_in_container/run.py
@@ -866,7 +866,7 @@ class DynamicEntityLaunchCommand(click.RichCommand):
         for name, var in inputs.items():
             if fixed and name in fixed:
                 continue
-            required = True
+            required = not is_optional(native_inputs[name])
             default_val = None
             if defaults and name in defaults:
                 if not defaults[name].required:

--- a/tests/flytekit/unit/cli/pyflyte/test_run.py
+++ b/tests/flytekit/unit/cli/pyflyte/test_run.py
@@ -26,7 +26,7 @@ from flytekit.image_spec.image_spec import (
 )
 from flytekit.interaction.click_types import DirParamType, FileParamType
 from flytekit.remote import FlyteRemote
-from typing import Iterator, List
+from typing import Iterator, List, Optional
 from flytekit.types.iterator import JSON
 from flytekit import workflow, LaunchPlan
 
@@ -1021,4 +1021,33 @@ def test_remote_workflow_with_version(mock_run_remote, mock_remote):
     assert len(call_args) == 4
     assert call_args[2] == "some_module.example_workflow"
     assert call_args[3] == "v1"
+    mock_run_remote.assert_called_once()
+
+
+@mock.patch("flytekit.configuration.plugin.FlyteRemote", spec=FlyteRemote)
+@mock.patch("flytekit.clis.sdk_in_container.run.run_remote")
+def test_remote_workflow_with_optional_arg(mock_run_remote, mock_remote):
+    @task()
+    def example_task(x: Optional[str]) -> str:
+        if x is None:
+            return ""
+        return f"{x}"
+
+    @workflow
+    def example_workflow(x: Optional[str]) -> str:
+        return example_task(x=x)
+
+    mock_remote_instance = mock.MagicMock()
+    mock_remote.return_value = mock_remote_instance
+    mock_remote_instance.fetch_workflow.return_value = example_workflow
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pyflyte.main,
+        ["run", "remote-workflow", "some_module.example_workflow"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    mock_remote_instance.fetch_workflow.assert_called_once()
     mock_run_remote.assert_called_once()


### PR DESCRIPTION
## Why are the changes needed?
This pull request addresses a regression introduced in https://github.com/flyteorg/flytekit/pull/3338

Running a remote-workflow used to involved retrieving an existing launch plan and crafting click options based on the launch plan defaults and the values provided on the CLI. When the code was changed to retrieve an existing workflow it does not include any possible default values from the launch plan so we update the code to introspect whether arguments are required or not based on the signature of the workflow. 

## How was this patch tested?

Tested in production as well as unit tests.

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
