### PR TITLE
ci: install flytectl directly instead of the broken setup action

### DIFF
--- a/.github/workflows/pythonbuild.yml
+++ b/.github/workflows/pythonbuild.yml
@@ -242,7 +242,12 @@ jobs:
           make setup-global-uv
           uv pip freeze
       - name: Install FlyteCTL
-        uses: unionai-oss/flytectl-setup-action@master
+        # unionai-oss/flytectl-setup-action resolves "latest" from the first page of flyteorg/flyte releases, which is
+        # now all Flyte 2.0 (v2.0.x) tags with no flytectl/ release on page 1, so it crashes on `reading 'assets'`.
+        # Install the last flytectl release directly instead.
+        run: |
+          curl -sL "https://github.com/flyteorg/flyte/releases/download/flytectl/v0.9.8/flytectl_Linux_x86_64.tar.gz" | sudo tar -xz -C /usr/local/bin flytectl
+          flytectl version
       - name: Setup Flyte Sandbox
         run: |
           flytectl demo start --disable-agent


### PR DESCRIPTION
## Why are the changes needed?

The `integration` jobs are red on `master` and on every PR. They fail at the **Install FlyteCTL** step:

```
##[error]Cannot read properties of undefined (reading 'assets')
```

`unionai-oss/flytectl-setup-action@master` resolves "latest" by listing the first page of `flyteorg/flyte` releases, filtering to `flytectl/`-prefixed tags, and reading `i[0].assets`. That page is now entirely Flyte 2.0 (`v2.0.x`) release tags — no `flytectl/` release appears on it — so the filtered list is empty and `i[0].assets` throws. (The `ctl.flyte.org` install script has the same first-page limitation, so it isn't a workaround either.)

## What changes were proposed in this pull request?

Install flytectl by downloading the last published release, `flytectl/v0.9.8`, directly from its asset URL — no release-list resolution involved. `v0.9.8` is the same version the action installed back when it worked.

Unblocks the red `integration` checks across all open PRs.

## How was this patch tested?

CI on this PR is the real check — the `integration` jobs now get past the FlyteCTL install and into `flytectl demo start`. Out of band I confirmed the asset URL resolves and the tarball holds the `flytectl` binary at its root. I can't run GitHub Actions locally, so I'm relying on this PR's run for the green.

## Check all the applicable boxes

- [ ] I updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
