### PR TITLE
Bump gcsfs again to pick up more fixes for close spam

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,7 +12,7 @@ absl-py==2.4.0
     #   tensorflow
 adlfs==2024.4.1
     # via flytekit
-aiobotocore==2.13.0
+aiobotocore==3.7.0
     # via s3fs
 aiohappyeyeballs==2.6.1
     # via aiohttp
@@ -58,7 +58,7 @@ azure-storage-blob==12.20.0
     # via adlfs
 backports-tarfile==1.2.0
     # via jaraco-context
-botocore==1.34.106
+botocore==1.43.0
     # via aiobotocore
 cachetools==5.3.3
     # via
@@ -145,7 +145,7 @@ frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2025.3.2
+fsspec==2026.3.0
     # via
     #   adlfs
     #   flytekit
@@ -153,14 +153,15 @@ fsspec==2025.3.2
     #   s3fs
 gast==0.7.0
     # via tensorflow
-gcsfs==2025.3.2
+gcsfs==2026.3.0
     # via flytekit
-google-api-core[grpc]==2.19.0
+google-api-core[grpc]==2.30.0
     # via
     #   google-cloud-bigquery
     #   google-cloud-bigquery-storage
     #   google-cloud-core
     #   google-cloud-storage
+    #   google-cloud-storage-control
 google-auth==2.29.0
     # via
     #   gcsfs
@@ -180,11 +181,13 @@ google-cloud-bigquery==3.23.1
     # via -r dev-requirements.in
 google-cloud-bigquery-storage==2.25.0
     # via -r dev-requirements.in
-google-cloud-core==2.4.1
+google-cloud-core==2.6.0
     # via
     #   google-cloud-bigquery
     #   google-cloud-storage
-google-cloud-storage==2.16.0
+google-cloud-storage==3.10.1
+    # via gcsfs
+google-cloud-storage-control==1.11.0
     # via gcsfs
 google-crc32c==1.5.0
     # via
@@ -192,17 +195,20 @@ google-crc32c==1.5.0
     #   google-resumable-media
 google-pasta==0.2.0
     # via tensorflow
-google-resumable-media==2.7.0
+google-resumable-media==2.9.0
     # via
     #   google-cloud-bigquery
     #   google-cloud-storage
-googleapis-common-protos==1.63.0
+googleapis-common-protos[grpc]==1.63.0
     # via
     #   flyteidl
     #   flytekit
     #   google-api-core
+    #   grpc-google-iam-v1
     #   grpcio-status
     #   protoc-gen-openapiv2
+grpc-google-iam-v1==0.14.3
+    # via google-cloud-storage-control
 grpcio==1.64.0
     # via
     #   flytekit
@@ -417,6 +423,7 @@ proto-plus==1.23.0
     # via
     #   google-api-core
     #   google-cloud-bigquery-storage
+    #   google-cloud-storage-control
 protobuf==4.25.8
     # via
     #   -r dev-requirements.in
@@ -541,7 +548,7 @@ rich-click==1.8.2
     # via flytekit
 rsa==4.9
     # via google-auth
-s3fs==2025.3.2
+s3fs==2026.3.0
     # via flytekit
 scikit-learn==1.5.0
     # via -r dev-requirements.in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,12 @@ dependencies = [
     "docker>=4.0.0",
     "docstring-parser>=0.9.0",
     "flyteidl>=1.16.7,<2.0.0a0",
-    # 2024.9.0 floor: aiohttp/gcsfs Python 3.12 shutdown-race fixes (_runner aclose loop safety)
-    "fsspec>=2024.9.0",
-    # 2024.9.0 floor: shutdown-race fixes (supersedes the 2024.2.0 bug, https://github.com/fsspec/gcsfs/pull/643)
-    # Bug in 2025.5.0, 2025.5.0post1 https://github.com/fsspec/gcsfs/issues/687
-    "gcsfs>=2024.9.0,!=2025.5.0,!=2025.5.0post1",
+    # 2026.3.0 floor: keeps the fsspec family aligned with the gcsfs pin below
+    "fsspec>=2026.3.0",
+    # 2026.3.0 floor: gcsfs teardown-exception fix that stops aiohttp connector-close log spam
+    # at process exit https://github.com/fsspec/gcsfs/pull/763 (supersedes the earlier
+    # _runner shutdown-race fixes and the 2025.5.0 bug https://github.com/fsspec/gcsfs/issues/687)
+    "gcsfs>=2026.3.0",
     "googleapis-common-protos>=1.57",
     "grpcio",
     "grpcio-status",
@@ -50,7 +51,7 @@ dependencies = [
     "requests>=2.18.4",
     "rich",
     "rich_click",
-    "s3fs>=2024.9.0",
+    "s3fs>=2026.3.0",
     "statsd>=3.0.0",
     "typing_extensions",
     "urllib3>=1.22",


### PR DESCRIPTION
## Why are the changes needed?

Picks up the release that includes https://github.com/fsspec/gcsfs/pull/763 which silences more noisy logs on close

## What changes were proposed in this pull request?

See PR title

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
