### PR TITLE
fix: eagerly refresh credentials on first gRPC call

### DIFF
--- a/flytekit/clients/grpc_utils/auth_interceptor.py
+++ b/flytekit/clients/grpc_utils/auth_interceptor.py
@@ -64,6 +64,8 @@ class AuthUnaryInterceptor(grpc.UnaryUnaryClientInterceptor, grpc.UnaryStreamCli
         Intercepts unary calls and adds auth metadata if available. On Unauthenticated, resets the token and refreshes
         and then retries with the new token
         """
+        if not self.authenticator.get_credentials():
+            self.authenticator.refresh_credentials()
         updated_call_details = self._call_details_with_auth_metadata(client_call_details)
         fut: grpc.Future = continuation(updated_call_details, request)
         e = fut.exception()
@@ -80,6 +82,8 @@ class AuthUnaryInterceptor(grpc.UnaryUnaryClientInterceptor, grpc.UnaryStreamCli
         """
         Handles a stream call and adds authentication metadata if needed
         """
+        if not self.authenticator.get_credentials():
+            self.authenticator.refresh_credentials()
         updated_call_details = self._call_details_with_auth_metadata(client_call_details)
         c: grpc.Call = continuation(updated_call_details, request)
         if c.code() == grpc.StatusCode.UNAUTHENTICATED:


### PR DESCRIPTION
## Tracking issue
<!--
If your PR fixes an open issue, use `Closes flyteorg/flyte#999` to link your PR with the issue.
Example: Closes flyteorg/flyte#999

If your PR is related to an issue or PR, use `Related to flyteorg/flyte#999` to link your PR.
Example: Related to flyteorg/flyte#999
-->
<!-- Remove this section if not applicable -->

## Why are the changes needed?

AuthUnaryInterceptor previously sent the first gRPC request without credentials even when an authenticator was configured, relying on a retry-on-UNAUTHENTICATED loop to fetch and attach the token. This wastes a round-trip on every new channel and, if the retry itself hits a transient failure, causes a needless error.

## What changes were proposed in this pull request?

Call refresh_credentials() before the first request when no credentials are present, so the initial gRPC call already carries the auth header. The existing retry-on-401 logic is preserved for token expiry during long-lived channels.

## How was this patch tested?

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Setup process

### Screenshots

## Check all the applicable boxes <!-- Follow the above conventions to check the box -->

- [ ] I updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] All commits are signed-off.

## Related PRs

<!-- Add related pull requests for reviewers to check -->

## Docs link

<!-- Add documentation link built by CI jobs here, and specify the changed place -->
