### PR TITLE
Bump requirements to avoid gcsfs close spam

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -139,13 +139,13 @@ filelock==3.20.3
     #   virtualenv
 flatbuffers==25.12.19
     # via tensorflow
-flyteidl==1.16.3
+flyteidl==1.16.7
     # via flytekit
 frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2024.5.0
+fsspec==2025.3.2
     # via
     #   adlfs
     #   flytekit
@@ -153,7 +153,7 @@ fsspec==2024.5.0
     #   s3fs
 gast==0.7.0
     # via tensorflow
-gcsfs==2024.5.0
+gcsfs==2025.3.2
     # via flytekit
 google-api-core[grpc]==2.19.0
     # via
@@ -541,7 +541,7 @@ rich-click==1.8.2
     # via flytekit
 rsa==4.9
     # via google-auth
-s3fs==2024.5.0
+s3fs==2025.3.2
     # via flytekit
 scikit-learn==1.5.0
     # via -r dev-requirements.in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,11 @@ dependencies = [
     "docker>=4.0.0",
     "docstring-parser>=0.9.0",
     "flyteidl>=1.16.7,<2.0.0a0",
-    "fsspec>=2023.3.0",
+    # 2024.9.0 floor: aiohttp/gcsfs Python 3.12 shutdown-race fixes (_runner aclose loop safety)
+    "fsspec>=2024.9.0",
+    # 2024.9.0 floor: shutdown-race fixes (supersedes the 2024.2.0 bug, https://github.com/fsspec/gcsfs/pull/643)
     # Bug in 2025.5.0, 2025.5.0post1 https://github.com/fsspec/gcsfs/issues/687
-    # Bug in 2024.2.0 https://github.com/fsspec/gcsfs/pull/643
-    "gcsfs>=2023.3.0,!=2024.2.0,!=2025.5.0,!=2025.5.0post1",
+    "gcsfs>=2024.9.0,!=2025.5.0,!=2025.5.0post1",
     "googleapis-common-protos>=1.57",
     "grpcio",
     "grpcio-status",
@@ -49,7 +50,7 @@ dependencies = [
     "requests>=2.18.4",
     "rich",
     "rich_click",
-    "s3fs>=2023.3.0,!=2024.3.1",
+    "s3fs>=2024.9.0",
     "statsd>=3.0.0",
     "typing_extensions",
     "urllib3>=1.22",


### PR DESCRIPTION
## Why are the changes needed?

Picks up fix in https://github.com/fsspec/gcsfs/pull/606 to reduce log spam

gcsfs's ClientSession/Connector close is being driven by the GC weakref callback at process teardown, lands in fsspec/asyn.py:_runner → asyncio.wait_for, and the underlying aiohttp/connector.py:1044 close raises because the loop is wrong/closed. PR #606 changes the cleanup to always use the session's associated event loop rather than get_event_loop()'s newly-created idle one.

This results in noisy task logs that frequently include

```
File \"/usr/local/lib/python3.12/asyncio/tasks.py\", line 520, in wait_for" "           ^^^^^^^^^" "  File \"/usr/local/lib/python3.12/site-packages/aiohttp/client.py\", line 1327, in close" "  File \"/usr/local/lib/python3.12/site-packages/aiohttp/connector.py\", line 1044, in close"]
```


## What changes were proposed in this pull request?

See PR title, bumps gcsfs and aiohttp

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
