### PR TITLE
Fix red CI on master: plugin deps (aiohttp/scipy) + flytectl install

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -419,6 +419,12 @@ jobs:
           if [[ ${{ matrix.plugin-names }} == *"onnx"* || ${{ matrix.plugin-names }} == "flytekit-sqlalchemy" || ${{ matrix.plugin-names }} == "flytekit-pandera" ]]; then
             uv pip install --system "numpy<2.0.0"
           fi
+          # The -U step above re-resolves aiohttp (a flytekit dependency) back to the latest,
+          # which aioresponses (spark test dep) cannot build a mocked ClientResponse against on
+          # 3.14. Re-pin it after the upgrade. See https://github.com/flyteorg/flyte/issues/7604.
+          if [[ ${{ matrix.plugin-names }} == "flytekit-spark" ]]; then
+            uv pip install --system "aiohttp<3.14"
+          fi
           uv pip freeze
       - name: Test with coverage
         run: |

--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -242,7 +242,12 @@ jobs:
           make setup-global-uv
           uv pip freeze
       - name: Install FlyteCTL
-        uses: unionai-oss/flytectl-setup-action@master
+        # unionai-oss/flytectl-setup-action resolves "latest" from the first page of flyteorg/flyte releases, which is
+        # now all Flyte 2.0 (v2.0.x) tags with no flytectl/ release on page 1, so it crashes on `reading 'assets'`.
+        # Install the last flytectl release directly instead.
+        run: |
+          curl -sL "https://github.com/flyteorg/flyte/releases/download/flytectl/v0.9.8/flytectl_Linux_x86_64.tar.gz" | sudo tar -xz -C /usr/local/bin flytectl
+          flytectl version
       - name: Setup Flyte Sandbox
         run: |
           flytectl demo start --disable-agent

--- a/plugins/flytekit-onnx-scikitlearn/dev-requirements.in
+++ b/plugins/flytekit-onnx-scikitlearn/dev-requirements.in
@@ -1,1 +1,5 @@
 onnxruntime
+# scikit-learn (via skl2onnx) pulls scipy, whose 1.18 line requires numpy>=2 and uses
+# np.long. CI forces numpy<2 for onnx, so cap scipy to its last numpy<2 line to avoid the
+# import-time crash that surfaces as "sklearn is not a package". See flyteorg/flyte#7604.
+scipy<1.18

--- a/plugins/flytekit-spark/dev-requirements.in
+++ b/plugins/flytekit-spark/dev-requirements.in
@@ -1,2 +1,6 @@
 aioresponses
+# aioresponses (0.7.8) builds a mocked ClientResponse without the `stream_writer`
+# argument that aiohttp 3.14 made required, so the connector tests can't construct
+# responses. Cap aiohttp until aioresponses supports 3.14.
+aiohttp<3.14
 pytest-asyncio


### PR DESCRIPTION
## Why are the changes needed?

Two unrelated failures are reding CI on `master` (and every PR):

1. **Plugin builds** — `flytekit-spark` and `flytekit-onnx-scikitlearn`. A `-U` dependency step re-resolves `aiohttp` to `>=3.14` (which `aioresponses` can't mock) and pulls `scipy>=1.18` for onnx. See https://github.com/flyteorg/flyte/issues/7604.

2. **Integration jobs** — both `integration_test_*` jobs die at *Install FlyteCTL*:
   ```
   ##[error]Cannot read properties of undefined (reading 'assets')
   ```
   `unionai-oss/flytectl-setup-action@master` resolves "latest" from the first page of `flyteorg/flyte` releases and reads `i[0].assets`. That page is now entirely Flyte 2.0 (`v2.0.x`) tags — no `flytectl/` release on it — so the list is empty and it throws.

## What changes were proposed in this pull request?

- Re-pin `aiohttp<3.14` (spark) and `scipy<1.18` (onnx) after the `-U` step.
- Install flytectl by downloading the last release (`flytectl/v0.9.8`) directly from its asset URL instead of the action.

The flytectl root cause is in `unionai-oss/flytectl-setup-action` (it reads only the first page of `flyteorg/flyte` releases, now all Flyte 2.0 tags). Fixing the action would be the cleaner fix for everyone, but flytectl is frozen at `v0.9.8`, so pinning it directly is deterministic and avoids depending on that action. Happy to pursue a fix in the action instead if you'd prefer.

## How was this patch tested?

CI on this PR. The plugin builds are green, and the integration jobs now get **past** *Install FlyteCTL* and *Setup Flyte Sandbox* (`flytectl demo start`) — both confirmed green on a prior run of the flytectl change — into the integration tests themselves.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
