### PR TITLE
fix(iterator): raise TypeTransformerFailedError with a message to prevent IndexError in callers

### DIFF
--- a/flytekit/types/iterator/iterator.py
+++ b/flytekit/types/iterator/iterator.py
@@ -57,10 +57,11 @@ class IteratorTransformer(TypeTransformer[typing.Iterator]):
         return Literal(collection=LiteralCollection(literals=lit_list))
 
     def to_python_value(self, ctx: FlyteContext, lv: Literal, expected_python_type: typing.Type[T]) -> FlyteIterator:
-        try:
-            lits = lv.collection.literals
-        except AttributeError:
-            raise TypeTransformerFailedError()
+        if lv.collection is None:
+            raise TypeTransformerFailedError(
+                f"Expected a collection literal for {expected_python_type}, but got a non-collection value."
+            )
+        lits = lv.collection.literals
         return FlyteIterator(ctx, lv, expected_python_type, len(lits))
 
 

--- a/tests/flytekit/unit/types/iterator/test_iterator.py
+++ b/tests/flytekit/unit/types/iterator/test_iterator.py
@@ -1,6 +1,12 @@
 import typing
 
+import pytest
+
 from flytekit import task, workflow
+from flytekit.core.context_manager import FlyteContextManager
+from flytekit.core.type_engine import TypeTransformerFailedError
+from flytekit.models.literals import Literal, Scalar, Primitive
+from flytekit.types.iterator.iterator import IteratorTransformer
 
 
 @task
@@ -21,3 +27,12 @@ def wf(a: int) -> typing.List[int]:
 
 def test_iterator():
     assert wf(a=4) == [0, 1, 2, 3]
+
+
+def test_to_python_value_non_collection_raises_with_message():
+    ctx = FlyteContextManager.current_context()
+    lit = Literal(scalar=Scalar(primitive=Primitive(integer=42)))
+    trans = IteratorTransformer()
+    with pytest.raises(TypeTransformerFailedError) as exc_info:
+        trans.to_python_value(ctx, lit, typing.Iterator[int])
+    assert exc_info.value.args[0]  # args[0] must be set — not empty tuple


### PR DESCRIPTION
## What's broken

When IteratorTransformer.to_python_value receives a non-collection literal (e.g. a scalar), it catches the AttributeError from lv.collection.literals and re-raises TypeTransformerFailedError() with no arguments (args = ()). Multiple callers in promise.py (lines 103, 1235, 1360), base_task.py (line 312), and base_connector.py (line 350) then do exc.args = (f"...{exc.args[0]}...",) to enrich the error message. Because exc.args is an empty tuple, accessing exc.args[0] raises IndexError: tuple index out of range, which swallows the original type conversion failure entirely.

## Why it happens

TypeTransformerFailedError() was raised with no arguments, leaving args as an empty tuple, which callers throughout the codebase assume is non-empty.

## Fix

Replace the bare except/re-raise with an explicit None-check on lv.collection and pass a descriptive message string to TypeTransformerFailedError, so exc.args[0] is always valid for callers to safely index.

## Test

Added test_to_python_value_non_collection_raises_with_message in tests/flytekit/unit/types/iterator/test_iterator.py that passes a scalar literal to to_python_value and asserts the raised TypeTransformerFailedError has a non-empty args tuple.