### PR TITLE
fix(spark): cap aiohttp<3.14 in test deps for aioresponses compat

### DIFF
--- a/plugins/flytekit-spark/dev-requirements.in
+++ b/plugins/flytekit-spark/dev-requirements.in
@@ -1,2 +1,6 @@
 aioresponses
+# aioresponses (0.7.8) builds a mocked ClientResponse without the `stream_writer`
+# argument that aiohttp 3.14 made required, so the connector tests can't construct
+# responses. Cap aiohttp until aioresponses supports 3.14.
+aiohttp<3.14
 pytest-asyncio


### PR DESCRIPTION
## Why are the changes needed?

The `flytekit-spark` build is red on master: `aioresponses` mocks a `ClientResponse` without the `stream_writer` argument that `aiohttp` 3.14 made required, and the plugin's test deps don't cap `aiohttp` (CI resolves 3.14.1).

## What changes were proposed in this pull request?

Cap `aiohttp<3.14` in `plugins/flytekit-spark/dev-requirements.in` (test-only) until `aioresponses` supports 3.14.

## How was this patch tested?

Ran `plugins/flytekit-spark/tests/test_connector.py` in a fresh py3.12 venv that resolved the same deps as CI (aiohttp 3.14.1, aioresponses 0.7.8):

- **Before:** `test_databricks_agent` fails with `TypeError: ClientResponse.__init__() missing 1 required keyword-only argument: 'stream_writer'` (`aioresponses/core.py:172`) — the exact error CI hits.
- **After:** installing from the capped `dev-requirements.in` resolves aiohttp 3.13.5; all 14 tests pass. The `InvalidSpecError` seen later in the CI run was a cascade off that first failure (the test never reached `mock.patch.stopall()`), so it clears too.

### Labels
fixed

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
