### PR TITLE
Encode string before xxhash in sagemaker boto3 mixin (fixes xxhash 4.0 TypeError)

### DIFF
--- a/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_mixin.py
+++ b/plugins/flytekit-aws-sagemaker/flytekitplugins/awssagemaker_inference/boto3_mixin.py
@@ -144,7 +144,7 @@ class Boto3ConnectorMixin:
         hash = ""
         if "idempotence_token" in str(updated_config):
             # compute hash of the config
-            hash = xxhash.xxh64(sorted_dict_str(updated_config)).hexdigest()
+            hash = xxhash.xxh64(sorted_dict_str(updated_config).encode("utf-8")).hexdigest()
             updated_config = format_dict(self._service, updated_config, args, idempotence_token=hash)
 
         # Asynchronous Boto3 session


### PR DESCRIPTION
## Why are the changes needed?

`build-plugins (flytekit-aws-sagemaker)` is failing on master:

```
>  hash = xxhash.xxh64(sorted_dict_str(updated_config)).hexdigest()
E  TypeError: Strings must be encoded before hashing

4 failed, 140 passed
```

xxhash 4.0 removed the implicit encoding of `str` inputs, so `xxh64()` on a
string now raises. The plugin pins `xxhash` unbounded (`plugins/flytekit-aws-sagemaker/setup.py`),
so CI picked up 4.x and every code path that computes an idempotence token broke.

Failing tests: `test_call_with_idempotence_token`,
`test_call_with_truncated_idempotence_token`,
`test_call_with_truncated_idempotence_token_as_input`,
`test_call_hashes_normalised_integer_values_consistently`.

## What changes were proposed in this pull request?

Encode the config string as utf-8 before hashing:

```python
hash = xxhash.xxh64(sorted_dict_str(updated_config).encode("utf-8")).hexdigest()
```

utf-8 is exactly what xxhash <4 did internally, so the digests are unchanged —
existing idempotence tokens (and the tokens asserted in the tests) stay the
same, and this works on both xxhash 3.x and 4.x. Pinning `xxhash<4` in setup.py
would also make CI green, but it leaves the latent bug in place, so I fixed the
call instead.

Verified the digest is stable across versions:

```
xxhash 3.8.1:  xxh64(s).hexdigest()                  -> 8d9d5330fea0133b
xxhash 3.8.1:  xxh64(s.encode("utf-8")).hexdigest()  -> 8d9d5330fea0133b
```

## How was this patch tested?

No new tests — this restores 4 existing tests that fail on master. Ran the
suite locally against xxhash 4.0.1:

```
# without the fix
4 failed, 6 passed in 0.72s

# with the fix
10 passed in 1.52s
```

The token assertions (`2de338ec95ee0da6`, `1a25e4bb988697a7`, `ce735d6a183643f1`)
pass unchanged, confirming the fix does not alter existing hashes.

## Check all the applicable boxes

- [x] I updated the documentation accordingly. (n/a)
- [x] All new and existing tests passed.
- [x] All commits are signed-off.
