### PR TITLE
fix: merge LaunchPlan security context per field on registration

### DIFF
--- a/flytekit/tools/translator.py
+++ b/flytekit/tools/translator.py
@@ -30,6 +30,7 @@ from flytekit.core.workflow import ReferenceWorkflow, WorkflowBase
 from flytekit.models import common as _common_models
 from flytekit.models import interface as interface_models
 from flytekit.models import launch_plan as _launch_plan_models
+from flytekit.models import security as _security_models
 from flytekit.models.admin import workflow as admin_workflow_models
 from flytekit.models.admin.workflow import WorkflowSpec
 from flytekit.models.concurrency import ConcurrencyPolicy
@@ -317,6 +318,26 @@ def get_serializable_workflow(
     )
 
 
+def _merge_security_context(
+    entity_sc: Optional[_security_models.SecurityContext],
+    options_sc: Optional[_security_models.SecurityContext],
+) -> Optional[_security_models.SecurityContext]:
+    """Merge the launch plan's authored security context with the one supplied via registration options.
+
+    Registration options override the authored launch plan per field (not wholesale), so e.g. registering with
+    only a service account does not drop secrets/tokens that were authored on the launch plan.
+    """
+    if options_sc is None:
+        return entity_sc
+    if entity_sc is None:
+        return options_sc
+    return _security_models.SecurityContext(
+        run_as=options_sc.run_as or entity_sc.run_as,
+        secrets=options_sc.secrets or entity_sc.secrets,
+        tokens=options_sc.tokens or entity_sc.tokens,
+    )
+
+
 def get_serializable_launch_plan(
     entity_mapping: OrderedDict,
     settings: SerializationSettings,
@@ -379,7 +400,7 @@ def get_serializable_launch_plan(
         auth_role=None,
         raw_output_data_config=raw_prefix_config,
         max_parallelism=options.max_parallelism or entity.max_parallelism,
-        security_context=options.security_context or entity.security_context,
+        security_context=_merge_security_context(entity.security_context, options.security_context),
         overwrite_cache=options.overwrite_cache or entity.overwrite_cache,
         concurrency_policy=concurrency_policy,
     )

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -7,11 +7,12 @@ import mock
 import pytest
 
 import flytekit.configuration
-from flytekit import ContainerTask, ImageSpec, kwtypes
+from flytekit import ContainerTask, ImageSpec, LaunchPlan, kwtypes
 from flytekit.configuration import Image, ImageConfig, SerializationSettings
 from flytekit.core.array_node_map_task import map_task
 from flytekit.core.condition import conditional
 from flytekit.core.dynamic_workflow_task import dynamic
+from flytekit.core.options import Options
 from flytekit.core.python_auto_container import get_registerable_container_image
 from flytekit.core.resources import Resources, ResourceSpec
 from flytekit.core.task import eager, task
@@ -30,6 +31,7 @@ from flytekit.models.literals import (
     Union,
     Void,
 )
+from flytekit.models.security import Identity, Secret, SecurityContext
 from flytekit.models.types import LiteralType, SimpleType, TypeStructure, UnionType
 from flytekit.tools.translator import get_serializable
 from flytekit.types.error.error import FlyteError
@@ -1273,11 +1275,11 @@ def test_default_resources_do_not_overriden_tasks_with_explicit_resources():
 
 
 def test_launch_plan_security_context_merge():
-    # Registration options override the authored launch plan per field; registering with only a
-    # service account must not drop secrets/tokens that were authored on the launch plan.
-    from flytekit import LaunchPlan
-    from flytekit.core.options import Options
-    from flytekit.models.security import Identity, Secret, SecurityContext
+    """Registration options override the authored launch plan per field.
+
+    Registering with only a service account must not drop secrets/tokens that were
+    authored on the launch plan.
+    """
 
     @task
     def t_sc() -> int:

--- a/tests/flytekit/unit/core/test_serialization.py
+++ b/tests/flytekit/unit/core/test_serialization.py
@@ -1,7 +1,6 @@
-import re
+import dataclasses
 import os
 import typing
-import dataclasses
 from collections import OrderedDict
 
 import mock
@@ -10,17 +9,17 @@ import pytest
 import flytekit.configuration
 from flytekit import ContainerTask, ImageSpec, kwtypes
 from flytekit.configuration import Image, ImageConfig, SerializationSettings
+from flytekit.core.array_node_map_task import map_task
 from flytekit.core.condition import conditional
+from flytekit.core.dynamic_workflow_task import dynamic
 from flytekit.core.python_auto_container import get_registerable_container_image
 from flytekit.core.resources import Resources, ResourceSpec
-from flytekit.core.dynamic_workflow_task import dynamic
-from flytekit.core.array_node_map_task import map_task
 from flytekit.core.task import eager, task
 from flytekit.core.workflow import workflow
 from flytekit.exceptions.user import FlyteAssertion, FlyteMissingTypeException
 from flytekit.image_spec.image_spec import ImageBuildEngine
+from flytekit.models import task as task_models
 from flytekit.models.admin.workflow import WorkflowSpec
-from flytekit.models.annotation import TypeAnnotation
 from flytekit.models.literals import (
     BindingData,
     BindingDataCollection,
@@ -32,7 +31,6 @@ from flytekit.models.literals import (
     Void,
 )
 from flytekit.models.types import LiteralType, SimpleType, TypeStructure, UnionType
-from flytekit.models import task as task_models
 from flytekit.tools.translator import get_serializable
 from flytekit.types.error.error import FlyteError
 
@@ -1272,3 +1270,31 @@ def test_default_resources_do_not_overriden_tasks_with_explicit_resources():
         ],
         limits=[]
     )
+
+
+def test_launch_plan_security_context_merge():
+    # Registration options override the authored launch plan per field; registering with only a
+    # service account must not drop secrets/tokens that were authored on the launch plan.
+    from flytekit import LaunchPlan
+    from flytekit.core.options import Options
+    from flytekit.models.security import Identity, Secret, SecurityContext
+
+    @task
+    def t_sc() -> int:
+        return 1
+
+    @workflow
+    def wf_sc() -> int:
+        return t_sc()
+
+    lp = LaunchPlan.get_or_create(
+        workflow=wf_sc,
+        name="lp_sc_merge",
+        security_context=SecurityContext(secrets=[Secret(group="g", key="k")]),
+    )
+    opts = Options(security_context=SecurityContext(run_as=Identity(k8s_service_account="my-sa")))
+
+    serialized = get_serializable(OrderedDict(), serialization_settings, lp, options=opts)
+    sc = serialized.spec.security_context
+    assert sc.run_as.k8s_service_account == "my-sa"
+    assert [(s.group, s.key) for s in sc.secrets] == [("g", "k")]


### PR DESCRIPTION
## Why are the changes needed?

Registering a launch plan that declares `secrets` (or `tokens`) while passing registration `Options` that only set a service account silently drops the secrets. `get_serializable_launch_plan` does `options.security_context or entity.security_context` — a wholesale replace — so any non-empty options context wipes whatever the launch plan authored.

## What changes were proposed in this pull request?

Merge the two security contexts per field instead of replacing wholesale: options win field-by-field (`run_as`, `secrets`, `tokens`), so a service-account-only override stops clobbering authored secrets.

## How was this patch tested?

`test_get_serializable_launch_plan` drives the same path. Also end-to-end against a real flyteadmin (`flyte demo`): register the secrets launch plan with service-account-only options and read it back — before, `secrets` returns `None` (dropped); after, it's preserved alongside the overridden service account.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
