### PR TITLE
Fix flytekit-greatexpectations tests: replace dead ge_tutorials CSV URL

### DIFF
--- a/plugins/flytekit-greatexpectations/tests/test_schema.py
+++ b/plugins/flytekit-greatexpectations/tests/test_schema.py
@@ -293,7 +293,7 @@ def test_ge_schema_remote_flytefile():
         return my_task(dataset=dataset)
 
     result = my_wf(
-        dataset="https://raw.githubusercontent.com/superconductive/ge_tutorials/main/data/yellow_tripdata_sample_2019-01.csv"
+        dataset="https://raw.githubusercontent.com/flyteorg/flytekit/master/plugins/flytekit-greatexpectations/tests/data/yellow_tripdata_sample_2019-01.csv"
     )
     assert result == 10000
 
@@ -313,7 +313,7 @@ def test_ge_schema_remote_flytefile_literal():
     @workflow
     def my_wf() -> int:
         return my_task(
-            dataset="https://raw.githubusercontent.com/superconductive/ge_tutorials/main/data/yellow_tripdata_sample_2019-01.csv"
+            dataset="https://raw.githubusercontent.com/flyteorg/flytekit/master/plugins/flytekit-greatexpectations/tests/data/yellow_tripdata_sample_2019-01.csv"
         )
 
     result = my_wf()

--- a/plugins/flytekit-greatexpectations/tests/test_task.py
+++ b/plugins/flytekit-greatexpectations/tests/test_task.py
@@ -205,7 +205,7 @@ def test_ge_remote_flytefile():
     )
 
     task_object(
-        dataset="https://raw.githubusercontent.com/superconductive/ge_tutorials/main/data/yellow_tripdata_sample_2019-01.csv"
+        dataset="https://raw.githubusercontent.com/flyteorg/flytekit/master/plugins/flytekit-greatexpectations/tests/data/yellow_tripdata_sample_2019-01.csv"
     )
 
 
@@ -229,7 +229,7 @@ def test_ge_remote_flytefile_with_task():
         return my_task(dataset=dataset)
 
     result = my_wf(
-        dataset="https://raw.githubusercontent.com/superconductive/ge_tutorials/main/data/yellow_tripdata_sample_2019-01.csv"
+        dataset="https://raw.githubusercontent.com/flyteorg/flytekit/master/plugins/flytekit-greatexpectations/tests/data/yellow_tripdata_sample_2019-01.csv"
     )
     assert result == 10000
 
@@ -246,7 +246,7 @@ def test_ge_remote_flytefile_workflow():
 
     @workflow
     def valid_wf(
-        dataset: CSVFile = "https://raw.githubusercontent.com/superconductive/ge_tutorials/main/data/yellow_tripdata_sample_2019-01.csv",
+        dataset: CSVFile = "https://raw.githubusercontent.com/flyteorg/flytekit/master/plugins/flytekit-greatexpectations/tests/data/yellow_tripdata_sample_2019-01.csv",
     ) -> None:
         task_object(dataset=dataset)
 
@@ -298,8 +298,8 @@ def test_ge_flytefile_multiple_args():
 
     @workflow
     def wf(
-        dataset_one: FlyteFile = "https://raw.githubusercontent.com/superconductive/ge_tutorials/main/data/yellow_tripdata_sample_2019-01.csv",
-        dataset_two: FlyteFile = "https://raw.githubusercontent.com/superconductive/ge_tutorials/main/data/yellow_tripdata_sample_2019-02.csv",
+        dataset_one: FlyteFile = "https://raw.githubusercontent.com/flyteorg/flytekit/master/plugins/flytekit-greatexpectations/tests/data/yellow_tripdata_sample_2019-01.csv",
+        dataset_two: FlyteFile = "https://raw.githubusercontent.com/flyteorg/flytekit/master/plugins/flytekit-greatexpectations/tests/data/yellow_tripdata_sample_2019-02.csv",
     ) -> typing.Tuple[int, int]:
         task_object_one(dataset=dataset_one)
         task_object_two(dataset=dataset_two)


### PR DESCRIPTION
## Why are the changes needed?

`build-plugins (flytekit-greatexpectations)` is failing on master. The
`superconductive/ge_tutorials` GitHub repo no longer exists, so
`https://raw.githubusercontent.com/superconductive/ge_tutorials/main/data/yellow_tripdata_sample_2019-01.csv`
returns 404 and every test that feeds a remote `FlyteFile`/`CSVFile` into a
Great Expectations task blows up with:

```
FlyteDataNotFoundException: USER:ValueError: error=Value error!
Received: https://raw.githubusercontent.com/superconductive/ge_tutorials/main/data/yellow_tripdata_sample_2019-01.csv. File not found
```

6 failures: `test_schema.py::test_ge_schema_remote_flytefile`,
`test_ge_schema_remote_flytefile_literal`, `test_task.py::test_ge_remote_flytefile`,
`test_ge_remote_flytefile_with_task`, `test_ge_remote_flytefile_workflow`,
`test_ge_flytefile_multiple_args`.

## What changes were proposed in this pull request?

Point those URLs at the copies of the same CSVs that are already committed in
this repo under `plugins/flytekit-greatexpectations/tests/data/`, served over
raw.githubusercontent.com from `master`. That keeps the tests exercising the
remote-http download path (which is the point of these tests) while removing
the dependency on a third-party repo we don't control.

Both files are byte-identical to the local ones the other tests already use
(md5 `38f1366...` for 2019-01, `e39a6b8...` for 2019-02), so the `== 10000`
row assertions are unchanged.

I also checked `great-expectations/gx_tutorials` as a replacement — it is live,
but its `2019-01` sample has 9999 rows instead of 10000 and its `2019-02` sample
differs, so it would have required changing the assertions.

## How was this patch tested?

No new tests — this restores 6 existing tests that fail on master.

Verified the new URLs resolve and that flytekit's `CSVFile` download path
returns the expected row count:

```
$ curl -s -o /dev/null -w '%{http_code}' https://raw.githubusercontent.com/flyteorg/flytekit/master/plugins/flytekit-greatexpectations/tests/data/yellow_tripdata_sample_2019-01.csv
200
```

```python
@task
def rows(dataset: CSVFile) -> int:
    return len(pd.read_csv(dataset))

@workflow
def wf(dataset: CSVFile = URL) -> int:
    return rows(dataset=dataset)

assert wf() == 10000   # passes
```

The full plugin suite needs great-expectations + pyspark 3.3.2, which I did not
install locally — CI on this PR is the real check.

## Check all the applicable boxes

- [x] I updated the documentation accordingly. (n/a — test-only change)
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
