### PR TITLE
Bump flyteidl minimum version to 1.16.7

### DIFF
--- a/plugins/flytekit-ray/setup.py
+++ b/plugins/flytekit-ray/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "ray"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["ray[default]", "flytekit>1.14.5", "flyteidl>=1.13.6"]
+plugin_requires = ["ray[default]", "flytekit>1.14.5", "flyteidl>=1.16.7"]
 
 __version__ = "0.0.0+develop"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "diskcache>=5.2.1",
     "docker>=4.0.0",
     "docstring-parser>=0.9.0",
-    "flyteidl>=1.16.1,<2.0.0a0",
+    "flyteidl>=1.16.7,<2.0.0a0",
     "fsspec>=2023.3.0",
     # Bug in 2025.5.0, 2025.5.0post1 https://github.com/fsspec/gcsfs/issues/687
     # Bug in 2024.2.0 https://github.com/fsspec/gcsfs/pull/643


### PR DESCRIPTION
## Why are the changes needed?

Bump the minimum required version of `flyteidl` from `1.16.1` to `1.16.7` so flytekit picks up the latest fixes and protobuf definitions shipped in the `1.16.x` line.

## What changes were proposed in this pull request?

- Updated the `flyteidl` lower bound in `pyproject.toml` from `>=1.16.1,<2.0.0a0` to `>=1.16.7,<2.0.0a0`.

## How was this patch tested?

CI.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.