### PR TITLE
Add grpc headers and deadline to unary/unary calls

### DIFF
--- a/flytekit/clients/auth_helper.py
+++ b/flytekit/clients/auth_helper.py
@@ -17,6 +17,7 @@ from flytekit.clients.auth.authenticator import (
     PKCEAuthenticator,
 )
 from flytekit.clients.grpc_utils.auth_interceptor import AuthUnaryInterceptor
+from flytekit.clients.grpc_utils.deadline_interceptor import ScopedGrpcDeadlineInterceptor
 from flytekit.clients.grpc_utils.default_metadata_interceptor import DefaultMetadataInterceptor
 from flytekit.clients.grpc_utils.wrap_exception_interceptor import RetryExceptionWrapperInterceptor
 from flytekit.configuration import AuthType, PlatformConfig
@@ -246,7 +247,8 @@ def wrap_exceptions_channel(cfg: PlatformConfig, in_channel: grpc.Channel) -> gr
     :param in_channel: grpc.Channel
     :return: grpc.Channel
     """
-    return grpc.intercept_channel(in_channel, RetryExceptionWrapperInterceptor(max_retries=cfg.rpc_retries))
+    deadline_channel = grpc.intercept_channel(in_channel, ScopedGrpcDeadlineInterceptor())
+    return grpc.intercept_channel(deadline_channel, RetryExceptionWrapperInterceptor(max_retries=cfg.rpc_retries))
 
 
 class AuthenticationHTTPAdapter(requests.adapters.HTTPAdapter):

--- a/flytekit/clients/grpc_utils/deadline_interceptor.py
+++ b/flytekit/clients/grpc_utils/deadline_interceptor.py
@@ -1,0 +1,50 @@
+import contextlib
+import contextvars
+import typing
+
+import grpc
+
+from flytekit.clients.grpc_utils.auth_interceptor import _ClientCallDetails
+
+_GRPC_DEADLINE_SECONDS: contextvars.ContextVar[typing.Optional[float]] = contextvars.ContextVar(
+    "flytekit_grpc_deadline_seconds", default=None
+)
+
+
+def get_scoped_grpc_deadline() -> typing.Optional[float]:
+    return _GRPC_DEADLINE_SECONDS.get()
+
+
+@contextlib.contextmanager
+def scoped_grpc_deadline(seconds: float):
+    token = _GRPC_DEADLINE_SECONDS.set(seconds)
+    try:
+        yield
+    finally:
+        _GRPC_DEADLINE_SECONDS.reset(token)
+
+
+class ScopedGrpcDeadlineInterceptor(grpc.UnaryUnaryClientInterceptor):
+    """Applies the currently scoped gRPC timeout to unary-unary calls."""
+
+    def intercept_unary_unary(
+        self,
+        continuation: typing.Callable,
+        client_call_details: grpc.ClientCallDetails,
+        request: typing.Any,
+    ):
+        scoped_timeout = get_scoped_grpc_deadline()
+        if scoped_timeout is None:
+            return continuation(client_call_details, request)
+
+        timeout = scoped_timeout
+        if client_call_details.timeout is not None:
+            timeout = min(scoped_timeout, client_call_details.timeout)
+
+        updated_call_details = _ClientCallDetails(
+            client_call_details.method,
+            timeout,
+            client_call_details.metadata,
+            client_call_details.credentials,
+        )
+        return continuation(updated_call_details, request)

--- a/flytekit/clients/grpc_utils/wrap_exception_interceptor.py
+++ b/flytekit/clients/grpc_utils/wrap_exception_interceptor.py
@@ -10,12 +10,13 @@ from flytekit.exceptions.user import (
     FlyteEntityAlreadyExistsException,
     FlyteEntityNotExistException,
     FlyteInvalidInputException,
+    FlyteTimeout,
 )
 
 
 class RetryExceptionWrapperInterceptor(grpc.UnaryUnaryClientInterceptor, grpc.UnaryStreamClientInterceptor):
     def __init__(self, max_retries: int = 3):
-        self._max_retries = 3
+        self._max_retries = max_retries
 
     @staticmethod
     def _raise_if_exc(request: typing.Any, e: Union[grpc.Call, grpc.Future]):
@@ -30,6 +31,8 @@ class RetryExceptionWrapperInterceptor(grpc.UnaryUnaryClientInterceptor, grpc.Un
                 raise FlyteInvalidInputException(request) from e
             elif e.code() == grpc.StatusCode.UNAVAILABLE:
                 raise FlyteSystemUnavailableException() from e
+            elif e.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
+                raise FlyteTimeout(f"gRPC request deadline exceeded: {e.details()}") from e
         raise FlyteSystemException() from e
 
     def intercept_unary_unary(self, continuation, client_call_details, request):
@@ -41,6 +44,8 @@ class RetryExceptionWrapperInterceptor(grpc.UnaryUnaryClientInterceptor, grpc.Un
                 if e:
                     self._raise_if_exc(request, e)
                 return fut
+            except FlyteTimeout as e:
+                raise e
             except FlyteException as e:
                 if retries == self._max_retries:
                     raise e

--- a/flytekit/clients/raw.py
+++ b/flytekit/clients/raw.py
@@ -49,9 +49,16 @@ class RawSynchronousFlyteClient(object):
         # StreamRemoved exception.
         # https://github.com/flyteorg/flyte/blob/e8588f3a04995a420559327e78c3f95fbf64dc01/flyteadmin/pkg/common/constants.go#L14
         # 32KB for error messages, 20MB for actual messages.
+        # Keepalive options let gRPC detect dead connections (idle TCP drops by
+        # load balancers / NAT) and reconnect transparently, instead of leaving
+        # subsequent RPCs blocked indefinitely on a black-hole socket.
         options = [
             ("grpc.max_metadata_size", 32 * 1024),
             ("grpc.max_receive_message_length", 20 * 1024 * 1024),
+            ("grpc.keepalive_time_ms", 30000),
+            ("grpc.keepalive_timeout_ms", 10000),
+            ("grpc.keepalive_permit_without_calls", 1),
+            ("grpc.http2.max_pings_without_data", 0),
         ] + kwargs.pop("options", [])
         self._cfg = cfg
         self._channel = wrap_exceptions_channel(

--- a/flytekit/remote/remote.py
+++ b/flytekit/remote/remote.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import configparser
+import contextlib
 import functools
 import gzip
 import hashlib
@@ -35,6 +36,7 @@ from rich.progress import Progress, TextColumn, TimeElapsedColumn
 
 from flytekit import ImageSpec, PodTemplate
 from flytekit.clients.friendly import SynchronousFlyteClient
+from flytekit.clients.grpc_utils.deadline_interceptor import get_scoped_grpc_deadline, scoped_grpc_deadline
 from flytekit.clients.helpers import iterate_node_executions, iterate_task_executions
 from flytekit.configuration import Config, DataConfig, FastSerializationSettings, ImageConfig, SerializationSettings
 from flytekit.configuration.file import ConfigFile
@@ -137,6 +139,16 @@ ExecutionDataResponse = typing.Union[WorkflowExecutionGetDataResponse, NodeExecu
 MOST_RECENT_FIRST = admin_common_models.Sort("created_at", admin_common_models.Sort.Direction.DESCENDING)
 
 LATEST_VERSION_STR = "latest"
+
+DEFAULT_SYNC_EXECUTION_RPC_TIMEOUT = timedelta(seconds=60)
+
+
+def _get_rpc_timeout_seconds(rpc_timeout: typing.Optional[typing.Union[timedelta, int]]) -> typing.Optional[float]:
+    if rpc_timeout is None:
+        return None
+    if isinstance(rpc_timeout, timedelta):
+        return rpc_timeout.total_seconds()
+    return float(rpc_timeout)
 
 
 class RegistrationSkipped(Exception):
@@ -2555,6 +2567,7 @@ class FlyteRemote(object):
         execution: FlyteWorkflowExecution,
         entity_definition: typing.Union[FlyteWorkflow, FlyteTask] = None,
         sync_nodes: bool = False,
+        rpc_timeout: typing.Optional[typing.Union[timedelta, int]] = DEFAULT_SYNC_EXECUTION_RPC_TIMEOUT,
     ) -> FlyteWorkflowExecution:
         """
         Sync a FlyteWorkflowExecution object with its corresponding remote state.
@@ -2562,6 +2575,22 @@ class FlyteRemote(object):
         if entity_definition is not None:
             raise ValueError("Entity definition arguments aren't supported when syncing workflow executions")
 
+        rpc_timeout_seconds = _get_rpc_timeout_seconds(rpc_timeout)
+        deadline_context = contextlib.nullcontext()
+        if rpc_timeout_seconds is not None and get_scoped_grpc_deadline() is None:
+            deadline_context = scoped_grpc_deadline(rpc_timeout_seconds)
+
+        with deadline_context:
+            return self._sync_execution(execution, sync_nodes=sync_nodes)
+
+    def _sync_execution(
+        self,
+        execution: FlyteWorkflowExecution,
+        sync_nodes: bool = False,
+    ) -> FlyteWorkflowExecution:
+        """
+        Sync a FlyteWorkflowExecution object with its corresponding remote state.
+        """
         # Update closure, and then data, because we don't want the execution to finish between when we get the data,
         # and then for the closure to have is_done to be true.
         execution._closure = self.client.get_execution(execution.id).closure

--- a/tests/flytekit/unit/clients/test_auth_helper.py
+++ b/tests/flytekit/unit/clients/test_auth_helper.py
@@ -23,6 +23,7 @@ from flytekit.clients.auth_helper import (
     wrap_exceptions_channel,
 )
 from flytekit.clients.grpc_utils.auth_interceptor import AuthUnaryInterceptor
+from flytekit.clients.grpc_utils.deadline_interceptor import ScopedGrpcDeadlineInterceptor
 from flytekit.clients.grpc_utils.wrap_exception_interceptor import RetryExceptionWrapperInterceptor
 from flytekit.configuration import AuthType, PlatformConfig
 
@@ -154,6 +155,7 @@ def test_wrap_exceptions_channel():
     ch = MagicMock()
     out_ch = wrap_exceptions_channel(PlatformConfig(), ch)
     assert isinstance(out_ch._interceptor, RetryExceptionWrapperInterceptor)  # noqa
+    assert isinstance(out_ch._channel._interceptor, ScopedGrpcDeadlineInterceptor)  # noqa
 
 
 def test_upgrade_channel_to_auth():

--- a/tests/flytekit/unit/clients/test_deadline_interceptor.py
+++ b/tests/flytekit/unit/clients/test_deadline_interceptor.py
@@ -1,0 +1,85 @@
+from unittest.mock import Mock
+
+import grpc
+import pytest
+
+from flytekit.clients.grpc_utils.auth_interceptor import _ClientCallDetails
+from flytekit.clients.grpc_utils.deadline_interceptor import (
+    ScopedGrpcDeadlineInterceptor,
+    get_scoped_grpc_deadline,
+    scoped_grpc_deadline,
+)
+from flytekit.clients.grpc_utils.wrap_exception_interceptor import RetryExceptionWrapperInterceptor
+from flytekit.exceptions.user import FlyteTimeout
+
+
+class DeadlineExceededError(grpc.RpcError):
+    def code(self):
+        return grpc.StatusCode.DEADLINE_EXCEEDED
+
+    def details(self):
+        return "deadline exceeded"
+
+
+def test_scoped_grpc_deadline_resets():
+    assert get_scoped_grpc_deadline() is None
+    with scoped_grpc_deadline(5):
+        assert get_scoped_grpc_deadline() == 5
+    assert get_scoped_grpc_deadline() is None
+
+
+def test_deadline_interceptor_only_handles_unary_unary():
+    interceptor = ScopedGrpcDeadlineInterceptor()
+    assert isinstance(interceptor, grpc.UnaryUnaryClientInterceptor)
+    assert not isinstance(interceptor, grpc.UnaryStreamClientInterceptor)
+
+
+def test_deadline_interceptor_applies_scoped_timeout():
+    interceptor = ScopedGrpcDeadlineInterceptor()
+    request = object()
+    continuation = Mock(return_value="response")
+    call_details = _ClientCallDetails("/flyteidl.service.AdminService/GetExecution", None, None, None)
+
+    with scoped_grpc_deadline(30):
+        assert interceptor.intercept_unary_unary(continuation, call_details, request) == "response"
+
+    continuation.assert_called_once()
+    updated_call_details = continuation.call_args.args[0]
+    assert updated_call_details.timeout == 30
+    assert continuation.call_args.args[1] is request
+
+
+def test_deadline_interceptor_preserves_shorter_existing_timeout():
+    interceptor = ScopedGrpcDeadlineInterceptor()
+    continuation = Mock(return_value="response")
+    call_details = _ClientCallDetails("/flyteidl.service.AdminService/GetExecution", 10, None, None)
+
+    with scoped_grpc_deadline(30):
+        assert interceptor.intercept_unary_unary(continuation, call_details, object()) == "response"
+
+    updated_call_details = continuation.call_args.args[0]
+    assert updated_call_details.timeout == 10
+
+
+def test_deadline_interceptor_ignores_calls_without_scoped_timeout():
+    interceptor = ScopedGrpcDeadlineInterceptor()
+    continuation = Mock(return_value="response")
+    call_details = _ClientCallDetails("/flyteidl.service.AdminService/GetExecution", None, None, None)
+
+    assert interceptor.intercept_unary_unary(continuation, call_details, object()) == "response"
+
+    assert continuation.call_args.args[0] is call_details
+
+
+def test_deadline_exceeded_maps_to_flyte_timeout_without_retry():
+    interceptor = RetryExceptionWrapperInterceptor()
+    continuation = Mock()
+    future = Mock()
+    future.exception.return_value = DeadlineExceededError()
+    continuation.return_value = future
+    call_details = _ClientCallDetails("/flyteidl.service.AdminService/GetExecution", None, None, None)
+
+    with pytest.raises(FlyteTimeout, match="deadline exceeded"):
+        interceptor.intercept_unary_unary(continuation, call_details, object())
+
+    assert continuation.call_count == 1

--- a/tests/flytekit/unit/clients/test_raw.py
+++ b/tests/flytekit/unit/clients/test_raw.py
@@ -35,6 +35,10 @@ def test_kwargs_passed_to_channel(mock_channel):
             # ensure we're always passing these defaults
             ("grpc.max_metadata_size", mock.ANY),
             ("grpc.max_receive_message_length", mock.ANY),
+            ("grpc.keepalive_time_ms", 30000),
+            ("grpc.keepalive_timeout_ms", 10000),
+            ("grpc.keepalive_permit_without_calls", 1),
+            ("grpc.http2.max_pings_without_data", 0),
             # as well as the user-provided options
             ("grpc.default_authority", "foo.b.net"),
         ],

--- a/tests/flytekit/unit/remote/test_remote.py
+++ b/tests/flytekit/unit/remote/test_remote.py
@@ -18,6 +18,7 @@ from mock import ANY, MagicMock, patch
 
 import flytekit.configuration
 from flytekit import CronSchedule, ImageSpec, LaunchPlan, WorkflowFailurePolicy, task, workflow, reference_task, map_task, dynamic, eager
+from flytekit.clients.grpc_utils.deadline_interceptor import scoped_grpc_deadline
 from flytekit.configuration import Config, DefaultImages, Image, ImageConfig, SerializationSettings
 from flytekit.core.base_task import PythonTask
 from flytekit.core.context_manager import FlyteContextManager
@@ -124,6 +125,35 @@ def test_remote_fetch_execution(remote):
     remote._client = mock_client
     flyte_workflow_execution = remote.fetch_execution(name="n1")
     assert flyte_workflow_execution.id == admin_workflow_execution.id
+
+
+def test_sync_execution_sets_default_rpc_deadline(remote):
+    execution = MagicMock()
+    with patch.object(remote, "_sync_execution", return_value=execution) as mock_sync:
+        with patch("flytekit.remote.remote.scoped_grpc_deadline") as mock_deadline:
+            assert remote.sync_execution(execution) is execution
+
+    mock_deadline.assert_called_once_with(60.0)
+    mock_sync.assert_called_once_with(execution, sync_nodes=False)
+
+
+def test_sync_execution_accepts_rpc_deadline_override(remote):
+    execution = MagicMock()
+    with patch.object(remote, "_sync_execution", return_value=execution):
+        with patch("flytekit.remote.remote.scoped_grpc_deadline") as mock_deadline:
+            assert remote.sync_execution(execution, rpc_timeout=5) is execution
+
+    mock_deadline.assert_called_once_with(5.0)
+
+
+def test_sync_execution_does_not_override_active_rpc_deadline(remote):
+    execution = MagicMock()
+    with patch.object(remote, "_sync_execution", return_value=execution):
+        with patch("flytekit.remote.remote.scoped_grpc_deadline") as mock_deadline:
+            with scoped_grpc_deadline(5):
+                assert remote.sync_execution(execution, rpc_timeout=30) is execution
+
+    mock_deadline.assert_not_called()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Why are the changes needed?

`FlyteRemote.wait()` polls execution state by repeatedly calling `sync_execution()`. When one of the underlying unary gRPC calls blocks on a stale or unhealthy connection, the wait loop can appear to hang because the loop timeout cannot be evaluated until the RPC returns.

The client also did not set gRPC keepalive options explicitly, so idle TCP connection drops through load balancers or NAT could leave the next RPC waiting on a connection that should have been detected as unhealthy.

## What changes were proposed in this pull request?

- Add default gRPC keepalive options to `RawSynchronousFlyteClient` so the client can detect dead idle connections and reconnect.
- Add a unary-unary-only scoped deadline interceptor for gRPC calls.
- Apply a default 60 second per-RPC deadline while `FlyteRemote.sync_execution()` is running.
- Keep streaming RPCs unaffected by the deadline interceptor.
- Map gRPC `DEADLINE_EXCEEDED` to `FlyteTimeout` and avoid retrying deadline-expired calls.
- Add unit coverage for the keepalive options, deadline interceptor behavior, channel wrapping, and `sync_execution` deadline scoping.

## How was this patch tested?

Targeted unit tests:

```bash
/Users/ytong/envs/flytekit/bin/python -m pytest \
  tests/flytekit/unit/clients/test_raw.py \
  tests/flytekit/unit/clients/test_auth_helper.py::test_wrap_exceptions_channel \
  tests/flytekit/unit/clients/test_deadline_interceptor.py \
  tests/flytekit/unit/remote/test_remote.py::test_remote_fetch_execution \
  tests/flytekit/unit/remote/test_remote.py::test_sync_execution_sets_default_rpc_deadline \
  tests/flytekit/unit/remote/test_remote.py::test_sync_execution_accepts_rpc_deadline_override \
  tests/flytekit/unit/remote/test_remote.py::test_sync_execution_does_not_override_active_rpc_deadline \
  -q
```

Result: `14 passed`.

A broader local run of `tests/flytekit/unit/clients/test_auth_helper.py` hit unrelated macOS keyring failures in the existing PKCE/deviceflow tests, so only the changed auth-helper test was included in the targeted verification above.

### Setup process

No special setup beyond the existing flytekit development environment.

### Screenshots

Not applicable.

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

None.

## Docs link

Not applicable.
