### PR TITLE
fix(async-fsspec): propagate concurrent download failures

### DIFF
--- a/plugins/flytekit-async-fsspec/flytekitplugins/async_fsspec/s3fs/s3fs.py
+++ b/plugins/flytekit-async-fsspec/flytekitplugins/async_fsspec/s3fs/s3fs.py
@@ -236,10 +236,18 @@ class AsyncS3FileSystem(S3FileSystem):
 
                 tasks = set()
                 current_chunk = 0
-                while current_chunk < chunk_count:
-                    while current_chunk < chunk_count and len(tasks) < concurrent_download:
-                        tasks.add(asyncio.create_task(download_chunk(current_chunk)))
-                        current_chunk += 1
-                    _, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-                    tasks = pending
-                await asyncio.gather(*tasks)
+                try:
+                    while current_chunk < chunk_count:
+                        while current_chunk < chunk_count and len(tasks) < concurrent_download:
+                            tasks.add(asyncio.create_task(download_chunk(current_chunk)))
+                            current_chunk += 1
+                        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+                        for task in done:
+                            task.result()
+                        tasks = pending
+                    await asyncio.gather(*tasks)
+                except BaseException:
+                    for task in tasks:
+                        task.cancel()
+                    await asyncio.gather(*tasks, return_exceptions=True)
+                    raise

--- a/plugins/flytekit-async-fsspec/tests/test_s3fs.py
+++ b/plugins/flytekit-async-fsspec/tests/test_s3fs.py
@@ -1,6 +1,7 @@
+import asyncio
 import os
 from unittest import mock
-from unittest.mock import MagicMock, mock_open
+from unittest.mock import AsyncMock, MagicMock, mock_open
 
 import pytest
 from flytekitplugins.async_fsspec import AsyncS3FileSystem
@@ -199,3 +200,28 @@ async def test_get_file_file_size_is_not_none(mock_isdir, mock_info, mock_call_s
         )
     mock_call_s3.assert_has_calls(get_object_calls)
     assert mock_call_s3.call_count == len(get_object_calls)
+
+
+@pytest.mark.asyncio
+async def test_get_file_propagates_completed_chunk_failure(tmp_path):
+    asyncs3fs = AsyncS3FileSystem(anon=True)
+    body = MagicMock()
+    body.read = AsyncMock(side_effect=[b"data", b""])
+
+    async def call_s3(*args, **kwargs):
+        if kwargs["Range"] == "bytes=0-3":
+            raise RuntimeError("download failed")
+        await asyncio.sleep(0.01)
+        return {"Body": body, "ContentLength": 4}
+
+    with (
+        mock.patch.object(asyncs3fs, "_info", return_value={"size": 8}),
+        mock.patch.object(asyncs3fs, "_call_s3", side_effect=call_s3),
+        pytest.raises(RuntimeError, match="download failed"),
+    ):
+        await asyncs3fs._get_file(
+            rpath="s3://bucket/object",
+            lpath=str(tmp_path / "object"),
+            chunksize=4,
+            concurrent_download=2,
+        )


### PR DESCRIPTION
## Tracking issue

None.

## Why are the changes needed?

Concurrent S3 downloads could return success after a ranged request failed. The caller received a partial file while asyncio logged `Task exception was never retrieved`.

## What changes were proposed in this pull request?

Read completed task results so download errors reach the caller. On failure or cancellation, cancel and await the remaining chunk tasks.

## How was this patch tested?

This command uses the real `s3fs` and `aiobotocore` HTTP path:

### Setup process

```bash
PYTHONPATH=plugins/flytekit-async-fsspec python - <<'PY'
import asyncio
from pathlib import Path
from aiohttp import web
from flytekitplugins.async_fsspec import AsyncS3FileSystem
w=asyncio.Event()
async def h(r):
 if r.method=="HEAD": return web.Response(headers={"Content-Length":"8","ETag":'"x"'})
 if r.headers["Range"]=="bytes=0-3":
  await w.wait(); return web.Response(status=403,body=b"<Error><Code>AccessDenied</Code><Message>injected ranged failure</Message></Error>",content_type="application/xml")
 x=web.StreamResponse(status=206,headers={"Content-Range":"bytes 4-7/8"});x.enable_chunked_encoding();await x.prepare(r);await x.write(b"EFGH");w.set();t=r.transport;await asyncio.sleep(1);print("closed",t is None or t.is_closing())
 try: await x.write_eof()
 except (ConnectionError,RuntimeError): pass
 return x
async def main():
 a=web.Application();a.router.add_route("*","/{p:.*}",h);z=web.AppRunner(a);await z.setup();s=web.TCPSite(z,"127.0.0.1",0);await s.start();port=s._server.sockets[0].getsockname()[1]
 f=AsyncS3FileSystem(anon=True,asynchronous=True,client_kwargs={"endpoint_url":f"http://127.0.0.1:{port}"},config_kwargs={"s3":{"addressing_style":"path"}});p=Path("partial.bin");p.unlink(missing_ok=True)
 try: await f._get_file("s3://b/k",str(p),chunksize=4,concurrent_download=2);print("returned")
 except Exception as e: print(type(e).__name__,e)
 print(p.read_bytes().hex());await asyncio.sleep(1);await f._s3creator.__aexit__(None,None,None);await z.cleanup()
asyncio.run(main())
PY
```

```text
master: returned; 0000000045464748; closed False
branch: PermissionError injected ranged failure; 0000000045464748; closed True
```

The expected file was `4142434445464748`. Plugin tests pass.

### Screenshots

Not applicable.

## Check all the applicable boxes

- [x] Documentation is unchanged.
- [x] All async fsspec plugin tests passed.
- [x] All commits are signed off.

## Related PRs

None.

## Docs link

Not applicable.
