### PR TITLE
Fix template replacement producing invalid image reference with digests

### DIFF
--- a/flytekit/core/python_auto_container.py
+++ b/flytekit/core/python_auto_container.py
@@ -467,10 +467,16 @@ def get_registerable_container_image(img: Optional[Union[str, ImageSpec]], cfg: 
             if img_cfg is None:
                 raise AssertionError(f"Image Config with name {name} not found in the configuration")
             if attr == "version":
-                if img_cfg.version is not None:
-                    img = img.replace(replace_group, img_cfg.version)
+                version = img_cfg.version if img_cfg.version is not None else cfg.default_image.version
+                if ":" in version:
+                    # version is a digest (e.g. sha256:...) — needs @ separator, not :
+                    colon_prefixed = f":{replace_group}"
+                    if colon_prefixed in img:
+                        img = img.replace(colon_prefixed, f"@{version}")
+                    else:
+                        img = img.replace(replace_group, version)
                 else:
-                    img = img.replace(replace_group, cfg.default_image.version)
+                    img = img.replace(replace_group, version)
             elif attr == "fqn":
                 img = img.replace(replace_group, img_cfg.fqn)
             elif attr == "":

--- a/tests/flytekit/unit/core/test_python_function_task.py
+++ b/tests/flytekit/unit/core/test_python_function_task.py
@@ -58,7 +58,13 @@ def test_container_image_conversion(mock_image_spec_builder):
         fqn="xyz.com/other5",
         tag="tag5"
     )
-    cfg = ImageConfig(default_image=default_img, images=[default_img, other_img, other_img2, other_img3, other_img4, other_img5])
+    # Simulates _parse_image_identifier("xyz.com/other6:tag6@sha256:...") where the tag is baked into fqn
+    other_img6 = Image(
+        name="other6",
+        fqn="xyz.com/other6:tag6",
+        digest="sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d",
+    )
+    cfg = ImageConfig(default_image=default_img, images=[default_img, other_img, other_img2, other_img3, other_img4, other_img5, other_img6])
     assert get_registerable_container_image(None, cfg) == "xyz.com/abc:tag1"
     assert get_registerable_container_image("", cfg) == "xyz.com/abc:tag1"
     assert get_registerable_container_image("abc", cfg) == "abc"
@@ -77,6 +83,16 @@ def test_container_image_conversion(mock_image_spec_builder):
     assert (
         get_registerable_container_image("{{.image.other2.fqn}}@{{.image.other2.version}}", cfg)
         == "xyz.com/other2@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
+    )
+    # Digest image with : separator in template should be fixed to @
+    assert (
+        get_registerable_container_image("{{.image.other2.fqn}}:{{.image.other2.version}}", cfg)
+        == "xyz.com/other2@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
+    )
+    # repo:tag@sha256:digest — fqn already contains the tag, digest needs @ separator
+    assert (
+        get_registerable_container_image("{{.image.other6.fqn}}:{{.image.other6.version}}", cfg)
+        == "xyz.com/other6:tag6@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d"
     )
     assert (
         get_registerable_container_image("{{.image.other3.fqn}}:{{.image.other3.version}}", cfg)


### PR DESCRIPTION
## Tracking Issue

Closes https://github.com/flyteorg/flyte/issues/7531

## Why are the changes needed?

When an image reference with a digest is passed to `pyflyte register --image` (e.g. `gcr.io/project/image:tag@sha256:digest`), the registered task spec contains an invalid image reference with `:` instead of `@` before the digest.

The root cause is in `get_registerable_container_image()`: when replacing `{{.image.<name>.version}}` in a template, the version value is substituted directly but the separator before the placeholder is always `:` (hardcoded in the template). When `version` is a digest (e.g. `sha256:...`), the separator should be `@`.

Example:
- Template: `{{.image.default.fqn}}:{{.image.default.version}}`
- Image: `gcr.io/project/image:tag@sha256:abc123`
- Before fix: `gcr.io/project/image:tag:sha256:abc123` (invalid)
- After fix: `gcr.io/project/image:tag@sha256:abc123` (valid)

This also affects digest-only references (no tag):
- Image: `gcr.io/project/image@sha256:abc123`
- Before fix: `gcr.io/project/image:sha256:abc123` (invalid)
- After fix: `gcr.io/project/image@sha256:abc123` (valid)

## What changes were proposed in this pull request?

In `get_registerable_container_image()`, when the resolved `version` is a digest (contains `:`), replace the preceding `:` separator with `@` in the output. Tags never contain `:`, so the check is unambiguous.

## How was this patch tested?

Added test cases for both scenarios to `test_container_image_conversion`:
1. Digest-only image (`fqn` without tag) with `:` template separator
2. Tag+digest image (`fqn` contains baked-in tag) with `:` template separator — the real-world case from `_parse_image_identifier("repo:tag@sha256:...")`

Existing tests continue to pass.